### PR TITLE
[MINI][FIX] fix: wire plugin loader at startup + 3 bug deploy-verify (Epik A2)

### DIFF
--- a/scripts/check-rls-coverage.mjs
+++ b/scripts/check-rls-coverage.mjs
@@ -30,18 +30,21 @@ async function checkRlsCoverage() {
   const db = createDatabase();
 
   try {
-    // Query pg_tables + pg_policies untuk cek status RLS
+    // Cek status RLS via pg_class (relrowsecurity/relforcerowsecurity) — pg_tables
+    // hanya punya rowsecurity, BUKAN forcerowsecurity.
     const rlsStatus = await sql`
       select
-        schemaname as schema,
-        tablename as "table",
-        rowsecurity as rls_enabled,
-        forcerowsecurity as rls_forced
-      from pg_tables
-      where (schemaname, tablename) in (
-        select unnest(array[${sql.join(REQUIRED_RLS_TABLES.map((t) => t.schema), sql`, `)}]::text[]),
-               unnest(array[${sql.join(REQUIRED_RLS_TABLES.map((t) => t.table), sql`, `)}]::text[])
-      )
+        n.nspname as schema,
+        c.relname as "table",
+        c.relrowsecurity as rls_enabled,
+        c.relforcerowsecurity as rls_forced
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      where c.relkind = 'r'
+        and (n.nspname, c.relname) in (
+          select unnest(array[${sql.join(REQUIRED_RLS_TABLES.map((t) => t.schema), sql`, `)}]::text[]),
+                 unnest(array[${sql.join(REQUIRED_RLS_TABLES.map((t) => t.table), sql`, `)}]::text[])
+        )
     `.execute(db);
 
     const statusMap = new Map(rlsStatus.rows.map((r) => [`${r.schema}.${r.table}`, r]));

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -10,6 +10,7 @@ import { serve } from "@hono/node-server";
 
 import { loadLocalEnvFiles } from "../scripts/_local-env.mjs";
 import { getRuntimeConfig } from "../src/config/runtime.mjs";
+import { loadAllPlugins } from "../src/plugins/loader.mjs";
 import { createApp } from "./app.mjs";
 
 if (process.env.NODE_ENV !== "production") {
@@ -19,6 +20,19 @@ if (process.env.NODE_ENV !== "production") {
 const runtimeConfig = getRuntimeConfig();
 const port = Number(process.env.PORT) || 3000;
 const app = createApp({ runtimeConfig });
+
+// Muat plugin aktif (register + seed permission + jalankan migration schema plugin)
+// sebelum melayani request. Idempoten (IF NOT EXISTS + onConflict doNothing).
+// Set PLUGINS_AUTOLOAD=false bila migrasi plugin dijalankan sebagai langkah terpisah.
+if (process.env.PLUGINS_AUTOLOAD !== "false") {
+  try {
+    await loadAllPlugins();
+    console.log("[server] plugins loaded (registry + permissions + schema migrations)");
+  } catch (error) {
+    console.error("[server] FATAL: gagal memuat plugin:", error);
+    process.exit(1);
+  }
+}
 
 serve(
   {

--- a/src/db/migrations/042_permissions_code_plugin_namespace.mjs
+++ b/src/db/migrations/042_permissions_code_plugin_namespace.mjs
@@ -1,0 +1,29 @@
+import { sql } from "kysely";
+
+/**
+ * Longgarkan check constraint `permissions.code` agar menerima **namespace
+ * permission plugin** `awcms:{module}:{resource}:{action}` (colon) selain format
+ * core `domain.resource.action` (dot).
+ *
+ * Latar: tabel `permissions` dibuat sebelum kontrak plugin (ADR-018) & namespace
+ * permission shared-standards §4.2. Plugin (SIKESRA/SatuSehat) men-seed permission
+ * ber-namespace colon yang sebelumnya melanggar `permissions_code_format_check`.
+ */
+
+const DOT_FORMAT = "^[a-z0-9]+(.[a-z0-9_]+){2}$"; // format core (dipertahankan apa adanya)
+const PLUGIN_NAMESPACE = "^awcms:[a-z0-9_]+:[a-z0-9_]+:[a-z0-9_]+$"; // awcms:{module}:{resource}:{action}
+
+export async function up(db) {
+  await sql`alter table permissions drop constraint if exists permissions_code_format_check`.execute(db);
+  await sql.raw(
+    `alter table permissions add constraint permissions_code_format_check check (` +
+      `code ~ '${DOT_FORMAT}' or code ~ '${PLUGIN_NAMESPACE}')`,
+  ).execute(db);
+}
+
+export async function down(db) {
+  await sql`alter table permissions drop constraint if exists permissions_code_format_check`.execute(db);
+  await sql.raw(
+    `alter table permissions add constraint permissions_code_format_check check (code ~ '${DOT_FORMAT}')`,
+  ).execute(db);
+}

--- a/src/plugins/registry.mjs
+++ b/src/plugins/registry.mjs
@@ -72,7 +72,10 @@ export async function seedPluginPermissions(db, manifest) {
         const parts = p.split(":");
         // Format: "awcms:{module}:{resource}:{action}" → parts[1]=module, [2]=resource, [3]=action
         const [, domain, resource, action] = parts;
-        return { code: p, domain, resource, action };
+        // id eksplisit & ringkas (kolom permissions.id varchar(64)); code sudah unik
+        // (mengandung module), jadi tidak perlu prefix pluginId yang membuat id panjang.
+        const id = `perm_${p.replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "")}`;
+        return { id, code: p, domain, resource, action };
       }),
     },
   ]);

--- a/tests/unit/plugin-permission-id-length.test.mjs
+++ b/tests/unit/plugin-permission-id-length.test.mjs
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Regresi: id permission plugin WAJIB muat di kolom permissions.id varchar(64).
+// Bug ditemukan saat verifikasi deploy (Epik A2): id `plugin_perm_{module}_{code}`
+// (module tertulis 2x) overflow untuk modul bernama panjang (satu_sehat_kobar).
+// Fix: id ringkas `perm_{sanitized_code}` (code sudah unik karena memuat module).
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pluginsDir = join(__dirname, "../../src/plugins");
+
+const MAX_ID_LEN = 64;
+
+// Replikasi logika id di seedPluginPermissions (src/plugins/registry.mjs).
+function pluginPermissionId(code) {
+  return `perm_${code.replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "")}`;
+}
+
+test("plugin permission id: semua manifest menghasilkan id <= 64 char", () => {
+  const offenders = [];
+  for (const entry of readdirSync(pluginsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifestPath = join(pluginsDir, entry.name, "manifest.json");
+    if (!existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    for (const code of manifest.permissions ?? []) {
+      const id = pluginPermissionId(code);
+      if (id.length > MAX_ID_LEN) {
+        offenders.push(`${entry.name}: "${id}" (${id.length} char)`);
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], `id permission plugin melebihi varchar(64):\n${offenders.join("\n")}`);
+});
+
+test("plugin permission id: kasus modul terpanjang (satu_sehat_kobar) tetap muat", () => {
+  const id = pluginPermissionId("awcms:satu_sehat_kobar:patient:read");
+  assert.ok(id.length <= MAX_ID_LEN, `id ${id} (${id.length}) harus <= ${MAX_ID_LEN}`);
+  assert.equal(id, "perm_awcms_satu_sehat_kobar_patient_read");
+});


### PR DESCRIPTION
## Summary
**Verifikasi runtime nyata (Bun image + PostgreSQL via Docker) menemukan & memperbaiki 4 bug integrasi** yang lolos unit test karena memerlukan aplikasi + DB berjalan.

### 1. `loadAllPlugins` tidak ter-wire di startup (gap kritis)
Plugin SIKESRA/SatuSehat **tak pernah dimuat di produksi** — schema tak dibuat, permission tak di-seed. Loader (#318) hanya teruji terisolasi.
**Fix:** panggil `loadAllPlugins()` di `server/index.mjs` sebelum `serve()` (fail-fast; opt-out `PLUGINS_AUTOLOAD=false`). Idempoten.

### 2. FF6 `check-rls-coverage` query bug
`pg_tables` tidak punya kolom `forcerowsecurity` (ada di `pg_class`) → script error. Lolos sebelumnya karena FF6 butuh DB nyata.
**Fix:** query via `pg_class.relrowsecurity/relforcerowsecurity`.

### 3. Namespace permission plugin vs constraint core
`awcms:{module}:{resource}:{action}` (colon, shared-standards §4.2) melanggar `permissions_code_format_check` (dot 3-seg).
**Fix:** migrasi `042` melonggarkan constraint menerima **kedua** format.

### 4. id permission plugin overflow `varchar(64)`
`plugin_perm_{module}_{code}` (module 2×) > 64 char untuk `satu_sehat_kobar`.
**Fix:** id ringkas `perm_{sanitized_code}` + test regresi.

## Verifikasi end-to-end (Docker + Postgres NYATA)
- ✅ `plugins loaded (registry + permissions + schema migrations)`; **health 200**.
- ✅ 2 schema plugin dibuat; **18 permission ter-seed** (colon); **6 tabel plugin RLS aktif**.
- ✅ **FF6 PASS** (13 tabel core+plugin); unit test registry/loader/id 13/13.

## Konteks
Epik **A2** dari `personal-coding/.../awcms-runtime-epics-execution-guide.md` — gate **health-200 + plugin-load LULUS**. Bagian dari verifikasi #326 (Bun runtime).

> Tanpa fix #1, plugin tidak pernah aktif di produksi meski kontrak & test-nya lengkap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)