### PR TITLE
docs(skills): add four improvement skills (UX, performance, integration, security-hardening)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -27,6 +27,17 @@ Skill Claude Code tingkat-proyek untuk AWCMS-Mini. Setiap skill meng-encode stan
 | `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)         | 09             |
 | `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)              | 07, 06         |
 
+## Katalog peningkatan (improvement/hardening)
+
+Skill di bawah bersifat **peningkatan** — menilai & menaikkan mutu artefak yang sudah ada, bukan membangunnya dari nol. Pakai setelah fitur jalan, saat audit, atau menjelang go-live.
+
+| Skill                           | Kapan dipakai                                                           | Sumber docs |
+| ------------------------------- | ----------------------------------------------------------------------- | ----------- |
+| `awcms-mini-ux-review`          | Audit & naikkan mutu UI/UX yang sudah ada (usability, a11y AA, i18n)    | 14, 15, 19  |
+| `awcms-mini-performance`        | Tuning performa aplikasi & database (query, index, pagination, pool)    | 16, 07      |
+| `awcms-mini-integration`        | Kerasan backend & integrasi eksternal (outbox, retry, webhook, kontrak) | 16, 05, 10  |
+| `awcms-mini-security-hardening` | Audit keamanan berbasis standar (OWASP Top 10, ASVS, ISO 27001)         | 20, 10, 13  |
+
 ## Peta pemakaian
 
 ```mermaid
@@ -47,6 +58,13 @@ flowchart TD
   PR --> SEC[awcms-mini-security-review]
   SEC --> PF[awcms-mini-production-preflight]
   PF --> REL[awcms-mini-release]
+
+  UI --> UXR[awcms-mini-ux-review]
+  EP --> PERF[awcms-mini-performance]
+  EP --> INT[awcms-mini-integration]
+  SEC --> HARD[awcms-mini-security-hardening]
+  PERF --> PF
+  HARD --> PF
 ```
 
 ## Subagents (`.claude/agents/`)

