### PR TITLE
docs: architecture update note (PostgreSQL-only, RLS wajib, SIKESRA/SatuSehat → Mini)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # AWCMS Mini
 
+> ## 🏛️ Architecture Update (2026-06-17)
+>
+> Penyelarasan dengan fondasi product line AWCMS. Keputusan yang berlaku untuk repo ini:
+> - **PostgreSQL murni tanpa Supabase** (sudah sesuai; pertahankan) — ADR-014.
+> - **RLS wajib (enforced) pada semua tabel** data/ber-`tenant_id` — ADR-015. Tracking: #310.
+> - **SIKESRA & SatuSehatKobar dibangun di AWCMS-Mini** — ADR-016. Tracking: #311, #312.
+> - Konektivitas DB via **pooler OSS** (Supavisor/PgBouncer); Hyperdrive ditunda — ADR-013.
+>
+> Backlog penyelarasan: #310 (RLS), #311 (SIKESRA-Mini), #312 (SatuSehatKobar), #313 (2FA/ABAC hardening), #314 (docs).
+
 AWCMS Mini is an EmDash-first, single-tenant governance overlay built on Astro, PostgreSQL, Kysely, and the EmDash CMS integration.
 
 It keeps EmDash as the host architecture and adds Mini-specific governance features for:


### PR DESCRIPTION
Menambahkan catatan **Architecture Update (2026-06-17)** di README sesuai keputusan fondasi product line AWCMS:

- PostgreSQL murni tanpa Supabase (ADR-014) — sudah sesuai untuk Mini.
- RLS wajib enforced semua tabel (ADR-015) — tracking #310.
- SIKESRA & SatuSehatKobar di AWCMS-Mini (ADR-016) — tracking #311, #312.
- Pooler OSS; Hyperdrive ditunda (ADR-013).

Backlog penyelarasan: #310–#314. Perubahan minimal (hanya catatan README); detail dikerjakan via issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)