### PR TITLE
[MINI] fix: loadAllPlugins injectable plugins (perbaiki test loader pasca-merge)

### DIFF
--- a/src/plugins/loader.mjs
+++ b/src/plugins/loader.mjs
@@ -43,12 +43,13 @@ const ACTIVE_PLUGINS = [
  * 3. Seed permission ke DB (idempotent)
  * 4. Jalankan migration plugin jika pluginModule.migrate tersedia
  *
- * @param {{ db?: import("kysely").Kysely<unknown> }} [options]
+ * @param {{ db?: import("kysely").Kysely<unknown>; plugins?: Array<{ getManifest: Function; getModule: Function }> }} [options]
+ *   plugins di-inject untuk testing; default = ACTIVE_PLUGINS.
  */
-export async function loadAllPlugins({ db } = {}) {
+export async function loadAllPlugins({ db, plugins = ACTIVE_PLUGINS } = {}) {
   const database = db ?? getDatabase();
 
-  for (const { getManifest, getModule } of ACTIVE_PLUGINS) {
+  for (const { getManifest, getModule } of plugins) {
     const manifestMod = await getManifest();
     const manifest = manifestMod.default ?? manifestMod;
 

--- a/tests/unit/plugin-loader.test.mjs
+++ b/tests/unit/plugin-loader.test.mjs
@@ -2,21 +2,50 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { loadAllPlugins } from "../../src/plugins/loader.mjs";
-import { listPlugins, clearRegistry } from "../../src/plugins/registry.mjs";
+import { listPlugins, clearRegistry, getPlugin } from "../../src/plugins/registry.mjs";
 
 test.afterEach(() => {
   clearRegistry();
 });
 
-test("plugin loader: loadAllPlugins dengan ACTIVE_PLUGINS kosong tidak error", async () => {
-  // ACTIVE_PLUGINS kosong (belum ada plugin SIKESRA/SatuSehat) — harus selesai tanpa error
+test("plugin loader: loadAllPlugins dengan daftar plugin kosong tidak error", async () => {
+  // plugins diinject kosong — independen dari ACTIVE_PLUGINS nyata
   await assert.doesNotReject(
-    loadAllPlugins({ db: null }),
-    "loadAllPlugins dengan ACTIVE_PLUGINS kosong harus selesai tanpa error",
+    loadAllPlugins({ db: null, plugins: [] }),
+    "loadAllPlugins dengan plugins kosong harus selesai tanpa error",
   );
 });
 
-test("plugin loader: loadAllPlugins dengan ACTIVE_PLUGINS kosong tidak mendaftarkan plugin", async () => {
-  await loadAllPlugins({ db: null });
+test("plugin loader: loadAllPlugins dengan plugins kosong tidak mendaftarkan plugin", async () => {
+  await loadAllPlugins({ db: null, plugins: [] });
   assert.deepEqual(listPlugins(), [], "Harus tidak ada plugin terdaftar");
+});
+
+test("plugin loader: loadAllPlugins mendaftarkan plugin yang diinject", async () => {
+  const manifest = {
+    id: "loader-test-plugin",
+    name: "Loader Test",
+    version: "0.1.0",
+    kind: "awcms-mini-plugin",
+    appliesTo: ["awcms-mini"],
+    permissions: [],
+    data: { adapter: "postgres", schema: "loader_test", rls: "required" },
+    audit: { required: false, events: [] },
+  };
+  let migrated = false;
+  const pluginModule = {
+    migrate: async () => {
+      migrated = true;
+    },
+  };
+
+  // db stub minimal untuk seedPluginPermissions (permissions kosong → tidak menyentuh db)
+  const dbStub = {};
+  await loadAllPlugins({
+    db: dbStub,
+    plugins: [{ getManifest: async () => manifest, getModule: async () => pluginModule }],
+  });
+
+  assert.ok(getPlugin("loader-test-plugin"), "plugin terdaftar di registry");
+  assert.equal(migrated, true, "migrate() plugin dipanggil");
 });


### PR DESCRIPTION
Perbaiki 2 test loader yang gagal di main setelah #322/#323 mengisi ACTIVE_PLUGINS. `loadAllPlugins({ db, plugins = ACTIVE_PLUGINS })` — inject untuk test (default ACTIVE_PLUGINS untuk runtime). 11/11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)