### PR TITLE
[MINI][SEQ-16] feat: CQRS-lite untuk pencarian (query side terpisah + users-search) (ADR-023)

### DIFF
--- a/src/db/migrations/041_users_search_trgm_index.mjs
+++ b/src/db/migrations/041_users_search_trgm_index.mjs
@@ -1,0 +1,26 @@
+import { sql } from "kysely";
+
+/**
+ * Index pencarian untuk CQRS-lite (ADR-023, Tahap 2).
+ * Mengaktifkan ekstensi pg_trgm + GIN trigram index pada kolom yang dicari di
+ * users-search (email, username, display_name) agar ILIKE '%q%' tidak full scan.
+ */
+
+const TRGM_COLUMNS = ["email", "username", "display_name"];
+
+export async function up(db) {
+  await sql`create extension if not exists pg_trgm`.execute(db);
+
+  for (const column of TRGM_COLUMNS) {
+    await sql
+      .raw(`create index if not exists users_${column}_trgm_idx on users using gin (${column} gin_trgm_ops)`)
+      .execute(db);
+  }
+}
+
+export async function down(db) {
+  for (const column of TRGM_COLUMNS) {
+    await sql.raw(`drop index if exists users_${column}_trgm_idx`).execute(db);
+  }
+  // Ekstensi pg_trgm sengaja TIDAK di-drop (mungkin dipakai index lain).
+}

--- a/src/search/query-contract.mjs
+++ b/src/search/query-contract.mjs
@@ -1,0 +1,76 @@
+/**
+ * Kontrak query CQRS-lite untuk pencarian (ADR-023).
+ *
+ * Query side bersifat READ-ONLY: menormalkan input pencarian dan membentuk
+ * hasil terstandar (selaras envelope API §6). Tidak melakukan mutasi dan tidak
+ * memanggil command repository.
+ *
+ * Lihat personal-coding `docs/architecture/awcms-cqrs-search.md`.
+ */
+
+export const DEFAULT_PAGE_SIZE = 20;
+export const MAX_PAGE_SIZE = 100;
+export const DEFAULT_SORT = { field: "created_at", dir: "desc" };
+
+function clampInteger(value, { min, max, fallback }) {
+  const n = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(n)) return fallback;
+  if (n < min) return min;
+  if (max !== undefined && n > max) return max;
+  return n;
+}
+
+/**
+ * Normalkan input pencarian mentah menjadi SearchQuery yang aman.
+ *
+ * @param {object} [input]
+ * @param {string} [input.q] - kata kunci pencarian
+ * @param {Record<string, unknown>} [input.filters]
+ * @param {number|string} [input.page] - 1-based (default 1)
+ * @param {number|string} [input.pageSize] - default 20, maks 100
+ * @param {{ field: string; dir: "asc"|"desc" }} [input.sort]
+ * @param {object} [options]
+ * @param {string[]} [options.allowedSortFields] - whitelist field sort (anti-injection)
+ * @returns {{ q: string|null; filters: Record<string, unknown>; page: number; pageSize: number; offset: number; sort: { field: string; dir: "asc"|"desc" } }}
+ */
+export function normalizeSearchQuery(input = {}, options = {}) {
+  const allowedSortFields = options.allowedSortFields ?? [DEFAULT_SORT.field, "id"];
+
+  const q = typeof input.q === "string" && input.q.trim() !== "" ? input.q.trim() : null;
+
+  const page = clampInteger(input.page, { min: 1, fallback: 1 });
+  const pageSize = clampInteger(input.pageSize, { min: 1, max: MAX_PAGE_SIZE, fallback: DEFAULT_PAGE_SIZE });
+
+  // Sort: field harus di-whitelist (cegah SQL injection lewat nama kolom).
+  const requestedField = input.sort?.field;
+  const field = allowedSortFields.includes(requestedField) ? requestedField : DEFAULT_SORT.field;
+  const dir = input.sort?.dir === "asc" ? "asc" : "desc";
+
+  return {
+    q,
+    filters: input.filters && typeof input.filters === "object" ? input.filters : {},
+    page,
+    pageSize,
+    offset: (page - 1) * pageSize,
+    sort: { field, dir },
+  };
+}
+
+/**
+ * Bentuk hasil pencarian terstandar.
+ *
+ * @template TDto
+ * @param {TDto[]} items - read DTO/projection (BUKAN entity domain)
+ * @param {{ page: number; pageSize: number; total: number }} meta
+ * @returns {{ items: TDto[]; page: number; pageSize: number; total: number; totalPages: number }}
+ */
+export function buildSearchResult(items, { page, pageSize, total }) {
+  const safeTotal = Number.isFinite(total) && total >= 0 ? total : items.length;
+  return {
+    items,
+    page,
+    pageSize,
+    total: safeTotal,
+    totalPages: pageSize > 0 ? Math.ceil(safeTotal / pageSize) : 0,
+  };
+}

