### PR TITLE
feat: align plugin descriptor contract with EmDash admin surface

### DIFF
--- a/docs/plugins/contract-overview.md
+++ b/docs/plugins/contract-overview.md
@@ -15,7 +15,7 @@ Mini adds governance-aware contract helpers so plugins can participate in the sa
 Mini currently provides:
 
 - EmDash plugin definitions created with `definePlugin(...)`
-- first-party plugin descriptors that register `id`, `entrypoint`, `format`, `capabilities`, and permissions with the host
+- first-party plugin descriptors that register `id`, `entrypoint`, `format`, `capabilities`, `permissions`, and any admin surface fields (`adminEntry`, `adminPages`, `adminWidgets`) with the host
 - plugin permission registration helper
 - plugin route authorization helper
 - plugin service authorization helper
@@ -33,7 +33,7 @@ Mini keeps setup, runtime bootstrap, database ledgers, and route authorization a
 ## Current Terminology
 
 - A plugin definition is the runtime object returned from `definePlugin(...)`.
-- A plugin descriptor is the registration object Mini exposes for EmDash to discover and load a plugin entrypoint, capability list, and permission catalog.
+- A plugin descriptor is the registration object Mini exposes for EmDash to discover and load a plugin entrypoint, capability list, permission catalog, and optional admin surface.
 - Plugin routes are the handler entries declared inside the plugin definition.
 - First-party admin experience currently ships through the `awcms-users-admin` plugin rather than a separate admin shell.
 

--- a/docs/plugins/contract-overview.md
+++ b/docs/plugins/contract-overview.md
@@ -15,7 +15,7 @@ Mini adds governance-aware contract helpers so plugins can participate in the sa
 Mini currently provides:
 
 - EmDash plugin definitions created with `definePlugin(...)`
-- first-party plugin descriptors that register `id`, `entrypoint`, `format`, and permissions with the host
+- first-party plugin descriptors that register `id`, `entrypoint`, `format`, `capabilities`, and permissions with the host
 - plugin permission registration helper
 - plugin route authorization helper
 - plugin service authorization helper
@@ -33,7 +33,7 @@ Mini keeps setup, runtime bootstrap, database ledgers, and route authorization a
 ## Current Terminology
 
 - A plugin definition is the runtime object returned from `definePlugin(...)`.
-- A plugin descriptor is the registration object Mini exposes for EmDash to discover and load a plugin entrypoint.
+- A plugin descriptor is the registration object Mini exposes for EmDash to discover and load a plugin entrypoint, capability list, and permission catalog.
 - Plugin routes are the handler entries declared inside the plugin definition.
 - First-party admin experience currently ships through the `awcms-users-admin` plugin rather than a separate admin shell.
 

--- a/docs/plugins/contract-overview.md
+++ b/docs/plugins/contract-overview.md
@@ -46,7 +46,7 @@ Plugins should consume shared governance services instead of bypassing them with
 The internal governance sample plugin demonstrates the contract end to end:
 
 - runtime definition and registration descriptor
-- permission manifest
+- capabilities and permission catalog
 - protected route declaration
 - service-level authorization
 - scoped resource resolution

--- a/docs/plugins/permission-registration.md
+++ b/docs/plugins/permission-registration.md
@@ -74,5 +74,5 @@ The helper also adds `plugin_id` so later contract layers can trace where the de
 
 - Permission codes must be unique across all registered plugins.
 - Every declaration must provide non-empty `code`, `domain`, `resource`, and `action` values.
-- Plugins should treat this manifest as the source of truth for route guards, service authorization, and audit helpers added in later contract steps.
+- Plugins should treat this permission catalog as the source of truth for route guards, service authorization, and audit helpers added in later contract steps.
 - Plugin permissions should remain additive overlays on top of EmDash host conventions, not a second permission system.

--- a/docs/plugins/permission-registration.md
+++ b/docs/plugins/permission-registration.md
@@ -1,6 +1,7 @@
 # Plugin Permission Registration
 
 Plugins should declare permissions through the plugin definition and descriptor `permissions` arrays, while the descriptor `capabilities` field follows EmDash host terminology for runtime loading and sandbox access.
