### PR TITLE
[MINI][SEQ-17] feat: CQRS Tahap 3 — search SIKESRA subjects (masking ketat) (ADR-023)

### DIFF
--- a/src/plugins/sikesra/search/subjects-search.mjs
+++ b/src/plugins/sikesra/search/subjects-search.mjs
@@ -1,0 +1,93 @@
+/**
+ * Query service pencarian SIKESRA subjects (CQRS-lite, ADR-023) — READ-ONLY,
+ * **masking ketat** karena data highly_restricted.
+ *
+ * Aturan keras:
+ * - NIK (`nik_enc`) dan `metadata` **TIDAK PERNAH** dikembalikan dari pencarian.
+ * - Caller WAJIB punya permission `awcms:sikesra:subject:read` dan **mengaudit**
+ *   pencarian (data sensitif) — lihat parameter `onAudit`.
+ * - RLS (ADR-015) tetap berlaku via koneksi ber-konteks.
+ *
+ * Lihat personal-coding `docs/architecture/awcms-cqrs-search.md` §3 (keamanan).
+ */
+
+import { getDatabase } from "../../../db/index.mjs";
+import { normalizeSearchQuery, buildSearchResult } from "../../../search/query-contract.mjs";
+
+const SCHEMA = "sikesra";
+const TABLE = "subjects";
+
+/** Proyeksi aman — TANPA nik_enc & metadata (highly_restricted). */
+export const SUBJECT_SEARCH_COLUMNS = ["id", "full_name", "gender", "classification", "created_at"];
+
+/** Field sort yang diizinkan (whitelist). */
+export const SUBJECT_SEARCH_SORT_FIELDS = ["created_at", "full_name"];
+
+/** Kolom yang dicari saat `q` diberikan. (Hanya full_name — bukan NIK.) */
+const SUBJECT_SEARCH_MATCH_COLUMNS = ["full_name"];
+
+/**
+ * Petakan baris → DTO aman. Defensif: buang nik_enc & metadata walau row membawanya.
+ */
+export function toSubjectSearchDto(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    fullName: row.full_name ?? null,
+    gender: row.gender ?? null,
+    classification: row.classification ?? "highly_restricted",
+    createdAt: row.created_at ?? null,
+  };
+}
+
+/**
+ * Cari SIKESRA subjects (read-only, masking ketat).
+ *
+ * @param {object} [input] - lihat normalizeSearchQuery
+ * @param {object} [deps]
+ * @param {import("kysely").Kysely<unknown>} [deps.db]
+ * @param {(info: { q: string|null; count: number }) => (void|Promise<void>)} [deps.onAudit]
+ *   Hook audit WAJIB diisi caller untuk mencatat pencarian data sensitif.
+ */
+export async function searchSubjects(input = {}, deps = {}) {
+  const db = deps.db ?? getDatabase();
+  const query = normalizeSearchQuery(input, { allowedSortFields: SUBJECT_SEARCH_SORT_FIELDS });
+
+  const applyFilters = (qb) => {
+    let next = qb.where("deleted_at", "is", null);
+    if (query.q) {
+      const pattern = `%${query.q}%`;
+      next = next.where((eb) =>
+        eb.or(SUBJECT_SEARCH_MATCH_COLUMNS.map((col) => eb(col, "ilike", pattern))),
+      );
+    }
+    if (typeof query.filters.gender === "string") {
+      next = next.where("gender", "=", query.filters.gender);
+    }
+    return next;
+  };
+
+  const countRow = await applyFilters(db.withSchema(SCHEMA).selectFrom(TABLE))
+    .select((eb) => eb.fn.countAll().as("count"))
+    .executeTakeFirst();
+  const total = Number(countRow?.count ?? 0);
+
+  const rows = await applyFilters(db.withSchema(SCHEMA).selectFrom(TABLE))
+    .select(SUBJECT_SEARCH_COLUMNS)
+    .orderBy(query.sort.field, query.sort.dir)
+    .orderBy("id", "asc")
+    .limit(query.pageSize)
+    .offset(query.offset)
+    .execute();
+
+  // Audit pencarian data sensitif (caller menyediakan hook).
+  if (typeof deps.onAudit === "function") {
+    await deps.onAudit({ q: query.q, count: total });
+  }
+
+  return buildSearchResult(rows.map(toSubjectSearchDto), {
+    page: query.page,
+    pageSize: query.pageSize,
+    total,
+  });
+}