--- a/src/search/users-search.mjs
+++ b/src/search/users-search.mjs
@@ -1,0 +1,97 @@
+/**
+ * Query service pencarian users (CQRS-lite, ADR-023) — READ-ONLY.
+ *
+ * Mengembalikan read DTO/projection (BUKAN entity domain): field sensitif
+ * (`password_hash`, dll) tidak pernah dikembalikan. Tidak memanggil command
+ * repository & tidak melakukan mutasi.
+ *
+ * RLS (ADR-015) tetap berlaku melalui koneksi ber-konteks; masking di sini =
+ * lapis tambahan (proyeksi kolom aman).
+ */
+
+import { getDatabase } from "../db/index.mjs";
+import { normalizeSearchQuery, buildSearchResult } from "./query-contract.mjs";
+
+/** Kolom proyeksi aman — TIDAK termasuk password_hash atau data sensitif lain. */
+export const USER_SEARCH_COLUMNS = [
+  "id",
+  "email",
+  "username",
+  "display_name",
+  "status",
+  "is_protected",
+  "created_at",
+];
+
+/** Field yang boleh dipakai untuk sort (whitelist, anti-injection). */
+export const USER_SEARCH_SORT_FIELDS = ["created_at", "email", "username", "display_name"];
+
+/** Kolom yang dicari saat `q` diberikan (trigram/ILIKE-friendly). */
+const USER_SEARCH_MATCH_COLUMNS = ["email", "username", "display_name"];
+
+/**
+ * Petakan baris DB → read DTO. Pure & defensif: hanya kolom proyeksi,
+ * jaminan tidak membocorkan field sensitif walau baris membawa lebih.
+ *
+ * @param {Record<string, unknown>} row
+ */
+export function toUserSearchDto(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    email: row.email,
+    username: row.username ?? null,
+    displayName: row.display_name ?? null,
+    status: row.status ?? null,
+    isProtected: Boolean(row.is_protected),
+    createdAt: row.created_at ?? null,
+  };
+}
+
+/**
+ * Cari users (read-only). Mengembalikan SearchResult berisi read DTO.
+ *
+ * @param {object} [input] - lihat normalizeSearchQuery
+ * @param {object} [deps]
+ * @param {import("kysely").Kysely<unknown>} [deps.db]
+ */
+export async function searchUsers(input = {}, deps = {}) {
+  const db = deps.db ?? getDatabase();
+  const query = normalizeSearchQuery(input, { allowedSortFields: USER_SEARCH_SORT_FIELDS });
+
+  // Predikat dasar: hanya baris aktif (soft-delete guard).
+  const applyFilters = (qb) => {
+    let next = qb.where("deleted_at", "is", null);
+    if (query.q) {
+      const pattern = `%${query.q}%`;
+      next = next.where((eb) =>
+        eb.or(USER_SEARCH_MATCH_COLUMNS.map((col) => eb(col, "ilike", pattern))),
+      );
+    }
+    if (typeof query.filters.status === "string") {
+      next = next.where("status", "=", query.filters.status);
+    }
+    return next;
+  };
+
+  // Total (count) — query terpisah pada predikat yang sama.
+  const countRow = await applyFilters(db.selectFrom("users"))
+    .select((eb) => eb.fn.countAll().as("count"))
+    .executeTakeFirst();
+  const total = Number(countRow?.count ?? 0);
+
+  // Halaman data dengan proyeksi aman + sort whitelist + paginasi.
+  const rows = await applyFilters(db.selectFrom("users"))
+    .select(USER_SEARCH_COLUMNS)
+    .orderBy(query.sort.field, query.sort.dir)
+    .orderBy("id", "asc") // tie-breaker deterministik
+    .limit(query.pageSize)
+    .offset(query.offset)
+    .execute();
+
+  return buildSearchResult(rows.map(toUserSearchDto), {
+    page: query.page,
+    pageSize: query.pageSize,
+    total,
+  });
+}

