### PR TITLE
feat(cms): Fase 3 #327 — plugin runtime native (definePlugin/PluginRouteError/runWithContext lepas emdash)

### DIFF
--- a/src/cms/context.mjs
+++ b/src/cms/context.mjs
@@ -1,10 +1,10 @@
 /**
- * Seam konteks request (decoupling EmDash, ADR-020 Fase 2).
+ * Seam konteks request (decoupling EmDash, ADR-020).
  *
- * Membungkus `runWithContext` dari EmDash agar kode app tidak mengimpor `emdash`
- * langsung. Saat helper konteks native siap (AsyncLocalStorage), implementasi di
- * balik seam ini ditukar tanpa mengubah call-site.
+ * Sejak Fase 3, implementasi sudah **native** (`./request-context.mjs`,
+ * AsyncLocalStorage) — tidak lagi mengimpor `emdash`. Seam dipertahankan agar
+ * call-site (`src/auth/middleware-entry.mjs`) tetap stabil bila implementasi
+ * di baliknya berubah lagi.
  */
 
-// eslint-disable-next-line no-restricted-imports -- satu-satunya tempat boleh impor emdash (seam)
-export { runWithContext } from "emdash";
+export { runWithContext, getRequestContext } from "./request-context.mjs";

--- a/src/cms/define-plugin.mjs
+++ b/src/cms/define-plugin.mjs
@@ -1,0 +1,177 @@
+/**
+ * `definePlugin` native (decoupling EmDash, ADR-020 Fase 3).
+ *
+ * Pengganti `definePlugin` dari paket `emdash`. Memvalidasi & menormalkan
+ * deskriptor plugin format native AWCMS (`id` + `version` + `routes`/`hooks`).
+ * Field ekstensi AWCMS (`permissions`, `adminPages`, `adminWidgets`) di-passthrough
+ * — tidak dibuang seperti pada EmDash — agar kontrak plugin native (manifest +
+ * registry + loader, #316–#318) menerima deskriptor utuh.
+ *
+ * Tidak ada dependency `emdash`; implementasi milik AWCMS-Mini sendiri.
+ */
+
+const SIMPLE_ID = /^[a-z0-9-]+$/;
+const SCOPED_ID = /^@[a-z0-9-]+\/[a-z0-9-]+$/;
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+/;
+
+const DEFAULT_PRIORITY = 100;
+const DEFAULT_TIMEOUT = 5000;
+const DEFAULT_ERROR_POLICY = "abort";
+
+// Nama kapabilitas lama → kanonik (selaras EmDash agar plugin lama tetap valid).
+const CAPABILITY_RENAMES = Object.freeze({
+  "network:fetch": "network:request",
+  "network:fetch:any": "network:request:unrestricted",
+  "read:content": "content:read",
+  "write:content": "content:write",
+  "read:media": "media:read",
+  "write:media": "media:write",
+  "read:users": "users:read",
+  "email:provide": "hooks.email-transport:register",
+  "email:intercept": "hooks.email-events:register",
+  "page:inject": "hooks.page-fragments:register",
+});
+
+const VALID_CAPABILITIES = new Set([
+  "network:request",
+  "network:request:unrestricted",
+  "content:read",
+  "content:write",
+  "media:read",
+  "media:write",
+  "users:read",
+  "email:send",
+  "hooks.email-transport:register",
+  "hooks.email-events:register",
+  "hooks.page-fragments:register",
+  ...Object.keys(CAPABILITY_RENAMES),
+]);
+
+function normalizeCapability(cap) {
+  return Object.hasOwn(CAPABILITY_RENAMES, cap) ? CAPABILITY_RENAMES[cap] : cap;
+}
+
+function normalizeCapabilities(caps) {
+  const seen = new Set();
+  const out = [];
+  for (const cap of caps) {
+    const normalized = normalizeCapability(cap);
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      out.push(normalized);
+    }
+  }
+  return out;
+}
+
+function isHookConfig(hook) {
+  return typeof hook === "object" && hook !== null && "handler" in hook;
+}
+
+function resolveHook(hook, pluginId) {
+  if (isHookConfig(hook)) {
+    if (hook.exclusive !== undefined && typeof hook.exclusive !== "boolean") {
+      throw new Error(
+        `Invalid "exclusive" value in hook config for plugin "${pluginId}". Must be boolean.`,
+      );
+    }
+    return {
+      priority: hook.priority ?? DEFAULT_PRIORITY,
+      timeout: hook.timeout ?? DEFAULT_TIMEOUT,
+      dependencies: hook.dependencies ?? [],
+      errorPolicy: hook.errorPolicy ?? DEFAULT_ERROR_POLICY,
+      exclusive: hook.exclusive ?? false,
+      handler: hook.handler,
+      pluginId,
+    };
+  }
+  return {
+    priority: DEFAULT_PRIORITY,
+    timeout: DEFAULT_TIMEOUT,
+    dependencies: [],
+    errorPolicy: DEFAULT_ERROR_POLICY,
+    exclusive: false,
+    handler: hook,
+    pluginId,
+  };
+}
+
+function resolveHooks(hooks, pluginId) {
+  const resolved = {};
+  for (const key of Object.keys(hooks)) {
+    const hook = hooks[key];
+    if (hook) resolved[key] = resolveHook(hook, pluginId);
+  }
+  return resolved;
+}
+
+/**
+ * Definisikan plugin native AWCMS. Memvalidasi id/version/capabilities,
+ * menormalkan kapabilitas (alias + implikasi), dan mengembalikan deskriptor
+ * yang siap dipakai registry/loader native.
+ *
+ * @param {object} definition deskriptor plugin (`id`, `version`, dst.)
+ * @returns {object} deskriptor ternormalkan
+ */
+export function definePlugin(definition) {
+  const {
+    id,
+    version,
+    capabilities = [],
+    allowedHosts = [],
+    hooks = {},
+    routes = {},
+    admin = {},
+  } = definition;
+
+  if (!SIMPLE_ID.test(id) && !SCOPED_ID.test(id)) {
+    throw new Error(
+      `Invalid plugin id "${id}". Must be lowercase alphanumeric with dashes (e.g., "my-plugin" or "@scope/my-plugin").`,
+    );
+  }
+  if (!SEMVER_PATTERN.test(version)) {
+    throw new Error(
+      `Invalid plugin version "${version}". Must be semver format (e.g., "1.0.0").`,
+    );
+  }
+
+  for (const cap of capabilities) {
+    if (!VALID_CAPABILITIES.has(cap)) {
+      throw new Error(`Invalid capability "${cap}" in plugin "${id}".`);
+    }
+  }
+
+  const canonical = normalizeCapabilities(capabilities);
+  const normalizedCapabilities = [...canonical];
+  // Implikasi kapabilitas: yang luas mengimplikasikan yang sempit.
+  if (canonical.includes("content:write") && !canonical.includes("content:read")) {
+    normalizedCapabilities.push("content:read");
+  }
+  if (canonical.includes("media:write") && !canonical.includes("media:read")) {
+    normalizedCapabilities.push("media:read");
+  }
+  if (
+    canonical.includes("network:request:unrestricted") &&
+    !canonical.includes("network:request")
+  ) {
+    normalizedCapabilities.push("network:request");
+  }
+
+  const descriptor = {
+    id,
+    version,
+    capabilities: normalizedCapabilities,
+    allowedHosts,
+    storage: definition.storage ?? {},
+    hooks: resolveHooks(hooks, id),
+    routes,
+    admin,
+  };
+
+  // Ekstensi native AWCMS (di-passthrough; EmDash membuangnya).
+  if (definition.permissions !== undefined) descriptor.permissions = definition.permissions;
+  if (definition.adminPages !== undefined) descriptor.adminPages = definition.adminPages;
+  if (definition.adminWidgets !== undefined) descriptor.adminWidgets = definition.adminWidgets;
+
+  return descriptor;
+}

