### PR TITLE
[MINI][SEQ-02] feat: plugin SIKESRA MVP — schema + repositories + RLS (closes #311)

### DIFF
--- a/server/middleware/plugin-db-context.mjs
+++ b/server/middleware/plugin-db-context.mjs
@@ -1,0 +1,28 @@
+// Middleware Hono: set konteks user aktif di PostgreSQL sebelum query plugin dijalankan.
+// Pasang pada router plugin, setelah middlewareOptionalAuth (yang meng-set c.get("actor")).
+
+import { getDatabase } from "../../src/db/index.mjs";
+import { setPluginDbContext } from "../../src/db/plugin-adapter.mjs";
+
+/**
+ * Middleware Hono untuk men-set app.current_user_id di PostgreSQL per request.
+ * Dibutuhkan agar RLS policy plugin (`plugin_user_isolation`) bisa mengevaluasi
+ * current_setting('app.current_user_id', true) dengan benar.
+ *
+ * Contoh pemakaian:
+ *   router.use("*", middlewarePluginDbContext());
+ *   router.get("/subjects", handler);
+ *
+ * @returns {import("hono").MiddlewareHandler}
+ */
+export function middlewarePluginDbContext() {
+  return async function pluginDbContextMiddleware(ctx, next) {
+    const actor = ctx.get("actor");
+
+    if (actor?.id) {
+      await setPluginDbContext(getDatabase(), actor.id);
+    }
+
+    await next();
+  };
+}

--- a/src/db/plugin-adapter.mjs
+++ b/src/db/plugin-adapter.mjs
@@ -1,0 +1,139 @@
+// Data adapter untuk plugin AWCMS-Mini (ADR-018, ADR-015)
+// Menyediakan: set konteks user per koneksi, RLS helper untuk migration, base repository factory.
+
+import { sql } from "kysely";
+
+import { getDatabase } from "./index.mjs";
+
+/**
+ * Set konteks user aktif di PostgreSQL untuk RLS policy plugin.
+ * Wajib dipanggil setiap request (via Hono middleware) sebelum query plugin dijalankan.
+ * Memakai set_config dengan local=true agar berlaku hanya untuk transaksi/request ini.
+ *
+ * @param {import("kysely").Kysely<unknown>} db
+ * @param {string} userId - ID user yang sedang aktif (dari session)
+ */
+export async function setPluginDbContext(db, userId) {
+  await sql`select set_config('app.current_user_id', ${userId ?? ""}, true)`.execute(db);
+}
+
+/**
+ * Hasilkan array SQL string untuk mengaktifkan RLS + policy isolasi per user pada tabel plugin.
+ * Dipanggil di dalam migrate.mjs plugin setelah createTable, bukan di runtime.
+ *
+ * Policy yang dibuat: user hanya bisa membaca/mengubah record yang created_by = user aktif.
+ * Untuk data highly_restricted (contoh: SIKESRA), ini wajib diperkuat dengan permission check
+ * di service layer (defense-in-depth).
+ *
+ * @param {string} schema - Nama schema plugin (snake_case, contoh: "sikesra")
+ * @param {string} tableName - Nama tabel (contoh: "subjects")
+ * @returns {string[]} Array SQL string yang harus dieksekusi berurutan
+ */
+export function buildPluginRlsStatements(schema, tableName) {
+  const qualified = `${schema}.${tableName}`;
+
+  return [
+    `alter table ${qualified} enable row level security`,
+    `alter table ${qualified} force row level security`,
+    // Policy: user hanya bisa akses record yang dia buat (single-tenant, per-user isolation)
+    `create policy plugin_user_isolation on ${qualified}
+       using (created_by = current_setting('app.current_user_id', true)::text)`,
+  ];
+}
+
+/**
+ * Factory base repository untuk plugin — wraps Kysely dengan soft-delete guard otomatis.
+ * Setiap method hanya mengembalikan record yang belum di-soft-delete (deleted_at IS NULL).
+ *
+ * Penggunaan:
+ *   const subjectsRepo = createPluginRepository("sikesra", "subjects");
+ *   const subjects = await subjectsRepo.findAll();
+ *
+ * @param {string} schema - Nama schema plugin (snake_case)
+ * @param {string} tableName - Nama tabel
+ */
+export function createPluginRepository(schema, tableName) {
+  function db() {
+    return getDatabase().withSchema(schema);
+  }
+
+  return {
+    /**
+     * Cari record berdasarkan ID. Mengembalikan undefined jika tidak ditemukan atau sudah dihapus.
+     */
+    async findById(id) {
+      return db()
+        .selectFrom(tableName)
+        .selectAll()
+        .where("id", "=", id)
+        .where("deleted_at", "is", null)
+        .executeTakeFirst();
+    },
+
+    /**
+     * Daftar semua record aktif (belum dihapus), dengan pagination.
+     */
+    async findAll({ limit = 50, offset = 0 } = {}) {
+      return db()
+        .selectFrom(tableName)
+        .selectAll()
+        .where("deleted_at", "is", null)
+        .limit(limit)
+        .offset(offset)
+        .execute();
+    },
+
+    /**
+     * Insert record baru. Otomatis mengisi created_at dan updated_at.
+     * Kolom created_by harus diisi oleh caller (dari session user).
+     */
+    async insert(record) {
+      return getDatabase()
+        .withSchema(schema)
+        .insertInto(tableName)
+        .values({
+          ...record,
+          created_at: new Date(),
+          updated_at: new Date(),
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+    },
+
+    /**
+     * Soft delete record — mengisi deleted_at dan deleted_by.
+     * Mengembalikan undefined jika record tidak ditemukan atau sudah dihapus.
+     */
+    async softDelete(id, deletedBy) {
+      return getDatabase()
+        .withSchema(schema)
+        .updateTable(tableName)
+        .set({
+          deleted_at: new Date(),
+          deleted_by: deletedBy,
+        })
+        .where("id", "=", id)
+        .where("deleted_at", "is", null)
+        .returningAll()
+        .executeTakeFirst();
+    },
+
+    /**
+     * Update field record. Otomatis mengisi updated_at.
+     * Tidak bisa update record yang sudah dihapus.
+     */
+    async update(id, fields) {
+      return getDatabase()
+        .withSchema(schema)
+        .updateTable(tableName)
+        .set({
+          ...fields,
+          updated_at: new Date(),
+        })
+        .where("id", "=", id)
+        .where("deleted_at", "is", null)
+        .returningAll()
+        .executeTakeFirst();
+    },
+  };
+}

--- a/src/plugins/loader.mjs
+++ b/src/plugins/loader.mjs
@@ -21,7 +21,12 @@ import { getDatabase } from "../db/index.mjs";
  *   },
  */
 const ACTIVE_PLUGINS = [
-  // Plugin akan ditambahkan di sini setelah issue #311 (SIKESRA) dan #312 (SatuSehatKobar) selesai
+  // SIKESRA — Sistem Kesehatan Rakyat (ADR-016, issue #311)
+  {
+    getManifest: () => import("./sikesra/manifest.json", { with: { type: "json" } }),
+    getModule: () => import("./sikesra/index.mjs"),
+  },
+  // SatuSehatKobar akan ditambahkan setelah issue #312 selesai
 ];
 
 /**

--- a/src/plugins/loader.mjs
+++ b/src/plugins/loader.mjs
@@ -1,0 +1,55 @@
+// Plugin loader AWCMS-Mini (ADR-018)
+// loadAllPlugins() dipanggil saat app start untuk mendaftarkan semua plugin aktif.
+
+import { registerPlugin, seedPluginPermissions } from "./registry.mjs";
+import { getDatabase } from "../db/index.mjs";
+
+/**
+ * Daftar plugin yang aktif di AWCMS-Mini.
+ * Tambahkan entry baru di sini setiap kali plugin baru dibuat.
+ *
+ * Format setiap entry:
+ *   {
+ *     getManifest: () => Promise<{ default?: object } | object>,  // import manifest JSON
+ *     getModule:   () => Promise<object>,                          // import index.mjs plugin
+ *   }
+ *
+ * Contoh (uncomment setelah plugin SIKESRA dari issue #311 siap):
+ *   {
+ *     getManifest: () => import("./sikesra/manifest.json", { with: { type: "json" } }),
+ *     getModule:   () => import("./sikesra/index.mjs"),
+ *   },
+ */
+const ACTIVE_PLUGINS = [
+  // Plugin akan ditambahkan di sini setelah issue #311 (SIKESRA) dan #312 (SatuSehatKobar) selesai
+];
+
+/**
+ * Muat dan daftarkan semua plugin aktif.
+ * Panggil sekali saat server start, sebelum menerima request.
+ *
+ * Untuk setiap plugin:
+ * 1. Import manifest dan module
+ * 2. Daftarkan ke registry (validasi manifest)
+ * 3. Seed permission ke DB (idempotent)
+ * 4. Jalankan migration plugin jika pluginModule.migrate tersedia
+ *
+ * @param {{ db?: import("kysely").Kysely<unknown> }} [options]
+ */
+export async function loadAllPlugins({ db } = {}) {
+  const database = db ?? getDatabase();
+
+  for (const { getManifest, getModule } of ACTIVE_PLUGINS) {
+    const manifestMod = await getManifest();
+    const manifest = manifestMod.default ?? manifestMod;
+
+    const pluginModule = await getModule();
+
+    registerPlugin(manifest, pluginModule);
+    await seedPluginPermissions(database, manifest);
+
+    if (typeof pluginModule.migrate === "function") {
+      await pluginModule.migrate(database);
+    }
+  }
+}

--- a/src/plugins/manifest.mjs
+++ b/src/plugins/manifest.mjs
@@ -1,0 +1,118 @@
+// Kontrak manifest plugin AWCMS-Mini (ADR-018, ADR-009)
+// Setiap plugin wajib memiliki manifest tervalidasi sebelum bisa di-register.
+
+const KEBAB_RE = /^[a-z][a-z0-9-]*[a-z0-9]$/;
+const SNAKE_RE = /^[a-z][a-z0-9_]*[a-z0-9]$/;
+const PERM_RE = /^awcms:[a-z0-9_]+:[a-z0-9_]+:[a-z0-9_]+$/;
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+
+/**
+ * Validasi manifest plugin AWCMS-Mini.
+ * Mengembalikan array error. Array kosong berarti manifest valid.
+ *
+ * @param {unknown} manifest
+ * @returns {{ field: string; message: string }[]}
+ */
+export function validatePluginManifest(manifest) {
+  const errors = [];
+
+  if (!manifest || typeof manifest !== "object") {
+    return [{ field: "manifest", message: "Manifest harus berupa object." }];
+  }
+
+  // id: kebab-case, minimal 3 karakter
+  if (!KEBAB_RE.test(manifest.id ?? "")) {
+    errors.push({ field: "id", message: 'id harus kebab-case (contoh: "sikesra", "satu-sehat-kobar").' });
+  }
+
+  // name: string non-kosong
+  if (typeof manifest.name !== "string" || manifest.name.trim() === "") {
+    errors.push({ field: "name", message: "name wajib diisi (string non-kosong)." });
+  }
+
+  // version: semver x.y.z
+  if (!SEMVER_RE.test(manifest.version ?? "")) {
+    errors.push({ field: "version", message: 'version harus semver (contoh: "0.1.0").' });
+  }
+
+  // kind: wajib "awcms-mini-plugin"
+  if (manifest.kind !== "awcms-mini-plugin") {
+    errors.push({ field: "kind", message: 'kind harus "awcms-mini-plugin".' });
+  }
+
+  // appliesTo: array yang mengandung "awcms-mini"
+  if (!Array.isArray(manifest.appliesTo) || !manifest.appliesTo.includes("awcms-mini")) {
+    errors.push({ field: "appliesTo", message: 'appliesTo harus array yang mengandung "awcms-mini".' });
+  }
+
+  // permissions: setiap item harus mengikuti namespace awcms:{module}:{resource}:{action}
+  if (Array.isArray(manifest.permissions)) {
+    manifest.permissions.forEach((p, i) => {
+      if (typeof p !== "string" || !PERM_RE.test(p)) {
+        errors.push({
+          field: `permissions[${i}]`,
+          message: `"${p}" harus mengikuti pola awcms:{module}:{resource}:{action}.`,
+        });
+      }
+    });
+  }
+
+  // data: wajib ada
+  const data = manifest.data;
+  if (!data || typeof data !== "object") {
+    errors.push({ field: "data", message: "data wajib ada (object dengan adapter, schema, rls)." });
+  } else {
+    // data.adapter: wajib "postgres" untuk awcms-mini-plugin
+    if (data.adapter !== "postgres") {
+      errors.push({ field: "data.adapter", message: 'data.adapter wajib "postgres" untuk awcms-mini-plugin (ADR-018).' });
+    }
+
+    // data.schema: snake_case
+    if (!SNAKE_RE.test(data.schema ?? "")) {
+      errors.push({ field: "data.schema", message: 'data.schema harus snake_case (contoh: "sikesra", "satu_sehat_kobar").' });
+    }
+
+    // data.rls: wajib "required" (ADR-015)
+    if (data.rls !== "required") {
+      errors.push({ field: "data.rls", message: 'data.rls wajib "required" — RLS enforced pada semua tabel plugin (ADR-015).' });
+    }
+  }
+
+  // audit: jika required=true, events tidak boleh kosong
+  const audit = manifest.audit;
+  if (audit && audit.required === true) {
+    if (!Array.isArray(audit.events) || audit.events.length === 0) {
+      errors.push({ field: "audit.events", message: "audit.events tidak boleh kosong bila audit.required=true." });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Validasi manifest dan lempar Error jika tidak valid.
+ * Gunakan ini di registry untuk memblokir registrasi plugin yang rusak.
+ *
+ * @param {unknown} manifest
+ * @returns {unknown} manifest yang valid (passthrough)
+ */
+export function assertValidPluginManifest(manifest) {
+  const errors = validatePluginManifest(manifest);
+
+  if (errors.length > 0) {
+    const detail = errors.map((e) => `  ${e.field}: ${e.message}`).join("\n");
+    throw new Error(`Manifest plugin tidak valid:\n${detail}`);
+  }
+
+  return manifest;
+}
+
+/**
+ * Kembalikan true jika manifest valid (tidak ada error).
+ *
+ * @param {unknown} manifest
+ * @returns {boolean}
+ */
+export function isValidPluginManifest(manifest) {
+  return validatePluginManifest(manifest).length === 0;
+}

--- a/src/plugins/registry.mjs
+++ b/src/plugins/registry.mjs
@@ -1,0 +1,100 @@
+// Plugin registry AWCMS-Mini (ADR-018)
+// Menyimpan plugin yang terdaftar; men-seed permission ke DB; menyediakan lookup.
+
+import { assertValidPluginManifest } from "./manifest.mjs";
+import { collectRegisteredPluginPermissions } from "./permission-registration.mjs";
+import { createPermissionRepository } from "../db/repositories/permissions.mjs";
+
+/** @type {Map<string, { manifest: object; module: object }>} */
+const _registry = new Map();
+
+/**
+ * Daftarkan plugin ke registry.
+ * Manifest divalidasi sebelum disimpan — melempar Error jika tidak valid atau duplikat.
+ *
+ * @param {object} manifest - Manifest plugin (harus lolos validatePluginManifest)
+ * @param {object} pluginModule - Module plugin (object yang diekspor dari index.mjs plugin)
+ */
+export function registerPlugin(manifest, pluginModule) {
+  assertValidPluginManifest(manifest);
+
+  if (_registry.has(manifest.id)) {
+    throw new Error(`Plugin "${manifest.id}" sudah terdaftar. Pastikan setiap plugin hanya di-register sekali.`);
+  }
+
+  _registry.set(manifest.id, { manifest, module: pluginModule });
+}
+
+/**
+ * Ambil entry plugin dari registry berdasarkan ID.
+ * Mengembalikan undefined jika tidak ditemukan.
+ *
+ * @param {string} pluginId
+ */
+export function getPlugin(pluginId) {
+  return _registry.get(pluginId);
+}
+
+/**
+ * Daftar semua manifest plugin yang terdaftar.
+ *
+ * @returns {object[]}
+ */
+export function listPlugins() {
+  return Array.from(_registry.values()).map((entry) => entry.manifest);
+}
+
+/**
+ * Bersihkan semua plugin dari registry.
+ * Gunakan hanya di test teardown — jangan panggil di production.
+ */
+export function clearRegistry() {
+  _registry.clear();
+}
+
+/**
+ * Seed permission dari manifest plugin ke tabel permissions di DB.
+ * Idempotent: pakai onConflict doNothing — aman dipanggil berulang kali.
+ *
+ * @param {import("kysely").Kysely<unknown>} db
+ * @param {object} manifest - Manifest plugin yang sudah tervalidasi
+ */
+export async function seedPluginPermissions(db, manifest) {
+  if (!Array.isArray(manifest.permissions) || manifest.permissions.length === 0) {
+    return;
+  }
+
+  // Konversi permission string "awcms:sikesra:subject:read" ke format yang diharapkan collectRegisteredPluginPermissions
+  const normalized = collectRegisteredPluginPermissions([
+    {
+      id: manifest.id,
+      permissions: manifest.permissions.map((p) => {
+        const parts = p.split(":");
+        // Format: "awcms:{module}:{resource}:{action}" → parts[1]=module, [2]=resource, [3]=action
+        const [, domain, resource, action] = parts;
+        return { code: p, domain, resource, action };
+      }),
+    },
+  ]);
+
+  const permRepo = createPermissionRepository(db);
+
+  for (const perm of normalized) {
+    // Lewati jika sudah ada (idempotent)
+    const existing = await permRepo.getPermissionById(perm.id).catch(() => null);
+    if (existing) {
+      continue;
+    }
+
+    await permRepo.createPermission({
+      id: perm.id,
+      code: perm.code,
+      domain: perm.domain,
+      resource: perm.resource,
+      action: perm.action,
+      description: perm.description ?? null,
+      is_protected: perm.is_protected ?? false,
+      created_at: null,
+    });
+  }
+}

--- a/src/plugins/sikesra/index.mjs
+++ b/src/plugins/sikesra/index.mjs
@@ -1,0 +1,10 @@
+// SIKESRA Plugin — entry point (ADR-016, ADR-018)
+// Plugin data kesehatan rakyat untuk AWCMS-Mini.
+// Semua data highly_restricted; NIK selalu terenkripsi di app layer.
+
+export { migrate } from "./migrate.mjs";
+export { subjectsRepository } from "./repositories/subjects.mjs";
+export { recordsRepository } from "./repositories/records.mjs";
+export { recordDocumentsRepository } from "./repositories/record-documents.mjs";
+
+export const PLUGIN_ID = "sikesra";

--- a/src/plugins/sikesra/manifest.json
+++ b/src/plugins/sikesra/manifest.json
@@ -1,0 +1,41 @@
+{
+  "id": "sikesra",
+  "name": "SIKESRA — Sistem Kesehatan Rakyat",
+  "version": "0.1.0",
+  "kind": "awcms-mini-plugin",
+  "appliesTo": ["awcms-mini"],
+  "permissions": [
+    "awcms:sikesra:subject:read",
+    "awcms:sikesra:subject:create",
+    "awcms:sikesra:subject:update",
+    "awcms:sikesra:subject:delete",
+    "awcms:sikesra:record:read",
+    "awcms:sikesra:record:create",
+    "awcms:sikesra:record:update",
+    "awcms:sikesra:document:read",
+    "awcms:sikesra:document:create",
+    "awcms:sikesra:document:download"
+  ],
+  "data": {
+    "adapter": "postgres",
+    "schema": "sikesra",
+    "rls": "required"
+  },
+  "audit": {
+    "required": true,
+    "events": [
+      "subject.create",
+      "subject.update",
+      "subject.delete",
+      "record.create",
+      "record.update",
+      "document.create",
+      "document.download"
+    ]
+  },
+  "admin": {
+    "menuGroup": "Kesehatan",
+    "menuOrder": 10,
+    "pages": []
+  }
+}

--- a/src/plugins/sikesra/migrate.mjs
+++ b/src/plugins/sikesra/migrate.mjs
@@ -1,0 +1,133 @@
+// Migration DDL schema SIKESRA (plugin AWCMS-Mini, ADR-015/016/018)
+// Referensi: docs/concepts/awcms-mini-sikesra-mvp-schema.md
+
+import { sql } from "kysely";
+
+import { buildPluginRlsStatements } from "../../db/plugin-adapter.mjs";
+
+/**
+ * Jalankan migration schema SIKESRA.
+ * Idempotent: semua CREATE memakai IF NOT EXISTS.
+ *
+ * @param {import("kysely").Kysely<unknown>} db
+ */
+export async function migrate(db) {
+  // Buat schema terpisah untuk SIKESRA (isolasi dari schema utama)
+  await sql`create schema if not exists sikesra`.execute(db);
+
+  // ─── sikesra.subjects ─────────────────────────────────────────────────────
+  // Data identitas + kesehatan dasar subjek (highly_restricted)
+  // NIK TIDAK PERNAH disimpan plaintext — selalu nik_enc (terenkripsi di app layer)
+  await db.schema
+    .withSchema("sikesra")
+    .createTable("subjects")
+    .ifNotExists()
+    .addColumn("id", "uuid", (c) => c.primaryKey().defaultTo(sql`gen_random_uuid()`))
+    .addColumn("nik_enc", "text")
+    .addColumn("full_name", "varchar(255)", (c) => c.notNull())
+    .addColumn("birth_date", "date")
+    .addColumn("gender", "varchar(10)")
+    .addColumn("classification", "text", (c) => c.notNull().defaultTo("highly_restricted"))
+    .addColumn("metadata", "jsonb", (c) => c.notNull().defaultTo(sql`'{}'::jsonb`))
+    .addColumn("created_by", "text", (c) => c.notNull())
+    .addColumn("updated_by", "text")
+    .addColumn("deleted_at", "timestamptz")
+    .addColumn("deleted_by", "text")
+    .addColumn("created_at", "timestamptz", (c) => c.notNull().defaultTo(sql`now()`))
+    .addColumn("updated_at", "timestamptz", (c) => c.notNull().defaultTo(sql`now()`))
+    .execute();
+
+  await db.schema
+    .withSchema("sikesra")
+    .createIndex("sikesra_subjects_created_by_idx")
+    .ifNotExists()
+    .on("subjects")
+    .column("created_by")
+    .execute();
+
+  await db.schema
+    .withSchema("sikesra")
+    .createIndex("sikesra_subjects_deleted_at_idx")
+    .ifNotExists()
+    .on("subjects")
+    .column("deleted_at")
+    .execute();
+
+  // Enable RLS pada sikesra.subjects
+  for (const stmt of buildPluginRlsStatements("sikesra", "subjects")) {
+    await sql.raw(stmt).execute(db);
+  }
+
+  // ─── sikesra.records ──────────────────────────────────────────────────────
+  // Catatan medis/layanan per subjek (highly_restricted)
+  await db.schema
+    .withSchema("sikesra")
+    .createTable("records")
+    .ifNotExists()
+    .addColumn("id", "uuid", (c) => c.primaryKey().defaultTo(sql`gen_random_uuid()`))
+    .addColumn("subject_id", "uuid", (c) => c.notNull().references("sikesra.subjects.id").onDelete("restrict"))
+    .addColumn("record_type", "varchar(64)", (c) => c.notNull())
+    .addColumn("record_date", "date", (c) => c.notNull())
+    .addColumn("notes", "text")
+    .addColumn("classification", "text", (c) => c.notNull().defaultTo("highly_restricted"))
+    .addColumn("metadata", "jsonb", (c) => c.notNull().defaultTo(sql`'{}'::jsonb`))
+    .addColumn("created_by", "text", (c) => c.notNull())
+    .addColumn("updated_by", "text")
+    .addColumn("deleted_at", "timestamptz")
+    .addColumn("deleted_by", "text")
+    .addColumn("created_at", "timestamptz", (c) => c.notNull().defaultTo(sql`now()`))
+    .addColumn("updated_at", "timestamptz", (c) => c.notNull().defaultTo(sql`now()`))
+    .execute();
+
+  await db.schema
+    .withSchema("sikesra")
+    .createIndex("sikesra_records_subject_id_idx")
+    .ifNotExists()
+    .on("records")
+    .column("subject_id")
+    .execute();
+
+  await db.schema
+    .withSchema("sikesra")
+    .createIndex("sikesra_records_created_by_idx")
+    .ifNotExists()
+    .on("records")
+    .column("created_by")
+    .execute();
+
+  for (const stmt of buildPluginRlsStatements("sikesra", "records")) {
+    await sql.raw(stmt).execute(db);
+  }
+
+  // ─── sikesra.record_documents ─────────────────────────────────────────────
+  // Metadata dokumen terlampir (file biner di R2, bukan di DB)
+  await db.schema
+    .withSchema("sikesra")
+    .createTable("record_documents")
+    .ifNotExists()
+    .addColumn("id", "uuid", (c) => c.primaryKey().defaultTo(sql`gen_random_uuid()`))
+    .addColumn("record_id", "uuid", (c) => c.notNull().references("sikesra.records.id").onDelete("restrict"))
+    .addColumn("filename", "varchar(512)", (c) => c.notNull())
+    .addColumn("mime_type", "varchar(128)", (c) => c.notNull())
+    .addColumn("size_bytes", "bigint")
+    .addColumn("r2_key", "text", (c) => c.notNull())
+    .addColumn("checksum_sha256", "text")
+    .addColumn("classification", "text", (c) => c.notNull().defaultTo("highly_restricted"))
+    .addColumn("created_by", "text", (c) => c.notNull())
+    .addColumn("deleted_at", "timestamptz")
+    .addColumn("deleted_by", "text")
+    .addColumn("created_at", "timestamptz", (c) => c.notNull().defaultTo(sql`now()`))
+    .execute();
+
+  await db.schema
+    .withSchema("sikesra")
+    .createIndex("sikesra_record_documents_record_id_idx")
+    .ifNotExists()
+    .on("record_documents")
+    .column("record_id")
+    .execute();
+
+  for (const stmt of buildPluginRlsStatements("sikesra", "record_documents")) {
+    await sql.raw(stmt).execute(db);
+  }
+}

--- a/src/plugins/sikesra/repositories/record-documents.mjs
+++ b/src/plugins/sikesra/repositories/record-documents.mjs
@@ -1,0 +1,34 @@
+// Repository sikesra.record_documents (metadata file; biner di R2)
+
+import { createPluginRepository } from "../../../db/plugin-adapter.mjs";
+
+const base = createPluginRepository("sikesra", "record_documents");
+
+export const recordDocumentsRepository = {
+  ...base,
+
+  async findByRecordId(recordId) {
+    const { getDatabase } = await import("../../../db/index.mjs");
+    return getDatabase()
+      .withSchema("sikesra")
+      .selectFrom("record_documents")
+      .selectAll()
+      .where("record_id", "=", recordId)
+      .where("deleted_at", "is", null)
+      .execute();
+  },
+
+  // r2Key adalah path di Cloudflare R2 (bukan URL raw)
+  // Format: tenants/{tenant}/modules/sikesra/highly_restricted/{year}/{month}/{filename}
+  async createDocument({ recordId, filename, mimeType, sizeBytes, r2Key, checksumSha256, createdBy }) {
+    return base.insert({
+      record_id: recordId,
+      filename,
+      mime_type: mimeType,
+      size_bytes: sizeBytes ?? null,
+      r2_key: r2Key,
+      checksum_sha256: checksumSha256 ?? null,
+      created_by: createdBy,
+    });
+  },
+};

--- a/src/plugins/sikesra/repositories/records.mjs
+++ b/src/plugins/sikesra/repositories/records.mjs
@@ -1,0 +1,33 @@
+// Repository sikesra.records
+
+import { createPluginRepository } from "../../../db/plugin-adapter.mjs";
+
+const base = createPluginRepository("sikesra", "records");
+
+export const recordsRepository = {
+  ...base,
+
+  async findBySubjectId(subjectId, { limit = 50, offset = 0 } = {}) {
+    const { getDatabase } = await import("../../../db/index.mjs");
+    return getDatabase()
+      .withSchema("sikesra")
+      .selectFrom("records")
+      .selectAll()
+      .where("subject_id", "=", subjectId)
+      .where("deleted_at", "is", null)
+      .limit(limit)
+      .offset(offset)
+      .execute();
+  },
+
+  async createRecord({ subjectId, recordType, recordDate, notes, createdBy, metadata = {} }) {
+    return base.insert({
+      subject_id: subjectId,
+      record_type: recordType,
+      record_date: recordDate,
+      notes: notes ?? null,
+      created_by: createdBy,
+      metadata,
+    });
+  },
+};

--- a/src/plugins/sikesra/repositories/subjects.mjs
+++ b/src/plugins/sikesra/repositories/subjects.mjs
@@ -1,0 +1,39 @@
+// Repository sikesra.subjects — wraps createPluginRepository dengan field khusus.
+
+import { createPluginRepository } from "../../../db/plugin-adapter.mjs";
+
+const base = createPluginRepository("sikesra", "subjects");
+
+export const subjectsRepository = {
+  ...base,
+
+  // NIK tidak pernah diekspor — strip nik_enc dari output default
+  // (reveal hanya via endpoint khusus dengan audit log)
+  async findById(id) {
+    const row = await base.findById(id);
+    return row ? stripNik(row) : undefined;
+  },
+
+  async findAll(opts) {
+    const rows = await base.findAll(opts);
+    return rows.map(stripNik);
+  },
+
+  // Insert wajib menggunakan nik_enc (terenkripsi), bukan nik plaintext
+  async createSubject({ nikEnc, fullName, birthDate, gender, createdBy, metadata = {} }) {
+    return base.insert({
+      nik_enc: nikEnc ?? null,
+      full_name: fullName,
+      birth_date: birthDate ?? null,
+      gender: gender ?? null,
+      created_by: createdBy,
+      metadata,
+    });
+  },
+};
+
+function stripNik(row) {
+  // eslint-disable-next-line no-unused-vars
+  const { nik_enc, ...rest } = row;
+  return rest;
+}

--- a/tests/unit/plugin-adapter.test.mjs
+++ b/tests/unit/plugin-adapter.test.mjs
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildPluginRlsStatements, createPluginRepository } from "../../src/db/plugin-adapter.mjs";
+
+// Unit test untuk bagian yang tidak butuh DB nyata:
+// - buildPluginRlsStatements: pure function, hanya string manipulation
+// - createPluginRepository: verifikasi factory menghasilkan object dengan method yang benar
+//
+// Integration test RLS (negative test) membutuhkan DB nyata dan dipisah ke test terpisah.
+
+test("plugin adapter: buildPluginRlsStatements menghasilkan 3 SQL string", () => {
+  const stmts = buildPluginRlsStatements("sikesra", "subjects");
+  assert.equal(stmts.length, 3, "Harus menghasilkan tepat 3 SQL statement");
+});
+
+test("plugin adapter: buildPluginRlsStatements — statement pertama enable RLS", () => {
+  const stmts = buildPluginRlsStatements("sikesra", "subjects");
+  assert.ok(
+    stmts[0].includes("enable row level security"),
+    `Statement pertama harus enable RLS, dapat: "${stmts[0]}"`,
+  );
+  assert.ok(stmts[0].includes("sikesra.subjects"), 'Harus menyebut "sikesra.subjects"');
+});
+
+test("plugin adapter: buildPluginRlsStatements — statement kedua force RLS", () => {
+  const stmts = buildPluginRlsStatements("sikesra", "subjects");
+  assert.ok(
+    stmts[1].includes("force row level security"),
+    `Statement kedua harus force RLS, dapat: "${stmts[1]}"`,
+  );
+});
+
+test("plugin adapter: buildPluginRlsStatements — statement ketiga create policy isolasi user", () => {
+  const stmts = buildPluginRlsStatements("sikesra", "subjects");
+  assert.ok(stmts[2].includes("create policy"), 'Statement ketiga harus "create policy"');
+  assert.ok(stmts[2].includes("current_setting"), 'Policy harus memakai current_setting');
+  assert.ok(stmts[2].includes("app.current_user_id"), 'Policy harus memakai app.current_user_id');
+});
+
+test("plugin adapter: buildPluginRlsStatements — memakai schema + tableName yang diberikan", () => {
+  const stmts = buildPluginRlsStatements("satu_sehat", "pasien");
+  for (const stmt of stmts) {
+    if (stmt.includes("table") || stmt.includes("policy")) {
+      assert.ok(
+        stmt.includes("satu_sehat.pasien"),
+        `Statement "${stmt}" harus menyebut "satu_sehat.pasien"`,
+      );
+    }
+  }
+});
+
+test("plugin adapter: createPluginRepository menghasilkan object dengan semua method", () => {
+  const repo = createPluginRepository("sikesra", "subjects");
+
+  assert.ok(typeof repo.findById === "function", "Harus ada method findById");
+  assert.ok(typeof repo.findAll === "function", "Harus ada method findAll");
+  assert.ok(typeof repo.insert === "function", "Harus ada method insert");
+  assert.ok(typeof repo.softDelete === "function", "Harus ada method softDelete");
+  assert.ok(typeof repo.update === "function", "Harus ada method update");
+});
+
+test("plugin adapter: createPluginRepository berbeda schema/tabel tidak sharing state", () => {
+  const repoA = createPluginRepository("sikesra", "subjects");
+  const repoB = createPluginRepository("satu_sehat", "pasien");
+
+  // Kedua repo harus merupakan object berbeda (factory, bukan singleton)
+  assert.notStrictEqual(repoA, repoB);
+});

--- a/tests/unit/plugin-loader.test.mjs
+++ b/tests/unit/plugin-loader.test.mjs
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { loadAllPlugins } from "../../src/plugins/loader.mjs";
+import { listPlugins, clearRegistry } from "../../src/plugins/registry.mjs";
+
+test.afterEach(() => {
+  clearRegistry();
+});
+
+test("plugin loader: loadAllPlugins dengan ACTIVE_PLUGINS kosong tidak error", async () => {
+  // ACTIVE_PLUGINS kosong (belum ada plugin SIKESRA/SatuSehat) — harus selesai tanpa error
+  await assert.doesNotReject(
+    loadAllPlugins({ db: null }),
+    "loadAllPlugins dengan ACTIVE_PLUGINS kosong harus selesai tanpa error",
+  );
+});
+
+test("plugin loader: loadAllPlugins dengan ACTIVE_PLUGINS kosong tidak mendaftarkan plugin", async () => {
+  await loadAllPlugins({ db: null });
+  assert.deepEqual(listPlugins(), [], "Harus tidak ada plugin terdaftar");
+});

--- a/tests/unit/plugin-manifest.test.mjs
+++ b/tests/unit/plugin-manifest.test.mjs
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { validatePluginManifest, assertValidPluginManifest, isValidPluginManifest } from "../../src/plugins/manifest.mjs";
+
+const VALID_SIKESRA_MANIFEST = {
+  id: "sikesra",
+  name: "SIKESRA — Sistem Kesehatan Rakyat",
+  version: "0.1.0",
+  kind: "awcms-mini-plugin",
+  appliesTo: ["awcms-mini"],
+  permissions: [
+    "awcms:sikesra:subject:read",
+    "awcms:sikesra:subject:create",
+    "awcms:sikesra:record:read",
+    "awcms:sikesra:record:create",
+    "awcms:sikesra:document:download",
+  ],
+  data: { adapter: "postgres", schema: "sikesra", rls: "required" },
+  audit: { required: true, events: ["subject.create", "record.create", "document.download"] },
+  admin: { menuGroup: "Kesehatan", menuOrder: 10, pages: [] },
+};
+
+test("plugin manifest: manifest SIKESRA valid lulus tanpa error", () => {
+  const errors = validatePluginManifest(VALID_SIKESRA_MANIFEST);
+  assert.deepEqual(errors, []);
+});
+
+test("plugin manifest: isValidPluginManifest mengembalikan true untuk manifest valid", () => {
+  assert.equal(isValidPluginManifest(VALID_SIKESRA_MANIFEST), true);
+});
+
+test("plugin manifest: manifest kosong menghasilkan array error", () => {
+  const errors = validatePluginManifest({});
+  assert.ok(errors.length >= 6, `Diharapkan ≥6 error, dapat ${errors.length}`);
+  const fields = errors.map((e) => e.field);
+  assert.ok(fields.includes("id"), "Harus ada error untuk id");
+  assert.ok(fields.includes("name"), "Harus ada error untuk name");
+  assert.ok(fields.includes("version"), "Harus ada error untuk version");
+  assert.ok(fields.includes("kind"), "Harus ada error untuk kind");
+  assert.ok(fields.includes("appliesTo"), "Harus ada error untuk appliesTo");
+  assert.ok(fields.includes("data"), "Harus ada error untuk data");
+});
+
+test("plugin manifest: bukan object mengembalikan error manifest", () => {
+  const errors = validatePluginManifest(null);
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].field, "manifest");
+});
+
+test("plugin manifest: id dengan spasi atau huruf besar tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, id: "Sikesra Plugin" });
+  assert.ok(errors.some((e) => e.field === "id"), "Harus ada error untuk id");
+});
+
+test("plugin manifest: kind bukan awcms-mini-plugin tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, kind: "emdash-plugin" });
+  assert.ok(errors.some((e) => e.field === "kind"), "Harus ada error untuk kind");
+});
+
+test("plugin manifest: data.adapter bukan postgres tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, data: { adapter: "d1", schema: "sikesra", rls: "required" } });
+  assert.ok(errors.some((e) => e.field === "data.adapter"), "Harus ada error untuk data.adapter");
+});
+
+test("plugin manifest: data.rls bukan required tidak valid (ADR-015)", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, data: { adapter: "postgres", schema: "sikesra", rls: "optional" } });
+  assert.ok(errors.some((e) => e.field === "data.rls"), "Harus ada error untuk data.rls");
+});
+
+test("plugin manifest: data.schema dengan huruf besar tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, data: { adapter: "postgres", schema: "Sikesra", rls: "required" } });
+  assert.ok(errors.some((e) => e.field === "data.schema"), "Harus ada error untuk data.schema");
+});
+
+test("plugin manifest: permission dengan format salah tidak valid", () => {
+  const errors = validatePluginManifest({
+    ...VALID_SIKESRA_MANIFEST,
+    permissions: ["sikesra:subject:read", "awcms:sikesra:subject:create"],
+  });
+  assert.ok(errors.some((e) => e.field === "permissions[0]"), "Harus ada error untuk permissions[0]");
+  assert.ok(!errors.some((e) => e.field === "permissions[1]"), "permissions[1] harus valid");
+});
+
+test("plugin manifest: audit.required=true dengan events kosong tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, audit: { required: true, events: [] } });
+  assert.ok(errors.some((e) => e.field === "audit.events"), "Harus ada error untuk audit.events");
+});
+
+test("plugin manifest: audit.required=false dengan events kosong valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, audit: { required: false, events: [] } });
+  assert.ok(!errors.some((e) => e.field === "audit.events"), "Tidak boleh ada error untuk audit.events bila required=false");
+});
+
+test("plugin manifest: assertValidPluginManifest melempar Error untuk manifest tidak valid", () => {
+  assert.throws(
+    () => assertValidPluginManifest({}),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.includes("Manifest plugin tidak valid"), `Pesan error tidak sesuai: ${err.message}`);
+      return true;
+    },
+  );
+});
+
+test("plugin manifest: assertValidPluginManifest mengembalikan manifest yang valid (passthrough)", () => {
+  const result = assertValidPluginManifest(VALID_SIKESRA_MANIFEST);
+  assert.strictEqual(result, VALID_SIKESRA_MANIFEST);
+});
+
+test("plugin manifest: appliesTo tanpa awcms-mini tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, appliesTo: ["awcms"] });
+  assert.ok(errors.some((e) => e.field === "appliesTo"), "Harus ada error untuk appliesTo");
+});
+
+test("plugin manifest: version bukan semver tidak valid", () => {
+  const errors = validatePluginManifest({ ...VALID_SIKESRA_MANIFEST, version: "1.0" });
+  assert.ok(errors.some((e) => e.field === "version"), "Harus ada error untuk version");
+});

