### PR TITLE
[MINI][SEQ-05] docs: update AGENTS.md + REQUIREMENTS.md — plugin contract + RLS (closes #314)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,31 @@ It is not:
 4. Use shared plugin helpers in `src/plugins/` instead of duplicating permission, auth, audit, or region-scoping logic.
 5. Keep jobs, roles, logical regions, and administrative regions as separate concepts.
 
+## Plugin Contract Rules (ADR-018)
+
+Every plugin MUST:
+
+1. Provide a `manifest.json` that passes `validatePluginManifest()` from `src/plugins/manifest.mjs`.
+2. Set `kind: "awcms-mini-plugin"` and `data.adapter: "postgres"`, `data.rls: "required"`.
+3. Declare all permissions using namespace `awcms:{module}:{resource}:{action}`.
+4. Include a `migrate.mjs` that calls `buildPluginRlsStatements()` for every table it creates.
+5. Use `createPluginRepository()` from `src/db/plugin-adapter.mjs` — never raw Kysely without schema scoping.
+6. Be registered via `src/plugins/loader.mjs` → `ACTIVE_PLUGINS`.
+
+**Security constraints (hard rules):**
+- NIK and other highly-restricted identifiers must be encrypted before DB write — store `nik_enc`, never `nik`.
+- `nik_enc` must be stripped from output by default (reveal only via audited endpoint).
+- File binaries go to R2 — never store in DB columns. Store only `r2_key` (path, not URL).
+- Do not expose raw R2 keys or URLs to clients.
+
+## RLS Rules (ADR-015)
+
+- RLS is enforced on all per-user tables via migration `040_rls_per_user_tables.mjs`.
+- All plugin tables require RLS via `buildPluginRlsStatements()` in their `migrate.mjs`.
+- The `server/middleware/db-context.mjs` sets `app.current_user_id` and `app.is_admin` per request.
+- `app.is_admin = 'true'` is set for actors with `staff_level >= 7` (admin bypass for listing operations).
+- Run `pnpm check:rls-coverage` (FF6) to verify RLS is active on all required tables.
+
 ## Required Reading By Task Type
 
 ### Governance Or Security Work
@@ -53,9 +78,12 @@ Read:
 
 Read:
 
-1. `docs/plugins/contract-overview.md`
-2. `docs/plugins/permission-registration.md`
-3. `src/plugins/internal-governance-sample/index.mjs`
+1. `src/plugins/manifest.mjs` — kontrak manifest + validator (ADR-018)
+2. `src/db/plugin-adapter.mjs` — base repository + RLS helper + konteks DB
+3. `src/plugins/registry.mjs` — register, seed permission, list plugin
+4. `src/plugins/loader.mjs` — ACTIVE_PLUGINS (tambahkan entry plugin baru di sini)
+5. `src/plugins/sikesra/` — contoh plugin nyata pertama (referensi implementasi)
+6. `src/plugins/internal-governance-sample/index.mjs` — contoh plugin lama (pola definePlugin)
 
 ### Admin Work
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -66,15 +66,20 @@ Required admin capabilities:
 
 Plugins must remain EmDash-compatible and consume shared governance helpers.
 
-Required plugin contract pieces:
+Required plugin contract pieces (ADR-018):
 
-- permission registration
-- route authorization helper
-- service authorization helper
-- audit helper
-- region-awareness helper
+- `manifest.json` validated by `src/plugins/manifest.mjs` (`kind: awcms-mini-plugin`, `data.rls: required`)
+- permission declaration with namespace `awcms:{module}:{resource}:{action}`
+- data adapter via `src/db/plugin-adapter.mjs` (not raw Kysely)
+- `migrate.mjs` that enables RLS via `buildPluginRlsStatements()` on every table
+- entry in `src/plugins/loader.mjs` `ACTIVE_PLUGINS`
+- route authorization helper (`src/plugins/route-authorization.mjs`)
+- service authorization helper (`src/plugins/service-authorization.mjs`)
+- audit helper (`src/plugins/audit-helper.mjs`)
 
 Plugins must not bypass shared governance services or write arbitrary policy state without shared validation.
+
+Row-Level Security (RLS) must be enforced on all plugin tables and all sensitive per-user tables (ADR-015). Run `pnpm check:rls-coverage` to verify.
 
 ## Documentation Requirements
 


### PR DESCRIPTION
## Summary

Update dua dokumen utama awcms-mini untuk mencerminkan arsitektur terbaru (ADR-015, ADR-018):
- `AGENTS.md`: tambah Plugin Contract Rules + RLS Rules + update Plugin Work reading list
- `REQUIREMENTS.md`: perbarui Plugin Requirements dengan daftar kontrak ADR-018 + RLS requirement

## Perubahan AGENTS.md

### Seksi baru: Plugin Contract Rules (ADR-018)

Setiap plugin WAJIB:
1. `manifest.json` lulus `validatePluginManifest()` dari `src/plugins/manifest.mjs`
2. `kind: awcms-mini-plugin`, `data.adapter: postgres`, `data.rls: required`
3. Permission namespace `awcms:{module}:{resource}:{action}`
4. `migrate.mjs` memanggil `buildPluginRlsStatements()` untuk setiap tabel
5. `createPluginRepository()` dari `src/db/plugin-adapter.mjs` (tidak raw Kysely)
6. Entry di `src/plugins/loader.mjs → ACTIVE_PLUGINS`

Hard constraints: NIK = `nik_enc` saja; biner di R2; tidak expose raw R2 URL.

### Seksi baru: RLS Rules (ADR-015)

- RLS per-user via `040_rls_per_user_tables.mjs`
- Plugin tables via `buildPluginRlsStatements()` di `migrate.mjs` masing-masing
- `server/middleware/db-context.mjs` set `app.current_user_id` + `app.is_admin` per request
- `pnpm check:rls-coverage` untuk verifikasi FF6

### Update Plugin Work reading list

Diganti ke file-file baru yang lebih relevan:
- `src/plugins/manifest.mjs` (kontrak + validator)
- `src/db/plugin-adapter.mjs` (repo factory + RLS helper)
- `src/plugins/registry.mjs` (register + seed permission)
- `src/plugins/loader.mjs` (ACTIVE_PLUGINS)
- `src/plugins/sikesra/` (plugin nyata sebagai referensi)

## Test plan

- [x] AGENTS.md tidak mengandung informasi yang bertentangan dengan REQUIREMENTS.md
- [x] Link ke file-file baru valid (ada di PR #319-#324)

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)