--- a/.claude/skills/awcms-mini-integration/SKILL.md
+++ b/.claude/skills/awcms-mini-integration/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: awcms-mini-integration
+description: Audit dan perkuat backend & integrasi eksternal AWCMS-Mini (resiliensi, outbox, webhook/provider, versioning API, observability). Gunakan saat menambah/mengeraskan integrasi ke provider luar (R2, WhatsApp, email, AI, pajak), memperbaiki keandalan delivery, atau menaikkan ketahanan backend. Menegakkan ADR-0006 (provider opsional, di luar transaksi) dan pola outbox doc 16.
+---
+
+# AWCMS-Mini — Backend & Integration Hardening
+
+Sumber kebenaran: **`docs/awcms-mini/16_backend_data_access_integration.md`** (transactional outbox, transaction wrapper, idempotency), **`docs/awcms-mini/05_openapi_asyncapi_detail.md`** (kontrak API/event), dan **`docs/awcms-mini/10_template_kode_coding_standard.md`** (guardrail). Skill ini **peningkatan**: menaikkan keandalan & ketahanan, bukan sekadar membuat endpoint (itu `awcms-mini-new-endpoint`).
+
+## Prinsip integrasi (non-negotiable)
+
+- **Provider eksternal opsional** (ADR-0006): R2/WA/email/AI/pajak **tidak boleh** jadi dependency alur operasional kritis, dan **tidak boleh** dipanggil di dalam transaksi DB. Provider off → aksi tetap masuk antrean, bukan gagal.
+- **Secret hanya dari environment** (doc 18); flag aktif tanpa kredensial → gagal start (fail-fast).
+
+## Checklist ketahanan
+
+- [ ] **Transactional outbox** — efek samping eksternal (kirim WA/email, upload objek, publish event) ditulis ke tabel outbox **dalam** transaksi bisnis, lalu dispatcher terpisah mengirim di luar transaksi (at-least-once). Bukan panggilan langsung inline. Contoh yang sudah ada: `awcms_mini_sync_outbox` dan `awcms_mini_object_sync_queue`; `awcms_mini_message_outbox` (WA/email, doc 04 §ERD) adalah pola yang direncanakan tetapi belum dibuat — aplikasi turunan yang butuh kanal pesan menambahkannya mengikuti pola sama.
+- [ ] **Timeout + retry + backoff** — tiap panggilan keluar punya timeout eksplisit; retry dengan exponential backoff berbatas (pola `evaluateObjectRetry`, maks percobaan); jangan retry tak terbatas.
+- [ ] **Circuit breaker** — dependency yang gagal beruntun dibuka sementara agar tak menyeret sistem (pola `src/lib/database/circuit-breaker.ts` dapat diperluas ke provider).
+- [ ] **Idempotency di batas integrasi** — dispatcher aman diulang (dedup by natural key / `Idempotency-Key` / ledger batch seperti `sync_push_batches`); pengiriman ganda tak menduplikasi efek.
+- [ ] **Dead-letter / status gagal** — item yang habis retry ditandai `failed` dengan `last_error`, bukan hilang diam-diam; ada jalur retry manual admin (mis. `/sync/object-queue/{id}/retry`).
+- [ ] **Verifikasi webhook masuk** — signature HMAC + anti-replay (timestamp skew) untuk callback provider, pola `awcms-mini-sync-hmac`. Jangan percaya payload tak tertandatangani.
+- [ ] **SSRF-safe** — URL provider dari konfigurasi tepercaya (env), bukan dari input user; validasi host bila perlu.
+- [ ] **Kontrak sinkron** — endpoint baru/berubah → OpenAPI diperbarui; event baru/berubah → AsyncAPI diperbarui; `module.ts` publishes/subscribes akurat. `bun run api:spec:check` hijau.
+- [ ] **Versioning & kompatibilitas** — perubahan breaking di path/skema butuh versi baru atau additive; jangan patahkan klien lama (pola cookie additive di `/auth/login`).
+- [ ] **Observability** — correlation ID diteruskan lintas hop (header `X-Correlation-ID`, middleware); log terstruktur JSON (hormati `LOG_LEVEL`); aksi high-risk masuk audit; redaksi secret/PII sebelum log.
+- [ ] **Degradasi anggun** — bila provider/flag off, endpoint operasional tetap jalan (POS tak berhenti); pesan/objek tetap terantre.
+- [ ] **Rate limiting / anti-abuse** — batasi endpoint publik/mahal; login sudah punya lockout — perluas pola ke titik lain bila perlu.
+
+## Verifikasi
+
+- Uji provider off: aksi tetap masuk outbox/queue, tak ada error operasional.
+- Uji retry: paksa gagal → item mundur backoff → habis percobaan → `failed` + `last_error`, retry manual mengembalikan ke `pending`.
+- Uji idempotency dispatcher: kirim ulang batch → efek tak berganda.
+- `bun run check` hijau; OpenAPI/AsyncAPI sinkron; correlation ID muncul di log lintas hop.
+
+## Skill terkait
+
+`awcms-mini-new-endpoint` / `awcms-mini-new-event` (kontrak), `awcms-mini-sync-hmac` (signature), `awcms-mini-idempotency` (mutation), `awcms-mini-audit-log` (jejak), `awcms-mini-performance` (I/O di luar transaksi).