--- a/tests/unit/plugin-registry.test.mjs
+++ b/tests/unit/plugin-registry.test.mjs
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPlugin, getPlugin, listPlugins, clearRegistry } from "../../src/plugins/registry.mjs";
+
+const VALID_MANIFEST = {
+  id: "test-plugin",
+  name: "Test Plugin",
+  version: "0.1.0",
+  kind: "awcms-mini-plugin",
+  appliesTo: ["awcms-mini"],
+  permissions: ["awcms:test_plugin:record:read"],
+  data: { adapter: "postgres", schema: "test_plugin", rls: "required" },
+  audit: { required: false, events: [] },
+};
+
+const VALID_MANIFEST_B = {
+  ...VALID_MANIFEST,
+  id: "test-plugin-b",
+  data: { ...VALID_MANIFEST.data, schema: "test_plugin_b" },
+};
+
+// Bersihkan registry setelah setiap test agar tidak ada state yang bocor
+test.afterEach(() => {
+  clearRegistry();
+});
+
+test("plugin registry: registerPlugin dengan manifest valid berhasil", () => {
+  registerPlugin(VALID_MANIFEST, {});
+  assert.equal(listPlugins().length, 1);
+  assert.equal(listPlugins()[0].id, "test-plugin");
+});
+
+test("plugin registry: registerPlugin dengan manifest tidak valid melempar Error", () => {
+  assert.throws(
+    () => registerPlugin({}, {}),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.includes("Manifest plugin tidak valid"), `Pesan: ${err.message}`);
+      return true;
+    },
+  );
+});
+
+test("plugin registry: registerPlugin dengan plugin ID duplikat melempar Error", () => {
+  registerPlugin(VALID_MANIFEST, {});
+  assert.throws(
+    () => registerPlugin(VALID_MANIFEST, {}),
+    (err) => {
+      assert.ok(err instanceof Error);
+      assert.ok(err.message.includes("sudah terdaftar"), `Pesan: ${err.message}`);
+      return true;
+    },
+  );
+});
+
+test("plugin registry: getPlugin mengembalikan entry yang terdaftar", () => {
+  const module = { migrate: async () => {} };
+  registerPlugin(VALID_MANIFEST, module);
+
+  const entry = getPlugin("test-plugin");
+  assert.ok(entry, "Entry harus ada");
+  assert.deepEqual(entry.manifest, VALID_MANIFEST);
+  assert.strictEqual(entry.module, module);
+});
+
+test("plugin registry: getPlugin mengembalikan undefined untuk plugin yang tidak terdaftar", () => {
+  const entry = getPlugin("tidak-ada");
+  assert.equal(entry, undefined);
+});
+
+test("plugin registry: listPlugins mengembalikan array manifest yang terdaftar", () => {
+  registerPlugin(VALID_MANIFEST, {});
+  registerPlugin(VALID_MANIFEST_B, {});
+
+  const manifests = listPlugins();
+  assert.equal(manifests.length, 2);
+  const ids = manifests.map((m) => m.id).sort();
+  assert.deepEqual(ids, ["test-plugin", "test-plugin-b"]);
+});
+
+test("plugin registry: listPlugins mengembalikan array kosong jika tidak ada plugin", () => {
+  assert.deepEqual(listPlugins(), []);
+});
+
+test("plugin registry: clearRegistry membersihkan semua plugin", () => {
+  registerPlugin(VALID_MANIFEST, {});
+  assert.equal(listPlugins().length, 1);
+  clearRegistry();
+  assert.equal(listPlugins().length, 0);
+});

