### PR TITLE
[MINI][SEQ-06] feat: plugin manifest contract + validator (ADR-018, closes #316)

### DIFF
--- a/src/plugins/manifest.mjs
+++ b/src/plugins/manifest.mjs
@@ -1,0 +1,118 @@
+// Kontrak manifest plugin AWCMS-Mini (ADR-018, ADR-009)
+// Setiap plugin wajib memiliki manifest tervalidasi sebelum bisa di-register.
+
+const KEBAB_RE = /^[a-z][a-z0-9-]*[a-z0-9]$/;
+const SNAKE_RE = /^[a-z][a-z0-9_]*[a-z0-9]$/;
+const PERM_RE = /^awcms:[a-z0-9_]+:[a-z0-9_]+:[a-z0-9_]+$/;
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+/**
+ * Validasi manifest plugin AWCMS-Mini.
+ * Mengembalikan array error. Array kosong berarti manifest valid.
+ *
+ * @param {unknown} manifest
+ * @returns {{ field: string; message: string }[]}
+ */
+export function validatePluginManifest(manifest) {
+  const errors = [];
+
+  if (!manifest || typeof manifest !== "object") {
+    return [{ field: "manifest", message: "Manifest harus berupa object." }];
+  }
+
+  // id: kebab-case, minimal 3 karakter
+  if (!KEBAB_RE.test(manifest.id ?? "")) {
+    errors.push({ field: "id", message: 'id harus kebab-case (contoh: "sikesra", "satu-sehat-kobar").' });
+  }
+
+  // name: string non-kosong
+  if (typeof manifest.name !== "string" || manifest.name.trim() === "") {
+    errors.push({ field: "name", message: "name wajib diisi (string non-kosong)." });
+  }
+
+  // version: semver x.y.z
+  if (!SEMVER_RE.test(manifest.version ?? "")) {
+    errors.push({ field: "version", message: 'version harus semver (contoh: "0.1.0").' });
+  }
+
+  // kind: wajib "awcms-mini-plugin"
+  if (manifest.kind !== "awcms-mini-plugin") {
+    errors.push({ field: "kind", message: 'kind harus "awcms-mini-plugin".' });
+  }
+
+  // appliesTo: array yang mengandung "awcms-mini"
+  if (!Array.isArray(manifest.appliesTo) || !manifest.appliesTo.includes("awcms-mini")) {
+    errors.push({ field: "appliesTo", message: 'appliesTo harus array yang mengandung "awcms-mini".' });
+  }
+
+  // permissions: setiap item harus mengikuti namespace awcms:{module}:{resource}:{action}
+  if (Array.isArray(manifest.permissions)) {
+    manifest.permissions.forEach((p, i) => {
+      if (typeof p !== "string" || !PERM_RE.test(p)) {
+        errors.push({
+          field: `permissions[${i}]`,
+          message: `"${p}" harus mengikuti pola awcms:{module}:{resource}:{action}.`,
+        });
+      }
+    });
+  }
+
+  // data: wajib ada
+  const data = manifest.data;
+  if (!data || typeof data !== "object") {
+    errors.push({ field: "data", message: "data wajib ada (object dengan adapter, schema, rls)." });
+  } else {
+    // data.adapter: wajib "postgres" untuk awcms-mini-plugin
+    if (data.adapter !== "postgres") {
+      errors.push({ field: "data.adapter", message: 'data.adapter wajib "postgres" untuk awcms-mini-plugin (ADR-018).' });
+    }
+
+    // data.schema: snake_case
+    if (!SNAKE_RE.test(data.schema ?? "")) {
+      errors.push({ field: "data.schema", message: 'data.schema harus snake_case (contoh: "sikesra", "satu_sehat_kobar").' });
+    }
+
+    // data.rls: wajib "required" (ADR-015)
+    if (data.rls !== "required") {
+      errors.push({ field: "data.rls", message: 'data.rls wajib "required" — RLS enforced pada semua tabel plugin (ADR-015).' });
+    }
+  }
+
+  // audit: jika required=true, events tidak boleh kosong
+  const audit = manifest.audit;
+  if (audit && audit.required === true) {
+    if (!Array.isArray(audit.events) || audit.events.length === 0) {
+      errors.push({ field: "audit.events", message: "audit.events tidak boleh kosong bila audit.required=true." });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Validasi manifest dan lempar Error jika tidak valid.
+ * Gunakan ini di registry untuk memblokir registrasi plugin yang rusak.
+ *
+ * @param {unknown} manifest
+ * @returns {unknown} manifest yang valid (passthrough)
+ */
+export function assertValidPluginManifest(manifest) {
+  const errors = validatePluginManifest(manifest);
+
+  if (errors.length > 0) {
+    const detail = errors.map((e) => `  ${e.field}: ${e.message}`).join("\n");
+    throw new Error(`Manifest plugin tidak valid:\n${detail}`);
+  }
+
+  return manifest;
+}
+
+/**
+ * Kembalikan true jika manifest valid (tidak ada error).
+ *
+ * @param {unknown} manifest
+ * @returns {boolean}
+ */
+export function isValidPluginManifest(manifest) {
+  return validatePluginManifest(manifest).length === 0;
+}

--- a/tests/unit/plugin-manifest.test.mjs
+++ b/tests/unit/plugin-manifest.test.mjs
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { validatePluginManifest, assertValidPluginManifest, isValidPluginManifest } from "../../src/plugins/manifest.mjs";
+
+const VALID_SIKESRA_MANIFEST = {
+  id: "sikesra",
+  name: "SIKESRA — Sistem Kesehatan Rakyat",
+  version: "0.1.0",
+  kind: "awcms-mini-plugin",
+  appliesTo: ["awcms-mini"],
+  permissions: [
+    "awcms:sikesra:subject:read",
+    "awcms:sikesra:subject:create",
+    "awcms:sikesra:record:read",
+    "awcms:sikesra:record:create",
+    "awcms:sikesra:document:download",
+  ],
+  data: { adapter: "postgres", schema: "sikesra", rls: "required" },
+  audit: { required: true, events: ["subject.create", "record.create", "document.download"] },
+  admin: { menuGroup: "Kesehatan", menuOrder: 10, pages: [] },
+};
+
+test("plugin manifest: manifest SIKESRA valid lulus tanpa error", () => {
+  const errors = validatePluginManifest(VALID_SIKESRA_MANIFEST);
+  assert.deepEqual(errors, []);
+});
+
+test("plugin manifest: isValidPluginManifest mengembalikan true untuk manifest valid", () => {
+  assert.equal(isValidPluginManifest(VALID_SIKESRA_MANIFEST), true);
+});
+
+test("plugin manifest: manifest kosong menghasilkan array error", () => {
+  const errors = validatePluginManifest({});
+  assert.ok(errors.length >= 6, `Diharapkan ≥6 error, dapat ${errors.length}`);
+  const fields = errors.map((e) => e.field);
+  assert.ok(fields.includes("id"), "Harus ada error untuk id");
+  assert.ok(fields.includes("name"), "Harus ada error untuk name");
+  assert.ok(fields.includes("version"), "Harus ada error untuk version");
+  assert.ok(fields.includes("kind"), "Harus ada error untuk kind");
+  assert.ok(fields.includes("appliesTo"), "Harus ada error untuk appliesTo");
+  assert.ok(fields.includes("data"), "Harus ada error untuk data");
+});
+
+test("plugin manifest: bukan object mengembalikan error manifest", () => {
+  const errors = validatePluginManifest(null);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].field, "manifest");
+});
+
+test("plugin manifest: id dengan spasi atau huruf besar tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, id: "Sikesra Plugin" });
+  assert.ok(errors.some((e) => e.field === "id"), "Harus ada error untuk id");
+});
+
+test("plugin manifest: kind bukan awcms-mini-plugin tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, kind: "emdash-plugin" });
+  assert.ok(errors.some((e) => e.field === "kind"), "Harus ada error untuk kind");
+});
+
+test("plugin manifest: data.adapter bukan postgres tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, data: { adapter: "d1", schema: "sikesra", rls: "required" } });
+  assert.ok(errors.some((e) => e.field === "data.adapter"), "Harus ada error untuk data.adapter");
+});
+
+test("plugin manifest: data.rls bukan required tidak valid (ADR-015)", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, data: { adapter: "postgres", schema: "sikesra", rls: "optional" } });
+  assert.ok(errors.some((e) => e.field === "data.rls"), "Harus ada error untuk data.rls");
+});
+
+test("plugin manifest: data.schema dengan huruf besar tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, data: { adapter: "postgres", schema: "Sikesra", rls: "required" } });
+  assert.ok(errors.some((e) => e.field === "data.schema"), "Harus ada error untuk data.schema");
+});
+
+test("plugin manifest: permission dengan format salah tidak valid", () => {
+  const errors = validatePluginManifest({
+    ...VALID_SIKESRA_MANIFEST,
+    permissions: ["sikesra:subject:read", "awcms:sikesra:subject:create"],
+  });
+  assert.ok(errors.some((e) => e.field === "permissions[0]"), "Harus ada error untuk permissions[0]");
+  assert.ok(!errors.some((e) => e.field === "permissions[1]"), "permissions[1] harus valid");
+});
+
+test("plugin manifest: audit.required=true dengan events kosong tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, audit: { required: true, events: [] } });
+  assert.ok(errors.some((e) => e.field === "audit.events"), "Harus ada error untuk audit.events");
+});
+
+test("plugin manifest: audit.required=false dengan events kosong valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, audit: { required: false, events: [] } });
+  assert.ok(!errors.some((e) => e.field === "audit.events"), "Tidak boleh ada error untuk audit.events bila required=false");
+});
+
+test("plugin manifest: assertValidPluginManifest melempar Error untuk manifest tidak valid", () => {
+  assert.throws(
+    () => assertValidPluginManifest({}),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.includes("Manifest plugin tidak valid"), `Pesan error tidak sesuai: ${err.message}`);
+      return true;
+    },
+  );
+});
+
+test("plugin manifest: assertValidPluginManifest mengembalikan manifest yang valid (passthrough)", () => {
+  const result = assertValidPluginManifest(VALID_SIKESRA_MANIFEST);
+  assert.strictEqual(result, VALID_SIKESRA_MANIFEST);
+});
+
+test("plugin manifest: appliesTo tanpa awcms-mini tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, appliesTo: ["awcms"] });
+  assert.ok(errors.some((e) => e.field === "appliesTo"), "Harus ada error untuk appliesTo");
+});
+
+test("plugin manifest: version bukan semver tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, version: "1.0" });
+  assert.ok(errors.some((e) => e.field === "version"), "Harus ada error untuk version");
+});


