### PR TITLE
fix(build): enforce LF line endings for patch files on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch text eol=lf


### PR DESCRIPTION
Fixes ahliweb/awcms-mini#244. This PR introduces a \.gitattributes\ file to enforce \LF\ line endings for \*.patch\ files, preventing \ERR_PNPM_INVALID_PATCH\ hunk header integrity check errors during \pnpm install\ on Windows environments.