### PR TITLE
fix(health): remediasi actionable untuk 503 credential_format (#303) + hardening dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,37 @@
+# Dependabot untuk AWCMS-Mini (toolchain Bun / ekosistem npm).
+#
+# CATATAN PENTING (bun.lock):
+# Dependabot BELUM meregenerasi `bun.lock` saat menaikkan versi, sehingga PR-nya
+# gagal di CI pada langkah `bun install --frozen-lockfile`. Untuk menyelesaikan
+# sebuah PR dependabot: checkout branch-nya, jalankan `bun install` untuk sinkron
+# lockfile, commit `bun.lock`, lalu push sebelum merge.
+#
+# Major framework (astro, @astrojs/*, hono, react) SENGAJA diabaikan di sini —
+# upgrade major harus dikerjakan sebagai tugas khusus bertes (build + typecheck
+# + E2E), bukan bump otomatis. `@dependabot rebase` pada PR lama juga bisa
+# meng-escalate target ke major terbaru; hindari untuk paket framework.
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    # Kelompokkan minor+patch agar tidak banjir PR satuan.
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Major framework core → tangani manual/bertes, bukan auto-bump.
+      - dependency-name: "astro"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@astrojs/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "hono"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]

--- a/server/routes/health.mjs
+++ b/server/routes/health.mjs
@@ -8,6 +8,7 @@
 import { Hono } from "hono";
 
 import { checkDatabaseHealth, describeDatabaseHealthPosture } from "../../src/db/health.mjs";