### PR DESCRIPTION
## Summary

- Tambah `src/plugins/manifest.mjs` — kontrak manifest plugin AWCMS-Mini (ADR-018, ADR-009)
- `validatePluginManifest(manifest)` — validasi lengkap, kembalikan array error
- `assertValidPluginManifest(manifest)` — lempar Error jika tidak valid (untuk registry)
- `isValidPluginManifest(manifest)` — kembalikan boolean
- Tambah `tests/unit/plugin-manifest.test.mjs` — 16 test, semua pass

## Aturan validasi yang di-enforce

| Field | Aturan |
|---|---|
| `id` | kebab-case |
| `kind` | wajib `awcms-mini-plugin` |
| `appliesTo` | wajib mengandung `awcms-mini` |
| `data.adapter` | wajib `postgres` (ADR-018) |
| `data.schema` | snake_case |
| `data.rls` | wajib `required` (ADR-015) |
| `permissions[]` | pola `awcms:{module}:{resource}:{action}` |
| `audit.events` | non-kosong bila `audit.required=true` |

## Test plan

- [x] `plugin-manifest.test.mjs` 16/16 pass (jalankan: `node --test tests/unit/plugin-manifest.test.mjs`)
- [x] Manifest SIKESRA valid lulus tanpa error
- [x] Object kosong menghasilkan ≥6 error
- [x] `assertValidPluginManifest` melempar Error dengan pesan deskriptif
- [x] Semua aturan validasi ter-cover dengan kasus positif dan negatif

## Prerequisites setelah merge

- #317 (plugin-adapter.mjs) akan `import { assertValidPluginManifest }` dari file ini
- #318 (registry.mjs) akan `import { validatePluginManifest }` dari file ini

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)