--- a/tests/unit/search-query-contract.test.mjs
+++ b/tests/unit/search-query-contract.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  normalizeSearchQuery,
+  buildSearchResult,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+} from "../../src/search/query-contract.mjs";
+
+test("query-contract: default page=1, pageSize=20, sort created_at desc", () => {
+  const q = normalizeSearchQuery({});
+  assert.equal(q.page, 1);
+  assert.equal(q.pageSize, DEFAULT_PAGE_SIZE);
+  assert.equal(q.offset, 0);
+  assert.deepEqual(q.sort, { field: "created_at", dir: "desc" });
+  assert.equal(q.q, null);
+});
+
+test("query-contract: q di-trim; kosong → null", () => {
+  assert.equal(normalizeSearchQuery({ q: "  budi " }).q, "budi");
+  assert.equal(normalizeSearchQuery({ q: "   " }).q, null);
+});
+
+test("query-contract: pageSize dibatasi maks 100", () => {
+  assert.equal(normalizeSearchQuery({ pageSize: 9999 }).pageSize, MAX_PAGE_SIZE);
+  assert.equal(normalizeSearchQuery({ pageSize: 0 }).pageSize, 1);
+  assert.equal(normalizeSearchQuery({ pageSize: 50 }).pageSize, 50);
+});
+
+test("query-contract: offset dihitung dari page & pageSize", () => {
+  const q = normalizeSearchQuery({ page: 3, pageSize: 25 });
+  assert.equal(q.offset, 50);
+});
+
+test("query-contract: page minimal 1 (negatif/0 → 1)", () => {
+  assert.equal(normalizeSearchQuery({ page: -5 }).page, 1);
+  assert.equal(normalizeSearchQuery({ page: 0 }).page, 1);
+});
+
+test("query-contract: sort field di-whitelist (anti-injection)", () => {
+  // field tak diizinkan → fallback ke default
+  const q1 = normalizeSearchQuery({ sort: { field: "password_hash; drop table", dir: "asc" } });
+  assert.equal(q1.sort.field, "created_at");
+  // field diizinkan → dipakai
+  const q2 = normalizeSearchQuery({ sort: { field: "email", dir: "asc" } }, { allowedSortFields: ["email", "created_at"] });
+  assert.deepEqual(q2.sort, { field: "email", dir: "asc" });
+});
+
+test("query-contract: dir hanya asc/desc (default desc)", () => {
+  assert.equal(normalizeSearchQuery({ sort: { field: "created_at", dir: "weird" } }).sort.dir, "desc");
+  assert.equal(normalizeSearchQuery({ sort: { field: "created_at", dir: "asc" } }).sort.dir, "asc");
+});
+
+test("query-contract: buildSearchResult menghitung totalPages", () => {
+  const r = buildSearchResult([{ id: 1 }], { page: 1, pageSize: 20, total: 41 });
+  assert.equal(r.total, 41);
+  assert.equal(r.totalPages, 3);
+  assert.equal(r.page, 1);
+  assert.equal(r.pageSize, 20);
+  assert.deepEqual(r.items, [{ id: 1 }]);
+});
+
+test("query-contract: buildSearchResult total invalid → fallback ke jumlah items", () => {
+  const r = buildSearchResult([{ id: 1 }, { id: 2 }], { page: 1, pageSize: 20, total: NaN });
+  assert.equal(r.total, 2);
+});