--- a/.claude/skills/awcms-mini-performance/SKILL.md
+++ b/.claude/skills/awcms-mini-performance/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: awcms-mini-performance
+description: Audit dan tingkatkan performa aplikasi & database AWCMS-Mini. Gunakan saat diminta "optimasi performa/query", ada endpoint lambat, N+1, masalah indexing/pagination, tuning connection pool, atau perencanaan materialized view/caching. Menegakkan pola akses data doc 16, pooling/backpressure, dan pagination keyset.
+---
+
+# AWCMS-Mini — Performance & Database Tuning
+
+Sumber kebenaran: **`docs/awcms-mini/16_backend_data_access_integration.md`** (lapisan akses data, pooling/backpressure, transaction), **`docs/awcms-mini/database-pooling.md`**, dan **`docs/awcms-mini/07_sprint_testing_production_readiness.md`** (target performa). Skill ini **peningkatan**: ukur → temukan bottleneck → perbaiki → ukur ulang.
+
+## Aturan emas
+
+**Ukur sebelum optimasi.** Jangan menebak — jalankan `EXPLAIN (ANALYZE, BUFFERS)` pada query yang dicurigai, dan benchmark endpoint (p50/p95/p99) sebelum & sesudah. Optimasi tanpa data = spekulasi.
+
+## Database
+
+- [ ] **Index RLS-aware** — query tenant-scoped selalu difilter `tenant_id`; index komposit **harus** berprefiks `(tenant_id, …)` agar cocok dengan predikat RLS + filter. Cek index hilang via `EXPLAIN` (Seq Scan pada tabel besar = merah).
+- [ ] **Hindari N+1** — jangan query dalam loop; batch pakai `= ANY(tx.array(ids, "uuid"))` (lihat memory Bun SQL array binding) atau `JOIN`. Cari pola `for (…) await tx\`SELECT …\``.
+- [ ] **Pagination keyset, bukan OFFSET** — `WHERE (created_at, id) < (:cursor)` + `LIMIT`, bukan `OFFSET n` besar (doc 14 §Pagination). OFFSET besar memindai lalu membuang baris.
+- [ ] **Kolom eksplisit** — hindari `SELECT *`; ambil hanya kolom yang dipakai (kurangi I/O + payload).
+- [ ] **`count(*)::int`** untuk agregat kecil; ingat bigint Postgres kembali sebagai string dari Bun.SQL → `Number(...)` eksplisit, jangan `as number`.
+- [ ] **jsonb** — index GIN hanya bila di-query berdasarkan isi; jangan simpan payload besar yang tak pernah difilter.
+- [ ] **Materialized view / read model** — untuk laporan agregasi berat yang tak butuh real-time; refresh terjadwal. Report base saat ini agregasi baca langsung (doc: reporting) — pertimbangkan MV bila data tumbuh.
+- [ ] **Statement timeout** — `DATABASE_STATEMENT_TIMEOUT_MS` mencegah query liar mengunci koneksi.
+
+## Aplikasi & koneksi
+
+- [ ] **Work-class pool + backpressure** — endpoint diklasifikasi (`critical_transaction`/`interactive`/`reporting`/`background_sync`/`maintenance`, doc 16). Laporan berat & sync **tidak** boleh di kelas `interactive`; saturasi → `503 DATABASE_BUSY`, bukan menjenuhkan seluruh pool.
+- [ ] **Transaksi seringkas mungkin** — kerja CPU-bound (argon2 hashing) & panggilan provider eksternal **di luar** transaksi DB (ADR-0006); jangan menahan koneksi/lock saat menunggu I/O eksternal.
+- [ ] **PgBouncer** — bila `DATABASE_PGBOUNCER=true`, prepared statement dinonaktifkan (mode transaction). Pastikan `DATABASE_POOL_MAX` selaras dengan limit pool server.
+- [ ] **SSR reuse** — halaman admin fetch via fungsi application-layer di dalam satu `withTenant`, bukan round-trip HTTP ke API sendiri (pola `*-directory.ts`/`*-report.ts`).
+- [ ] **Locking** — `FOR UPDATE` hanya pada baris yang benar-benar dimutasi bersama (mis. stok); hindari lock rentang lebar.
+
+## Verifikasi
+
+- `EXPLAIN ANALYZE` sebelum/sesudah menunjukkan perbaikan nyata (Seq→Index Scan, plan cost turun).
+- Benchmark p95 endpoint membaik; tak ada regresi fungsional (`bun run check` hijau).
+- Uji beban ringan: query saturasi kelas pool → `503`, mengering ke 0 (bukti backpressure, seperti verifikasi Issue 10.2).
+- Tak ada N+1 baru; tak ada `OFFSET` besar; index cocok dengan predikat.
+
+## Skill terkait
+
+`awcms-mini-new-migration` (tambah index via migration berurutan), `awcms-mini-integration` (I/O eksternal & outbox), `awcms-mini-testing` (benchmark/load test), `awcms-mini-production-preflight` (`db:pool:health`).

