### PR TITLE
[MINI][SEQ-10] feat: seam src/cms + alihkan import emdash runtime (Fase 2 decoupling, #329)

### DIFF
--- a/src/auth/middleware-entry.mjs
+++ b/src/auth/middleware-entry.mjs
@@ -1,5 +1,6 @@
 import { defineMiddleware } from "astro:middleware";
-import { runWithContext } from "emdash";
+
+import { runWithContext } from "../cms/context.mjs";
 
 import { redirectAdminEntryAlias, redirectAdminHostEntry } from "./admin-host-routing.mjs";
 

--- a/src/cms/README.md
+++ b/src/cms/README.md
@@ -1,0 +1,22 @@
+# `src/cms/` — Seam Kontrak Internal (decoupling EmDash, ADR-020)
+
+Lapisan **seam** (pola *strangler fig*) yang membungkus kapabilitas yang saat ini
+berasal dari paket `emdash`, agar kode aplikasi `awcms-mini` **tidak mengimpor
+`emdash` secara langsung**.
+
+## Aturan (Fase 2 epic #327)
+
+- Kode di luar `src/cms/` (dan `astro.config.mjs`) **DILARANG** `import ... from "emdash"`.
+- Semua kebutuhan runtime EmDash diakses lewat seam ini.
+- Saat penggantian native siap (Fase 3–5), **implementasi di balik seam ditukar**
+  tanpa mengubah call-site.
+
+## Isi
+
+| Modul | Menyediakan | Sumber sekarang | Pengganti (fase) |
+|---|---|---|---|
+| `context.mjs` | `runWithContext` | `emdash` | helper konteks native (Fase 2/4) |
+| `plugin-runtime.mjs` | `definePlugin`, `PluginRouteError` | `emdash` | registry/loader + tipe error native (#318, Fase 3) |
+
+> Rujukan: personal-coding `docs/architecture/awcms-mini-emdash-decoupling-plan.md`,
+> `docs/architecture/emdash-touchpoint-inventory.md` (di repo ini), ADR-020.

--- a/src/cms/context.mjs
+++ b/src/cms/context.mjs
@@ -1,0 +1,10 @@
+/**
+ * Seam konteks request (decoupling EmDash, ADR-020 Fase 2).
+ *
+ * Membungkus `runWithContext` dari EmDash agar kode app tidak mengimpor `emdash`
+ * langsung. Saat helper konteks native siap (AsyncLocalStorage), implementasi di
+ * balik seam ini ditukar tanpa mengubah call-site.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- satu-satunya tempat boleh impor emdash (seam)
+export { runWithContext } from "emdash";

--- a/src/cms/plugin-runtime.mjs
+++ b/src/cms/plugin-runtime.mjs
@@ -1,0 +1,11 @@
+/**
+ * Seam runtime plugin (decoupling EmDash, ADR-020 Fase 2).
+ *
+ * Membungkus `definePlugin` & `PluginRouteError` dari EmDash agar kode plugin
+ * tidak mengimpor `emdash` langsung. Pada Fase 3 (#318), `definePlugin` diganti
+ * registry/loader native dan `PluginRouteError` diganti tipe error native —
+ * cukup menukar implementasi di balik seam ini.
+ */
+
+// eslint-disable-next-line no-restricted-imports -- satu-satunya tempat boleh impor emdash (seam)
+export { definePlugin, PluginRouteError } from "emdash";

--- a/src/plugins/awcms-users-admin/index.mjs
+++ b/src/plugins/awcms-users-admin/index.mjs
@@ -1,4 +1,4 @@
-import { definePlugin, PluginRouteError } from "emdash";
+import { definePlugin, PluginRouteError } from "../../cms/plugin-runtime.mjs";
 
 import { getDatabase } from "../../db/index.mjs";
 import { createAdministrativeRegionRepository } from "../../db/repositories/administrative-regions.mjs";

--- a/src/plugins/internal-governance-sample/index.mjs
+++ b/src/plugins/internal-governance-sample/index.mjs
@@ -1,4 +1,4 @@
-import { definePlugin, PluginRouteError } from "emdash";
+import { definePlugin, PluginRouteError } from "../../cms/plugin-runtime.mjs";
 
 import { collectRegisteredPluginPermissions } from "../permission-registration.mjs";
 import { createAuthorizedPluginRoute } from "../route-authorization.mjs";

--- a/src/plugins/route-authorization.mjs
+++ b/src/plugins/route-authorization.mjs
@@ -1,4 +1,4 @@
-import { PluginRouteError } from "emdash";
+import { PluginRouteError } from "../cms/plugin-runtime.mjs";
 import { createPluginServiceAuthorizationHelper } from "./service-authorization.mjs";
 
 function createPermissionIndex(permissions) {

--- a/tests/unit/cms-seam.test.mjs
+++ b/tests/unit/cms-seam.test.mjs
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { runWithContext } from "../../src/cms/context.mjs";
+import { definePlugin, PluginRouteError } from "../../src/cms/plugin-runtime.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const srcDir = join(__dirname, "../../src");
+
+test("cms-seam: context.mjs mengekspor runWithContext", () => {
+  assert.equal(typeof runWithContext, "function");
+});
+
+test("cms-seam: plugin-runtime.mjs mengekspor definePlugin & PluginRouteError", () => {
+  assert.equal(typeof definePlugin, "function");
+  assert.ok(PluginRouteError, "PluginRouteError harus terdefinisi");
+});
+
+// Guard Fase 2 (ADR-020): tidak boleh ada `import ... from "emdash"` di luar src/cms/.
+test("cms-seam: tidak ada import langsung 'from \"emdash\"' di luar src/cms/", () => {
+  const offenders = [];
+  function walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === "cms") continue; // seam dikecualikan
+        walk(full);
+        continue;
+      }
+      if (!/\.(mjs|js|ts|tsx)$/.test(entry.name)) continue;
+      const text = readFileSync(full, "utf8");
+      // hanya cocokkan import dari paket "emdash" persis (bukan "emdash/...")
+      if (/from\s+["']emdash["']/.test(text)) offenders.push(full.replace(srcDir, "src"));
+    }
+  }
+  walk(srcDir);
+  assert.deepEqual(offenders, [], `Import langsung 'emdash' harus lewat src/cms/ seam. Pelanggar: ${offenders.join(", ")}`);
+});


### PR DESCRIPTION
## Summary
Slice **aman** Fase 2 epic decoupling EmDash (#327/#329) — pola *strangler fig* (ADR-020): kode app tidak lagi mengimpor `emdash` langsung; semua lewat **seam `src/cms/`**. Implementasi di balik seam ditukar native pada Fase 3–5 tanpa mengubah call-site.

- `src/cms/context.mjs` — re-export `runWithContext`.
- `src/cms/plugin-runtime.mjs` — re-export `definePlugin`, `PluginRouteError`.
- `src/cms/README.md` — kontrak seam + aturan Fase 2.
- Alihkan **4 call-site**: `middleware-entry` (context), `route-authorization` + `awcms-users-admin` + `internal-governance-sample` (plugin-runtime).
- `tests/unit/cms-seam.test.mjs` — verifikasi ekspor + **guard fitness function**: "tidak ada `import ... from \"emdash\"` di luar `src/cms/`".

## Sifat
- **Perilaku identik** (re-export murni) — risiko minimal.
- Sisa `emdash/*` subpath (`live.config.ts`, `astro.config.mjs`, `admin.tsx`) = **Fase 4** (CMS/admin/config), di luar scope PR ini.

## Test plan
- [x] Test terdampak 24/24 pass (middleware-entry, route-authorization, 2 plugin).
- [x] Seam 3/3 pass termasuk guard "no direct emdash import outside src/cms/".

Bagian epic #327 / issue #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)