--- a/tests/unit/plugin-sikesra-manifest.test.mjs
+++ b/tests/unit/plugin-sikesra-manifest.test.mjs
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { validatePluginManifest } from "../../src/plugins/manifest.mjs";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { readFileSync } from "node:fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const manifest = JSON.parse(readFileSync(join(__dirname, "../../src/plugins/sikesra/manifest.json"), "utf8"));
+
+test("sikesra: manifest.json lulus validatePluginManifest tanpa error", () => {
+  const errors = validatePluginManifest(manifest);
+  assert.deepEqual(errors, [], `Manifest SIKESRA tidak valid:\n${JSON.stringify(errors, null, 2)}`);
+});
+
+test("sikesra: manifest id = sikesra", () => {
+  assert.equal(manifest.id, "sikesra");
+});
+
+test("sikesra: manifest kind = awcms-mini-plugin", () => {
+  assert.equal(manifest.kind, "awcms-mini-plugin");
+});
+
+test("sikesra: manifest data.adapter = postgres", () => {
+  assert.equal(manifest.data.adapter, "postgres");
+});
+
+test("sikesra: manifest data.rls = required (ADR-015)", () => {
+  assert.equal(manifest.data.rls, "required");
+});
+
+test("sikesra: manifest data.schema = sikesra (snake_case)", () => {
+  assert.equal(manifest.data.schema, "sikesra");
+});
+
+test("sikesra: manifest audit.required = true dengan events tidak kosong", () => {
+  assert.equal(manifest.audit.required, true);
+  assert.ok(Array.isArray(manifest.audit.events) && manifest.audit.events.length > 0, "audit.events harus non-kosong");
+});
+
+test("sikesra: manifest permissions semua mengikuti namespace awcms:{module}:{resource}:{action}", () => {
+  const PERM_RE = /^awcms:[a-z0-9_]+:[a-z0-9_]+:[a-z0-9_]+$/;
+  for (const p of manifest.permissions) {
+    assert.ok(PERM_RE.test(p), `Permission "${p}" tidak sesuai namespace`);
+    assert.ok(p.startsWith("awcms:sikesra:"), `Permission "${p}" harus dimulai dengan awcms:sikesra:`);
+  }
+});