+When the plugin exposes admin UI, the same descriptor may also include `adminEntry`, `adminPages`, and `adminWidgets`.
 
 ## Contract
 

--- a/docs/plugins/permission-registration.md
+++ b/docs/plugins/permission-registration.md
@@ -1,6 +1,6 @@
 # Plugin Permission Registration
 
-Plugins should declare permissions through the plugin definition and descriptor `permissions` arrays so plugin-defined capabilities can be normalized into the same catalog shape as core permissions.
+Plugins should declare permissions through the plugin definition and descriptor `permissions` arrays, while the descriptor `capabilities` field follows EmDash host terminology for runtime loading and sandbox access.
 
 ## Contract
 
@@ -53,7 +53,7 @@ export function createPlugin() {
 }
 ```
 
-The same normalized permission array should be reused by the plugin definition and the plugin descriptor so route guards and host registration stay aligned.
+The same normalized permission array should be reused by the plugin definition and the plugin descriptor so route guards, host registration, and capability-gated loading stay aligned.
 
 ## Normalized Shape
 

--- a/docs/process/emdash-alignment-and-security-plan-2026.md
+++ b/docs/process/emdash-alignment-and-security-plan-2026.md
@@ -24,7 +24,7 @@ It is based on:
 ### Confirmed Repository State
 
 - AWCMS Mini remains structurally aligned with EmDash-first architecture.
-- The installed `emdash` package version is now `0.8.0`, which matches the current local EmDash core package version inspected in `/home/data/dev_react/emdash-awcms/`.
+- The installed `emdash` package version is now `0.8.0`, which matches the current local EmDash core package version inspected in a checked-out copy of `emdash-cms/emdash`.
 - The current sync gap is no longer package-version drift at the dependency pin. The confirmed local EmDash divergence now lives in the tracked `pnpm` patch and the reviewed Mini compatibility seams it still carries.
 - The tracked patch currently covers the reviewed Mini-local setup/runtime seams, including setup-safe middleware routing, setup route database/config fallbacks, and the fail-fast runtime-init safeguard.
 - Beyond that patch surface, the bigger gap remains operational and architectural maturity around runtime configuration, security controls, and plugin/admin integration conventions.

--- a/docs/process/migration-deployment-checklist.md
+++ b/docs/process/migration-deployment-checklist.md
@@ -166,7 +166,7 @@ Validate the live system in this order.
 
 ### Plugin Contract
 
-- [ ] Plugin permission manifests still normalize correctly
+- [ ] Plugin permission catalogs still normalize correctly
 - [ ] Declarative plugin route authorization still works for protected routes
 - [ ] Plugin service authorization helpers still evaluate declared permissions correctly
 - [ ] Plugin audit helper still appends plugin-tagged audit entries

--- a/scripts/check-emdash-drift.mjs
+++ b/scripts/check-emdash-drift.mjs
@@ -6,8 +6,20 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
-const referenceRoot = path.resolve(repoRoot, "../emdash-awcms/packages/core");
 const patchPath = path.resolve(repoRoot, "patches/emdash@0.8.0.patch");
+
+function resolveReferenceRoot() {
+  const envReferenceRoot = process.env.EMDASH_REFERENCE_ROOT?.trim();
+  const candidates = [
+    envReferenceRoot ? path.resolve(envReferenceRoot) : null,
+    path.resolve(repoRoot, "../emdash/packages/core"),
+    path.resolve(repoRoot, "../emdash-awcms/packages/core"),
+  ].filter(Boolean);
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
+}
+
+const referenceRoot = resolveReferenceRoot();
 
 function runGitApply(args) {
   return spawnSync("git", args, {

--- a/src/plugins/awcms-users-admin/index.mjs
+++ b/src/plugins/awcms-users-admin/index.mjs
@@ -2231,6 +2231,7 @@ export function awcmsUsersAdminPlugin() {
     format: "native",
     entrypoint: "/src/plugins/awcms-users-admin/index.mjs",
     adminEntry: "/src/plugins/awcms-users-admin/admin.tsx",
+    capabilities: ["read:users"],
     permissions: USER_ADMIN_PLUGIN_PERMISSIONS,
     adminPages: [
       { path: "/", label: "Users", icon: "users" },

--- a/src/plugins/internal-governance-sample/index.mjs
+++ b/src/plugins/internal-governance-sample/index.mjs
@@ -227,6 +227,7 @@ export function internalGovernanceSamplePlugin() {
     version: "0.1.0",
     format: "native",
     entrypoint: "/src/plugins/internal-governance-sample/index.mjs",
+    capabilities: [],
     permissions: SAMPLE_PLUGIN_PERMISSIONS,
   };
 }

--- a/src/plugins/internal-governance-sample/index.mjs
+++ b/src/plugins/internal-governance-sample/index.mjs
@@ -228,6 +228,8 @@ export function internalGovernanceSamplePlugin() {
     format: "native",
     entrypoint: "/src/plugins/internal-governance-sample/index.mjs",
     capabilities: [],
+    adminPages: [],
+    adminWidgets: [],
     permissions: SAMPLE_PLUGIN_PERMISSIONS,
   };
 }

--- a/tests/unit/awcms-users-admin-plugin.test.mjs
+++ b/tests/unit/awcms-users-admin-plugin.test.mjs
@@ -824,6 +824,7 @@ test("awcms users admin plugin exposes admin pages and read-only routes", async 
     assert.equal(authorizationCalls[1].resource.is_protected, true);
 
     const manifest = awcmsUsersAdminPlugin();
+    assert.deepEqual(manifest.capabilities, ["read:users"]);
     assert.equal(manifest.permissions.length, USER_ADMIN_PLUGIN_PERMISSIONS.length);
     assert.equal(manifest.permissions.some((entry) => entry.code === "audit.logs.read"), true);
   } finally {

--- a/tests/unit/awcms-users-admin-plugin.test.mjs
+++ b/tests/unit/awcms-users-admin-plugin.test.mjs
@@ -825,6 +825,9 @@ test("awcms users admin plugin exposes admin pages and read-only routes", async 
 
     const manifest = awcmsUsersAdminPlugin();
     assert.deepEqual(manifest.capabilities, ["read:users"]);
+    assert.equal(manifest.adminEntry, "/src/plugins/awcms-users-admin/admin.tsx");
+    assert.equal(manifest.adminPages.length, 10);
+    assert.equal(manifest.adminWidgets, undefined);
     assert.equal(manifest.permissions.length, USER_ADMIN_PLUGIN_PERMISSIONS.length);
     assert.equal(manifest.permissions.some((entry) => entry.code === "audit.logs.read"), true);
   } finally {

--- a/tests/unit/emdash-drift.test.mjs
+++ b/tests/unit/emdash-drift.test.mjs
@@ -6,9 +6,11 @@ import { fileURLToPath } from "node:url";
 const driftScriptPath = fileURLToPath(new URL("../../scripts/check-emdash-drift.mjs", import.meta.url));
 const packageJsonPath = fileURLToPath(new URL("../../package.json", import.meta.url));
 
-test("EmDash drift checker targets the linked reference checkout", async () => {
+test("EmDash drift checker targets the canonical reference checkout", async () => {
   const contents = await readFile(driftScriptPath, "utf8");
 
+  assert.match(contents, /EMDASH_REFERENCE_ROOT/);
+  assert.match(contents, /\.\.\/emdash\/packages\/core/);
   assert.match(contents, /\.\.\/emdash-awcms\/packages\/core/);
   assert.match(contents, /apply", "--check", "--exclude=dist\/\*\*"/);
   assert.match(contents, /apply", "--reverse", "--check", "--exclude=dist\/\*\*"/);

--- a/tests/unit/internal-governance-sample-plugin.test.mjs
+++ b/tests/unit/internal-governance-sample-plugin.test.mjs
@@ -77,6 +77,8 @@ test("internal governance sample plugin exercises the governance contract end to
 
     const manifest = internalGovernanceSamplePlugin();
     assert.deepEqual(manifest.capabilities, []);
+    assert.deepEqual(manifest.adminPages, []);
+    assert.deepEqual(manifest.adminWidgets, []);
     assert.equal(manifest.permissions.length, SAMPLE_PLUGIN_PERMISSIONS.length);
 
     const listBody = await plugin.routes["records/list"].handler({

--- a/tests/unit/internal-governance-sample-plugin.test.mjs
+++ b/tests/unit/internal-governance-sample-plugin.test.mjs
@@ -76,6 +76,7 @@ test("internal governance sample plugin exercises the governance contract end to
     assert.equal(SAMPLE_PLUGIN_PERMISSIONS.some((entry) => entry.code === "sample.records.flag"), true);
 
     const manifest = internalGovernanceSamplePlugin();
+    assert.deepEqual(manifest.capabilities, []);
     assert.equal(manifest.permissions.length, SAMPLE_PLUGIN_PERMISSIONS.length);
 
     const listBody = await plugin.routes["records/list"].handler({


### PR DESCRIPTION
## Summary\n- Align first-party plugin descriptors with current EmDash terminology and shape, including , , and admin surface fields.\n- Keep the EmDash drift checker pointed at canonical checkouts and document the plugin contract shape more clearly.\n\n## Validation\n- 
> awcms-mini@0.1.0 test:unit /home/data/dev_react/awcms-mini
> node --test tests/unit/**/*.test.mjs

TAP version 13
# [b8451ecc-2cbb-4397-97f8-9cde07bfb113] GET /health → 503 (28ms)
# Subtest: GET /health returns a JSON health check response
ok 1 - GET /health returns a JSON health check response
  ---
  duration_ms: 58.702233
  type: 'test'
  ...
# [f2aed6a8-62ed-42de-a077-d1e93e631111] GET /health → 503 (4ms)
# Subtest: GET /health sets X-Request-Id response header
ok 2 - GET /health sets X-Request-Id response header
  ---
  duration_ms: 6.620128
  type: 'test'
  ...
# [test-id-abc] GET /health → 503 (4ms)
# Subtest: GET /health echoes X-Request-Id from request when provided
ok 3 - GET /health echoes X-Request-Id from request when provided
  ---
  duration_ms: 4.65403
  type: 'test'
  ...
# [43bcf575-f5ea-4b39-badd-f0e5b785d6ab] GET /health → 503 (4ms)
# [c81ac5a6-853a-440e-93ab-cb06d99b05be] GET /api/v1 → 200 (1ms)
# [c151b9ea-df24-4dbc-8469-55ed18537b58] GET /openapi.json → 200 (1ms)
# [bbfe018f-c188-45a0-8dea-99b474aa57e0] POST /api/v1/auth/login → 200 (1ms)
# [0f130b57-f801-4f31-9055-5db78dc00c39] GET /nonexistent-route-xyz → 404 (1ms)
# [e2244a58-f9c1-4aba-bd77-409bd4b87ae4] GET /api/v1/roles → 401 (0ms)
# [4664268f-c44b-4f98-b749-416e27dee57b] GET /api/v1/roles → 200 (0ms)
# [a04b0572-cc17-4c2e-868b-4df66f2ded4e] GET /api/v1/permissions → 403 (0ms)
# [286d4a5a-916d-44c7-878b-452687e276d7] GET /api/v1/permissions → 403 (1ms)
# [66ddb861-08d2-4cb0-975f-fa23d2817a4a] GET /api/v1/auth/me → 200 (1ms)
# [5763330e-3b67-4263-bba8-88672c090450] GET /api/v1/roles → 200 (0ms)
# [c3038083-0935-4352-9709-027d8552a98d] POST /api/v1/auth/login → 403 (1ms)
# [029b2cfc-90dd-4f51-86de-a9d691bcd5dc] POST /api/v1/auth/login → 400 (0ms)
# [620c8fee-8bbe-4cfb-9f5a-085a74565851] POST /api/v1/auth/login → 401 (1ms)
# [db9f7c05-1eb4-4fc7-b5f8-f9ac57ae1718] POST /api/v1/auth/login → 403 (1ms)
# [bae8edf7-84b0-4f8b-bcf2-f5c2ecbc3e90] POST /api/v1/auth/logout → 401 (1ms)
# [6d9d1899-af57-4093-8c11-bde7e79b2447] POST /api/v1/auth/logout → 200 (0ms)
# [c0c09a41-e421-453f-b831-a8f9d316aca0] POST /api/v1/auth/refresh → 200 (0ms)
# [2f389681-0be6-4154-bfe1-996ef695e71c] POST /api/v1/auth/refresh → 401 (1ms)
# [5f214e10-8f0f-4315-ab12-f9e0ef862650] POST /api/v1/auth/refresh → 400 (1ms)
# [b461eba1-0d39-4148-b484-aa7011874d1a] POST /api/v1/security/2fa/setup → 401 (0ms)
# [e2349b4b-1f37-4640-9250-e30afa31eb55] POST /api/v1/security/2fa/setup → 200 (0ms)
# [2ac46bcc-3b50-4284-967c-db237d8d494b] POST /api/v1/security/2fa/confirm → 200 (0ms)
# [eb3d8459-b787-4f43-814d-be163f97c31c] POST /api/v1/security/2fa/recovery-codes/regenerate → 401 (0ms)
# [f658cd33-9695-476f-a64b-3b44cd48da82] POST /api/v1/security/2fa/recovery-codes/regenerate → 200 (0ms)
# [feba42d4-0128-49b9-a2c8-c65d580517d8] POST /api/v1/security/2fa/disable → 401 (0ms)
# [f5f97bc9-bbd3-41c5-a238-25362107dad7] POST /api/v1/security/2fa/disable → 400 (0ms)
# [ba2ef63e-390c-4745-861a-fd4b8829bde0] POST /api/v1/security/2fa/disable → 200 (0ms)
# [ee96cd0b-6698-421d-86bc-f11c8342af1b] POST /api/v1/auth/login/verify-2fa → 200 (0ms)
# [bc8a95d0-6d49-471d-acab-6813aafb5585] POST /api/v1/auth/login/verify-2fa → 400 (0ms)
# [39f9b908-3540-4c56-b4e0-49e9743fea49] POST /api/v1/auth/login/verify-2fa → 400 (0ms)
# [3285309a-ce52-4e82-97b5-78a710ffdbc7] POST /api/v1/files/upload-request → 200 (1ms)
# [8d599d0a-df60-4547-8b5c-abe4ac31f950] POST /api/v1/files/upload-request → 200 (0ms)
# [318eb4b4-2926-40a1-81e9-8809f975c8ab] POST /api/v1/files/complete-upload → 200 (1ms)
# [3b8de7b6-ffb6-4443-adf1-6ed93d671751] POST /api/v1/files/upload-request → 200 (0ms)
# [c28c228c-8158-4626-b48a-c5f822f0fdda] POST /api/v1/files/complete-upload → 200 (0ms)
# [d6d2e766-8feb-49bd-ad9a-540641dc903e] GET /api/v1/files/58859110-d4f6-4137-9577-0193ff5ea349/signed-url → 200 (1ms)
# [ac30f95b-9fc7-4df1-9872-e024448c6248] POST /api/v1/notifications/email/send → 200 (0ms)
# [157aa838-aae1-4d8b-9c42-47bced77aace] POST /api/v1/notifications/email/send → 200 (1ms)
# [25c17b02-b064-4ae8-a14b-7738c941e6ab] GET /api/v1/notifications/5c4fc214-92f9-452f-980f-ee4f52604457 → 200 (0ms)
# [7ab65775-cc57-41c9-88b8-404bcb233f9c] POST /api/v1/message-templates → 201 (0ms)
# [24f5cd37-9d4b-4c51-b43d-33723e2671f9] GET /api/v1/auth/activate → 200 (1ms)
# [7fba5ae0-fcc2-4b0b-9268-d253b0f46da0] POST /api/v1/auth/activate → 302 (2ms)
# Subtest: GET /health sets security headers
ok 4 - GET /health sets security headers
  ---
  duration_ms: 4.968812
  type: 'test'
  ...
# Subtest: GET /api/v1 returns version metadata
ok 5 - GET /api/v1 returns version metadata
  ---
  duration_ms: 3.140445
  type: 'test'
  ...
# Subtest: GET /openapi.json returns the current OpenAPI document
ok 6 - GET /openapi.json returns the current OpenAPI document
  ---
  duration_ms: 3.821528
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/login returns 501 not-yet-implemented
ok 7 - POST /api/v1/auth/login returns 501 not-yet-implemented
  ---
  duration_ms: 3.397526
  type: 'test'
  ...
# Subtest: GET /nonexistent returns 404
ok 8 - GET /nonexistent returns 404
  ---
  duration_ms: 1.324596
  type: 'test'
  ...
# Subtest: GET /api/v1/roles requires authentication
ok 9 - GET /api/v1/roles requires authentication
  ---
  duration_ms: 2.87219
  type: 'test'
  ...
# Subtest: GET /api/v1/roles returns role catalog when injected actor is allowed
ok 10 - GET /api/v1/roles returns role catalog when injected actor is allowed
  ---
  duration_ms: 1.600275
  type: 'test'
  ...
# Subtest: GET /api/v1/permissions returns 403 when ABAC denies
ok 11 - GET /api/v1/permissions returns 403 when ABAC denies
  ---
  duration_ms: 1.267312
  type: 'test'
  ...
# Subtest: GET /api/v1/permissions writes an audit record when ABAC denies
ok 12 - GET /api/v1/permissions writes an audit record when ABAC denies
  ---
  duration_ms: 1.010259
  type: 'test'
  ...
# Subtest: GET /api/v1/auth/me returns current bearer-authenticated user
ok 13 - GET /api/v1/auth/me returns current bearer-authenticated user
  ---
  duration_ms: 1.106874
  type: 'test'
  ...
# Subtest: GET /api/v1/roles uses bearer-authenticated actor for ABAC
ok 14 - GET /api/v1/roles uses bearer-authenticated actor for ABAC
  ---
  duration_ms: 1.209684
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/login returns 403 when Turnstile validation fails
ok 15 - POST /api/v1/auth/login returns 403 when Turnstile validation fails
  ---
  duration_ms: 1.671619
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/login requires email and password
ok 16 - POST /api/v1/auth/login requires email and password
  ---
  duration_ms: 1.247893
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/login returns edge-auth errors
ok 17 - POST /api/v1/auth/login returns edge-auth errors
  ---
  duration_ms: 1.967044
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/login returns explicit two-factor challenge payload
ok 18 - POST /api/v1/auth/login returns explicit two-factor challenge payload
  ---
  duration_ms: 2.654955
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/logout returns 401 when not authenticated
ok 19 - POST /api/v1/auth/logout returns 401 when not authenticated
  ---
  duration_ms: 1.049662
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/logout revokes current bearer-authenticated session
ok 20 - POST /api/v1/auth/logout revokes current bearer-authenticated session
  ---
  duration_ms: 1.063962
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/refresh returns a rotated token pair
ok 21 - POST /api/v1/auth/refresh returns a rotated token pair
  ---
  duration_ms: 1.259053
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/refresh returns edge-auth refresh errors
ok 22 - POST /api/v1/auth/refresh returns edge-auth refresh errors
  ---
  duration_ms: 1.527357
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/refresh requires a refresh token
ok 23 - POST /api/v1/auth/refresh requires a refresh token
  ---
  duration_ms: 1.124048
  type: 'test'
  ...
# Subtest: POST /api/v1/security/2fa/setup requires authentication
ok 24 - POST /api/v1/security/2fa/setup requires authentication
  ---
  duration_ms: 1.011578
  type: 'test'
  ...
# Subtest: POST /api/v1/security/2fa/setup returns enrollment payload
ok 25 - POST /api/v1/security/2fa/setup returns enrollment payload
  ---
  duration_ms: 1.056461
  type: 'test'
  ...
# Subtest: POST /api/v1/security/2fa/confirm returns verification payload
ok 26 - POST /api/v1/security/2fa/confirm returns verification payload
  ---
  duration_ms: 1.466939
  type: 'test'
  ...
# Subtest: POST /api/v1/security/2fa/recovery-codes/regenerate requires authentication
ok 27 - POST /api/v1/security/2fa/recovery-codes/regenerate requires authentication
  ---
  duration_ms: 1.161089
  type: 'test'
  ...
# Subtest: POST /api/v1/security/2fa/recovery-codes/regenerate returns a new recovery code set
ok 28 - POST /api/v1/security/2fa/recovery-codes/regenerate returns a new recovery code set
  ---
  duration_ms: 1.052948
  type: 'test'
  ...
# Subtest: POST /api/v1/security/2fa/disable requires authentication
ok 29 - POST /api/v1/security/2fa/disable requires authentication
  ---
  duration_ms: 0.952217
  type: 'test'
  ...
# Subtest: POST /api/v1/security/2fa/disable requires a fresh code or recovery code
ok 30 - POST /api/v1/security/2fa/disable requires a fresh code or recovery code
  ---
  duration_ms: 1.012347
  type: 'test'
  ...
# Subtest: POST /api/v1/security/2fa/disable disables enrolled two-factor auth
ok 31 - POST /api/v1/security/2fa/disable disables enrolled two-factor auth
  ---
  duration_ms: 0.954823
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/login/verify-2fa returns token pair after second factor
ok 32 - POST /api/v1/auth/login/verify-2fa returns token pair after second factor
  ---
  duration_ms: 1.0171
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/login/verify-2fa requires code or recovery code
ok 33 - POST /api/v1/auth/login/verify-2fa requires code or recovery code
  ---
  duration_ms: 0.920332
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/login/verify-2fa requires email and password
ok 34 - POST /api/v1/auth/login/verify-2fa requires email and password
  ---
  duration_ms: 0.992404
  type: 'test'
  ...
# Subtest: POST /api/v1/files/upload-request returns signed upload URL
ok 35 - POST /api/v1/files/upload-request returns signed upload URL
  ---
  duration_ms: 1.739619
  type: 'test'
  ...
# Subtest: POST /api/v1/files/complete-upload marks metadata as ready
ok 36 - POST /api/v1/files/complete-upload marks metadata as ready
  ---
  duration_ms: 1.824435
  type: 'test'
  ...
# Subtest: GET /api/v1/files/:id/signed-url returns short-lived URL
ok 37 - GET /api/v1/files/:id/signed-url returns short-lived URL
  ---
  duration_ms: 2.290822
  type: 'test'
  ...
# Subtest: POST /api/v1/notifications/email/send creates a sent notification
ok 38 - POST /api/v1/notifications/email/send creates a sent notification
  ---
  duration_ms: 1.574313
  type: 'test'
  ...
# Subtest: GET /api/v1/notifications/:id returns notification status
ok 39 - GET /api/v1/notifications/:id returns notification status
  ---
  duration_ms: 1.662986
  type: 'test'
  ...
# Subtest: POST /api/v1/message-templates creates template
ok 40 - POST /api/v1/message-templates creates template
  ---
  duration_ms: 1.275642
  type: 'test'
  ...
# Subtest: GET /api/v1/auth/activate returns activation metadata
ok 41 - GET /api/v1/auth/activate returns activation metadata
  ---
  duration_ms: 1.309562
  type: 'test'
  ...
# Subtest: POST /api/v1/auth/activate redirects success to /activate
ok 42 - POST /api/v1/auth/activate redirects success to /activate
  ---
  duration_ms: 2.999551
  type: 'test'
  ...
1..42
# tests 42
# suites 0
# pass 42
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 60313.109246\n- 
> awcms-mini@0.1.0 lint /home/data/dev_react/awcms-mini
> pnpm prettier --check README.md DOCS_INDEX.md REQUIREMENTS.md SECURITY.md AGENTS.md docs/**/*.md package.json

Checking formatting...
All matched files use Prettier code style!\n- 
> awcms-mini@0.1.0 check:emdash-drift /home/data/dev_react/awcms-mini
> node ./scripts/check-emdash-drift.mjs

EmDash compatibility patch applies cleanly against the reference checkout.\n