--- a/src/cms/plugin-route-error.mjs
+++ b/src/cms/plugin-route-error.mjs
@@ -1,0 +1,55 @@
+/**
+ * Error rute plugin native (decoupling EmDash, ADR-020 Fase 3).
+ *
+ * Pengganti `PluginRouteError` dari paket `emdash`. Error subclass yang membawa
+ * `code` + `status` (HTTP) + `details` sehingga `server/middleware/error-handler.mjs`
+ * dapat memetakannya ke respons HTTP (duck-typed: membaca `.status`/`.code`).
+ *
+ * Tidak ada dependency `emdash`; implementasi milik AWCMS-Mini sendiri.
+ */
+
+export class PluginRouteError extends Error {
+  /**
+   * @param {string} code kode error mesin-baca (mis. "BAD_REQUEST")
+   * @param {string} message pesan manusia-baca
+   * @param {number} [status=400] status HTTP
+   * @param {unknown} [details] detail tambahan (opsional)
+   */
+  constructor(code, message, status = 400, details) {
+    super(message);
+    this.code = code;
+    this.status = status;
+    this.details = details;
+    this.name = "PluginRouteError";
+  }
+
+  /** 400 Bad Request */
+  static badRequest(message, details) {
+    return new PluginRouteError("BAD_REQUEST", message, 400, details);
+  }
+
+  /** 401 Unauthorized */
+  static unauthorized(message = "Unauthorized") {
+    return new PluginRouteError("UNAUTHORIZED", message, 401);
+  }
+
+  /** 403 Forbidden */
+  static forbidden(message = "Forbidden") {
+    return new PluginRouteError("FORBIDDEN", message, 403);
+  }
+
+  /** 404 Not Found */
+  static notFound(message = "Not found") {
+    return new PluginRouteError("NOT_FOUND", message, 404);
+  }
+
+  /** 409 Conflict */
+  static conflict(message, details) {
+    return new PluginRouteError("CONFLICT", message, 409, details);
+  }
+
+  /** 500 Internal Error */
+  static internal(message = "Internal error") {
+    return new PluginRouteError("INTERNAL_ERROR", message, 500);
+  }
+}