### PR DESCRIPTION
## Summary

Plugin SIKESRA pertama yang menggunakan kontrak manifest plugin AWCMS-Mini (ADR-018, ADR-016).

**File baru:**
- `src/plugins/sikesra/manifest.json` — manifest valid (`awcms-mini-plugin`, RLS required, 10 permissions, audit required)
- `src/plugins/sikesra/migrate.mjs` — DDL schema `sikesra` (3 tabel + RLS enforced + index)
- `src/plugins/sikesra/repositories/subjects.mjs` — repo dengan strip `nik_enc` default
- `src/plugins/sikesra/repositories/records.mjs` — repo + `findBySubjectId`
- `src/plugins/sikesra/repositories/record-documents.mjs` — repo metadata file (biner di R2)
- `src/plugins/sikesra/index.mjs` — export `migrate` + repositories
- `src/plugins/loader.mjs` — ACTIVE_PLUGINS diisi entry SIKESRA
- `tests/unit/plugin-sikesra-manifest.test.mjs` — 8 test, semua pass

## Schema yang dibuat (migrate.mjs)

```
sikesra.subjects        — identitas subjek, highly_restricted, nik_enc (terenkripsi)
sikesra.records         — catatan medis/layanan per subjek
sikesra.record_documents — metadata file (r2_key = path R2, bukan URL)
```

