### PR TITLE
fix: simplify Dockerfile to avoid corepack and use pnpm start:api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM node:22-alpine
 
-RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
-
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 
-RUN pnpm install --prod --frozen-lockfile
+RUN npm install -g pnpm@10.28.0 && pnpm install --prod --frozen-lockfile
 
 COPY . .
 
@@ -15,4 +13,4 @@ ENV PORT=3000
 
 EXPOSE 3000
 
-CMD ["node", "server/index.mjs"]
+CMD ["pnpm", "start:api"]


### PR DESCRIPTION
Use npm install -g pnpm instead of corepack enable. Use pnpm start:api as CMD.