+import { describeDatabaseErrorRemediation } from "../../src/db/errors.mjs";
 
 /**
  * @param {object} [options]
@@ -34,6 +35,10 @@ export function routeHealth(options = {}) {
               : {
                   kind: database.kind,
                   reason: database.reason,
+                  // Petunjuk remediasi aman (tanpa pesan/kredensial mentah); null bila tak ada.
+                  ...(describeDatabaseErrorRemediation(database.reason)
+                    ? { hint: describeDatabaseErrorRemediation(database.reason) }
+                    : {}),
                 }),
             posture,
           },

--- a/src/db/errors.mjs
+++ b/src/db/errors.mjs
@@ -143,6 +143,29 @@ export function describeDatabaseErrorReason(error) {
   return DATABASE_ERROR_REASON.UNKNOWN;
 }
 
+/**
+ * Petunjuk remediasi aman (tanpa membocorkan kredensial/pesan mentah) per reason.
+ * Dipakai di /health agar operator langsung tahu langkah perbaikan — khususnya
+ * kasus `credential_format` yang menyebabkan 503 saat deploy Coolify (#303):
+ * DATABASE_URL tanpa password atau password ber-karakter khusus yang tidak
+ * di-percent-encode → pg gagal parse → SASL "client password must be a string".
+ */
+export const DATABASE_ERROR_REMEDIATION = {
+  [DATABASE_ERROR_REASON.CREDENTIAL_FORMAT]:
+    "DATABASE_URL password missing or contains unescaped characters — percent-encode the password (RFC 3986) and confirm the secret is injected before the health probe runs.",
+  [DATABASE_ERROR_REASON.REFUSED]:
+    "Postgres refused the connection — verify the service is running and reachable on the configured host/port.",
+  [DATABASE_ERROR_REASON.DNS]: "Database hostname did not resolve — check the host in DATABASE_URL and private-network DNS.",
+  [DATABASE_ERROR_REASON.CONNECTION_TIMEOUT]:
+    "Connection timed out — check network path/pooler and databaseConnectTimeoutMs.",
+  [DATABASE_ERROR_REASON.TLS]: "TLS/certificate mismatch — verify sslmode and the server certificate.",
+  [DATABASE_ERROR_REASON.TERMINATED]: "Connection terminated — check pooler/idle limits or a server restart.",
+};
+
+export function describeDatabaseErrorRemediation(reason) {
+  return DATABASE_ERROR_REMEDIATION[reason] ?? null;
+}
+
 export function formatDatabaseErrorDiagnostic(error) {
   const kind = classifyDatabaseError(error);
   const reason = describeDatabaseErrorReason(error);

--- a/tests/unit/db.test.mjs
+++ b/tests/unit/db.test.mjs
@@ -13,6 +13,7 @@ import {
   DATABASE_ERROR_REASON,
   classifyDatabaseError,
   describeDatabaseErrorReason,
+  describeDatabaseErrorRemediation,
   extractDatabaseErrorMessage,
   formatDatabaseErrorDiagnostic,
 } from "../../src/db/errors.mjs";
@@ -115,6 +116,23 @@ test("describeDatabaseErrorReason identifies connection timeout failures", () =>
 test("describeDatabaseErrorReason identifies DNS failures", () => {
   const reason = describeDatabaseErrorReason(new Error("getaddrinfo ENOTFOUND id1.ahlikoding.com"));
   assert.equal(reason, DATABASE_ERROR_REASON.DNS);
+});
+
+test("credential_format from a passwordless/malformed DATABASE_URL yields an actionable remediation hint (#303)", () => {
+  // pg melempar ini saat password tidak ada/bukan string (mis. secret Coolify
+  // belum di-inject atau password ber-karakter khusus tanpa percent-encode).
+  const error = new Error("SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string");
+  assert.equal(classifyDatabaseError(error), DATABASE_ERROR_KIND.AUTHENTICATION);
+  assert.equal(describeDatabaseErrorReason(error), DATABASE_ERROR_REASON.CREDENTIAL_FORMAT);
+
+  const hint = describeDatabaseErrorRemediation(DATABASE_ERROR_REASON.CREDENTIAL_FORMAT);
+  assert.match(hint, /percent-encode/i);
+  // Petunjuk tidak boleh membocorkan kredensial/pesan mentah.
+  assert.doesNotMatch(hint, /password must be a string/i);
+});
+
+test("describeDatabaseErrorRemediation returns null for reasons without a hint", () => {
+  assert.equal(describeDatabaseErrorRemediation(DATABASE_ERROR_REASON.UNKNOWN), null);
 });
 
 test("classifyDatabaseError identifies aggregate ETIMEDOUT failures as connection blockers", () => {


### PR DESCRIPTION
## Konteks
Dua perbaikan infrastruktur kecil bertes.

### 1. Healthcheck #303 — diagnosis actionable
`/health` mengembalikan 503 `authentication/credential_format` saat deploy Coolify → rollback. **Akar masalah:** pg melempar `client password must be a string` (SASL) ketika password `DATABASE_URL` tidak ada/bukan string — secret belum di-inject **atau** password ber-karakter khusus tanpa percent-encode. Ini kredensial **hilang/rusak**, bukan **ditolak** (yang akan `28P01`).

- `describeDatabaseErrorRemediation(reason)` → hint aman per reason (tanpa membocorkan pesan/kredensial mentah).
- `/health` kini menyertakan `hint` saat DB tak sehat → operator langsung tahu langkah perbaikan (percent-encode password, pastikan secret ter-inject sebelum probe).
- Tidak mengubah semantik 200/503; murni observability.

### 2. Dependabot hardening
- Group minor+patch, batasi open-PR, **abaikan major** framework (astro/@astrojs/hono/react) → mencegah bump major mislabeled seperti #307/#308.
- Dokumentasikan caveat: dependabot **tidak** regen `bun.lock` → CI `bun install --frozen-lockfile` gagal; lockfile harus di-`bun install` ulang saat menyelesaikan PR-nya.

## Verifikasi
- `bun run test:unit` → **531 test, 5 skip, 0 fail** (2 test baru untuk remediation).
- Live `/health` menampilkan `hint` untuk kasus credential_format (diverifikasi lokal).
- lint hijau; `dependabot.yml` valid YAML.

Refs #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)