### PR TITLE
feat(auth): SSO Tahap 1 #351 — skema auth.sso_providers + auth.sso_identities + kontrak config

### DIFF
--- a/src/auth/sso/provider-config.mjs
+++ b/src/auth/sso/provider-config.mjs
@@ -1,0 +1,118 @@
+/**
+ * Kontrak konfigurasi provider SSO (ADR-024 / DL-022, #351 Tahap 1).
+ *
+ * Validasi & normalisasi konfigurasi provider SSO sebelum persist ke
+ * `auth.sso_providers`. Modul **pure** (tanpa I/O) agar mudah diuji.
+ *
+ * Keamanan (standar SSO §6/§8):
+ *   - Kontrak ini TIDAK menerima/menyimpan/mencetak secret IdP mentah. Secret
+ *     ditangani terpisah sebagai `client_secret_enc` (AES-256-GCM, pola
+ *     src/security/totp.mjs) di lapisan persistensi — bukan di kontrak ini.
+ *   - `redirect_uri` divalidasi (whitelist) di Tahap 2 (alur login), bukan di sini.
+ *
+ * Cakupan single-tenant (awcms-mini): tanpa `tenant_id`. awcms multi-tenant
+ * memperluas kontrak ini dengan resolusi tenant.
+ */
+
+/** Jenis provider yang didukung (OIDC primer; SAML opsional). */
+export const SSO_PROVIDER_KINDS = Object.freeze(["oidc", "saml"]);
+
+/** Scope OIDC default bila tidak ditentukan. */
+export const DEFAULT_OIDC_SCOPES = Object.freeze(["openid", "email", "profile"]);
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function isHttpsUrl(value) {
+  if (!isNonEmptyString(value)) return false;
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeStringArray(value, fallback) {
+  if (value === undefined || value === null) return fallback ? [...fallback] : [];
+  if (!Array.isArray(value)) {
+    throw new TypeError("scopes/allowed_email_domains harus array string.");
+  }
+  const out = [];
+  const seen = new Set();
+  for (const item of value) {
+    if (!isNonEmptyString(item)) continue;
+    const v = item.trim().toLowerCase();
+    if (!seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  }
+  return out;
+}
+
+/**
+ * Validasi & normalkan konfigurasi provider SSO.
+ *
+ * @param {object} input konfigurasi mentah (mis. dari API/seed)
+ * @returns {object} konfigurasi ternormalkan siap persist (tanpa secret mentah)
+ * @throws {TypeError|Error} bila tidak valid
+ */
+export function validateSsoProviderConfig(input) {
+  if (input === null || typeof input !== "object") {
+    throw new TypeError("Konfigurasi provider SSO harus berupa objek.");
+  }
+
+  const kind = isNonEmptyString(input.kind) ? input.kind.trim().toLowerCase() : "";
+  if (!SSO_PROVIDER_KINDS.includes(kind)) {
+    throw new Error(
+      `kind tidak valid: "${input.kind}". Harus salah satu dari ${SSO_PROVIDER_KINDS.join(", ")}.`,
+    );
+  }
+
+  if (!isNonEmptyString(input.display_name)) {
+    throw new Error("display_name wajib diisi.");
+  }
+  if (!isNonEmptyString(input.issuer)) {
+    throw new Error("issuer wajib diisi.");
+  }
+  // issuer OIDC WAJIB HTTPS (standar SSO §3 — validasi iss + JWKS via issuer).
+  if (kind === "oidc" && !isHttpsUrl(input.issuer)) {
+    throw new Error("issuer OIDC harus URL HTTPS yang valid.");
+  }
+  if (!isNonEmptyString(input.client_id)) {
+    throw new Error("client_id wajib diisi.");
+  }
+
+  // Endpoint opsional, tapi bila diisi WAJIB HTTPS (cegah token leakage §6).
+  for (const field of ["jwks_uri", "authorization_endpoint", "token_endpoint"]) {
+    if (input[field] !== undefined && input[field] !== null && !isHttpsUrl(input[field])) {
+      throw new Error(`${field} harus URL HTTPS yang valid bila diisi.`);
+    }
+  }
+
+  const claimMappings =
+    input.claim_mappings === undefined || input.claim_mappings === null
+      ? {}
+      : input.claim_mappings;
+  if (typeof claimMappings !== "object" || Array.isArray(claimMappings)) {
+    throw new TypeError("claim_mappings harus objek (peta klaim → atribut internal).");
+  }
+
+  return {
+    kind,
+    display_name: input.display_name.trim(),
+    issuer: input.issuer.trim(),
+    client_id: input.client_id.trim(),
+    jwks_uri: isNonEmptyString(input.jwks_uri) ? input.jwks_uri.trim() : null,
+    authorization_endpoint: isNonEmptyString(input.authorization_endpoint)
+      ? input.authorization_endpoint.trim()
+      : null,
+    token_endpoint: isNonEmptyString(input.token_endpoint) ? input.token_endpoint.trim() : null,
+    scopes: normalizeStringArray(input.scopes, DEFAULT_OIDC_SCOPES),
+    claim_mappings: claimMappings,
+    allow_jit: input.allow_jit === true,
+    allowed_email_domains: normalizeStringArray(input.allowed_email_domains),
+    enabled: input.enabled === undefined ? true : input.enabled === true,
+  };
+}

--- a/src/db/migrations/043_sso_provider_identity_tables.mjs
+++ b/src/db/migrations/043_sso_provider_identity_tables.mjs
@@ -1,0 +1,229 @@
+// SSO Tahap 1 (ADR-024 / DL-022, #351): skema `auth.sso_providers` +
+// `auth.sso_identities` dengan RLS.
+//
+// Konteks: awcms-mini = single-tenant → TANPA kolom `tenant_id` (awcms
+// multi-tenant menambahkannya + isolasi per-tenant). SSO MELENGKAPI auth
+// internal (JWT/claims + RBAC/ABAC/RLS tetap otoritas); tabel ini hanya
+// menyimpan konfigurasi provider + tautan identitas eksternal↔user internal.
+//
+// Keamanan (standar SSO §6/§8):
+//   - `client_secret_enc` WAJIB terenkripsi (AES-256-GCM, pola
+//     src/security/totp.mjs) — JANGAN simpan secret IdP mentah.
+//   - RLS (ADR-015) di kedua tabel + `force row level security` agar owner
+//     (role yang menjalankan migrasi) pun tunduk RLS — konsisten migrasi 040.
+//
+// Policy:
+//   - sso_providers  = konfigurasi admin-only (baca/tulis hanya bila
+//     app.is_admin='true'); user biasa tak boleh melihat secret/issuer.
+//   - sso_identities = per-user (user lihat tautan miliknya) + admin bypass.
+//
+// Set konteks RLS: src/db/plugin-adapter.mjs withUserContext / setPluginDbContext.
+
+import { sql } from "kysely";
+
+export const SSO_SCHEMA = "auth";
+export const SSO_PROVIDERS_TABLE = "sso_providers";
+export const SSO_IDENTITIES_TABLE = "sso_identities";
+
+export const SSO_PROVIDERS_COLUMNS = [
+  "id",
+  "kind",
+  "display_name",
+  "issuer",
+  "client_id",
+  "client_secret_enc",
+  "jwks_uri",
+  "authorization_endpoint",
+  "token_endpoint",
+  "scopes",
+  "claim_mappings",
+  "allow_jit",
+  "allowed_email_domains",
+  "enabled",
+  "created_at",
+  "updated_at",
+  "created_by",
+  "deleted_at",
+];
+
+export const SSO_IDENTITIES_COLUMNS = [
+  "id",
+  "user_id",
+  "provider_id",
+  "subject_external",
+  "email_external",
+  "linked_at",
+  "last_login_at",
+  "created_at",
+  "updated_at",
+  "deleted_at",
+];
+
+// RLS: konfigurasi provider = admin-only (no per-user akses).
+export function buildSsoProvidersRlsStatements() {
+  const qualified = `${SSO_SCHEMA}.${SSO_PROVIDERS_TABLE}`;
+  return [
+    `alter table ${qualified} enable row level security`,
+    `alter table ${qualified} force row level security`,
+    `create policy rls_sso_providers_admin_only on ${qualified}
+       using (current_setting('app.is_admin', true) = 'true')`,
+  ];
+}
+
+// RLS: tautan identitas = per-user (user_id match) ATAU admin bypass.
+export function buildSsoIdentitiesRlsStatements() {
+  const qualified = `${SSO_SCHEMA}.${SSO_IDENTITIES_TABLE}`;
+  return [
+    `alter table ${qualified} enable row level security`,
+    `alter table ${qualified} force row level security`,
+    `create policy rls_sso_identities_per_user on ${qualified}
+       using (
+         user_id::text = current_setting('app.current_user_id', true)
+         or current_setting('app.is_admin', true) = 'true'
+       )`,
+  ];
+}
+
+export async function up(db) {
+  await sql.raw(`create schema if not exists ${SSO_SCHEMA}`).execute(db);
+
+  // ------------------------------------------------------------------
+  // auth.sso_providers — konfigurasi provider SSO (admin-only)
+  // ------------------------------------------------------------------
+  await db.schema
+    .withSchema(SSO_SCHEMA)
+    .createTable(SSO_PROVIDERS_TABLE)
+    .addColumn("id", "varchar(64)", (column) => column.primaryKey())
+    .addColumn("kind", "varchar(16)", (column) =>
+      column.notNull().check(sql`kind in ('oidc', 'saml')`),
+    )
+    .addColumn("display_name", "text", (column) => column.notNull())
+    .addColumn("issuer", "text", (column) => column.notNull())
+    .addColumn("client_id", "text", (column) => column.notNull())
+    .addColumn("client_secret_enc", "text") // terenkripsi (AES-256-GCM); nullable utk klien publik/PKCE
+    .addColumn("jwks_uri", "text")
+    .addColumn("authorization_endpoint", "text")
+    .addColumn("token_endpoint", "text")
+    .addColumn("scopes", sql`text[]`, (column) =>
+      column.notNull().defaultTo(sql`array['openid','email','profile']::text[]`),
+    )
+    .addColumn("claim_mappings", "jsonb", (column) =>
+      column.notNull().defaultTo(sql`'{}'::jsonb`),
+    )
+    .addColumn("allow_jit", "boolean", (column) => column.notNull().defaultTo(false))
+    .addColumn("allowed_email_domains", sql`text[]`)
+    .addColumn("enabled", "boolean", (column) => column.notNull().defaultTo(true))
+    .addColumn("created_at", "timestamptz", (column) =>
+      column.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn("updated_at", "timestamptz", (column) =>
+      column.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn("created_by", "varchar(64)")
+    .addColumn("deleted_at", "timestamptz")
+    .execute();
+
+  await db.schema
+    .withSchema(SSO_SCHEMA)
+    .createIndex("sso_providers_enabled_index")
+    .on(SSO_PROVIDERS_TABLE)
+    .column("enabled")
+    .where(sql`deleted_at is null`)
+    .execute();
+
+  await db.schema
+    .withSchema(SSO_SCHEMA)
+    .createIndex("sso_providers_issuer_unique")
+    .on(SSO_PROVIDERS_TABLE)
+    .column("issuer")
+    .unique()
+    .where(sql`deleted_at is null`)
+    .execute();
+
+  // ------------------------------------------------------------------
+  // auth.sso_identities — tautan identitas eksternal ↔ user internal (per-user)
+  // ------------------------------------------------------------------
+  await db.schema
+    .withSchema(SSO_SCHEMA)
+    .createTable(SSO_IDENTITIES_TABLE)
+    .addColumn("id", "varchar(64)", (column) => column.primaryKey())
+    .addColumn("user_id", "varchar(64)", (column) =>
+      column.notNull().references("public.users.id").onDelete("cascade"),
+    )
+    .addColumn("provider_id", "varchar(64)", (column) =>
+      column.notNull().references("auth.sso_providers.id").onDelete("cascade"),
+    )
+    .addColumn("subject_external", "text", (column) => column.notNull())
+    .addColumn("email_external", "text")
+    .addColumn("linked_at", "timestamptz", (column) =>
+      column.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn("last_login_at", "timestamptz")
+    .addColumn("created_at", "timestamptz", (column) =>
+      column.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn("updated_at", "timestamptz", (column) =>
+      column.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn("deleted_at", "timestamptz")
+    .execute();
+
+  // Satu subject IdP hanya boleh tertaut sekali per provider (cegah duplikasi).
+  await db.schema
+    .withSchema(SSO_SCHEMA)
+    .createIndex("sso_identities_provider_subject_unique")
+    .on(SSO_IDENTITIES_TABLE)
+    .columns(["provider_id", "subject_external"])
+    .unique()
+    .where(sql`deleted_at is null`)
+    .execute();
+
+  await db.schema
+    .withSchema(SSO_SCHEMA)
+    .createIndex("sso_identities_user_id_index")
+    .on(SSO_IDENTITIES_TABLE)
+    .column("user_id")
+    .execute();
+
+  // RLS
+  for (const stmt of buildSsoProvidersRlsStatements()) {
+    await sql.raw(stmt).execute(db);
+  }
+  for (const stmt of buildSsoIdentitiesRlsStatements()) {
+    await sql.raw(stmt).execute(db);
+  }
+}
+
+export async function down(db) {
+  await sql
+    .raw(`drop policy if exists rls_sso_identities_per_user on ${SSO_SCHEMA}.${SSO_IDENTITIES_TABLE}`)
+    .execute(db);
+  await sql
+    .raw(`drop policy if exists rls_sso_providers_admin_only on ${SSO_SCHEMA}.${SSO_PROVIDERS_TABLE}`)
+    .execute(db);
+
+  await db.schema
+    .withSchema(SSO_SCHEMA)
+    .dropIndex("sso_identities_user_id_index")
+    .ifExists()
+    .execute();
+  await db.schema
+    .withSchema(SSO_SCHEMA)
+    .dropIndex("sso_identities_provider_subject_unique")
+    .ifExists()
+    .execute();
+  await db.schema.withSchema(SSO_SCHEMA).dropTable(SSO_IDENTITIES_TABLE).ifExists().execute();
+
+  await db.schema
+    .withSchema(SSO_SCHEMA)
+    .dropIndex("sso_providers_issuer_unique")
+    .ifExists()
+    .execute();
+  await db.schema
+    .withSchema(SSO_SCHEMA)
+    .dropIndex("sso_providers_enabled_index")
+    .ifExists()
+    .execute();
+  await db.schema.withSchema(SSO_SCHEMA).dropTable(SSO_PROVIDERS_TABLE).ifExists().execute();
+  // Catatan: schema `auth` sengaja TIDAK di-drop (dapat dipakai objek auth lain).
+}

--- a/tests/unit/sso-provider-config.test.mjs
+++ b/tests/unit/sso-provider-config.test.mjs
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  validateSsoProviderConfig,
+  SSO_PROVIDER_KINDS,
+  DEFAULT_OIDC_SCOPES,
+} from "../../src/auth/sso/provider-config.mjs";
+
+const validOidc = {
+  kind: "oidc",
+  display_name: "Keycloak",
+  issuer: "https://idp.example.com/realms/awcms",
+  client_id: "awcms-mini",
+};
+
+test("sso config: konstanta kind & default scopes", () => {
+  assert.deepEqual([...SSO_PROVIDER_KINDS], ["oidc", "saml"]);
+  assert.deepEqual([...DEFAULT_OIDC_SCOPES], ["openid", "email", "profile"]);
+});
+
+test("sso config: OIDC valid ternormalkan + scopes default", () => {
+  const out = validateSsoProviderConfig(validOidc);
+  assert.equal(out.kind, "oidc");
+  assert.equal(out.issuer, "https://idp.example.com/realms/awcms");
+  assert.deepEqual(out.scopes, ["openid", "email", "profile"]);
+  assert.equal(out.allow_jit, false);
+  assert.equal(out.enabled, true);
+  assert.deepEqual(out.claim_mappings, {});
+});
+
+test("sso config: tolak input non-objek", () => {
+  assert.throws(() => validateSsoProviderConfig(null), /harus berupa objek/);
+  assert.throws(() => validateSsoProviderConfig("x"), /harus berupa objek/);
+});
+
+test("sso config: tolak kind tidak dikenal", () => {
+  assert.throws(() => validateSsoProviderConfig({ ...validOidc, kind: "ldap" }), /kind tidak valid/);
+});
+
+test("sso config: field wajib", () => {
+  assert.throws(() => validateSsoProviderConfig({ ...validOidc, display_name: "" }), /display_name/);
+  assert.throws(() => validateSsoProviderConfig({ ...validOidc, issuer: "" }), /issuer/);
+  assert.throws(() => validateSsoProviderConfig({ ...validOidc, client_id: "" }), /client_id/);
+});
+
+test("sso config: issuer OIDC wajib HTTPS", () => {
+  assert.throws(
+    () => validateSsoProviderConfig({ ...validOidc, issuer: "http://insecure.example.com" }),
+    /HTTPS/,
+  );
+});
+
+test("sso config: endpoint non-HTTPS ditolak bila diisi", () => {
+  assert.throws(
+    () => validateSsoProviderConfig({ ...validOidc, jwks_uri: "http://x/jwks" }),
+    /jwks_uri harus URL HTTPS/,
+  );
+});
+
+test("sso config: scopes & domain dinormalkan (lowercase, unik)", () => {
+  const out = validateSsoProviderConfig({
+    ...validOidc,
+    scopes: ["OpenID", "openid", "Email"],
+    allowed_email_domains: ["Example.COM", "example.com"],
+  });
+  assert.deepEqual(out.scopes, ["openid", "email"]);
+  assert.deepEqual(out.allowed_email_domains, ["example.com"]);
+});
+
+test("sso config: claim_mappings non-objek ditolak", () => {
+  assert.throws(
+    () => validateSsoProviderConfig({ ...validOidc, claim_mappings: ["x"] }),
+    /claim_mappings harus objek/,
+  );
+});
+
+test("sso config: TIDAK meneruskan secret mentah", () => {
+  const out = validateSsoProviderConfig({ ...validOidc, client_secret: "PLAINTEXT-SECRET" });
+  assert.ok(!("client_secret" in out), "kontrak tidak boleh meneruskan client_secret mentah");
+  assert.ok(!("client_secret_enc" in out), "enkripsi ditangani di lapisan persistensi, bukan kontrak");
+});

--- a/tests/unit/sso-provider-identity-migration.test.mjs
+++ b/tests/unit/sso-provider-identity-migration.test.mjs
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Unit test struktur migrasi 043 (SSO Tahap 1, #351). Test integrasi DB nyata
+// dijalankan di CI/Docker (RLS via role non-superuser).
+
+import {
+  up,
+  down,
+  SSO_SCHEMA,
+  SSO_PROVIDERS_TABLE,
+  SSO_IDENTITIES_TABLE,
+  SSO_PROVIDERS_COLUMNS,
+  SSO_IDENTITIES_COLUMNS,
+  buildSsoProvidersRlsStatements,
+  buildSsoIdentitiesRlsStatements,
+} from "../../src/db/migrations/043_sso_provider_identity_tables.mjs";
+
+test("sso migrasi 043: up & down diekspor", () => {
+  assert.equal(typeof up, "function");
+  assert.equal(typeof down, "function");
+});
+
+test("sso migrasi 043: schema = auth, tabel sesuai standar SSO §8", () => {
+  assert.equal(SSO_SCHEMA, "auth");
+  assert.equal(SSO_PROVIDERS_TABLE, "sso_providers");
+  assert.equal(SSO_IDENTITIES_TABLE, "sso_identities");
+});
+
+test("sso migrasi 043: kolom sso_providers mencakup secret terenkripsi + soft-delete", () => {
+  for (const col of [
+    "id",
+    "kind",
+    "issuer",
+    "client_id",
+    "client_secret_enc",
+    "scopes",
+    "claim_mappings",
+    "allow_jit",
+    "allowed_email_domains",
+    "enabled",
+    "deleted_at",
+  ]) {
+    assert.ok(SSO_PROVIDERS_COLUMNS.includes(col), `sso_providers harus punya kolom ${col}`);
+  }
+  // Tidak boleh menyimpan secret mentah.
+  assert.ok(
+    !SSO_PROVIDERS_COLUMNS.includes("client_secret"),
+    "DILARANG kolom client_secret mentah — hanya client_secret_enc",
+  );
+});
+
+test("sso migrasi 043: kolom sso_identities = tautan eksternal↔internal", () => {
+  for (const col of ["id", "user_id", "provider_id", "subject_external", "email_external"]) {
+    assert.ok(SSO_IDENTITIES_COLUMNS.includes(col), `sso_identities harus punya kolom ${col}`);
+  }
+});
+
+test("sso migrasi 043: single-tenant — TANPA tenant_id (mini)", () => {
+  assert.ok(!SSO_PROVIDERS_COLUMNS.includes("tenant_id"));
+  assert.ok(!SSO_IDENTITIES_COLUMNS.includes("tenant_id"));
+});
+
+test("sso migrasi 043: RLS providers = admin-only + force RLS", () => {
+  const stmts = buildSsoProvidersRlsStatements().join("\n");
+  assert.match(stmts, /enable row level security/);
+  assert.match(stmts, /force row level security/);
+  assert.match(stmts, /current_setting\('app\.is_admin', true\) = 'true'/);
+  // Admin-only: TIDAK ada klausa per-user untuk tabel konfigurasi.
+  assert.doesNotMatch(stmts, /app\.current_user_id/);
+});
+
+test("sso migrasi 043: RLS identities = per-user + admin bypass + force RLS", () => {
+  const stmts = buildSsoIdentitiesRlsStatements().join("\n");
+  assert.match(stmts, /force row level security/);
+  assert.match(stmts, /user_id::text = current_setting\('app\.current_user_id', true\)/);
+  assert.match(stmts, /current_setting\('app\.is_admin', true\) = 'true'/);
+});


### PR DESCRIPTION
## Ringkasan

**Tahap 1** implementasi SSO (ADR-024 / DL-022; standar [`awcms-sso-standard.md` §8](https://github.com/ahliweb/personal-coding)). SSO **melengkapi** auth internal (JWT/claims + RBAC/ABAC/RLS tetap otoritas) — bukan menggantikan. `awcms-mini` = **single-tenant** (TANPA `tenant_id`).

## Perubahan

**`src/db/migrations/043_sso_provider_identity_tables.mjs`**
- Schema `auth` + dua tabel:
  - `sso_providers` — konfigurasi provider SSO (**admin-only**)
  - `sso_identities` — tautan identitas eksternal ↔ user internal (**per-user**)
- **RLS (ADR-015) + `force row level security`** di kedua tabel (owner pun tunduk RLS — konsisten migrasi 040):
  - providers: `using (app.is_admin = 'true')`
  - identities: `using (user_id = app.current_user_id OR app.is_admin = 'true')`
- `client_secret_enc` **terenkripsi** (AES-256-GCM, pola `src/security/totp.mjs`) — **tidak ada kolom secret mentah**.
- Unique: `issuer`; `(provider_id, subject_external)`. Helper RLS diekspor untuk test.

**`src/auth/sso/provider-config.mjs`** — kontrak config **pure**: validasi `kind` (oidc/saml), issuer HTTPS (OIDC), endpoint HTTPS, normalisasi scopes/email-domain (lowercase, unik), `claim_mappings`. Kontrak **tidak menerima/meneruskan secret mentah**.

## Verifikasi

- ✅ **17/17** unit test baru lolos (struktur migrasi + RLS statements + kontrak config; termasuk guard "tidak ada `client_secret` mentah" & "tanpa `tenant_id`").
- ✅ SQL builder Kysely **compile valid** (cross-schema FK `public.users`/`auth.sso_providers`, `text[]` default, partial unique index).
- ✅ Suite: **499 pass** (5 fail **pra-ada** `setup-status.test.mjs`, independen).
- Test integrasi RLS DB nyata (role non-superuser) → CI/Docker.

## Lanjutan

Tahap 2: OIDC Authorization Code + PKCE + validasi token (JWKS, iss/aud/exp, nonce/state) — IdP pembukti Keycloak.

Refs #351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)