### PR TITLE
feat(plugins): RLS plugin assignment/role-based — akses lintas-creator via penugasan region (#353)

### DIFF
--- a/src/db/plugin-adapter.mjs
+++ b/src/db/plugin-adapter.mjs
@@ -44,26 +44,60 @@ export async function withUserContext(db, userId, callback) {
 }
 
 /**
- * Hasilkan array SQL string untuk mengaktifkan RLS + policy isolasi per user pada tabel plugin.
+ * Hasilkan array SQL string untuk mengaktifkan RLS + policy akses pada tabel plugin.
  * Dipanggil di dalam migrate.mjs plugin setelah createTable, bukan di runtime.
  *
- * Policy yang dibuat: user hanya bisa membaca/mengubah record yang created_by = user aktif.
- * Untuk data highly_restricted (contoh: SIKESRA), ini wajib diperkuat dengan permission check
- * di service layer (defense-in-depth).
+ * Model akses (keputusan #353 — assignment/role-based):
+ *   1. **Creator** — `created_by = app.current_user_id` (selalu).
+ *   2. **Admin bypass** (opsional) — `app.is_admin = 'true'` (di-set middleware admin).
+ *   3. **Region assignment** (opsional) — bila `regionColumn` diberikan, user yang
+ *      punya **penugasan aktif** ke region baris (via `user_administrative_region_assignments`)
+ *      boleh akses **lintas-creator**. NULL-safe: baris dengan region NULL hanya
+ *      diakses creator/admin (tidak melebar).
+ *
+ * Akses lintas-creator pada data sensitif (highly_restricted: SIKESRA) **WAJIB
+ * diaudit** + permission ketat di service layer (defense-in-depth) — lihat
+ * `server/routes/api-v1-search.mjs` (onAudit).
+ *
+ * Idempotent: policy lama (`plugin_user_isolation`) & baru (`plugin_access`)
+ * di-`drop ... if exists` sebelum dibuat ulang → aman dijalankan berkali-kali.
  *
  * @param {string} schema - Nama schema plugin (snake_case, contoh: "sikesra")
  * @param {string} tableName - Nama tabel (contoh: "subjects")
+ * @param {{ regionColumn?: string, adminBypass?: boolean, createdByColumn?: string }} [options]
  * @returns {string[]} Array SQL string yang harus dieksekusi berurutan
  */
-export function buildPluginRlsStatements(schema, tableName) {
+export function buildPluginRlsStatements(schema, tableName, options = {}) {
   const qualified = `${schema}.${tableName}`;
+  const createdByColumn = options.createdByColumn ?? "created_by";
+  const clauses = [
+    `${qualified}.${createdByColumn} = current_setting('app.current_user_id', true)::text`,
+  ];
+
+  if (options.adminBypass) {
+    clauses.push(`current_setting('app.is_admin', true) = 'true'`);
+  }
+
+  if (options.regionColumn) {
+    // Lintas-creator HANYA bila region baris terisi DAN user punya penugasan aktif
+    // ke region tsb. `ends_at is null` = penugasan masih berlaku (effective-dated).
+    clauses.push(
+      `(${qualified}.${options.regionColumn} is not null and exists (
+         select 1 from public.user_administrative_region_assignments ura
+         where ura.user_id = current_setting('app.current_user_id', true)
+           and ura.administrative_region_id = ${qualified}.${options.regionColumn}
+           and ura.ends_at is null
+       ))`,
+    );
+  }
 
   return [
     `alter table ${qualified} enable row level security`,
     `alter table ${qualified} force row level security`,
-    // Policy: user hanya bisa akses record yang dia buat (single-tenant, per-user isolation)
-    `create policy plugin_user_isolation on ${qualified}
-       using (created_by = current_setting('app.current_user_id', true)::text)`,
+    `drop policy if exists plugin_user_isolation on ${qualified}`,
+    `drop policy if exists plugin_access on ${qualified}`,
+    `create policy plugin_access on ${qualified}
+       using (${clauses.join("\n         or ")})`,
   ];
 }
 

--- a/src/plugins/satu-sehat-kobar/migrate.mjs
+++ b/src/plugins/satu-sehat-kobar/migrate.mjs
@@ -50,7 +50,16 @@ export async function migrate(db) {
     .column("ihs_number")
     .execute();
 
-  for (const stmt of buildPluginRlsStatements("satu_sehat_kobar", "patients")) {
+  // Region scoping (#353): kolom region + index untuk akses berbasis penugasan.
+  // NULL-safe — baris lama (region NULL) tetap hanya creator/admin.
+  await sql`alter table satu_sehat_kobar.patients add column if not exists administrative_region_id varchar(64)`.execute(db);
+  await sql`create index if not exists ssk_patients_admin_region_idx on satu_sehat_kobar.patients (administrative_region_id)`.execute(db);
+
+  // Enable RLS — model assignment/role-based (#353): creator OR admin OR penugasan region aktif.
+  for (const stmt of buildPluginRlsStatements("satu_sehat_kobar", "patients", {
+    regionColumn: "administrative_region_id",
+    adminBypass: true,
+  })) {
     await sql.raw(stmt).execute(db);
   }
 

--- a/src/plugins/sikesra/migrate.mjs
+++ b/src/plugins/sikesra/migrate.mjs
@@ -53,8 +53,18 @@ export async function migrate(db) {
     .column("deleted_at")
     .execute();
 
-  // Enable RLS pada sikesra.subjects
-  for (const stmt of buildPluginRlsStatements("sikesra", "subjects")) {
+  // Region scoping (#353): kolom region + index untuk akses berbasis penugasan.
+  // NULL-safe — baris lama (region NULL) tetap hanya creator/admin. Pengisian
+  // region saat create = tugas app layer (follow-up domain).
+  await sql`alter table sikesra.subjects add column if not exists administrative_region_id varchar(64)`.execute(db);
+  await sql`create index if not exists sikesra_subjects_admin_region_idx on sikesra.subjects (administrative_region_id)`.execute(db);
+
+  // Enable RLS pada sikesra.subjects — model assignment/role-based (#353):
+  // creator OR admin OR penugasan region aktif (lintas-creator; audit wajib di service).
+  for (const stmt of buildPluginRlsStatements("sikesra", "subjects", {
+    regionColumn: "administrative_region_id",
+    adminBypass: true,
+  })) {
     await sql.raw(stmt).execute(db);
   }
 

--- a/tests/unit/plugin-adapter.test.mjs
+++ b/tests/unit/plugin-adapter.test.mjs
@@ -9,33 +9,47 @@ import { buildPluginRlsStatements, createPluginRepository } from "../../src/db/p
 //
 // Integration test RLS (negative test) membutuhkan DB nyata dan dipisah ke test terpisah.
 
-test("plugin adapter: buildPluginRlsStatements menghasilkan 3 SQL string", () => {
+test("plugin adapter: buildPluginRlsStatements (default) — enable+force+drop×2+create = 5 statement", () => {
   const stmts = buildPluginRlsStatements("sikesra", "subjects");
-  assert.equal(stmts.length, 3, "Harus menghasilkan tepat 3 SQL statement");
+  assert.equal(stmts.length, 5, "Harus menghasilkan 5 SQL statement (idempotent: 2 drop policy)");
 });
 
-test("plugin adapter: buildPluginRlsStatements — statement pertama enable RLS", () => {
+test("plugin adapter: buildPluginRlsStatements — enable & force RLS", () => {
   const stmts = buildPluginRlsStatements("sikesra", "subjects");
-  assert.ok(
-    stmts[0].includes("enable row level security"),
-    `Statement pertama harus enable RLS, dapat: "${stmts[0]}"`,
-  );
-  assert.ok(stmts[0].includes("sikesra.subjects"), 'Harus menyebut "sikesra.subjects"');
+  assert.ok(stmts[0].includes("enable row level security"));
+  assert.ok(stmts[0].includes("sikesra.subjects"));
+  assert.ok(stmts[1].includes("force row level security"));
 });
 
-test("plugin adapter: buildPluginRlsStatements — statement kedua force RLS", () => {
-  const stmts = buildPluginRlsStatements("sikesra", "subjects");
-  assert.ok(
-    stmts[1].includes("force row level security"),
-    `Statement kedua harus force RLS, dapat: "${stmts[1]}"`,
-  );
+test("plugin adapter: buildPluginRlsStatements — idempotent (drop policy lama & baru)", () => {
+  const stmts = buildPluginRlsStatements("sikesra", "subjects").join("\n");
+  assert.match(stmts, /drop policy if exists plugin_user_isolation on sikesra\.subjects/);
+  assert.match(stmts, /drop policy if exists plugin_access on sikesra\.subjects/);
 });
 
-test("plugin adapter: buildPluginRlsStatements — statement ketiga create policy isolasi user", () => {
-  const stmts = buildPluginRlsStatements("sikesra", "subjects");
-  assert.ok(stmts[2].includes("create policy"), 'Statement ketiga harus "create policy"');
-  assert.ok(stmts[2].includes("current_setting"), 'Policy harus memakai current_setting');
-  assert.ok(stmts[2].includes("app.current_user_id"), 'Policy harus memakai app.current_user_id');
+test("plugin adapter: buildPluginRlsStatements (default) — policy creator-only", () => {
+  const policy = buildPluginRlsStatements("sikesra", "subjects").at(-1);
+  assert.ok(policy.includes("create policy plugin_access"));
+  assert.ok(policy.includes("sikesra.subjects.created_by = current_setting('app.current_user_id', true)"));
+  // Tanpa opsi: tidak ada admin bypass / region.
+  assert.ok(!policy.includes("app.is_admin"), "default tidak boleh admin bypass");
+  assert.ok(!policy.includes("user_administrative_region_assignments"), "default tidak boleh region");
+});
+
+test("plugin adapter: buildPluginRlsStatements (assignment) — creator OR admin OR region (#353)", () => {
+  const policy = buildPluginRlsStatements("sikesra", "subjects", {
+    regionColumn: "administrative_region_id",
+    adminBypass: true,
+  }).at(-1);
+  // Creator
+  assert.match(policy, /sikesra\.subjects\.created_by = current_setting\('app\.current_user_id', true\)/);
+  // Admin bypass
+  assert.match(policy, /current_setting\('app\.is_admin', true\) = 'true'/);
+  // Region assignment, NULL-safe + penugasan aktif (ends_at is null)
+  assert.match(policy, /sikesra\.subjects\.administrative_region_id is not null/);
+  assert.match(policy, /user_administrative_region_assignments ura/);
+  assert.match(policy, /ura\.administrative_region_id = sikesra\.subjects\.administrative_region_id/);
+  assert.match(policy, /ura\.ends_at is null/);
 });
 
 test("plugin adapter: buildPluginRlsStatements — memakai schema + tableName yang diberikan", () => {


### PR DESCRIPTION
## Ringkasan

Implementasi **keputusan #353**: model akses RLS tabel plugin = **assignment/role-based** (pilihan pemilik, bukan sekadar admin-bypass). Untuk SIKESRA/SatuSehat (data kesehatan), akses **lintas-creator** berbasis **penugasan region aktif** + audit wajib.

## Perubahan

**`buildPluginRlsStatements(schema, table, options)`** — diperluas:
- Model akses (policy `plugin_access`):
  ```sql
  created_by = app.current_user_id
  OR app.is_admin = 'true'                 -- opsi adminBypass
  OR (regionColumn is not null AND exists(  -- opsi regionColumn
        penugasan aktif di user_administrative_region_assignments
        WHERE ura.administrative_region_id = <row>.regionColumn
          AND ura.ends_at is null))
  ```
- **NULL-safe**: baris region NULL → hanya creator/admin (tidak melebar).
- **Idempotent**: `drop policy if exists` (nama lama `plugin_user_isolation` + baru `plugin_access`) sebelum create.

**`sikesra.subjects` & `satu_sehat_kobar.patients`**: + kolom `administrative_region_id` (nullable) + index; opt-in region scoping + admin bypass. **Tabel anak** (records/record_documents/encounters/sync_logs) **tidak diubah** — tetap ketat; inheritance region = follow-up domain.

**Audit lintas-creator**: sudah wajib di `server/routes/api-v1-search.mjs` (`onAudit` semua pencarian SIKESRA/SatuSehat).

## Verifikasi

- ✅ 8/8 test `plugin-adapter` (default **creator-only** tanpa opsi; mode assignment = creator OR admin OR region aktif, NULL-safe).
- ✅ Suite: **500 pass** (5 fail **pra-ada** `setup-status`, independen).
- Test isolasi RLS DB nyata (role non-superuser, via pooler) → CI/Docker (pola PR #352).

## Follow-up (perlu domain + app berjalan)

1. Pengisian `administrative_region_id` saat create subject/patient (app layer). Tanpa itu, perilaku = creator/admin only (aman, tidak memblokir).
2. Region inheritance untuk tabel anak (records/encounters) bila perlu akses lintas-creator pada child.

Refs #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)