--- a/tests/unit/sikesra-subjects-search.test.mjs
+++ b/tests/unit/sikesra-subjects-search.test.mjs
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  searchSubjects,
+  toSubjectSearchDto,
+  SUBJECT_SEARCH_COLUMNS,
+  SUBJECT_SEARCH_SORT_FIELDS,
+} from "../../src/plugins/sikesra/search/subjects-search.mjs";
+
+function createStubDb({ rows = [], count = 0 } = {}) {
+  const captured = { schema: null, orderBy: [], limit: null, offset: null };
+  function makeQb() {
+    const qb = {
+      where() {
+        return qb;
+      },
+      select() {
+        return qb;
+      },
+      orderBy(field, dir) {
+        captured.orderBy.push([field, dir]);
+        return qb;
+      },
+      limit(n) {
+        captured.limit = n;
+        return qb;
+      },
+      offset(n) {
+        captured.offset = n;
+        return qb;
+      },
+      async executeTakeFirst() {
+        return { count };
+      },
+      async execute() {
+        return rows;
+      },
+    };
+    return qb;
+  }
+  return {
+    db: {
+      withSchema(schema) {
+        captured.schema = schema;
+        return { selectFrom: () => makeQb() };
+      },
+    },
+    captured,
+  };
+}
+
+test("sikesra-search: SUBJECT_SEARCH_COLUMNS TIDAK mengandung nik_enc/metadata", () => {
+  assert.ok(!SUBJECT_SEARCH_COLUMNS.includes("nik_enc"), "tidak boleh expose nik_enc");
+  assert.ok(!SUBJECT_SEARCH_COLUMNS.includes("metadata"), "tidak boleh expose metadata");
+  assert.ok(SUBJECT_SEARCH_COLUMNS.includes("id") && SUBJECT_SEARCH_COLUMNS.includes("full_name"));
+});
+
+test("sikesra-search: toSubjectSearchDto membuang nik_enc & metadata walau row membawanya", () => {
+  const dto = toSubjectSearchDto({
+    id: "s1",
+    full_name: "Budi Santoso",
+    gender: "M",
+    classification: "highly_restricted",
+    created_at: "2026-01-01T00:00:00.000Z",
+    nik_enc: "ENCRYPTED_NIK_LEAK",
+    metadata: { secret: "x" },
+  });
+  assert.equal(dto.id, "s1");
+  assert.equal(dto.fullName, "Budi Santoso");
+  assert.ok(!("nik_enc" in dto), "DTO tidak boleh punya nik_enc");
+  assert.ok(!("nikEnc" in dto), "DTO tidak boleh punya nikEnc");
+  assert.ok(!("metadata" in dto), "DTO tidak boleh punya metadata");
+});
+
+test("sikesra-search: searchSubjects memakai schema sikesra + DTO tanpa NIK", async () => {
+  const { db, captured } = createStubDb({
+    rows: [{ id: "s1", full_name: "Budi", gender: "M", classification: "highly_restricted", created_at: "2026-01-01T00:00:00.000Z", nik_enc: "LEAK", metadata: { a: 1 } }],
+    count: 5,
+  });
+  const result = await searchSubjects({ q: "budi", page: 1, pageSize: 20 }, { db });
+
+  assert.equal(captured.schema, "sikesra");
+  assert.equal(result.total, 5);
+  assert.equal(result.items.length, 1);
+  assert.ok(!("nik_enc" in result.items[0]), "hasil search tidak boleh bocor nik_enc");
+  assert.ok(!("metadata" in result.items[0]), "hasil search tidak boleh bocor metadata");
+});
+
+test("sikesra-search: onAudit dipanggil dengan q & count (audit data sensitif)", async () => {
+  const { db } = createStubDb({ rows: [], count: 3 });
+  let audited = null;
+  await searchSubjects({ q: "x" }, { db, onAudit: (info) => { audited = info; } });
+  assert.deepEqual(audited, { q: "x", count: 3 });
+});
+
+test("sikesra-search: sort field di luar whitelist → fallback created_at", async () => {
+  const { db, captured } = createStubDb({ rows: [], count: 0 });
+  await searchSubjects({ sort: { field: "nik_enc", dir: "asc" } }, { db });
+  assert.equal(captured.orderBy[0][0], "created_at");
+  assert.ok(!SUBJECT_SEARCH_SORT_FIELDS.includes("nik_enc"));
+});


### PR DESCRIPTION
## Summary
Perluasan CQRS-lite ke data **highly_restricted** (SIKESRA), Tahap 3 (ADR-023 §3).

- `src/plugins/sikesra/search/subjects-search.mjs` — `searchSubjects` READ-ONLY:
  - Proyeksi `SUBJECT_SEARCH_COLUMNS` **tanpa `nik_enc` & `metadata`**.
  - `toSubjectSearchDto` membuang field sensitif (defensif).
  - Cari hanya by `full_name` (bukan NIK); schema `sikesra`; soft-delete guard.
  - Hook `onAudit` WAJIB diisi caller → audit pencarian data sensitif.
- 5 test, semua pass.

## Keamanan (masking ketat)
- NIK (`nik_enc`) & `metadata` **tidak pernah** keluar dari pencarian (diuji walau row membawanya).
- Sort field di-whitelist; RLS (ADR-015) tetap via koneksi ber-konteks.
- Caller WAJIB: permission `awcms:sikesra:subject:read` + audit (hook disediakan).

## Test plan
- [x] 5/5 pass: DTO tanpa nik_enc/metadata, schema sikesra, onAudit count, sort whitelist.
- [ ] Integrasi DB nyata + audit service wiring (saat endpoint dibuat).

Selaras ADR-023. Kontrak query bersama `src/search/query-contract.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)