### PR TITLE
feat(abac): mode enforce/audit-only ABAC dikontrol env (default enforce) (#313)

### DIFF
--- a/docs/security/operations.md
+++ b/docs/security/operations.md
@@ -111,6 +111,23 @@ Mini now supports:
 
 These are rollout tools, not permanent substitutes for full enforcement.
 
+### ABAC enforcement mode (env-controlled)
+
+ABAC **enforces by default** — when unset, every flag below is `false`, so sensitive
+denies (`DENY_REGION_SCOPE_MISMATCH`, `DENY_PROTECTED_TARGET`) block the request.
+Set a flag to `true` only for a temporary audit-only rollout, where the deny is
+**logged but allowed** (reason `ALLOW_ABAC_AUDIT_ONLY`) so you can observe impact
+before enforcing. Revert to enforce by unsetting (or `false`).
+
+| Env var                                 | Effect when `true`                           |
+| --------------------------------------- | -------------------------------------------- |
+| `MINI_ABAC_AUDIT_ONLY`                  | Audit-only for all sensitive ABAC deny paths |
+| `MINI_ABAC_REGION_SCOPE_AUDIT_ONLY`     | Audit-only for region-scope mismatch only    |
+| `MINI_ABAC_PROTECTED_TARGET_AUDIT_ONLY` | Audit-only for protected-target only         |
+
+Only the exact string `true` (case-insensitive) enables a flag; any other value is enforce.
+An explicit `featureFlags` passed to `createAuthorizationService()` overrides the env.
+
 ## Cross-References
 
 - `docs/security/emergency-recovery-runbook.md`

--- a/src/services/authorization/flags.mjs
+++ b/src/services/authorization/flags.mjs
@@ -8,6 +8,27 @@ function normalizeBoolean(value) {
   return value === true;
 }
 
+function parseEnvBoolean(value) {
+  return typeof value === "string" && value.trim().toLowerCase() === "true";
+}
+
+/**
+ * Sumber flag ABAC yang dikontrol operator (env), default semua `false` = ENFORCE.
+ * Set ke `true` hanya untuk rollout audit-only sementara (deny dicatat, tidak
+ * memblokir) — mis. saat memantau dampak sebelum enforce penuh (#313).
+ *
+ *   MINI_ABAC_AUDIT_ONLY                  → downgrade semua deny ABAC sensitif
+ *   MINI_ABAC_REGION_SCOPE_AUDIT_ONLY     → hanya DENY_REGION_SCOPE_MISMATCH
+ *   MINI_ABAC_PROTECTED_TARGET_AUDIT_ONLY → hanya DENY_PROTECTED_TARGET
+ */
+function readAuthorizationFeatureFlagsFromEnv(env = process.env) {
+  return normalizeAuthorizationFeatureFlags({
+    abac_audit_only: parseEnvBoolean(env?.MINI_ABAC_AUDIT_ONLY),
+    abac_region_scope_audit_only: parseEnvBoolean(env?.MINI_ABAC_REGION_SCOPE_AUDIT_ONLY),
+    abac_protected_target_audit_only: parseEnvBoolean(env?.MINI_ABAC_PROTECTED_TARGET_AUDIT_ONLY),
+  });
+}
+
 function normalizeAuthorizationFeatureFlags(input = {}) {
   return {
     abac_audit_only: normalizeBoolean(input.abac_audit_only),
@@ -39,5 +60,6 @@ function shouldUseAuditOnlyMode(flags, result) {
 export {
   DEFAULT_AUTHORIZATION_FEATURE_FLAGS,
   normalizeAuthorizationFeatureFlags,
+  readAuthorizationFeatureFlagsFromEnv,
   shouldUseAuditOnlyMode,
 };

--- a/src/services/authorization/service.mjs
+++ b/src/services/authorization/service.mjs
@@ -21,7 +21,7 @@ import {
   evaluateScopedAllowRules,
   evaluateStaffLevelDenyRule,
 } from "./rules.mjs";
-import { normalizeAuthorizationFeatureFlags, shouldUseAuditOnlyMode } from "./flags.mjs";
+import { normalizeAuthorizationFeatureFlags, readAuthorizationFeatureFlagsFromEnv, shouldUseAuditOnlyMode } from "./flags.mjs";
 
 function createPermissionMissingResult(permissionCode) {
   return createAuthorizationResult({
@@ -243,7 +243,9 @@ function createAuthorizationAdministrativeRegionContextResolver(database) {
 
 export function createAuthorizationService(options = {}) {
   const database = options.database ?? getDatabase();
-  const featureFlags = normalizeAuthorizationFeatureFlags(options.featureFlags);
+  // Flag eksplisit menang; jika tidak, ambil dari env (default semua false = ENFORCE).
+  // Env yang tak di-set → perilaku identik dengan sebelumnya (tidak mengunci akses).
+  const featureFlags = normalizeAuthorizationFeatureFlags(options.featureFlags ?? readAuthorizationFeatureFlagsFromEnv());
   const cache = options.cache ?? createNoopAuthorizationCache();
   const resolveCurrentJobContext =
     options.jobContextResolver ?? (options.database ? createAuthorizationJobContextResolver(database) : async (subject) => subject);

--- a/tests/unit/authorization-service.test.mjs
+++ b/tests/unit/authorization-service.test.mjs
@@ -7,6 +7,7 @@ import {
   createAuthorizationLogicalRegionContextResolver,
   createAuthorizationService,
 } from "../../src/services/authorization/service.mjs";
+import { readAuthorizationFeatureFlagsFromEnv } from "../../src/services/authorization/flags.mjs";
 
 function createAuthorizationContextDatabase(state) {
   return {
@@ -388,6 +389,67 @@ test("authorization service can switch logical region scope denies into audit-on
   assert.equal(result.reason.details.original_reason_code, "DENY_REGION_SCOPE_MISMATCH");
   assert.equal(auditOnlyReports.length, 1);
   assert.equal(auditOnlyReports[0].denied_result.reason.code, "DENY_REGION_SCOPE_MISMATCH");
+});
+
+test("readAuthorizationFeatureFlagsFromEnv defaults to ENFORCE and only opts in on explicit 'true' (#313)", () => {
+  // Env kosong → semua false = enforce (tidak mengunci akses siapa pun).
+  assert.deepEqual(readAuthorizationFeatureFlagsFromEnv({}), {
+    abac_audit_only: false,
+    abac_region_scope_audit_only: false,
+    abac_protected_target_audit_only: false,
+  });
+
+  // Hanya string "true" (case-insensitive) yang mengaktifkan audit-only.
+  const flags = readAuthorizationFeatureFlagsFromEnv({
+    MINI_ABAC_REGION_SCOPE_AUDIT_ONLY: "TRUE",
+    MINI_ABAC_PROTECTED_TARGET_AUDIT_ONLY: "1",
+    MINI_ABAC_AUDIT_ONLY: "yes",
+  });
+  assert.equal(flags.abac_region_scope_audit_only, true);
+  assert.equal(flags.abac_protected_target_audit_only, false);
+  assert.equal(flags.abac_audit_only, false);
+});
+
+test("authorization service enforces region-scope deny by default, but env flag flips it to audit-only (#313)", async () => {
+  const buildService = () =>
+    createAuthorizationService({
+      logicalRegionContextResolver: async (evaluation) => ({
+        ...evaluation,
+        subject: { ...evaluation.subject, logical_region_ids: ["region_root", "region_north"] },
+        resource: { ...evaluation.resource, logical_region_ids: ["region_south"] },
+      }),
+      permissionResolver: {
+        async getEffectivePermissions() {
+          return { user_id: "user_manager", permission_codes: ["admin.users.read"] };
+        },
+      },
+    });
+  const evaluation = {
+    subject: { kind: "user", user_id: "user_manager" },
+    resource: { kind: "user", target_user_id: "user_target" },
+    context: { permission_code: "admin.users.read", action: "read" },
+  };
+
+  const previous = process.env.MINI_ABAC_REGION_SCOPE_AUDIT_ONLY;
+  try {
+    // Default (env tak di-set) → ENFORCE: deny tetap deny.
+    delete process.env.MINI_ABAC_REGION_SCOPE_AUDIT_ONLY;
+    const enforced = await buildService().evaluate(evaluation);
+    assert.equal(enforced.allowed, false);
+    assert.equal(enforced.reason.code, "DENY_REGION_SCOPE_MISMATCH");
+
+    // Flip env → audit-only: deny di-downgrade jadi allow tercatat.
+    process.env.MINI_ABAC_REGION_SCOPE_AUDIT_ONLY = "true";
+    const audited = await buildService().evaluate(evaluation);
+    assert.equal(audited.allowed, true);
+    assert.equal(audited.reason.code, "ALLOW_ABAC_AUDIT_ONLY");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.MINI_ABAC_REGION_SCOPE_AUDIT_ONLY;
+    } else {
+      process.env.MINI_ABAC_REGION_SCOPE_AUDIT_ONLY = previous;
+    }
+  }
 });
 
 test("authorization service allows requests when target logical region falls within actor subtree scope", async () => {


### PR DESCRIPTION
## Konteks (#313)
Slice **aman & non-destruktif** dari epic 2FA/ABAC hardening. ABAC sebenarnya **sudah enforce by default** (flag audit-only = `false`), tetapi flag-nya belum bisa dikontrol operator — tidak ada jalur konfigurasi untuk rollout audit-only sementara sebelum enforce penuh.

## Perubahan
- **Env-driven flags** (`readAuthorizationFeatureFlagsFromEnv`): `MINI_ABAC_AUDIT_ONLY`, `MINI_ABAC_REGION_SCOPE_AUDIT_ONLY`, `MINI_ABAC_PROTECTED_TARGET_AUDIT_ONLY`. Hanya `"true"` (case-insensitive) yang mengaktifkan.
- **Service default** membaca env bila `featureFlags` tak diberikan eksplisit. Flag eksplisit tetap menang → test lama tak terpengaruh.
- **Docs** operator: tabel env + semantik default enforce.

## Keamanan / kompatibilitas
- **Default = enforce** (env kosong) → perilaku **identik** dengan sekarang; tidak mengunci akses siapa pun.
- Memberi operator "flip flag" untuk rollout audit-only terkontrol, lalu balik ke enforce.

## Test negatif (AC #313)
- Enforce path: default → `DENY_REGION_SCOPE_MISMATCH` (allowed=false).
- Flip env → `ALLOW_ABAC_AUDIT_ONLY` (deny dicatat, tidak memblokir).
- Reader: env kosong → semua false; opt-in ketat hanya `"true"`.

`bun run test:unit` → **533 test, 5 skip, 0 fail**. lint hijau.

## Di luar slice ini (butuh lingkungan nyata / keputusan)
- Uji multi-instance & transisi enforce penuh lintas seluruh route sensitif (AC lain #313).

Refs #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)