### PR TITLE
[MINI][SEQ-22] docs(api): OpenAPI untuk endpoint search (CQRS, ADR-023)

### DIFF
--- a/server/routes/openapi.mjs
+++ b/server/routes/openapi.mjs
@@ -22,6 +22,7 @@ function createOpenApiDocument() {
       { name: "storage", description: "R2-backed file upload and download metadata routes." },
       { name: "authorization", description: "RBAC and ABAC protected catalog routes." },
       { name: "security", description: "Two-factor enrollment and recovery routes." },
+      { name: "search", description: "CQRS query-side search routes (read-only, ADR-023)." },
     ],
     paths: {
       "/health": {
@@ -521,6 +522,66 @@ function createOpenApiDocument() {
           },
         },
       },
+      "/api/v1/search/users": {
+        get: {
+          tags: ["search"],
+          summary: "Search users (CQRS query side)",
+          description: "Read-only user search. Mengembalikan read DTO (tanpa password_hash). Butuh permission admin.users.read.",
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            { name: "q", in: "query", required: false, schema: { type: "string" }, description: "Kata kunci (ILIKE email/username/display_name)." },
+            { name: "page", in: "query", required: false, schema: { type: "integer", minimum: 1 }, description: "Halaman 1-based (default 1)." },
+            { name: "pageSize", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 100 }, description: "Ukuran halaman (default 20, maks 100)." },
+            { name: "sortField", in: "query", required: false, schema: { type: "string", enum: ["created_at", "email", "username", "display_name"] } },
+            { name: "sortDir", in: "query", required: false, schema: { type: "string", enum: ["asc", "desc"] } },
+          ],
+          responses: {
+            200: { description: "Search result.", content: { "application/json": { schema: createJsonSchemaRef("SearchEnvelope") } } },
+            401: { description: "Authentication required.", content: { "application/json": { schema: createJsonSchemaRef("ErrorEnvelope") } } },
+            403: { description: "Permission denied.", content: { "application/json": { schema: createJsonSchemaRef("ForbiddenEnvelope") } } },
+          },
+        },
+      },
+      "/api/v1/search/sikesra/subjects": {
+        get: {
+          tags: ["search"],
+          summary: "Search SIKESRA subjects (sensitive, audited)",
+          description: "Read-only. Data highly_restricted: DTO tanpa NIK. Butuh permission awcms:sikesra:subject:read. Pencarian diaudit.",
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            { name: "q", in: "query", required: false, schema: { type: "string" }, description: "Kata kunci (ILIKE full_name)." },
+            { name: "page", in: "query", required: false, schema: { type: "integer", minimum: 1 } },
+            { name: "pageSize", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 100 } },
+            { name: "sortField", in: "query", required: false, schema: { type: "string", enum: ["created_at", "full_name"] } },
+            { name: "sortDir", in: "query", required: false, schema: { type: "string", enum: ["asc", "desc"] } },
+          ],
+          responses: {
+            200: { description: "Search result (DTO tanpa NIK).", content: { "application/json": { schema: createJsonSchemaRef("SearchEnvelope") } } },
+            401: { description: "Authentication required.", content: { "application/json": { schema: createJsonSchemaRef("ErrorEnvelope") } } },
+            403: { description: "Permission denied.", content: { "application/json": { schema: createJsonSchemaRef("ForbiddenEnvelope") } } },
+          },
+        },
+      },
+      "/api/v1/search/satusehat/patients": {
+        get: {
+          tags: ["search"],
+          summary: "Search SatuSehat patients (sensitive, audited)",
+          description: "Read-only. Data restricted: DTO tanpa NIK & nilai IHS number (hanya hasIhs). Butuh permission awcms:satu_sehat_kobar:patient:read. Pencarian diaudit.",
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            { name: "q", in: "query", required: false, schema: { type: "string" }, description: "Kata kunci (ILIKE full_name)." },
+            { name: "page", in: "query", required: false, schema: { type: "integer", minimum: 1 } },
+            { name: "pageSize", in: "query", required: false, schema: { type: "integer", minimum: 1, maximum: 100 } },
+            { name: "sortField", in: "query", required: false, schema: { type: "string", enum: ["created_at", "full_name"] } },
+            { name: "sortDir", in: "query", required: false, schema: { type: "string", enum: ["asc", "desc"] } },
+          ],
+          responses: {
+            200: { description: "Search result (DTO tanpa NIK/IHS value).", content: { "application/json": { schema: createJsonSchemaRef("SearchEnvelope") } } },
+            401: { description: "Authentication required.", content: { "application/json": { schema: createJsonSchemaRef("ErrorEnvelope") } } },
+            403: { description: "Permission denied.", content: { "application/json": { schema: createJsonSchemaRef("ForbiddenEnvelope") } } },
+          },
+        },
+      },
       "/api/v1/security/2fa/setup": {
         post: {
           tags: ["security"],
@@ -937,6 +998,25 @@ function createOpenApiDocument() {
           required: ["data"],
           properties: {
             data: { type: "array", items: { type: "object", additionalProperties: true } },
+          },
+          additionalProperties: false,
+        },
+        SearchEnvelope: {
+          type: "object",
+          required: ["data"],
+          properties: {
+            data: {
+              type: "object",
+              required: ["items", "page", "pageSize", "total"],
+              properties: {
+                items: { type: "array", items: { type: "object", additionalProperties: true }, description: "Read DTO/projection (field sensitif tidak disertakan)." },
+                page: { type: "integer" },
+                pageSize: { type: "integer" },
+                total: { type: "integer" },
+                totalPages: { type: "integer" },
+              },
+              additionalProperties: false,
+            },
           },
           additionalProperties: false,
         },

--- a/tests/unit/openapi-search.test.mjs
+++ b/tests/unit/openapi-search.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { routeOpenApi } from "../../server/routes/openapi.mjs";
+
+async function getOpenApiDoc() {
+  const app = routeOpenApi();
+  const res = await app.fetch(new Request("http://localhost/openapi.json"));
+  assert.equal(res.status, 200);
+  return res.json();
+}
+
+test("openapi: mendokumentasikan 3 endpoint search (users/sikesra/satusehat)", async () => {
+  const doc = await getOpenApiDoc();
+  assert.ok(doc.paths["/api/v1/search/users"]?.get, "path search/users harus ada");
+  assert.ok(doc.paths["/api/v1/search/sikesra/subjects"]?.get, "path search/sikesra harus ada");
+  assert.ok(doc.paths["/api/v1/search/satusehat/patients"]?.get, "path search/satusehat harus ada");
+});
+
+test("openapi: endpoint search ber-tag 'search' + security bearerAuth + 403", async () => {
+  const doc = await getOpenApiDoc();
+  const op = doc.paths["/api/v1/search/users"].get;
+  assert.ok(op.tags.includes("search"));
+  assert.deepEqual(op.security, [{ bearerAuth: [] }]);
+  assert.ok(op.responses["403"], "harus dokumentasikan 403 (permission denied)");
+  assert.ok(op.responses["200"], "harus dokumentasikan 200");
+});
+
+test("openapi: endpoint search punya parameter q/page/pageSize/sort", async () => {
+  const doc = await getOpenApiDoc();
+  const names = doc.paths["/api/v1/search/users"].get.parameters.map((p) => p.name);
+  for (const n of ["q", "page", "pageSize", "sortField", "sortDir"]) {
+    assert.ok(names.includes(n), `parameter ${n} harus ada`);
+  }
+});
+
+test("openapi: schema SearchEnvelope terdefinisi (items/page/total)", async () => {
+  const doc = await getOpenApiDoc();
+  const schema = doc.components.schemas.SearchEnvelope;
+  assert.ok(schema, "SearchEnvelope harus terdefinisi");
+  const dataProps = schema.properties.data.properties;
+  for (const k of ["items", "page", "pageSize", "total"]) {
+    assert.ok(dataProps[k], `SearchEnvelope.data.${k} harus ada`);
+  }
+});
+
+test("openapi: tag 'search' terdaftar", async () => {
+  const doc = await getOpenApiDoc();
+  assert.ok(doc.tags.some((t) => t.name === "search"), "tag search harus terdaftar");
+});


### PR DESCRIPTION
## Summary
Endpoint search (CQRS) sudah ter-wire tapi belum di kontrak API. Tambah ke `server/routes/openapi.mjs`:
- Tag **search**; 3 path: `/api/v1/search/users`, `/api/v1/search/sikesra/subjects`, `/api/v1/search/satusehat/patients`.
- Parameter `q/page/pageSize/sortField/sortDir`; `security: bearerAuth`; responses 200/401/403.
- Deskripsi masking (DTO tanpa NIK/IHS) + catatan audit untuk endpoint sensitif.
- Schema `SearchEnvelope` (`items/page/pageSize/total/totalPages`).
- `tests/unit/openapi-search.test.mjs` — 5 test.

## Test plan
- [x] 5/5 openapi-search pass (path ada, tag, security+403, params, schema).
- [x] app.test 42/42 (`/openapi.json` tetap 200, doc valid).

Pure dokumentasi kontrak API; tidak mengubah perilaku endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)