### PR TITLE
fix: add options-table check to setup migration guard

### DIFF
--- a/docs/process/infrastructure-resource-setup.md
+++ b/docs/process/infrastructure-resource-setup.md
@@ -106,6 +106,10 @@ HEALTHCHECK_EXPECT_DATABASE_SSLMODE=verify-full \
 pnpm healthcheck
 ```
 
+### Setup Recovery
+
+If the EmDash setup wizard reports `Failed to run database migrations` on a partially bootstrapped database, the current setup flow skips replaying core migrations once the `options` table already exists. Retry the setup POST after confirming the backend is pointed at the intended PostgreSQL resource.
+
 ## Architecture Boundary
 
 ```

--- a/patches/emdash@0.9.0.patch
+++ b/patches/emdash@0.9.0.patch
@@ -292,7 +292,20 @@ index bbf59ce62a3a158812a4204c8534ffcb46fc365c..a2502000461ef495507b2b752f10bc30
  
 -export const POST: APIRoute = async ({ request, url, locals }) => {
 -	const { emdash } = locals;
++async function hasSetupOptionsTable(db) {
++	try {
++		const result = await sql`SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'options' LIMIT 1`.execute(db);
++		return result.rows.length > 0;
++	} catch {
++		return false;
++	}
++}
++
 +async function shouldRunSetupCoreMigrations(db) {
++	if (await hasSetupOptionsTable(db)) {
++		return false;
++	}
++
 +	try {
 +		const applied = await db.selectFrom("_emdash_migrations").select("name").limit(1).execute();
 +		if (applied.length > 0) {


### PR DESCRIPTION
## Summary
Add `hasSetupOptionsTable` check to the EmDash setup migration guard so first-run setup skips core migration replay when the `options` table already exists on a partially bootstrapped database. Also document the recovery path in the infrastructure setup guide.

## Validation
- pnpm lint