### PR TITLE
feat(cms): Fase 4a #327 — native plugin admin utils (lepas emdash/plugin-utils)

### DIFF
--- a/src/cms/plugin-admin-utils.ts
+++ b/src/cms/plugin-admin-utils.ts
@@ -1,0 +1,58 @@
+/**
+ * Utilitas UI admin plugin native (decoupling EmDash, ADR-020 Fase 4).
+ *
+ * Pengganti `emdash/plugin-utils` untuk komponen `admin.tsx` plugin. Menyediakan
+ * `apiFetch` (fetch + header anti-CSRF), `parseApiResponse` (membuka envelope
+ * `{ data }`), `getErrorMessage`, dan `isRecord`.
+ *
+ * Catatan kontrak: header `X-EmDash-Request: 1` **dipertahankan** karena admin
+ * backend saat ini (admin shell EmDash, dilepas pada Fase 4/5) masih menolak
+ * request state-changing tanpa header tsb. Saat admin shell diganti native,
+ * ganti `CSRF_HEADER` ke header milik AWCMS sendiri.
+ *
+ * Tidak ada dependency `emdash`; implementasi milik AWCMS-Mini sendiri.
+ */
+
+const CSRF_HEADER = "X-EmDash-Request";
+
+/**
+ * Pembungkus `fetch` yang menambahkan header proteksi CSRF.
+ * Semua panggilan API admin plugin sebaiknya memakai ini, bukan `fetch()` mentah.
+ */
+export function apiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const headers = new Headers(init?.headers);
+  headers.set(CSRF_HEADER, "1");
+  return fetch(input, { ...init, headers });
+}
+
+/**
+ * Parse respons API, membuka envelope `{ data: T }`. Pada respons non-2xx,
+ * melempar `Error` dengan pesan dari server (`{ error: { message } }`) atau fallback.
+ */
+export async function parseApiResponse<T>(
+  response: Response,
+  fallbackMessage = "Request failed",
+): Promise<T> {
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response, `${fallbackMessage}: ${response.statusText}`));
+  }
+  return (await response.json()).data as T;
+}
+
+/**
+ * Ambil pesan error dari respons API gagal (shape `{ error: { code, message } }`).
+ * Menelan kegagalan parse JSON dengan anggun.
+ */
+export async function getErrorMessage(response: Response, fallback: string): Promise<string> {
+  const body = await response.json().catch(() => ({}));
+  if (isRecord(body) && isRecord(body.error)) {
+    const msg = (body.error as Record<string, unknown>).message;
+    if (typeof msg === "string") return msg;
+  }
+  return fallback;
+}
+
+/** Sempitkan `unknown` ke record objek biasa. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/plugins/awcms-users-admin/admin.tsx
+++ b/src/plugins/awcms-users-admin/admin.tsx
@@ -1,4 +1,4 @@
-import { apiFetch, parseApiResponse } from "emdash/plugin-utils";
+import { apiFetch, parseApiResponse } from "../../cms/plugin-admin-utils";
 import * as React from "react";
 
 const API_BASE = "/_emdash/api/plugins/awcms-users-admin";


### PR DESCRIPTION
## Ringkasan

**Fase 4a** epic decoupling EmDash (#327). `admin.tsx` plugin tak lagi mengimpor `emdash/plugin-utils`; util client disalin native ke seam.

> Stacked di atas #355 (Fase 3). Base = `feat/327-phase3-native-plugin-runtime`. Diff PR ini = 2 file.

## Perubahan

| File | Isi |
|---|---|
| `src/cms/plugin-admin-utils.ts` (baru) | `apiFetch` (fetch + header anti-CSRF), `parseApiResponse<T>` (buka envelope `{ data }`), `getErrorMessage`, `isRecord` |
| `src/plugins/awcms-users-admin/admin.tsx` | impor dari `../../cms/plugin-admin-utils` (bukan `emdash/plugin-utils`) |

**Kontrak CSRF dipertahankan:** header `X-EmDash-Request: 1` tetap (lewat konstanta `CSRF_HEADER`) karena admin backend saat ini masih menolak request state-changing tanpa header tsb. Diganti ke header AWCMS saat admin shell native (Fase 4c/5).

## Verifikasi

- ✅ Typecheck proyek: `admin.tsx` & util baru **0 error**. (Satu-satunya error TS = `astro:content` di `live.config.ts` — **pra-ada**, butuh `astro check` yang men-generate tipe virtual; bukan regresi PR ini.)
- ✅ `cms-seam` 3/3 lolos.

## Sisa Fase 4

`emdash/runtime` (`live.config.ts`), `emdash/astro` (`astro.config.mjs`) — butuh app berjalan.

Refs #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)