--- a/.claude/skills/awcms-mini-security-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-security-hardening/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: awcms-mini-security-hardening
+description: Audit keamanan berbasis standar (OWASP Top 10, OWASP ASVS, ISO/IEC 27001 Annex A) untuk AWCMS-Mini. Gunakan saat diminta "security hardening", audit OWASP/ASVS/ISO, penilaian kepatuhan, atau pengerasan menjelang go-live/audit eksternal. Berbeda dari awcms-mini-security-review (checklist DoD per modul) — skill ini memetakan kontrol ke kerangka standar industri.
+---
+
+# AWCMS-Mini — Security Hardening (OWASP / ASVS / ISO)
+
+Sumber kebenaran: **`docs/awcms-mini/20_threat_model_security_architecture.md`** (STRIDE, kontrol berlapis, trust boundary), **`docs/awcms-mini/10_template_kode_coding_standard.md`** (guardrail), dan **`docs/awcms-mini/13_final_master_index_traceability.md`** (matrix kontrol). Skill ini **memetakan** kontrol proyek ke kerangka standar; pakai bersama `awcms-mini-security-review` (checklist per modul) dan subagent `awcms-mini-security-auditor`.
+
+## OWASP Top 10 (2021) → kontrol di base
+
+| #   | Kategori                       | Cek utama di AWCMS-Mini                                                                                                                                                                                                               |
+| --- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A01 | Broken Access Control          | ABAC default-deny + deny-overrides (ADR-0004); RLS `ENABLE`+`FORCE` (ADR-0003); DB role non-superuser; `WHERE id=<tenant>` eksplisit pada tabel RLS-free (`awcms_mini_tenants`); IDOR — cek tiap resource difilter tenant/kepemilikan |
+| A02 | Cryptographic Failures         | Password argon2id (`Bun.password`); token sesi opaque (hanya hash disimpan); identifier sensitif `value_hash`+`masked_value`; HTTPS di produksi; cookie `HttpOnly`/`Secure`/`SameSite`                                                |
+| A03 | Injection                      | Query hanya via tagged template parametrik `Bun.SQL` (tak ada string-concat SQL); `tx.unsafe`/`SET LOCAL` hanya untuk nilai tervalidasi (`assertUuid`); validasi input tiap endpoint; output encoding (Astro auto-escape)             |
+| A04 | Insecure Design                | Threat model doc 20; immutability posted; idempotency; self-approval ditolak; fail-closed default (GUC tenant zero-UUID)                                                                                                              |
+| A05 | Security Misconfiguration      | Secret hanya env; `.env` gitignored; CI menolak `.env`; `security:readiness` memblokir go-live (RLS FORCE, role bukan superuser); error tanpa stack trace                                                                             |
+| A06 | Vulnerable Components          | Bun-only (ADR-0002); Dependabot; lockfile terkunci; minim dependency                                                                                                                                                                  |
+| A07 | Identification & Auth Failures | Login lockout setelah N gagal; pesan generik anti-enumeration; TTL sesi; revoke saat logout                                                                                                                                           |
+| A08 | Software & Data Integrity      | Checksum file sync/objek/backup; audit append-only; CodeQL; migration checksum                                                                                                                                                        |
+| A09 | Logging & Monitoring Failures  | Audit high-risk + decision log + correlation ID; log terstruktur; **redaksi** secret/PII wajib sebelum log                                                                                                                            |
+| A10 | SSRF                           | URL provider dari env tepercaya, bukan input user; provider di luar transaksi (ADR-0006)                                                                                                                                              |
+
+## OWASP ASVS (L1/L2 relevan)
+
+- [ ] **V2 Auth** — hashing modern, lockout, session fixation dicegah (token baru saat login), logout mencabut sesi.
+- [ ] **V3 Session** — cookie `HttpOnly`+`SameSite=Lax`+`Secure` (prod); token opaque server-side; expiry.
+- [ ] **V4 Access Control** — default deny, cek per-request (bukan sekali), RLS defense-in-depth, tak ada IDOR.
+- [ ] **V5 Validation/Encoding** — validasi tiap input, output encoding, CSRF via Astro `checkOrigin` (wajib `Content-Type` pada mutation).
+- [ ] **V7 Error/Logging** — error aman tanpa detail internal; log tanpa data sensitif.
+- [ ] **V9 Communications** — TLS di produksi; HMAC untuk kanal mesin-ke-mesin (sync).
+- [ ] **V12 Files** — checksum diverifikasi; path/objek tak dari input tak tepercaya.
+
+## ISO/IEC 27001:2022 Annex A (kontrol yang relevan ke kode)
+
+A.5.15 access control · A.5.17 authentication info · A.8.2 privileged access (DB role least-privilege) · A.8.5 secure authentication · A.8.12 data leakage prevention (masking/redaction) · A.8.15 logging · A.8.16 monitoring · A.8.24 cryptography · A.8.28 secure coding (guardrail doc 10) · A.8.31 separation of environments. Sisanya (kebijakan, personel, fisik) di luar cakupan kode base.
+
+## Cara kerja
+
+1. Petakan tiap item ke bukti nyata di repo (query DB, panggilan fungsi domain, grep file) — **bukan** asumsi; pola sama seperti `scripts/security-readiness.ts`.
+2. Tandai: terpenuhi / gap / di luar scope base. Temuan **critical** memblokir go-live.
+3. Prioritaskan gap berdasarkan dampak (STRIDE/EoP & Info-disclosure paling tinggi).
+
+## Output
+
+Matrix kepatuhan (kategori → status → bukti/lokasi → remediasi) + daftar temuan berperingkat critical→low + saran patch. Jalankan `bun run security:readiness` sebagai gate objektif.
+
+## Skill terkait
+
+`awcms-mini-security-review` (checklist DoD per modul), `awcms-mini-abac-guard`, `awcms-mini-audit-log`, `awcms-mini-sensitive-data`, `awcms-mini-sync-hmac`, `awcms-mini-production-preflight`; subagent `awcms-mini-security-auditor`.

