### PR TITLE
[MINI][SEQ-15] feat: koneksi PostgreSQL via pooler + mode Session/Transaction (closes #334)

### DIFF
--- a/docs/architecture/database-access.md
+++ b/docs/architecture/database-access.md
@@ -11,6 +11,37 @@ This document defines the shared database access surface for services in AWCMS M
 - transaction wrapper: `src/db/transactions.mjs`
 - error classifier: `src/db/errors.mjs`
 
+## Connection Pooler (ADR-013)
+
+PostgreSQL diakses via **connection pooler open-source** (Supavisor/PgBouncer/PgCat). Lihat personal-coding `awcms-shared-standards.md` §7.1/§7.2.
+
+### Environment
+
+| Env                     | Default                                    | Keterangan                                                            |
+| ----------------------- | ------------------------------------------ | --------------------------------------------------------------------- |
+| `DATABASE_URL`          | `postgres://localhost:5432/awcms_mini_dev` | Koneksi direct (fallback & dev/diagnostik)                            |
+| `DATABASE_TRANSPORT`    | `direct`                                   | `direct` \| `pooler`                                                  |
+| `DATABASE_POOLER_URL`   | _(kosong)_                                 | Connection string ke pooler; dipakai bila `DATABASE_TRANSPORT=pooler` |
+| `DATABASE_POOLING_MODE` | `session`                                  | `session` (app long-running, default) \| `transaction` (serverless)   |
+
+### Mode pooling
+
+- **`session` (default & DISARANKAN untuk awcms-mini):** app Hono long-running di Coolify; konteks sesi & RLS `set_config` terjaga.
+- **`transaction`:** hanya untuk runtime serverless/auto-scaling tinggi.
+
+### Aturan transaction mode (§7.2)
+
+- Driver `pg` + Kysely **tidak** memprepare statement (query tanpa `name`) → aman di transaction mode tanpa flag `prepare:false` khusus. Jangan beri `name` pada query di hot path.
+- RLS: `set_config('app.current_user_id', ..., true)` + query yang memakainya **WAJIB** satu transaksi (lihat `withTransaction`).
+- Negative test isolasi RLS **WAJIB** dijalankan via pooler.
+
+### Setup operator (Coolify)
+
+1. Jalankan PgBouncer/Supavisor sebagai service yang menunjuk PostgreSQL utama.
+2. Set `DATABASE_TRANSPORT=pooler` + `DATABASE_POOLER_URL=<url-pooler>` di environment app.
+3. Set `DATABASE_POOLING_MODE=session` (default) untuk awcms-mini.
+4. Pertahankan `DATABASE_URL` (direct) untuk migrasi/diagnostik.
+
 ## Rules
 
 - services should acquire database access through `src/db/index.mjs`

--- a/src/config/runtime.mjs
+++ b/src/config/runtime.mjs
@@ -1,5 +1,8 @@
 export const DEFAULT_DATABASE_URL = "postgres://localhost:5432/awcms_mini_dev";
 export const DEFAULT_DATABASE_TRANSPORT = "direct";
+// Mode pooling default = session (app long-running Hono; konteks sesi & RLS
+// set_config terjaga). Lihat personal-coding awcms-shared-standards.md §7.1.
+export const DEFAULT_DATABASE_POOLING_MODE = "session";
 export const DEFAULT_RUNTIME_TARGET = "node";
 export const DEFAULT_TRUSTED_PROXY_MODE = "direct";
 export const DEFAULT_R2_MEDIA_BUCKET_BINDING = "MEDIA_BUCKET";
@@ -26,7 +29,11 @@ function normalizeRuntimeTarget(value) {
 }
 
 function normalizeDatabaseTransport(value) {
-  return value === "direct" ? value : DEFAULT_DATABASE_TRANSPORT;
+  return value === "direct" || value === "pooler" ? value : DEFAULT_DATABASE_TRANSPORT;
+}
+
+function normalizeDatabasePoolingMode(value) {
+  return value === "session" || value === "transaction" ? value : DEFAULT_DATABASE_POOLING_MODE;
 }
 
 function normalizeOptionalString(value) {
@@ -118,6 +125,8 @@ export function getRuntimeConfig() {
   return {
     databaseUrl: process.env.DATABASE_URL || DEFAULT_DATABASE_URL,
     databaseTransport: normalizeDatabaseTransport(process.env.DATABASE_TRANSPORT),
+    databasePoolerUrl: normalizeOptionalString(process.env.DATABASE_POOLER_URL),
+    databasePoolingMode: normalizeDatabasePoolingMode(process.env.DATABASE_POOLING_MODE),
     databaseConnectTimeoutMs: normalizePositiveInteger(
       process.env.DATABASE_CONNECT_TIMEOUT_MS,
       DEFAULT_DATABASE_CONNECT_TIMEOUT_MS,

--- a/src/db/client/postgres.mjs
+++ b/src/db/client/postgres.mjs
@@ -5,9 +5,9 @@ import { getRuntimeConfig } from "../../config/runtime.mjs";
 
 const { Pool } = pg;
 
-export function resolvePostgresSslOptions(runtimeConfig = getRuntimeConfig()) {
+function sslOptionsFromConnectionString(connectionString) {
   try {
-    const parsed = new URL(runtimeConfig.databaseUrl);
+    const parsed = new URL(connectionString);
     const sslmode = parsed.searchParams.get("sslmode");
 
     if (sslmode === "verify-full") {
@@ -24,7 +24,35 @@ export function resolvePostgresSslOptions(runtimeConfig = getRuntimeConfig()) {
   return undefined;
 }
 
+export function resolvePostgresSslOptions(runtimeConfig = getRuntimeConfig()) {
+  return sslOptionsFromConnectionString(runtimeConfig.databaseUrl);
+}
+
+/**
+ * Mode pooling efektif (ADR-013; personal-coding awcms-shared-standards.md §7.1).
+ * - "session" (default): app long-running (Hono); konteks sesi & RLS set_config terjaga.
+ * - "transaction": serverless/auto-scaling; koneksi berpindah per-transaksi.
+ *
+ * Catatan prepared statement (§7.2): driver `pg` + Kysely TIDAK memprepare
+ * statement (query tanpa `name`), sehingga aman di transaction mode tanpa flag
+ * `prepare:false` khusus. Jangan beri `name` pada query di hot path.
+ */
+export function resolvePostgresPoolingMode(runtimeConfig = getRuntimeConfig()) {
+  return runtimeConfig.databasePoolingMode === "transaction" ? "transaction" : "session";
+}
+
 export function resolvePostgresConnectionTarget(runtimeConfig = getRuntimeConfig(), options = {}) {
+  // Transport "pooler" (ADR-013): pakai DATABASE_POOLER_URL bila tersedia.
+  // Default tetap "direct" (DATABASE_URL) agar backward-compatible.
+  if (runtimeConfig.databaseTransport === "pooler" && runtimeConfig.databasePoolerUrl) {
+    return {
+      transport: "pooler",
+      source: "DATABASE_POOLER_URL",
+      connectionString: runtimeConfig.databasePoolerUrl,
+      poolingMode: resolvePostgresPoolingMode(runtimeConfig),
+    };
+  }
+
   return {
     transport: "direct",
     source: "DATABASE_URL",
@@ -37,11 +65,13 @@ export function resolvePostgresConnectionString(runtimeConfig = getRuntimeConfig
 }
 
 export function buildPostgresPoolConfig(runtimeConfig = getRuntimeConfig(), options = {}) {
+  const connectionString = resolvePostgresConnectionString(runtimeConfig, options);
   return {
-    connectionString: resolvePostgresConnectionString(runtimeConfig, options),
+    connectionString,
     connectionTimeoutMillis: runtimeConfig.databaseConnectTimeoutMs,
     allowExitOnIdle: true,
-    ssl: resolvePostgresSslOptions(runtimeConfig),
+    // SSL diturunkan dari connection string aktif (pooler URL bila transport=pooler).
+    ssl: sslOptionsFromConnectionString(connectionString),
   };
 }
 

--- a/tests/unit/db-pooler.test.mjs
+++ b/tests/unit/db-pooler.test.mjs
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolvePostgresConnectionTarget,
+  resolvePostgresPoolingMode,
+  buildPostgresPoolConfig,
+} from "../../src/db/client/postgres.mjs";
+
+const DIRECT_URL = "postgres://app:secret@db.internal:5432/awcms_mini?sslmode=verify-full";
+const POOLER_URL = "postgres://app:secret@pooler.internal:6432/awcms_mini?sslmode=require";
+
+test("pooler: transport default direct memakai DATABASE_URL", () => {
+  const target = resolvePostgresConnectionTarget({
+    databaseUrl: DIRECT_URL,
+    databaseTransport: "direct",
+  });
+  assert.equal(target.transport, "direct");
+  assert.equal(target.source, "DATABASE_URL");
+  assert.equal(target.connectionString, DIRECT_URL);
+});
+
+test("pooler: transport pooler + DATABASE_POOLER_URL memakai pooler", () => {
+  const target = resolvePostgresConnectionTarget({
+    databaseUrl: DIRECT_URL,
+    databaseTransport: "pooler",
+    databasePoolerUrl: POOLER_URL,
+    databasePoolingMode: "session",
+  });
+  assert.equal(target.transport, "pooler");
+  assert.equal(target.source, "DATABASE_POOLER_URL");
+  assert.equal(target.connectionString, POOLER_URL);
+  assert.equal(target.poolingMode, "session");
+});
+
+test("pooler: transport pooler tanpa poolerUrl fallback ke direct (aman)", () => {
+  const target = resolvePostgresConnectionTarget({
+    databaseUrl: DIRECT_URL,
+    databaseTransport: "pooler",
+    databasePoolerUrl: null,
+  });
+  assert.equal(target.transport, "direct");
+  assert.equal(target.connectionString, DIRECT_URL);
+});
+
+test("pooler: resolvePostgresPoolingMode default session", () => {
+  assert.equal(resolvePostgresPoolingMode({}), "session");
+  assert.equal(resolvePostgresPoolingMode({ databasePoolingMode: "session" }), "session");
+});
+
+test("pooler: resolvePostgresPoolingMode transaction bila di-set", () => {
+  assert.equal(resolvePostgresPoolingMode({ databasePoolingMode: "transaction" }), "transaction");
+});
+
+test("pooler: resolvePostgresPoolingMode nilai tak dikenal → session", () => {
+  assert.equal(resolvePostgresPoolingMode({ databasePoolingMode: "weird" }), "session");
+});
+
+test("pooler: buildPostgresPoolConfig memakai pooler URL + SSL dari pooler URL", () => {
+  const config = buildPostgresPoolConfig({
+    databaseUrl: DIRECT_URL, // verify-full → rejectUnauthorized true
+    databaseTransport: "pooler",
+    databasePoolerUrl: POOLER_URL, // require → rejectUnauthorized false
+    databasePoolingMode: "session",
+    databaseConnectTimeoutMs: 8000,
+  });
+  assert.equal(config.connectionString, POOLER_URL);
+  assert.equal(config.connectionTimeoutMillis, 8000);
+  assert.equal(config.allowExitOnIdle, true);
+  // SSL diturunkan dari pooler URL (require), bukan databaseUrl (verify-full)
+  assert.deepEqual(config.ssl, { rejectUnauthorized: false });
+});
+
+test("pooler: buildPostgresPoolConfig direct tetap memakai DATABASE_URL + SSL-nya", () => {
+  const config = buildPostgresPoolConfig({
+    databaseUrl: DIRECT_URL,
+    databaseTransport: "direct",
+    databaseConnectTimeoutMs: 10000,
+  });
+  assert.equal(config.connectionString, DIRECT_URL);
+  assert.deepEqual(config.ssl, { rejectUnauthorized: true });
+});


### PR DESCRIPTION
## Summary

Dukungan **connection pooler OSS** (ADR-013) untuk awcms-mini, dengan pemilihan **mode pooling** Session/Transaction. **Backward-compatible** — default tetap direct (`DATABASE_URL`).

- `src/config/runtime.mjs` — `DATABASE_TRANSPORT` kini `direct|pooler`; tambah `DATABASE_POOLER_URL` + `DATABASE_POOLING_MODE` (`session` default | `transaction`).
- `src/db/client/postgres.mjs` — `resolvePostgresConnectionTarget` honor transport pooler (fallback aman ke direct bila URL kosong); `resolvePostgresPoolingMode`; SSL diturunkan dari **connection string aktif** (pooler URL saat pooler mode).
- `tests/unit/db-pooler.test.mjs` — 8 test.
- `docs/architecture/database-access.md` — bagian Connection Pooler (env, mode, aturan, setup Coolify).

## Konfigurasi

| Env | Default | Keterangan |
|---|---|---|
| `DATABASE_TRANSPORT` | `direct` | `direct` \| `pooler` |
| `DATABASE_POOLER_URL` | _(kosong)_ | URL pooler; dipakai bila transport=pooler |
| `DATABASE_POOLING_MODE` | `session` | `session` (long-running, default) \| `transaction` (serverless) |

## Pilihan mode (§7.1)
- **awcms-mini = Session mode (default).** Hono long-running di Coolify → konteks sesi & RLS `set_config` terjaga.
- Transaction mode hanya untuk serverless/auto-scaling (bukan kasus Mini saat ini).

## Catatan prepared statement (§7.2)
Driver `pg` + Kysely **tidak** memprepare statement (query tanpa `name`) → **aman di transaction mode tanpa flag `prepare:false` khusus**. Disiplin: jangan beri `name` pada query di hot path. RLS `set_config` + query WAJIB satu transaksi.

## Test plan
- [x] 8/8 test pooler baru pass (transport default/pooler, fallback tanpa URL, mode session/transaction, SSL dari pooler URL).
- [x] **Backward-compatible**: db.test 21/21 + runtime-config 2/2 tetap hijau (total 31/31).
- [x] SSL benar mengikuti URL aktif (pooler `require` vs direct `verify-full`).
- [ ] Integrasi nyata via PgBouncer/Supavisor + negative test RLS via pooler → saat setup operator (didokumentasikan).

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)