### PR TITLE
[MINI][FIX] fix(docker): perbaiki build image Bun (toolchain native + .dockerignore) — Epik A1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Dependencies di-install di dalam image (stage deps) — jangan salin dari host.
+node_modules
+
+# VCS & CI
+.git
+.github
+
+# Build & runtime artifacts
+dist
+.astro
+.wrangler
+
+# Lockfile non-Bun & env lokal
+pnpm-lock.yaml
+package-lock.json
+.env
+.env.*
+.dev.vars
+.dev.vars.*
+
+# Editor / OS
+.vscode
+.idea
+.DS_Store
+
+# Test & coverage
+coverage
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 # Runtime utama AWCMS-Mini = Bun (ADR-019).
-# Base alpine/musl agar native module (transitif, mis. better-sqlite3 via emdash)
-# kompatibel dengan runtime alpine.
-FROM oven/bun:1-alpine
+#
+# Stage `deps`: install dependencies + kompilasi native module.
+# better-sqlite3 (transitif via emdash) tidak punya prebuilt untuk ABI Bun+musl,
+# sehingga node-gyp mengompilasinya dari source → butuh toolchain (python3/make/g++).
+# Toolchain hanya ada di stage ini agar image runtime tetap lean.
+FROM oven/bun:1-alpine AS deps
 
-RUN apk add --no-cache ca-certificates curl
+RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
 
@@ -13,6 +16,15 @@ COPY package.json bun.lock ./
 # --frozen-lockfile: gagal bila bun.lock tidak sinkron dengan package.json
 RUN bun install --production --frozen-lockfile
 
+# Stage runtime: base bun:1-alpine yang sama (musl-match) tanpa toolchain build.
+FROM oven/bun:1-alpine
+
+RUN apk add --no-cache ca-certificates curl
+
+WORKDIR /app
+
+# node_modules (termasuk better-sqlite3.node musl) dari stage deps.
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
**Verifikasi deploy Bun runtime (#326) via Docker nyata menemukan 2 deploy-blocker** — kini diperbaiki & terverifikasi.

### Bug 1 — better-sqlite3 gagal kompilasi di `oven/bun:1-alpine`
`better-sqlite3` (transitif via `emdash`) tak punya prebuilt untuk ABI Bun+musl → node-gyp kompilasi dari source → gagal (`gyp ERR! not ok`) karena alpine tak punya `python3/make/g++`.
**Fix:** Dockerfile **multi-stage** — toolchain (`apk add python3 make g++`) di stage `deps` untuk kompilasi; runtime stage `bun:1-alpine` tetap **lean** (tanpa toolchain); `node_modules` (better-sqlite3.node musl) disalin dari `deps`.

### Bug 2 — tidak ada `.dockerignore`
`COPY . .` menyalin `node_modules` host → bentrok dengan `node_modules` stage deps (`cannot replace directory ... with file`).
**Fix:** tambah `.dockerignore` (node_modules, .git, dist, lockfile non-bun, env, dst).

## Verifikasi NYATA (docker di environment build)
- ✅ `docker build` sukses — better-sqlite3 ter-compile untuk alpine/musl.
- ✅ `docker run` → log: **"AWCMS Mini API listening on port 3000"** (production, Bun).
- ✅ `GET /health` → **503** (server UP; hanya DB tak tersedia pada smoke — sesuai harapan).
- ✅ `better-sqlite3 *.node` hadir di image.

## Konteks
Epik **A1** dari `personal-coding/docs/concepts/awcms-runtime-epics-execution-guide.md` — gate **build + container start LULUS**. Sisa A2–A4 (PostgreSQL nyata + smoke alur + promote) butuh Coolify.

Tanpa fix ini, deploy image Bun (#326) **akan gagal build** di Coolify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)