### PR TITLE
feat: add Dockerfile for Coolify Hono API deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22-alpine AS base
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml* .npmrc* package.json ./
+
+RUN pnpm fetch --prod
+
+COPY . .
+
+RUN pnpm install --offline --prod --frozen-lockfile
+
+FROM base AS release
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+EXPOSE 3000
+
+CMD ["node", "server/index.mjs"]


### PR DESCRIPTION
Add production Dockerfile for deploying the Hono API (`server/index.mjs`) on Coolify.
Uses pnpm with Node.js 22 Alpine base.