--- a/tests/unit/users-search-trgm-migration.test.mjs
+++ b/tests/unit/users-search-trgm-migration.test.mjs
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { up, down } from "../../src/db/migrations/041_users_search_trgm_index.mjs";
+
+test("trgm migration 041: up & down diekspor sebagai function", () => {
+  assert.equal(typeof up, "function");
+  assert.equal(typeof down, "function");
+});
+
+test("trgm migration 041: up mengaktifkan pg_trgm + GIN index untuk kolom search", async () => {
+  const executed = [];
+  const fakeDb = {};
+  // Tangkap SQL yang dieksekusi via stub `sql` — di sini kita uji lewat pemanggilan nyata
+  // dengan executor stub yang merekam string. Karena migrasi memakai tagged template &
+  // sql.raw, kita verifikasi idempotensi marker pada sumbernya.
+  const src = await import("node:fs").then((fs) =>
+    fs.promises.readFile(new URL("../../src/db/migrations/041_users_search_trgm_index.mjs", import.meta.url), "utf8"),
+  );
+  assert.match(src, /create extension if not exists pg_trgm/);
+  for (const col of ["email", "username", "display_name"]) {
+    assert.match(src, new RegExp(`users_\\$\\{column\\}_trgm_idx|users_${col}_trgm_idx`));
+  }
+  assert.match(src, /gin_trgm_ops/);
+  assert.match(src, /if not exists/); // idempoten
+  void executed;
+  void fakeDb;
+});
+
+test("trgm migration 041: down memakai drop index if exists (aman) & tidak drop ekstensi", async () => {
+  const src = await import("node:fs").then((fs) =>
+    fs.promises.readFile(new URL("../../src/db/migrations/041_users_search_trgm_index.mjs", import.meta.url), "utf8"),
+  );
+  assert.match(src, /drop index if exists/);
+  assert.doesNotMatch(src, /drop extension/);
+});

--- a/tests/unit/users-search.test.mjs
+++ b/tests/unit/users-search.test.mjs
@@ -1,0 +1,121 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  searchUsers,
+  toUserSearchDto,
+  USER_SEARCH_COLUMNS,
+  USER_SEARCH_SORT_FIELDS,
+} from "../../src/search/users-search.mjs";
+
+// Stub Kysely-like query builder: merekam paginasi/sort & mengembalikan rows canned.
+// Callback `where((eb) => ...)` diabaikan (tidak crash); SQL ILIKE nyata diuji di integrasi.
+function createStubDb({ rows = [], count = 0 } = {}) {
+  const captured = { selectArgs: [], orderBy: [], limit: null, offset: null, fromTables: [] };
+  function makeQb() {
+    const qb = {
+      where() {
+        return qb;
+      },
+      select(arg) {
+        captured.selectArgs.push(arg);
+        return qb;
+      },
+      orderBy(field, dir) {
+        captured.orderBy.push([field, dir]);
+        return qb;
+      },
+      limit(n) {
+        captured.limit = n;
+        return qb;
+      },
+      offset(n) {
+        captured.offset = n;
+        return qb;
+      },
+      async executeTakeFirst() {
+        return { count };
+      },
+      async execute() {
+        return rows;
+      },
+    };
+    return qb;
+  }
+  return {
+    db: {
+      selectFrom(table) {
+        captured.fromTables.push(table);
+        return makeQb();
+      },
+    },
+    captured,
+  };
+}
+
+test("users-search: USER_SEARCH_COLUMNS TIDAK mengandung password_hash", () => {
+  assert.ok(!USER_SEARCH_COLUMNS.includes("password_hash"), "proyeksi tidak boleh expose password_hash");
+  assert.ok(USER_SEARCH_COLUMNS.includes("id") && USER_SEARCH_COLUMNS.includes("email"));
+});
+
+test("users-search: toUserSearchDto membuang field sensitif walau row membawanya", () => {
+  const dto = toUserSearchDto({
+    id: "u1",
+    email: "a@b.com",
+    username: "budi",
+    display_name: "Budi",
+    status: "active",
+    is_protected: true,
+    created_at: "2026-01-01T00:00:00.000Z",
+    password_hash: "$2b$RAHASIA",
+    data: { secret: "x" },
+  });
+  assert.equal(dto.id, "u1");
+  assert.equal(dto.email, "a@b.com");
+  assert.equal(dto.displayName, "Budi");
+  assert.equal(dto.isProtected, true);
+  assert.ok(!("password_hash" in dto), "DTO tidak boleh punya password_hash");
+  assert.ok(!("passwordHash" in dto), "DTO tidak boleh punya passwordHash");
+  assert.ok(!("data" in dto), "DTO tidak boleh membocorkan kolom data");
+});
+
+test("users-search: toUserSearchDto(null) → null", () => {
+  assert.equal(toUserSearchDto(null), undefined ?? null);
+});
+
+test("users-search: searchUsers mengembalikan DTO tanpa password_hash + meta paginasi", async () => {
+  const { db } = createStubDb({
+    rows: [
+      { id: "u1", email: "a@b.com", username: "budi", display_name: "Budi", status: "active", is_protected: false, created_at: "2026-01-01T00:00:00.000Z", password_hash: "$2b$LEAK" },
+    ],
+    count: 41,
+  });
+
+  const result = await searchUsers({ q: "budi", page: 2, pageSize: 20 }, { db });
+
+  assert.equal(result.total, 41);
+  assert.equal(result.page, 2);
+  assert.equal(result.pageSize, 20);
+  assert.equal(result.totalPages, 3);
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0].email, "a@b.com");
+  assert.ok(!("password_hash" in result.items[0]), "hasil search tidak boleh bocor password_hash");
+});
+
+test("users-search: paginasi (offset) & sort tie-breaker diterapkan", async () => {
+  const { db, captured } = createStubDb({ rows: [], count: 0 });
+  await searchUsers({ page: 3, pageSize: 10, sort: { field: "email", dir: "asc" } }, { db });
+
+  assert.equal(captured.limit, 10);
+  assert.equal(captured.offset, 20); // (3-1)*10
+  // orderBy dipanggil: field utama (email asc) lalu tie-breaker id asc
+  assert.deepEqual(captured.orderBy[0], ["email", "asc"]);
+  assert.deepEqual(captured.orderBy[1], ["id", "asc"]);
+});
+
+test("users-search: sort field di luar whitelist → fallback created_at", async () => {
+  const { db, captured } = createStubDb({ rows: [], count: 0 });
+  await searchUsers({ sort: { field: "password_hash", dir: "asc" } }, { db });
+  assert.equal(captured.orderBy[0][0], "created_at");
+  assert.ok(USER_SEARCH_SORT_FIELDS.includes("email") && !USER_SEARCH_SORT_FIELDS.includes("password_hash"));
+});