Semua tabel: RLS `ENABLE + FORCE + policy plugin_user_isolation` via `buildPluginRlsStatements`.

## Aturan keamanan yang diterapkan

- **NIK tidak pernah plaintext** — kolom `nik_enc` (enkripsi di app layer sebelum masuk DB)
- `subjectsRepository.findById/findAll` **strip `nik_enc`** dari output secara default
- **File biner di R2** — `record_documents.r2_key` menyimpan path R2, bukan URL atau konten
- **RLS enforced** pada ketiga tabel (`enable row level security` + `force row level security`)
- Migration idempotent: semua `CREATE` memakai `IF NOT EXISTS`

## Test plan

- [x] 8/8 test manifest SIKESRA pass (`plugin-sikesra-manifest.test.mjs`)
- [x] Manifest lulus `validatePluginManifest` (dari #316)
- [x] Semua permission mengikuti namespace `awcms:sikesra:{resource}:{action}`
- [ ] Integration test migration + RLS (membutuhkan DB test) — diselesaikan dalam CI

## Dependensi PR

Stacked di atas:
- #319 `feat/plugin-manifest-contract` (manifest.mjs)
- #320 `feat/plugin-postgres-adapter` (plugin-adapter.mjs)
- #321 `feat/plugin-registry-loader` (registry.mjs + loader.mjs)

Harap merge dalam urutan: #319 → #320 → #321 → PR ini

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)