--- a/src/cms/plugin-runtime.mjs
+++ b/src/cms/plugin-runtime.mjs
@@ -1,11 +1,11 @@
 /**
- * Seam runtime plugin (decoupling EmDash, ADR-020 Fase 2).
+ * Seam runtime plugin (decoupling EmDash, ADR-020).
  *
- * Membungkus `definePlugin` & `PluginRouteError` dari EmDash agar kode plugin
- * tidak mengimpor `emdash` langsung. Pada Fase 3 (#318), `definePlugin` diganti
- * registry/loader native dan `PluginRouteError` diganti tipe error native —
- * cukup menukar implementasi di balik seam ini.
+ * Sejak Fase 3 (#327), implementasi sudah **native**: `definePlugin`
+ * (`./define-plugin.mjs`) dan `PluginRouteError` (`./plugin-route-error.mjs`) —
+ * tidak lagi mengimpor `emdash`. Seam dipertahankan agar call-site plugin tetap
+ * stabil bila implementasi di baliknya berubah lagi.
  */
 
-// eslint-disable-next-line no-restricted-imports -- satu-satunya tempat boleh impor emdash (seam)
-export { definePlugin, PluginRouteError } from "emdash";
+export { definePlugin } from "./define-plugin.mjs";
+export { PluginRouteError } from "./plugin-route-error.mjs";

