### PR TITLE
docs(i18n): refine i18n spec — .po gettext for UI, DB per-locale content, English default, flag switcher

### DIFF
--- a/.claude/skills/awcms-mini-ui-screen/SKILL.md
+++ b/.claude/skills/awcms-mini-ui-screen/SKILL.md
@@ -15,7 +15,7 @@ Ikuti **`docs/awcms-mini/14_ui_ux_design_system.md`** (token, komponen, layout, 
 4. **Island seperlunya** — halaman SSR; interaktivitas hanya di island (POS, form, chat). Data awal via SSR, mutation via API client.
 5. **API client** — semua call lewat `apiFetch` (header tenant/correlation/idempotency otomatis); jangan `fetch` mentah.
 6. **Navigasi role-aware** — filter menu dari permission `GET /auth/me`; backend tetap validasi (UI hiding bukan kontrol).
-7. **i18n** — semua string via katalog `namespace.key`; format IDR/tanggal `Asia/Jakarta`.
+7. **i18n** — string UI statis via katalog **`.po`** gettext `namespace.key` (default **en**, min en+id), bukan hardcode; konten data multi-bahasa dari DB per locale aktif; format IDR/tanggal sadar-locale `Asia/Jakarta` (doc 14 §i18n).
 8. **A11y (WCAG 2.1 AA)** — kontras ≥4.5:1, fokus terlihat, label eksplisit, dialog trap fokus + Esc, target sentuh ≥44px (mobile), status tidak hanya warna.
 9. **Masking** — data sensitif tampil lewat `MaskedText`; jangan cache PII mentah di IndexedDB.
 10. **POS khusus** — keyboard map F1–F10 (doc 14), cart optimistic dengan rollback, offline outbox + `SyncIndicator` (doc 15).

--- a/.claude/skills/awcms-mini-ux-review/SKILL.md
+++ b/.claude/skills/awcms-mini-ux-review/SKILL.md
@@ -21,7 +21,7 @@ Ukur dulu, baru ubah: identifikasi masalah nyata (heuristik usability, hasil axe
 - [ ] **Dark/light parity** — kedua tema diuji; kontras & keterbacaan setara; `data-theme` konsisten.
 - [ ] **Responsif** — admin desktop-first tapi tetap usable di tablet; portal customer mobile-first; tak ada horizontal scroll tak sengaja; tabel lebar → scroll container.
 - [ ] **Form UX** — validasi inline + pesan spesifik per field (bukan hanya banner), disable saat submit, cegah double-submit, preserve input saat error, autocomplete/inputmode tepat.
-- [ ] **Micro-copy & i18n-ready** — teks jelas, ringkas, konsisten istilah (doc 19 glossary); semua string siap diekstrak ke katalog `namespace.key` (doc 14 §i18n), bukan hardcode; format IDR/tanggal `Asia/Jakarta`.
+- [ ] **Micro-copy & i18n-ready** — teks jelas, ringkas, konsisten istilah (doc 19 glossary); semua string UI statis siap diekstrak ke katalog **`.po`** gettext `namespace.key` (default locale **en**, min en+id), bukan hardcode; konten data multi-bahasa dari DB per locale aktif; language switcher berikon bendera; format IDR/tanggal sadar-locale `Asia/Jakarta` (doc 14 §i18n, doc 04 §Konten multi-bahasa).
 - [ ] **Masking di UI** — data sensitif lewat `MaskedText`; tak ada PII mentah tercache di IndexedDB/localStorage.
 - [ ] **Offline-first terlihat** — status koneksi & antrean sync jelas (`SyncIndicator`/`OfflineBanner`); aksi tetap tersimpan lokal saat offline (doc 15).
 

--- a/docs/awcms-mini/03_srs_detail_per_modul.md
+++ b/docs/awcms-mini/03_srs_detail_per_modul.md
@@ -335,7 +335,7 @@ Audit wajib untuk:
 - Customer receipt portal.
 - Navigation role-aware.
 - Dark/light/system theme.
-- i18n minimal ID/EN.
+- i18n minimal EN/ID (default **EN**), string UI via katalog `.po` gettext (doc 14 §i18n).
 
 ### Security
 

--- a/docs/awcms-mini/04_erd_data_dictionary.md
+++ b/docs/awcms-mini/04_erd_data_dictionary.md
@@ -102,10 +102,12 @@ erDiagram
 | `tenant_name`    | text | Nama operasional          |
 | `legal_name`     | text | Nama legal                |
 | `status`         | text | active/inactive/suspended |
-| `default_locale` | text | id/en/ms/ar               |
+| `default_locale` | text | en/id/ms/ar               |
 | `default_theme`  | text | light/dark/system         |
 
 Index: unique `tenant_code`.
+
+`default_locale` — locale default tenant (min **en**, **id**). **Target default `'en'`**; migration `002` saat ini masih `DEFAULT 'id'` — diubah ke `'en'` via migration baru saat i18n dibangun (issue #433, milestone M9). Locale efektif = preferensi per-user (bila ada) → `default_locale` tenant.
 
 ### `awcms_mini_offices`
 
@@ -201,6 +203,21 @@ Kolom penting: `contact_id`, `channel_type`, `provider_code`, `message_type`, `p
 Event lokal yang perlu disinkronkan.
 
 Kolom penting: `node_id`, `event_type`, `aggregate_type`, `aggregate_id`, `payload_json`, `status`.
+
+## Konten multi-bahasa (translatable content)
+
+Berbeda dari **string UI statis** (label/tombol/pesan error) yang memakai katalog `.po` gettext di sisi aplikasi (doc 14 §i18n), **data input pengguna** yang perlu tampil multi-bahasa disimpan **di database, satu nilai per bahasa aktif**. Base generik belum punya kolom konten yang di-i18n-kan (itu scope aplikasi turunan); ini **konvensi/standar** yang wajib diikuti aplikasi turunan saat menambah field konten translatable.
+
+Pola yang diizinkan (pilih per kebutuhan, konsisten dalam satu modul):
+
+- **JSONB per-locale** — kolom `<field>_i18n jsonb` berisi `{ "en": "...", "id": "..." }` untuk semua **bahasa aktif** tenant. Cocok untuk field bebas yang jarang di-query per-bahasa. Fallback ke `default_locale` bila key locale aktif kosong.
+- **Tabel translasi terpisah** — `<entity>_translations (entity_id, locale, field, value)` dengan unique `(entity_id, locale, field)`. Cocok bila konten di-query/urut/cari per-bahasa (perlu index). Tetap tenant-scoped + RLS.
+
+Aturan:
+
+- Wajib menyimpan nilai untuk **setiap locale aktif** tenant (minimal `en`+`id`); tampilan memilih nilai locale aktif dengan fallback ke `default_locale`.
+- Tetap ikut RLS tenant isolation, soft delete (bila entity-nya soft-deletable), dan masking bila field sensitif.
+- Nilai locale bukan secret; tetap divalidasi & di-escape saat render (anti-XSS, auto-escape Astro).
 
 ## Soft delete standard
 

--- a/docs/awcms-mini/14_ui_ux_design_system.md
+++ b/docs/awcms-mini/14_ui_ux_design_system.md
@@ -222,18 +222,33 @@ stateDiagram-v2
 
 ## Internationalization (i18n)
 
-- Locale awal: **id**, **en** (siap ms/ar). Default dari `awcms_mini_tenants.default_locale`.
-- Format PO/message catalog (migration `009_awcms_mini_i18n_po_schema.sql`).
-- Kunci pesan: `namespace.key` (mis. `pos.button.post`, `error.stock_not_available`).
-- Angka/mata uang: IDR, pemisah ribuan lokal; tanggal `Asia/Jakarta`.
-- Semua string UI melalui i18n; hindari hardcode teks.
+> **Status:** desain target. Runtime i18n **belum diimplementasikan** (string UI masih hardcode) — dikerjakan di issue #433 (milestone M9). Bagian ini adalah spesifikasi yang harus diikuti saat membangunnya.
+
+i18n memakai **dua lapisan terpisah** sesuai sumber teksnya:
+
+**1. String UI statis** (chrome aplikasi: label, tombol, judul, pesan error, navigasi) → **file katalog `.po`/`.pot` standar gettext**, di-**bundle bersama aplikasi**, bukan di database. Satu template `messages.pot` + satu berkas per locale (`en.po`, `id.po`). Kunci pesan `namespace.key` (mis. `auth.login.submit`, `error.access_denied`). Semua string UI dirender lewat helper `t(key, params)`; **tidak ada teks hardcode**.
+
+**2. Data input pengguna** (konten yang diketik user dan perlu tampil multi-bahasa, mis. nama/deskripsi/catatan yang di-i18n-kan aplikasi turunan) → disimpan **di database untuk setiap locale aktif** (satu nilai per bahasa aktif), **bukan** di `.po`. Pola penyimpanan per-bahasa didokumentasikan di `docs/awcms-mini/04_erd_data_dictionary.md` §Konten multi-bahasa. `.po` hanya untuk teks statis pengembang, DB untuk konten dinamis pengguna.
+
+- **Locale minimal**: **en** dan **id** (arsitektur siap ms/ar). **Default = `en`** (`awcms_mini_tenants.default_locale`, target default `'en'`).
+- **Resolusi locale**: default tenant (`default_locale`) → override preferensi per-user bila ada; tersedia untuk SSR (tanpa flash, pola sama seperti resolusi tema no-flash di `AdminLayout.astro`) maupun island.
+- **Language switcher** menampilkan **ikon bendera** per bahasa + label (mis. 🇬🇧 English, 🇮🇩 Indonesia); bendera ilustratif/boleh dikonfigurasi aplikasi turunan.
+- **Format lokal**: angka/mata uang (IDR + pemisah ribuan sesuai locale) dan tanggal (`Asia/Jakarta`) sadar-locale.
 
 ```mermaid
 flowchart LR
-  Key[Kunci pesan] --> Cat[Catalog per locale]
-  Cat --> Fmt[Formatter angka/tanggal/mata uang]
-  Fmt --> Render[Render komponen]
-  Loc[Locale aktif user/tenant] --> Cat
+  subgraph Statis
+    POT[messages.pot] --> PO[en.po / id.po]
+    PO --> T["t(key, params)"]
+  end
+  subgraph Konten
+    DB[(DB per locale aktif)] --> Pick[Pilih nilai locale aktif]
+  end
+  Loc[Locale aktif: user pref → tenant default en] --> T
+  Loc --> Pick
+  T --> Render[Render komponen]
+  Pick --> Render
+  Render --> Fmt[Formatter angka/tanggal/mata uang]
 ```
 
 ## Peta keyboard POS

--- a/docs/awcms-mini/17_default_seed_rbac_abac.md
+++ b/docs/awcms-mini/17_default_seed_rbac_abac.md
@@ -150,7 +150,7 @@ Setup wizard membuat data awal berikut (idempotent, sekali sebelum locked):
 2. **Office** pertama (`head_office`).
 3. **Role default** (10 role di atas) + **permission** + **role_permission**.
 4. **ABAC default policy** (11 policy di atas).
-5. **Tenant settings**: `default_locale=id`, `default_theme=system`, timezone `Asia/Jakarta`, feature flag provider = off (doc 18).
+5. **Tenant settings**: `default_locale=en` (default bahasa English; min en+id, siap ms/ar — doc 14 §i18n), `default_theme=system`, timezone `Asia/Jakarta`, feature flag provider = off (doc 18).
 6. **Unit dasar**: `pcs`, `box`, `kg`, `liter` (opsional, dapat ditambah).
 7. **Assignment**: owner → role Owner.
 8. **Audit**: `tenant.created`, `access.assignment` awal.

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -35,7 +35,7 @@ flowchart LR
 ```
 
 - Runtime/secret (DB, JWT, HMAC, provider key): dari **environment**.
-- Preferensi tenant (locale, theme): dari **`awcms_mini_tenants`**; flag fitur tampilan: dari **`awcms_mini_tenant_settings`**. Keduanya dikelola lewat `GET/PATCH /api/v1/settings` dan layar `/admin/settings` (Settings PR).
+- Preferensi tenant (locale — default **en**, theme): dari **`awcms_mini_tenants`**; flag fitur tampilan: dari **`awcms_mini_tenant_settings`**. Keduanya dikelola lewat `GET/PATCH /api/v1/settings` dan layar `/admin/settings` (Settings PR). String UI statis via katalog `.po` gettext (di-bundle, bukan DB); konten data multi-bahasa di DB per locale aktif (doc 14 §i18n, doc 04 §Konten multi-bahasa).
 - Retention soft delete/purge dapat menjadi tenant policy, tetapi tidak boleh menonaktifkan audit, RLS, atau default filter `deleted_at IS NULL`.
 
 ## Referensi environment variable

--- a/docs/awcms-mini/19_glossary_terminology.md
+++ b/docs/awcms-mini/19_glossary_terminology.md
@@ -139,18 +139,18 @@ flowchart LR
 
 ## Frontend dan UI
 
-| Istilah                  | Definisi                                                                              |
-| ------------------------ | ------------------------------------------------------------------------------------- |
-| **SSR**                  | Server-Side Rendering — halaman dirender di server (Astro output server).             |
-| **Island**               | Bagian interaktif yang di-hydrate di klien (Astro islands).                           |
-| **PWA / Service worker** | Progressive Web App; service worker meng-cache app shell & mengelola background sync. |
-| **IndexedDB**            | Penyimpanan klien untuk outbox transaksi offline & cache master.                      |
-| **Design token**         | Variabel desain (warna, tipografi, spacing) sebagai CSS custom properties.            |
-| **State pattern**        | Loading / empty / error / success yang wajib di tiap layar.                           |
-| **Optimistic UI**        | Menampilkan hasil sebelum konfirmasi server, rollback bila ditolak.                   |
-| **i18n / locale**        | Internasionalisasi; locale awal id/en.                                                |
-| **WCAG 2.1 AA**          | Standar aksesibilitas target AWCMS-Mini.                                              |
-| **Sync indicator**       | Komponen UI penunjuk status koneksi & antrean sync.                                   |
+| Istilah                  | Definisi                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **SSR**                  | Server-Side Rendering — halaman dirender di server (Astro output server).                                                                        |
+| **Island**               | Bagian interaktif yang di-hydrate di klien (Astro islands).                                                                                      |
+| **PWA / Service worker** | Progressive Web App; service worker meng-cache app shell & mengelola background sync.                                                            |
+| **IndexedDB**            | Penyimpanan klien untuk outbox transaksi offline & cache master.                                                                                 |
+| **Design token**         | Variabel desain (warna, tipografi, spacing) sebagai CSS custom properties.                                                                       |
+| **State pattern**        | Loading / empty / error / success yang wajib di tiap layar.                                                                                      |
+| **Optimistic UI**        | Menampilkan hasil sebelum konfirmasi server, rollback bila ditolak.                                                                              |
+| **i18n / locale**        | Internasionalisasi; min en+id (default **en**). String UI statis via `.po` gettext; konten data multi-bahasa di DB per locale aktif (doc 14/04). |
+| **WCAG 2.1 AA**          | Standar aksesibilitas target AWCMS-Mini.                                                                                                         |
+| **Sync indicator**       | Komponen UI penunjuk status koneksi & antrean sync.                                                                                              |
 
 ## Peran (persona)
 


### PR DESCRIPTION
## Ringkasan

Menyesuaikan spesifikasi i18n di seluruh paket dokumen sesuai kebutuhan yang dipertajam (menyempurnakan issue #433):

- **String UI statis** → **katalog `.po`/`.pot` gettext standar** (di-bundle, bukan DB).
- **Data input pengguna multi-bahasa** → **disimpan di DB per locale aktif** (JSONB-per-locale atau tabel translasi) — konvensi baru di doc 04 §Konten multi-bahasa.
- **Default bahasa = English (`en`)**; minimal **en+id**, siap ms/ar. Target `default_locale='en'` (migration 002 masih `'id'` sampai i18n dibangun di #433).
- **Language switcher** menampilkan **ikon bendera** per bahasa.

## Perubahan

- `docs/awcms-mini/14_ui_ux_design_system.md` §i18n — ditulis ulang (dua lapisan `.po`/DB + diagram + catatan status "belum diimplementasikan → #433/M9").
- `docs/awcms-mini/04_erd_data_dictionary.md` — catatan `default_locale` (target `en`) + section baru §Konten multi-bahasa (pola penyimpanan translatable content).
- Referensi kecil disinkronkan: doc 03 (§Frontend), doc 17 (seed `default_locale=en`), doc 18 (§Presedensi), doc 19 (glossary).
- Skill `awcms-mini-ux-review` & `awcms-mini-ui-screen` — bullet i18n diperbarui (`.po`, default en, bendera, konten DB).

## Verifikasi

- Docs/skill-only, tidak ada perubahan kode/schema/API.
- `bun run check` bersih (prettier, check:docs, api:spec:check, typecheck, 240 unit pass, build).
- **GitHub issue #433** (implementasi i18n) & **epic #438** (M9) diperbarui agar cocok dengan spec ini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)