### PR TITLE
fix: robust setup migration guard — direct table probe and resilient catch

### DIFF
--- a/patches/emdash@0.9.0.patch
+++ b/patches/emdash@0.9.0.patch
@@ -292,17 +292,22 @@ index bbf59ce62a3a158812a4204c8534ffcb46fc365c..a2502000461ef495507b2b752f10bc30
  
 -export const POST: APIRoute = async ({ request, url, locals }) => {
 -	const { emdash } = locals;
-+async function hasSetupOptionsTable(db) {
++async function tableExists(db, name) {
 +	try {
-+		const result = await sql`SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'options' LIMIT 1`.execute(db);
-+		return result.rows.length > 0;
++		const result = await sql`SELECT 1 FROM `.append(sql.literal(name)).append(sql` LIMIT 1`).execute(db);
++		void result;
++		return true;
 +	} catch {
 +		return false;
 +	}
 +}
 +
++async function setupSchemaAlreadyBootstrapped(db) {
++	return (await tableExists(db, "options")) || (await tableExists(db, "users"));
++}
++
 +async function shouldRunSetupCoreMigrations(db) {
-+	if (await hasSetupOptionsTable(db)) {
++	if (await setupSchemaAlreadyBootstrapped(db)) {
 +		return false;
 +	}
 +
@@ -314,7 +319,7 @@ index bbf59ce62a3a158812a4204c8534ffcb46fc365c..a2502000461ef495507b2b752f10bc30
 +	} catch {
 +		// Missing EmDash ledger can still be valid on Mini-owned schemas.
 +	}
- 
+
 -	if (!emdash?.db) {
 -		return apiError("NOT_CONFIGURED", "EmDash is not initialized", 500);
 +	try {
@@ -390,7 +395,11 @@ index bbf59ce62a3a158812a4204c8534ffcb46fc365c..a2502000461ef495507b2b752f10bc30
 +			}
 +			await ensureSetupCompatibilitySchema(db);
  		} catch (error) {
- 			return handleError(error, "Failed to run database migrations", "MIGRATION_ERROR");
++			if (await setupSchemaAlreadyBootstrapped(db)) {
++				await ensureSetupCompatibilitySchema(db);
++			} else {
++				return handleError(error, "Failed to run database migrations", "MIGRATION_ERROR");
++			}
  		}
 @@ -70,30 +133,39 @@ export const POST: APIRoute = async ({ request, url, locals }) => {
  


### PR DESCRIPTION
## Summary
Replace `information_schema.tables` introspection with direct `SELECT 1 FROM options` / `SELECT 1 FROM users` table probes that work without special PostgreSQL permissions. Also make the migration catch block resilient: if `runMigrations` fails but the schema already exists, run `ensureSetupCompatibilitySchema` and continue instead of returning a 500.

## Root Cause
The previous `hasSetupOptionsTable` function queried `information_schema.tables`, which fails silently on PostgreSQL instances where the application user lacks schema introspection permissions. This caused `shouldRunSetupCoreMigrations` to return `true` when it should have returned `false`, replaying core migrations on an already-bootstrapped database.

## Changes
- `hasSetupOptionsTable` → `tableExists(db, name)` using a direct `SELECT 1 FROM <table>` probe
- New `setupSchemaAlreadyBootstrapped(db)` checks both `options` and `users` tables
- Migration catch block now continues safely when schema already exists

## Validation
- pnpm lint