### PR TITLE
fix(sync): stop double-encoding jsonb payloads in sync push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format mengikuti [Keep a Changelog](https://keepachangelog.com/id/1.1.0/) dan pr
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-07-05
+
+### Fixed
+
+- `POST /sync/push` (Issue 6.1) melakukan `JSON.stringify` sebelum bind ke kolom `payload_json` (jsonb) — Bun.SQL sudah menyerialisasi value yang di-bind ke kolom jsonb sendiri, sehingga stringify tambahan menghasilkan jsonb string scalar (teks JSON dalam tanda kutip), bukan objek jsonb nyata. Ditemukan saat membangun audit trail Issue 10.1 (kelas bug yang sama sempat muncul di kode baru dan tertangkap sebelum ship). Diperbaiki dengan bind `event.payload` langsung.
+
 ## [0.11.0] - 2026-07-05
 
 ### Added
@@ -207,7 +213,8 @@ Aplikasi turunan (mis. AWPOS) memakai peta versinya sendiri di atas base ini.
 
 Nomor versi naik progresif per rilis, bukan hanya saat satu slot epic selesai penuh: rilis `0.2.0`-`0.4.0` berisi Issue 2.1 (tenant/office), 2.2 (central profile), dan 2.3 (identity/login) dari slot "Tenant, identity, profile" (tuntas); rilis `0.5.0` berisi Issue 2.4 (RBAC/ABAC) dari slot "RBAC/ABAC evaluator + assignment" (tuntas). Epic M2 (2.1–2.4) selesai penuh. Rilis `0.6.0` berisi Issue 12.1 (Setup Wizard) dan rilis `0.7.0` berisi Issue 6.1 (Sync Outbox/Inbox) — keduanya tidak punya slot eksplisit sendiri di tabel peta versi doc 09 (12.1 ditempatkan setelah M2, 6.1 dimulai dari slot "Sync storage" `v0.4.0` yang sebelumnya ditarget jauh lebih lambat dari realisasi progresif ini). Rilis `0.8.0` berisi Issue 6.2 (Sync Conflict Tracking/Resolution), lanjutan langsung dari slot "Sync storage" yang sama dengan 6.1. Rilis `0.9.0` berisi Issue 6.3 (R2 Object Sync Queue), menuntaskan epic M5 (Sync Storage) sepenuhnya. Rilis `0.10.0` berisi Issue 8.1 (Admin Layout Shell), issue pertama epic M7 (UI/UX & Reporting) dan issue frontend pertama di repo ini. Rilis `0.11.0` berisi Issue 9.1 (Management Reporting Views), menuntaskan epic M7 sepenuhnya.
 
-[Unreleased]: https://github.com/ahliweb/awcms-mini/compare/awcms-mini@0.11.0...HEAD
+[Unreleased]: https://github.com/ahliweb/awcms-mini/compare/awcms-mini@0.11.1...HEAD
+[0.11.1]: https://github.com/ahliweb/awcms-mini/compare/awcms-mini@0.11.0...awcms-mini@0.11.1
 [0.11.0]: https://github.com/ahliweb/awcms-mini/compare/awcms-mini@0.10.0...awcms-mini@0.11.0
 [0.10.0]: https://github.com/ahliweb/awcms-mini/compare/awcms-mini@0.9.0...awcms-mini@0.10.0
 [0.9.0]: https://github.com/ahliweb/awcms-mini/compare/awcms-mini@0.8.0...awcms-mini@0.9.0

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Backlog base generik ada di [`docs/awcms-mini/06_github_issues_detail.md`](docs/
 
 ## Versioning
 
-**Semantic Versioning** + **[Changesets](.changeset/README.md)**; riwayat di [`CHANGELOG.md`](CHANGELOG.md). Setiap PR yang mengubah perilaku wajib menyertakan changeset. Versi saat ini `0.11.0` (Foundation skeleton SSR + Issue 2.1-2.4: tenant/office, central profile, identity/login, RBAC/ABAC + Issue 12.1 setup wizard + epic M5 Sync Storage tuntas: Issue 6.1 sync outbox/inbox, 6.2 sync conflict tracking/resolution, 6.3 R2 object sync queue + epic M7 UI/UX & Reporting tuntas: Issue 8.1 admin layout shell, 9.1 management reporting views).
+**Semantic Versioning** + **[Changesets](.changeset/README.md)**; riwayat di [`CHANGELOG.md`](CHANGELOG.md). Setiap PR yang mengubah perilaku wajib menyertakan changeset. Versi saat ini `0.11.1` (Foundation skeleton SSR + Issue 2.1-2.4: tenant/office, central profile, identity/login, RBAC/ABAC + Issue 12.1 setup wizard + epic M5 Sync Storage tuntas: Issue 6.1 sync outbox/inbox, 6.2 sync conflict tracking/resolution, 6.3 R2 object sync queue + epic M7 UI/UX & Reporting tuntas: Issue 8.1 admin layout shell, 9.1 management reporting views + patch: fix double-encoding jsonb pada sync push).
 
 ## Lisensi
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "awcms-mini",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "AWCMS-Mini — Modular Monolith Standard (Bun + Astro foundation skeleton)",
   "license": "MIT",

--- a/src/pages/api/v1/sync/push.ts
+++ b/src/pages/api/v1/sync/push.ts
@@ -86,7 +86,7 @@ export const POST: APIRoute = async ({ request }) => {
             (tenant_id, node_id, batch_id, event_type, aggregate_type, aggregate_id, payload_json)
           VALUES (
             ${tenantId}, ${node.id}, ${batchId}, ${event.eventType}, ${event.aggregateType},
-            null, ${JSON.stringify(event.payload)}
+            null, ${event.payload}
           )
         `;
         acceptedCount += 1;
@@ -112,7 +112,7 @@ export const POST: APIRoute = async ({ request }) => {
             (tenant_id, node_id, batch_id, aggregate_type, aggregate_id, conflict_type, payload_json)
           VALUES (
             ${tenantId}, ${node.id}, ${batchId}, ${event.aggregateType}, ${event.aggregateId},
-            ${evaluation.conflictType}, ${JSON.stringify(event.payload)}
+            ${evaluation.conflictType}, ${event.payload}
           )
         `;
         conflictedCount += 1;
@@ -124,7 +124,7 @@ export const POST: APIRoute = async ({ request }) => {
           (tenant_id, node_id, batch_id, event_type, aggregate_type, aggregate_id, payload_json)
         VALUES (
           ${tenantId}, ${node.id}, ${batchId}, ${event.eventType}, ${event.aggregateType},
-          ${event.aggregateId}, ${JSON.stringify(event.payload)}
+          ${event.aggregateId}, ${event.payload}
         )
       `;
 


### PR DESCRIPTION
## Summary
- `POST /sync/push` called `JSON.stringify(event.payload)` before binding it to the `payload_json` jsonb columns on `awcms_mini_sync_inbox`/`awcms_mini_sync_conflicts`. Bun.SQL already serializes bound values for jsonb columns itself, so the extra stringify produced a jsonb string scalar (JSON text in quotes) instead of a real jsonb object — any consumer (`GET /sync/pull`, future dispatchers) would see a quoted JSON string instead of a nested object.
- Found while building Issue 10.1's audit trail, which hit the identical class of bug in new code and caught it before shipping; this fixes the pre-existing occurrence in Issue 6.1's push handler.
- Fixed by binding `event.payload` directly at all 3 call sites.

## Test plan
- [x] `bun run check` (lint, docs check, api spec check, typecheck, 132 tests, build) all pass
- [x] Live-verified against PostgreSQL 16 + a running Astro SSR server: pushed a nested payload, confirmed via raw SQL select that the stored jsonb column round-trips as a real JS object (`typeof "object"`, correct nested structure), not a double-encoded string

🤖 Generated with [Claude Code](https://claude.com/claude-code)