### PR DESCRIPTION
## Summary

Implementasi **CQRS-lite untuk pencarian** (ADR-023) — query side (baca) terpisah dari command side (tulis), dengan pembukti `users-search`.

- `src/search/query-contract.mjs` — `normalizeSearchQuery` (paginasi default 20/maks 100, offset, **sort whitelist anti-injection**) + `buildSearchResult` (total/totalPages).
- `src/search/users-search.mjs` — `searchUsers` **READ-ONLY**: proyeksi DTO aman (`USER_SEARCH_COLUMNS` **tanpa `password_hash`**), `toUserSearchDto` membuang field sensitif, ILIKE multi-kolom, sort whitelist + tie-breaker `id`, count terpisah. **Tidak memanggil command repository, tidak mutasi.**
- `src/db/migrations/041_users_search_trgm_index.mjs` — `pg_trgm` + GIN trigram index (email/username/display_name) agar ILIKE tidak full scan.
- 18 unit test (query-contract 9, users-search 6, migrasi 3) — semua pass.

## Properness (mengapa CQRS-lite)
- **Pemisahan read/write**: `src/search/` (query) vs `src/db/repositories/` (command).
- **Read DTO/projection**, bukan entity domain → tidak bocor kolom sensitif.
- **PostgreSQL native**: trigram index untuk pencarian partial/fuzzy.
- **Tanpa over-engineering**: satu PostgreSQL, tanpa event sourcing; read replica/search engine = opsional kemudian di balik kontrak query yang sama.

## Keamanan (ADR-015 + klasifikasi)
- RLS tetap berlaku via koneksi ber-konteks.
- DTO + proyeksi = lapis masking tambahan: `password_hash`/`data` **tidak pernah** keluar dari search (diuji eksplisit walau row stub membawa `password_hash`).
- Sort field di-whitelist → cegah injeksi nama kolom.

## Test plan
- [x] 18/18 pass (`search-query-contract`, `users-search`, `users-search-trgm-migration`).
- [x] `USER_SEARCH_COLUMNS` & `toUserSearchDto` terbukti tidak expose `password_hash`/`data`.
- [x] Paginasi (offset), sort whitelist + tie-breaker, total/totalPages benar.
- [ ] Integrasi ILIKE + trigram index via DB nyata (saat CI/DB tersedia).

## Catatan
- Migrasi `041` (gap setelah `040` RLS di PR #324) — runner berbasis nama, gap aman.
- Lockfile `main` (pnpm); pino tidak terkait. Pola siap diperluas ke modul lain (SIKESRA/SatuSehat dengan masking ketat) — Tahap 3.

Selaras ADR-023/DL-021. Referensi: personal-coding `docs/architecture/awcms-cqrs-search.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)