--- a/.claude/skills/awcms-mini-ux-review/SKILL.md
+++ b/.claude/skills/awcms-mini-ux-review/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: awcms-mini-ux-review
+description: Audit dan tingkatkan kualitas UI/UX AWCMS-Mini di atas baseline design system. Gunakan saat diminta "review UX", "perbaiki tampilan/usability", audit aksesibilitas, atau menaikkan kualitas layar admin/POS/portal yang sudah ada. Berbeda dari awcms-mini-ui-screen (membangun layar baru sesuai standar) — skill ini menilai & menaikkan mutu layar yang sudah jadi.
+---
+
+# AWCMS-Mini — UI/UX Improvement Review
+
+Sumber kebenaran: **`docs/awcms-mini/14_ui_ux_design_system.md`** (token, komponen, state pattern, a11y, i18n, theming) dan **`docs/awcms-mini/15_frontend_architecture_integration.md`** (SSR/islands, API client, offline). Skill ini **peningkatan** — bukan membangun dari nol (itu `awcms-mini-ui-screen`), melainkan menemukan gap kualitas dan menaikkannya.
+
+## Prinsip peningkatan
+
+Ukur dulu, baru ubah: identifikasi masalah nyata (heuristik usability, hasil axe/kontras, layout shift) sebelum menyentuh kode. Perbaikan UX **tidak boleh** melemahkan kontrol backend (UI hiding bukan otorisasi) atau membocorkan data sensitif.
+
+## Checklist audit
+
+- [ ] **Empat state lengkap** — setiap list/detail punya loading (skeleton, bukan spinner kosong), empty (+CTA), error (pesan aman ter-i18n dari error code doc 05), ready. Cari layar yang hanya render "ready".
+- [ ] **A11y WCAG 2.1 AA** — kontras ≥4.5:1 (teks) / ≥3:1 (UI/grafik), fokus terlihat, label eksplisit tiap input, `aria-*` benar, dialog trap fokus + `Esc`, status tak hanya lewat warna, target sentuh ≥44px di mobile. Jalankan mental-pass axe.
+- [ ] **Keyboard-only** — semua aksi tercapai tanpa mouse; POS mengikuti peta F1–F10 (doc 14); urutan tab logis; skip-link bila perlu.
+- [ ] **Perceived performance** — tanpa layout shift (reserve ruang gambar/tabel), optimistic update dengan rollback (POS cart), no flash of wrong theme, feedback <100ms untuk aksi lokal.
+- [ ] **Konsistensi token/komponen** — tak ada warna/ukuran/spacing hardcode; pakai `--color-*`/`--sp-*`/`--fs-*`; komponen dari `src/components/ui`, bukan duplikat ad-hoc.
+- [ ] **Dark/light parity** — kedua tema diuji; kontras & keterbacaan setara; `data-theme` konsisten.
+- [ ] **Responsif** — admin desktop-first tapi tetap usable di tablet; portal customer mobile-first; tak ada horizontal scroll tak sengaja; tabel lebar → scroll container.
+- [ ] **Form UX** — validasi inline + pesan spesifik per field (bukan hanya banner), disable saat submit, cegah double-submit, preserve input saat error, autocomplete/inputmode tepat.
+- [ ] **Micro-copy & i18n-ready** — teks jelas, ringkas, konsisten istilah (doc 19 glossary); semua string siap diekstrak ke katalog `namespace.key` (doc 14 §i18n), bukan hardcode; format IDR/tanggal `Asia/Jakarta`.
+- [ ] **Masking di UI** — data sensitif lewat `MaskedText`; tak ada PII mentah tercache di IndexedDB/localStorage.
+- [ ] **Offline-first terlihat** — status koneksi & antrean sync jelas (`SyncIndicator`/`OfflineBanner`); aksi tetap tersimpan lokal saat offline (doc 15).
+
+## Heuristik usability (Nielsen, ringkas)
+
+Visibilitas status sistem · kecocokan dengan dunia nyata · kontrol & kebebasan user (undo/cancel) · konsistensi & standar · pencegahan error (konfirmasi aksi destruktif) · recognition over recall · fleksibilitas (shortcut) · desain minimalis · pesan error membantu pemulihan · bantuan/dokumentasi bila perlu.
+
+## Output
+
+Daftar temuan berperingkat (blocker a11y → mayor → minor → polish), tiap temuan: lokasi (file/komponen), dampak ke user, dan patch yang disarankan. Verifikasi: 4 state dapat didemokan, keyboard-only pass, axe/kontras pass AA, tak ada string/warna hardcode, tak ada `fetch` mentah (lewat `apiFetch`).
+
+## Skill terkait
+
+`awcms-mini-ui-screen` (membangun layar sesuai standar), `awcms-mini-sensitive-data` (masking), `awcms-mini-testing` (render/state test), `awcms-mini-performance` (waktu muat & data fetching).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,15 @@ AWCMS-Mini menyediakan **skill Claude Code tingkat-proyek** yang meng-encode sta
 | Rilis versi (Changesets, tag, CHANGELOG)   | `awcms-mini-release`              |
 | Migrasi data legacy (dry-run, backfill)    | `awcms-mini-legacy-migration`     |
 