--- a/src/cms/request-context.mjs
+++ b/src/cms/request-context.mjs
@@ -1,0 +1,43 @@
+/**
+ * Konteks request native (decoupling EmDash, ADR-020 Fase 3).
+ *
+ * Pengganti `runWithContext`/`getRequestContext` dari paket `emdash`. Memakai
+ * `AsyncLocalStorage` agar state ber-scope request tersedia tanpa propagasi
+ * parameter eksplisit. Instance ALS disimpan di `globalThis` dengan kunci Symbol
+ * agar tetap singleton walau bundler menduplikasi modul antar code-split chunk.
+ *
+ * Tidak ada dependency `emdash`; ini implementasi milik AWCMS-Mini sendiri.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const ALS_KEY = Symbol.for("awcms:request-context");
+
+const storage =
+  globalThis[ALS_KEY] ??
+  (() => {
+    const als = new AsyncLocalStorage();
+    globalThis[ALS_KEY] = als;
+    return als;
+  })();
+
+/**
+ * Jalankan fungsi di dalam konteks request. Dipanggil middleware untuk
+ * membungkus `next()` sehingga konteks tersedia ke seluruh kode hilir.
+ *
+ * @template T
+ * @param {unknown} ctx konteks request
+ * @param {() => T} fn
+ * @returns {T}
+ */
+export function runWithContext(ctx, fn) {
+  return storage.run(ctx, fn);
+}
+
+/**
+ * Ambil konteks request saat ini. Mengembalikan `undefined` bila tidak ada
+ * konteks (fast path pengguna anonim).
+ */
+export function getRequestContext() {
+  return storage.getStore();
+}


### PR DESCRIPTION
## Ringkasan

**Fase 3** epic decoupling EmDash (#327): mengganti implementasi di balik seam `src/cms/*` dengan versi **native**, tanpa mengubah call-site (sesuai tujuan seam Fase 2). Setelah PR ini, seam `src/cms/*` **100% bebas `import ... from "emdash"`**.

EmDash tetap **referensi arsitektur saja** untuk awcms-mini (ADR-020); full EmDash hanya awcms-micro.

## Perubahan

| File | Isi |
|---|---|
| `src/cms/request-context.mjs` (baru) | `runWithContext`/`getRequestContext` native via `AsyncLocalStorage` (Symbol `awcms:request-context`) |
| `src/cms/plugin-route-error.mjs` (baru) | `PluginRouteError` native — `Error` subclass + static `badRequest/unauthorized/forbidden/notFound/conflict/internal`; membawa `.code`/`.status` untuk `error-handler` |
| `src/cms/define-plugin.mjs` (baru) | `definePlugin` native — validasi id/semver, validasi+normalisasi kapabilitas (alias + implikasi), `resolveHooks`; **passthrough** `permissions`/`adminPages`/`adminWidgets` (EmDash membuangnya) |
| `src/cms/context.mjs`, `plugin-runtime.mjs` | re-export dari modul native — tidak lagi impor `emdash` |

Konsumen tidak berubah: `auth/middleware-entry`, `plugins/route-authorization`, `plugins/awcms-users-admin`, `plugins/internal-governance-sample`.

## Verifikasi

- ✅ `tests/unit/cms-seam.test.mjs` 3/3 lolos (termasuk guard "tidak ada import emdash di luar seam").
- ✅ Smoke: `definePlugin` menormalkan `read:users`→`users:read` & menyimpan `permissions`; `PluginRouteError.forbidden`→`FORBIDDEN`/403 `instanceof Error`; `runWithContext` mempropagasi konteks; kedua plugin `createPlugin()` membangun deskriptor (35 & 2 route).
- ✅ Suite unit: **482 pass**. 5 fail **PRA-ADA** (`setup-status.test.mjs` — patch `dist` emdash belum diterapkan, ditunda **Fase 5**), terbukti independen (gagal juga tanpa perubahan ini).

## Sisa (Fase 4 — butuh app berjalan)

`emdash/runtime` (`live.config.ts`), `emdash/plugin-utils` (`admin.tsx`), `emdash/astro` (`astro.config.mjs`).

Refs #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)