### PR TITLE
[MINI][SEQ-07] feat: plugin PostgreSQL data adapter + Hono middleware (closes #317)

### DIFF
--- a/server/middleware/plugin-db-context.mjs
+++ b/server/middleware/plugin-db-context.mjs
@@ -1,0 +1,28 @@
+// Middleware Hono: set konteks user aktif di PostgreSQL sebelum query plugin dijalankan.
+// Pasang pada router plugin, setelah middlewareOptionalAuth (yang meng-set c.get("actor")).
+
+import { getDatabase } from "../../src/db/index.mjs";
+import { setPluginDbContext } from "../../src/db/plugin-adapter.mjs";
+
+/**
+ * Middleware Hono untuk men-set app.current_user_id di PostgreSQL per request.
+ * Dibutuhkan agar RLS policy plugin (`plugin_user_isolation`) bisa mengevaluasi
+ * current_setting('app.current_user_id', true) dengan benar.
+ *
+ * Contoh pemakaian:
+ *   router.use("*", middlewarePluginDbContext());
+ *   router.get("/subjects", handler);
+ *
+ * @returns {import("hono").MiddlewareHandler}
+ */
+export function middlewarePluginDbContext() {
+  return async function pluginDbContextMiddleware(ctx, next) {
+    const actor = ctx.get("actor");
+
+    if (actor?.id) {
+      await setPluginDbContext(getDatabase(), actor.id);
+    }
+
+    await next();
+  };
+}

--- a/src/db/plugin-adapter.mjs
+++ b/src/db/plugin-adapter.mjs
@@ -1,0 +1,139 @@
+// Data adapter untuk plugin AWCMS-Mini (ADR-018, ADR-015)
+// Menyediakan: set konteks user per koneksi, RLS helper untuk migration, base repository factory.
+
+import { sql } from "kysely";
+
+import { getDatabase } from "./index.mjs";
+
+/**
+ * Set konteks user aktif di PostgreSQL untuk RLS policy plugin.
+ * Wajib dipanggil setiap request (via Hono middleware) sebelum query plugin dijalankan.
+ * Memakai set_config dengan local=true agar berlaku hanya untuk transaksi/request ini.
+ *
+ * @param {import("kysely").Kysely<unknown>} db
+ * @param {string} userId - ID user yang sedang aktif (dari session)
+ */
+export async function setPluginDbContext(db, userId) {
+  await sql`select set_config('app.current_user_id', ${userId ?? ""}, true)`.execute(db);
+}
+
+/**
+ * Hasilkan array SQL string untuk mengaktifkan RLS + policy isolasi per user pada tabel plugin.
+ * Dipanggil di dalam migrate.mjs plugin setelah createTable, bukan di runtime.
+ *
+ * Policy yang dibuat: user hanya bisa membaca/mengubah record yang created_by = user aktif.
+ * Untuk data highly_restricted (contoh: SIKESRA), ini wajib diperkuat dengan permission check
+ * di service layer (defense-in-depth).
+ *
+ * @param {string} schema - Nama schema plugin (snake_case, contoh: "sikesra")
+ * @param {string} tableName - Nama tabel (contoh: "subjects")
+ * @returns {string[]} Array SQL string yang harus dieksekusi berurutan
+ */
+export function buildPluginRlsStatements(schema, tableName) {
+  const qualified = `${schema}.${tableName}`;
+
+  return [
+    `alter table ${qualified} enable row level security`,
+    `alter table ${qualified} force row level security`,
+    // Policy: user hanya bisa akses record yang dia buat (single-tenant, per-user isolation)
+    `create policy plugin_user_isolation on ${qualified}
+       using (created_by = current_setting('app.current_user_id', true)::text)`,
+  ];
+}
+
+/**
+ * Factory base repository untuk plugin — wraps Kysely dengan soft-delete guard otomatis.
+ * Setiap method hanya mengembalikan record yang belum di-soft-delete (deleted_at IS NULL).
+ *
+ * Penggunaan:
+ *   const subjectsRepo = createPluginRepository("sikesra", "subjects");
+ *   const subjects = await subjectsRepo.findAll();
+ *
+ * @param {string} schema - Nama schema plugin (snake_case)
+ * @param {string} tableName - Nama tabel
+ */
+export function createPluginRepository(schema, tableName) {
+  function db() {
+    return getDatabase().withSchema(schema);
+  }
+
+  return {
+    /**
+     * Cari record berdasarkan ID. Mengembalikan undefined jika tidak ditemukan atau sudah dihapus.
+     */
+    async findById(id) {
+      return db()
+        .selectFrom(tableName)
+        .selectAll()
+        .where("id", "=", id)
+        .where("deleted_at", "is", null)
+        .executeTakeFirst();
+    },
+
+    /**
+     * Daftar semua record aktif (belum dihapus), dengan pagination.
+     */
+    async findAll({ limit = 50, offset = 0 } = {}) {
+      return db()
+        .selectFrom(tableName)
+        .selectAll()
+        .where("deleted_at", "is", null)
+        .limit(limit)
+        .offset(offset)
+        .execute();
+    },
+
+    /**
+     * Insert record baru. Otomatis mengisi created_at dan updated_at.
+     * Kolom created_by harus diisi oleh caller (dari session user).
+     */
+    async insert(record) {
+      return getDatabase()
+        .withSchema(schema)
+        .insertInto(tableName)
+        .values({
+          ...record,
+          created_at: new Date(),
+          updated_at: new Date(),
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+    },
+
+    /**
+     * Soft delete record — mengisi deleted_at dan deleted_by.
+     * Mengembalikan undefined jika record tidak ditemukan atau sudah dihapus.
+     */
+    async softDelete(id, deletedBy) {
+      return getDatabase()
+        .withSchema(schema)
+        .updateTable(tableName)
+        .set({
+          deleted_at: new Date(),
+          deleted_by: deletedBy,
+        })
+        .where("id", "=", id)
+        .where("deleted_at", "is", null)
+        .returningAll()
+        .executeTakeFirst();
+    },
+
+    /**
+     * Update field record. Otomatis mengisi updated_at.
+     * Tidak bisa update record yang sudah dihapus.
+     */
+    async update(id, fields) {
+      return getDatabase()
+        .withSchema(schema)
+        .updateTable(tableName)
+        .set({
+          ...fields,
+          updated_at: new Date(),
+        })
+        .where("id", "=", id)
+        .where("deleted_at", "is", null)
+        .returningAll()
+        .executeTakeFirst();
+    },
+  };
+}

--- a/tests/unit/plugin-adapter.test.mjs
+++ b/tests/unit/plugin-adapter.test.mjs
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildPluginRlsStatements, createPluginRepository } from "../../src/db/plugin-adapter.mjs";
+
+// Unit test untuk bagian yang tidak butuh DB nyata:
+// - buildPluginRlsStatements: pure function, hanya string manipulation
+// - createPluginRepository: verifikasi factory menghasilkan object dengan method yang benar
+//
+// Integration test RLS (negative test) membutuhkan DB nyata dan dipisah ke test terpisah.
+
+test("plugin adapter: buildPluginRlsStatements menghasilkan 3 SQL string", () => {
+  const stmts = buildPluginRlsStatements("sikesra", "subjects");
+  assert.equal(stmts.length, 3, "Harus menghasilkan tepat 3 SQL statement");
+});
+
+test("plugin adapter: buildPluginRlsStatements — statement pertama enable RLS", () => {
+  const stmts = buildPluginRlsStatements("sikesra", "subjects");
+  assert.ok(
+    stmts[0].includes("enable row level security"),
+    `Statement pertama harus enable RLS, dapat: "${stmts[0]}"`,
+  );
+  assert.ok(stmts[0].includes("sikesra.subjects"), 'Harus menyebut "sikesra.subjects"');
+});
+
+test("plugin adapter: buildPluginRlsStatements — statement kedua force RLS", () => {
+  const stmts = buildPluginRlsStatements("sikesra", "subjects");
+  assert.ok(
+    stmts[1].includes("force row level security"),
+    `Statement kedua harus force RLS, dapat: "${stmts[1]}"`,
+  );
+});
+
+test("plugin adapter: buildPluginRlsStatements — statement ketiga create policy isolasi user", () => {
+  const stmts = buildPluginRlsStatements("sikesra", "subjects");
+  assert.ok(stmts[2].includes("create policy"), 'Statement ketiga harus "create policy"');
+  assert.ok(stmts[2].includes("current_setting"), 'Policy harus memakai current_setting');
+  assert.ok(stmts[2].includes("app.current_user_id"), 'Policy harus memakai app.current_user_id');
+});
+
+test("plugin adapter: buildPluginRlsStatements — memakai schema + tableName yang diberikan", () => {
+  const stmts = buildPluginRlsStatements("satu_sehat", "pasien");
+  for (const stmt of stmts) {
+    if (stmt.includes("table") || stmt.includes("policy")) {
+      assert.ok(
+        stmt.includes("satu_sehat.pasien"),
+        `Statement "${stmt}" harus menyebut "satu_sehat.pasien"`,
+      );
+    }
+  }
+});
+
+test("plugin adapter: createPluginRepository menghasilkan object dengan semua method", () => {
+  const repo = createPluginRepository("sikesra", "subjects");
+
+  assert.ok(typeof repo.findById === "function", "Harus ada method findById");
+  assert.ok(typeof repo.findAll === "function", "Harus ada method findAll");
+  assert.ok(typeof repo.insert === "function", "Harus ada method insert");
+  assert.ok(typeof repo.softDelete === "function", "Harus ada method softDelete");
+  assert.ok(typeof repo.update === "function", "Harus ada method update");
+});
+
+test("plugin adapter: createPluginRepository berbeda schema/tabel tidak sharing state", () => {
+  const repoA = createPluginRepository("sikesra", "subjects");
+  const repoB = createPluginRepository("satu_sehat", "pasien");
+
+  // Kedua repo harus merupakan object berbeda (factory, bukan singleton)
+  assert.notStrictEqual(repoA, repoB);
+});


### PR DESCRIPTION
## Summary

- `src/db/plugin-adapter.mjs` — data adapter untuk plugin (ADR-018, ADR-015)
- `server/middleware/plugin-db-context.mjs` — Hono middleware set konteks DB per request
- `tests/unit/plugin-adapter.test.mjs` — 7 unit test, semua pass

## Apa yang disediakan

### `setPluginDbContext(db, userId)`
Set `app.current_user_id` di PostgreSQL menggunakan `set_config(..., local=true)` — berlaku hanya untuk transaksi/request aktif. Dibutuhkan agar RLS policy plugin bisa mengevaluasi `current_setting('app.current_user_id', true)`.

### `buildPluginRlsStatements(schema, tableName)`
Hasilkan 3 SQL string untuk migration plugin:
1. `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`
2. `ALTER TABLE ... FORCE ROW LEVEL SECURITY`
3. `CREATE POLICY plugin_user_isolation ... USING (created_by = current_setting('app.current_user_id', true)::text)`

### `createPluginRepository(schema, tableName)`
Factory base repository dengan:
- `findById(id)` — soft-delete guard otomatis
- `findAll({ limit, offset })` — soft-delete guard + pagination
- `insert(record)` — auto-fill `created_at`/`updated_at`
- `softDelete(id, deletedBy)` — isi `deleted_at`/`deleted_by`
- `update(id, fields)` — auto-fill `updated_at`

### `middlewarePluginDbContext()`
Hono middleware — panggil `setPluginDbContext` dari `actor.id` yang sudah di-set oleh `middlewareOptionalAuth`. Pasang pada router plugin sebelum handler.

## Cara pakai

```js
// server/routes/api-v1.mjs (contoh penambahan router plugin)
import { middlewarePluginDbContext } from "../middleware/plugin-db-context.mjs";
const pluginRouter = new Hono();
pluginRouter.use("*", middlewarePluginDbContext());
pluginRouter.route("/sikesra", sikesraRouter);
```

```js
// src/plugins/sikesra/migrate.mjs (contoh migration plugin)
import { buildPluginRlsStatements } from "../../db/plugin-adapter.mjs";
for (const stmt of buildPluginRlsStatements("sikesra", "subjects")) {
  await sql.raw(stmt).execute(db);
}
```

## Test plan

- [x] 7/7 unit test pass (`node --test tests/unit/plugin-adapter.test.mjs`)
- [x] `buildPluginRlsStatements` menghasilkan 3 SQL string yang benar
- [x] `createPluginRepository` factory menghasilkan object dengan semua method
- [ ] Integration test RLS (negative test: query tanpa set_config ditolak policy) — dikerjakan di issue #311 saat schema sikesra tersedia

## Prerequisites

- Bebas dari #316 karena tidak import dari `manifest.mjs`

## Setelah merge

- #318 (registry/loader) akan import `setPluginDbContext` dari `src/db/plugin-adapter.mjs`
- #311 (SIKESRA) akan menggunakan `createPluginRepository` dan `buildPluginRlsStatements`

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)