+**Peningkatan (audit & hardening artefak yang sudah ada):**
+
+| Butuh…                                | Skill                           |
+| ------------------------------------- | ------------------------------- |
+| Audit & naikkan mutu UI/UX yang ada   | `awcms-mini-ux-review`          |
+| Tuning performa aplikasi & database   | `awcms-mini-performance`        |
+| Kerasan backend & integrasi eksternal | `awcms-mini-integration`        |
+| Audit keamanan OWASP/ASVS/ISO         | `awcms-mini-security-hardening` |
+
 ```mermaid
 flowchart LR
   II[awcms-mini-implement-issue] --> NM[new-module]
@@ -124,6 +133,10 @@ flowchart LR
   EP --> SD[sensitive-data]
   EV --> SYNC[sync-hmac]
   II --> PR[pr-review] --> SEC[security-review] --> PF[production-preflight]
+  UI2[ui-screen] --> UXR[ux-review]
+  EP --> PERF[performance]
+  EP --> INT[integration]
+  SEC --> HARD[security-hardening]
 ```
 
 Skill merujuk `docs/awcms-mini/*` sebagai sumber kebenaran; bila standar berubah, perbarui doc **dan** skill terkait.


### PR DESCRIPTION
## Ringkasan

Menambahkan empat **skill peningkatan** tingkat-proyek yang menilai & mengeraskan artefak yang sudah ada — berbeda dari skill build-time yang menegakkan standar saat membangun:

| Skill | Fokus | Sumber docs |
|---|---|---|
| `awcms-mini-ux-review` | Audit mutu UI/UX (usability, WCAG 2.1 AA, i18n-readiness, 4-state) | 14, 15, 19 |
| `awcms-mini-performance` | Tuning performa app & DB (EXPLAIN, index RLS-aware, keyset pagination, work-class pool) | 16, 07 |
| `awcms-mini-integration` | Kerasan backend & integrasi eksternal (outbox, retry/backoff, webhook HMAC, kontrak, observability; ADR-0006) | 16, 05, 10 |
| `awcms-mini-security-hardening` | Audit berbasis standar → OWASP Top 10 (2021), OWASP ASVS, ISO 27001 Annex A | 20, 10, 13 |

Terdaftar di `.claude/skills/README.md` (section baru "Katalog peningkatan" + peta pemakaian) dan tabel skill `AGENTS.md`.

## Verifikasi

- Docs/skill-only, tidak ada perubahan kode/schema/API.
- `bun run check` bersih (prettier, check:docs, api:spec:check, typecheck, 240 unit pass, build).
- Referensi ke kontrol nyata di repo diverifikasi (`circuit-breaker.ts` ada; `awcms_mini_message_outbox` ditandai sebagai pola terencana, bukan tabel yang sudah ada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)