### PR TITLE
feat(sso): OIDC login core — state/nonce/PKCE + callback validation (#351)

### DIFF
--- a/src/auth/sso/authorization-request.mjs
+++ b/src/auth/sso/authorization-request.mjs
@@ -1,0 +1,137 @@
+/**
+ * OIDC login initiation — Tahap 2 (#351, ADR-024). Modul **pure** (hanya
+ * `node:crypto`, tanpa I/O) agar mudah diuji tanpa IdP nyata.
+ *
+ * Cakupan: membangun Authorization Request + parameter anti-forgery, dan
+ * memvalidasi parameter callback. Pertukaran code→token & verifikasi ID token
+ * (JWKS/iss/aud/nonce) menyusul di slice berikutnya.
+ *
+ * Keamanan (standar SSO §3/§6):
+ *   - `state`  — anti-CSRF; wajib cocok saat callback.
+ *   - `nonce`  — anti-replay ID token; diverifikasi saat validasi ID token.
+ *   - PKCE S256 — `code_verifier`/`code_challenge` mencegah code interception.
+ *   - `redirect_uri` WAJIB HTTPS dan berada di allowlist (cegah open redirect
+ *     & token leakage). authorization_endpoint WAJIB HTTPS.
+ *   - `code_verifier` bersifat rahasia sesi — JANGAN dikirim ke authorize,
+ *     hanya dipakai saat token exchange.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+
+function base64UrlRandom(byteLength = 32) {
+  return randomBytes(byteLength).toString("base64url");
+}
+
+function isHttpsUrl(value) {
+  if (typeof value !== "string" || value.trim() === "") return false;
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Buat parameter anti-forgery untuk satu percobaan login OIDC.
+ * `state`/`nonce`/`codeVerifier` harus disimpan di sisi server (terikat sesi),
+ * bukan dibocorkan ke klien selain lewat Authorization Request.
+ *
+ * @returns {{ state: string, nonce: string, codeVerifier: string, codeChallenge: string, codeChallengeMethod: "S256" }}
+ */
+export function createOidcLoginState() {
+  const codeVerifier = base64UrlRandom(32);
+  const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
+
+  return {
+    state: base64UrlRandom(32),
+    nonce: base64UrlRandom(32),
+    codeVerifier,
+    codeChallenge,
+    codeChallengeMethod: "S256",
+  };
+}
+
+/**
+ * Bangun URL Authorization Request OIDC (response_type=code + PKCE).
+ *
+ * @param {object} provider provider ternormalkan (lihat validateSsoProviderConfig)
+ * @param {object} params { redirectUri, state, nonce, codeChallenge, allowedRedirectUris }
+ * @returns {string} URL absolut ke authorization_endpoint
+ * @throws {Error} bila endpoint/redirect tidak memenuhi syarat keamanan
+ */
+export function buildAuthorizationRequestUrl(provider, params = {}) {
+  if (!provider || typeof provider !== "object") {
+    throw new TypeError("provider wajib berupa objek terkonfigurasi.");
+  }
+  if (!isHttpsUrl(provider.authorization_endpoint)) {
+    throw new Error("authorization_endpoint provider harus URL HTTPS yang valid.");
+  }
+
+  const { redirectUri, state, nonce, codeChallenge, allowedRedirectUris } = params;
+
+  if (!isHttpsUrl(redirectUri)) {
+    throw new Error("redirect_uri harus URL HTTPS yang valid.");
+  }
+  // Allowlist wajib bila diberikan — cegah open redirect / token leakage.
+  if (Array.isArray(allowedRedirectUris) && !allowedRedirectUris.includes(redirectUri)) {
+    throw new Error("redirect_uri tidak berada di allowlist.");
+  }
+  for (const [name, value] of [
+    ["state", state],
+    ["nonce", nonce],
+    ["codeChallenge", codeChallenge],
+  ]) {
+    if (typeof value !== "string" || value.trim() === "") {
+      throw new Error(`${name} wajib diisi (string non-kosong).`);
+    }
+  }
+
+  const url = new URL(provider.authorization_endpoint);
+  const scopes = Array.isArray(provider.scopes) && provider.scopes.length > 0 ? provider.scopes : ["openid"];
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", provider.client_id);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("scope", scopes.join(" "));
+  url.searchParams.set("state", state);
+  url.searchParams.set("nonce", nonce);
+  url.searchParams.set("code_challenge", codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+
+  return url.toString();
+}
+
+/**
+ * Validasi parameter callback dari IdP.
+ * Memakai perbandingan panjang-tetap untuk `state` (anti timing).
+ *
+ * @param {object} args { params, expectedState }
+ * @returns {{ code: string, state: string }}
+ * @throws {Error} bila IdP mengembalikan error, state tak cocok, atau code hilang
+ */
+export function validateAuthorizationCallback({ params = {}, expectedState } = {}) {
+  if (typeof params.error === "string" && params.error.trim() !== "") {
+    throw new Error(`IdP mengembalikan error: ${params.error}`);
+  }
+  if (typeof expectedState !== "string" || expectedState.trim() === "") {
+    throw new Error("expectedState (state sesi) tidak tersedia.");
+  }
+  if (typeof params.state !== "string" || !timingSafeEqualString(params.state, expectedState)) {
+    throw new Error("state callback tidak cocok — kemungkinan CSRF.");
+  }
+  if (typeof params.code !== "string" || params.code.trim() === "") {
+    throw new Error("authorization code tidak ada di callback.");
+  }
+
+  return { code: params.code, state: params.state };
+}
+
+function timingSafeEqualString(a, b) {
+  if (typeof a !== "string" || typeof b !== "string" || a.length !== b.length) {
+    return false;
+  }
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}

--- a/tests/unit/sso-authorization-request.test.mjs
+++ b/tests/unit/sso-authorization-request.test.mjs
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+import {
+  buildAuthorizationRequestUrl,
+  createOidcLoginState,
+  validateAuthorizationCallback,
+} from "../../src/auth/sso/authorization-request.mjs";
+
+const provider = {
+  client_id: "mini-client",
+  authorization_endpoint: "https://idp.example.com/authorize",
+  scopes: ["openid", "email", "profile"],
+};
+
+test("createOidcLoginState produces distinct high-entropy values with a correct PKCE S256 challenge", () => {
+  const a = createOidcLoginState();
+  const b = createOidcLoginState();
+
+  // Anti-forgery values harus acak & berbeda antar percobaan.
+  assert.notEqual(a.state, b.state);
+  assert.notEqual(a.nonce, b.nonce);
+  assert.notEqual(a.codeVerifier, b.codeVerifier);
+  for (const v of [a.state, a.nonce, a.codeVerifier]) {
+    assert.ok(v.length >= 43, "harus >= 43 char base64url (32 byte)");
+    assert.match(v, /^[A-Za-z0-9_-]+$/, "base64url tanpa padding");
+  }
+
+  // code_challenge = BASE64URL(SHA256(code_verifier)).
+  const expected = createHash("sha256").update(a.codeVerifier).digest("base64url");
+  assert.equal(a.codeChallenge, expected);
+  assert.equal(a.codeChallengeMethod, "S256");
+});
+
+test("buildAuthorizationRequestUrl sets all required OIDC + PKCE parameters", () => {
+  const { state, nonce, codeChallenge } = createOidcLoginState();
+  const href = buildAuthorizationRequestUrl(provider, {
+    redirectUri: "https://app.example.com/auth/sso/callback",
+    state,
+    nonce,
+    codeChallenge,
+  });
+  const url = new URL(href);
+
+  assert.equal(url.origin + url.pathname, "https://idp.example.com/authorize");
+  assert.equal(url.searchParams.get("response_type"), "code");
+  assert.equal(url.searchParams.get("client_id"), "mini-client");
+  assert.equal(url.searchParams.get("redirect_uri"), "https://app.example.com/auth/sso/callback");
+  assert.equal(url.searchParams.get("scope"), "openid email profile");
+  assert.equal(url.searchParams.get("state"), state);
+  assert.equal(url.searchParams.get("nonce"), nonce);
+  assert.equal(url.searchParams.get("code_challenge"), codeChallenge);
+  assert.equal(url.searchParams.get("code_challenge_method"), "S256");
+});
+
+test("buildAuthorizationRequestUrl rejects non-HTTPS endpoints and off-allowlist redirects", () => {
+  const { state, nonce, codeChallenge } = createOidcLoginState();
+  const good = "https://app.example.com/auth/sso/callback";
+
+  assert.throws(
+    () => buildAuthorizationRequestUrl({ ...provider, authorization_endpoint: "http://idp/x" }, { redirectUri: good, state, nonce, codeChallenge }),
+    /authorization_endpoint/,
+  );
+  assert.throws(
+    () => buildAuthorizationRequestUrl(provider, { redirectUri: "http://app/cb", state, nonce, codeChallenge }),
+    /redirect_uri harus URL HTTPS/,
+  );
+  assert.throws(
+    () =>
+      buildAuthorizationRequestUrl(provider, {
+        redirectUri: "https://evil.example.com/cb",
+        state,
+        nonce,
+        codeChallenge,
+        allowedRedirectUris: [good],
+      }),
+    /allowlist/,
+  );
+});
+
+test("validateAuthorizationCallback enforces state match, surfaces IdP errors, and requires a code", () => {
+  const expectedState = "state-abc";
+
+  assert.deepEqual(
+    validateAuthorizationCallback({ params: { code: "auth-code", state: expectedState }, expectedState }),
+    { code: "auth-code", state: expectedState },
+  );
+
+  // state mismatch → tolak (CSRF).
+  assert.throws(
+    () => validateAuthorizationCallback({ params: { code: "c", state: "wrong" }, expectedState }),
+    /state callback tidak cocok/,
+  );
+  // IdP error param → tolak.
+  assert.throws(
+    () => validateAuthorizationCallback({ params: { error: "access_denied", state: expectedState }, expectedState }),
+    /IdP mengembalikan error/,
+  );
+  // code hilang → tolak.
+  assert.throws(
+    () => validateAuthorizationCallback({ params: { state: expectedState }, expectedState }),
+    /authorization code tidak ada/,
+  );
+  // expectedState hilang → tolak (tak bisa validasi).
+  assert.throws(() => validateAuthorizationCallback({ params: { code: "c", state: "x" } }), /expectedState/);
+});


### PR DESCRIPTION
## Konteks (#351 Tahap 2)
Lanjutan SSO OIDC setelah Tahap 1 (skema `auth.sso_providers`/`auth.sso_identities` + config, #357). Slice **pure & non-destruktif** — inti keamanan alur login, tanpa perlu IdP nyata.

## Perubahan (`src/auth/sso/authorization-request.mjs`)
- `createOidcLoginState()` — `state` (anti-CSRF), `nonce` (anti-replay), PKCE `code_verifier`/`code_challenge` (S256).
- `buildAuthorizationRequestUrl()` — Authorization Request `response_type=code` + PKCE. `authorization_endpoint` & `redirect_uri` **wajib HTTPS**; `redirect_uri` dicek **allowlist** (cegah open redirect/token leakage).
- `validateAuthorizationCallback()` — verifikasi `state` **timing-safe** (anti-CSRF), surfacing error IdP, wajib ada `code`.

## Keamanan
Mengikuti standar SSO §3/§6: anti-CSRF, anti-replay, PKCE, HTTPS-only, allowlist redirect. `code_verifier` rahasia sesi (tidak dikirim ke authorize).

## Non-destruktif
Helper murni; **belum diwire ke route**. Route login SSO menyusul di belakang flag bersama token-exchange + verifikasi ID token (JWKS/iss/aud/nonce).

`bun run test:unit` → **537 test, 5 skip, 0 fail** (4 test baru). lint hijau.

Refs #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)