### PR TITLE
docs: sync active docs with completed base state (Issue #450)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Dokumen ini adalah **kontrak kerja** untuk coding agent (Claude Code, Codex, dsb.) maupun developer manusia yang mengimplementasikan AWCMS-Mini. Setiap sesi implementasi **wajib membaca file ini terlebih dahulu**, lalu dokumen terkait di `docs/awcms-mini/`.
 
-> AWCMS-Mini sudah memiliki **Sprint foundation Issue 0.1-0.3**: Astro build, health endpoint, module contract, response helper, soft-delete convention, folder standar, runner migrasi PostgreSQL berbasis checksum, serta baseline OpenAPI/AsyncAPI dengan validator. Modul tenant/auth/RBAC/sync/deployment belum diimplementasikan dan harus mengikuti issue berikutnya.
+> **Status base generik: selesai (v0.23.5).** Seluruh 18 issue backlog base generik (doc 06) tuntas — foundation, tenant/office, central profile, identity/login, RBAC/ABAC, setup wizard, Sync Storage (outbox/inbox/conflict/object-queue), management reporting, structured logging & audit trail, connection pooling & backpressure, production readiness, workflow approval, dan deployment profile — plus perawatan/peningkatan pasca-backlog milestone M9 (penegakan RLS + role least-privilege, Access & Users / Sync / Settings admin, runtime i18n, audit UX/UI & aksesibilitas AA, audit performa, dispatcher object-sync + kerasan integrasi, security hardening OWASP/ASVS/ISO, dan aktivasi sistem log). Tabel tenant/auth/RBAC/sync/logging/deployment **sudah** ada dan berjalan — jangan membangunnya ulang. Pekerjaan baru = **aplikasi turunan / modul domain** di atas base ini (lihat [`docs/awcms-mini/README.md`](docs/awcms-mini/README.md) §Langkah berikutnya), atau perawatan/peningkatan lanjutan. Status per-issue historis dicatat di [`docs/awcms-mini/AUDIT_STANDAR_PENGEMBANGAN_2026-07-04.md`](docs/awcms-mini/AUDIT_STANDAR_PENGEMBANGAN_2026-07-04.md).
 
 ## Ringkasan proyek
 
@@ -191,7 +191,7 @@ untuk setiap kode baru sesuai doc 07 §Testing Strategy dan doc 10.
 
 ## Perintah standar (target)
 
-Skrip berikut menjadi target repository (lihat doc 11). Setelah Issue 0.1-0.3, script dev/build/preview/check, `db:migrate`, dan `api:spec:check` sudah tersedia; script deployment readiness masuk issue berikutnya.
+Skrip berikut menjadi target repository (lihat doc 11). Seluruhnya kini **sudah tersedia** (base generik selesai, v0.23.5): dev/build/preview/check, `db:migrate`, `api:spec:check`, `changeset`/`changeset:version`, tooling readiness (`db:pool:health`, `security:readiness`, `production:preflight`, `config:validate`), serta job terjadwal (`sync:objects:dispatch`, `logs:audit:purge`).
 
 ```bash
 bun install
@@ -331,7 +331,9 @@ Next recommended step:
 
 ## Mulai dari sini
 
-```text
-Kerjakan Issue 0.1 — Initialize AWCMS-Mini Modular Monolith Repository Structure.
-Lanjutkan sesuai urutan di doc 09 dan doc 12.
-```
+Base generik sudah selesai (v0.23.5, lihat blockquote status di atas) — tidak ada lagi "Issue 0.1" untuk dikerjakan sebagai pekerjaan baru. Untuk kontribusi baru:
+
+- **Membangun aplikasi turunan / modul domain** (AWPOS, portal, sistem pengaduan, dsb.) di atas base ini → mulai dengan skill `awcms-mini-new-module`, lalu `awcms-mini-new-migration` → `awcms-mini-new-endpoint` → `awcms-mini-new-event` → `awcms-mini-testing` → `awcms-mini-security-review` → `awcms-mini-production-preflight`. Orkestrasi penuh: skill `awcms-mini-implement-issue`. Lihat panduan lengkap di [`docs/awcms-mini/README.md`](docs/awcms-mini/README.md) §Langkah berikutnya.
+- **Perawatan / peningkatan base** (performa, UX, integrasi, keamanan, observability) → pakai skill peningkatan terkait (`awcms-mini-performance`, `awcms-mini-ux-review`, `awcms-mini-integration`, `awcms-mini-security-hardening`, `awcms-mini-observability`) dan catat di §Perawatan pasca-backlog pada `AUDIT_STANDAR_PENGEMBANGAN_2026-07-04.md`.
+
+Pertahankan lapisan reusable base; ganti/ tambah hanya lapisan spesifik domain. Doc 09 dan doc 12 tetap acuan konvensi commit/roadmap/generator, bukan urutan pengerjaan issue foundation yang sudah selesai.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,4 +9,4 @@ Rujukan kanonik:
 - `docs/adr/` untuk keputusan arsitektural.
 - `docs/awcms-mini/01_canvas_induk.md` sampai `docs/awcms-mini/20_threat_model_security_architecture.md` untuk dokumen master.
 
-Issue 0.1 menyediakan foundation skeleton: Astro build, module contract, module registry, response helper, soft-delete convention, health endpoint, dan folder standar. Modul tenant/auth/RBAC/sync/reporting/deployment ditambahkan pada issue berikutnya.
+Foundation skeleton (Issue 0.1) menyediakan Astro build, module contract, module registry, response helper, soft-delete convention, health endpoint, dan folder standar. Modul tenant/auth/RBAC/sync/reporting/deployment **sudah** ditambahkan dan berjalan — base generik selesai (v0.23.5, seluruh 18 issue backlog doc 06 + peningkatan pasca-backlog M9 tuntas; lihat `README.md` §Versioning dan `docs/awcms-mini/AUDIT_STANDAR_PENGEMBANGAN_2026-07-04.md`). Pekerjaan baru = aplikasi turunan / modul domain di atas base ini (lihat `docs/awcms-mini/README.md` §Langkah berikutnya).

--- a/docs/awcms-mini/12_generator_prompt.md
+++ b/docs/awcms-mini/12_generator_prompt.md
@@ -526,6 +526,8 @@ Wajib laporkan:
 
 ## Instruksi final coding pertama
 
+> **Catatan status (base selesai, v0.23.5).** Prompt bootstrap di bawah adalah instruksi asli yang dipakai untuk membangun base generik dari nol — seluruh 18 issue backlog (doc 06) sudah tuntas, jadi ini **arsip**, bukan pekerjaan yang perlu dikerjakan lagi. Untuk pekerjaan baru (aplikasi turunan / modul domain atau perawatan base), lihat [`../../AGENTS.md`](../../AGENTS.md) §Mulai dari sini dan [`README.md`](README.md) §Langkah berikutnya.
+
 ```text
 Kerjakan Issue 0.1 — Initialize AWCMS-Mini Modular Monolith Repository Structure.
 

--- a/docs/awcms-mini/13_final_master_index_traceability.md
+++ b/docs/awcms-mini/13_final_master_index_traceability.md
@@ -367,6 +367,8 @@ Semua file `docs/awcms-mini/01` sampai `19` harus menjadi acuan sebelum coding. 
 
 ## Final coding instruction
 
+> **Catatan status (base selesai, v0.23.5).** Urutan bootstrap di bawah adalah rencana asli membangun base generik dari nol dan seluruhnya sudah tuntas (18 issue backlog doc 06 + peningkatan M9) — arsip, bukan pekerjaan baru. Untuk kontribusi baru lihat [`../../AGENTS.md`](../../AGENTS.md) §Mulai dari sini dan [`README.md`](README.md) §Langkah berikutnya.
+
 ```text
 Mulai dari Issue 0.1.
 Jangan lompat ke POS sebelum foundation, tenant, profile, auth, dan ABAC selesai.

--- a/docs/awcms-mini/README.md
+++ b/docs/awcms-mini/README.md
@@ -197,10 +197,24 @@ SemVer + [Changesets](../../.changeset/README.md); riwayat di [`../../CHANGELOG.
 
 ## Langkah berikutnya
 
-Mulai dari:
+**Base generik sudah selesai** (v0.23.5) — seluruh 18 issue backlog base (doc 06) + peningkatan pasca-backlog milestone M9 tuntas (ringkasan di [`../../README.md`](../../README.md) §Versioning dan log per-issue di `AUDIT_STANDAR_PENGEMBANGAN_2026-07-04.md`). Tenant/office, identity/login, RBAC/ABAC, Sync Storage, reporting, audit/logging, workflow approval, dan deployment profile **sudah** ada dan berjalan; jangan membangunnya ulang.
 
-```text
-Issue 0.1 — Initialize AWCMS-Mini Modular Monolith Repository Structure
-```
+Kontribusi baru masuk salah satu dari dua jalur:
 
-Lanjutkan sesuai urutan di dokumen `09_roadmap_repository_commit.md` dan `12_generator_prompt.md`.
+**A. Membangun aplikasi turunan / modul domain** (mis. AWPOS retail/POS, portal sekolah, sistem pengaduan, sistem manajemen mutu) di atas base ini:
+
+1. Definisikan PRD/SRS domain (pola doc 02/03, ganti entitas retail/POS ilustratif dengan domain Anda).
+2. Scaffold modul domain di `src/modules/` — skill `awcms-mini-new-module`.
+3. Migration PostgreSQL + RLS tenant-scoped — skill `awcms-mini-new-migration`.
+4. Seed RBAC/ABAC domain (doc 17) — permission/role/policy khusus domain.
+5. Endpoint REST + OpenAPI — skill `awcms-mini-new-endpoint`; domain event + AsyncAPI — skill `awcms-mini-new-event`.
+6. UI/admin screen sesuai design system (doc 14/15) — skill `awcms-mini-ui-screen`; string via i18n — skill `awcms-mini-i18n`.
+7. Audit/logging aksi high-risk — skill `awcms-mini-audit-log`; idempotency mutation high-risk — skill `awcms-mini-idempotency`.
+8. Test berlapis — skill `awcms-mini-testing`; review keamanan — skill `awcms-mini-security-review`.
+9. Deployment & go-live — skill `awcms-mini-production-preflight`.
+
+Orkestrasi penuh satu unit kerja: skill `awcms-mini-implement-issue`. Pertahankan lapisan reusable (tabel §AWCMS-Mini sebagai standar pengembangan di atas), ganti hanya lapisan spesifik domain.
+
+**B. Perawatan / peningkatan base** (performa, UX/a11y, integrasi, keamanan, observability): pakai skill peningkatan terkait dan catat di §Perawatan pasca-backlog pada `AUDIT_STANDAR_PENGEMBANGAN_2026-07-04.md`.
+
+Dokumen `09_roadmap_repository_commit.md` dan `12_generator_prompt.md` tetap acuan konvensi commit/roadmap/generator — bukan lagi daftar urutan issue foundation yang sudah tuntas.

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -1,15 +1,18 @@
 # Shared Runtime Library
 
-Folder `src/lib/` disediakan untuk helper lintas-modul:
+Folder `src/lib/` berisi helper lintas-modul (base generik selesai, v0.23.5 — folder ini sudah terimplementasi, bukan lagi placeholder):
 
-- `auth/`
-- `database/`
-- `errors/`
-- `files/`
-- `i18n/`
-- `logging/`
+- `auth/` — sesi/token, `ssr-session.ts`, password hashing.
+- `database/` — `client.ts`, `tenant-context.ts` (`withTenant`), `work-class.ts`, `circuit-breaker.ts` (registry per-provider, Issue #436).
+- `errors/` — tipe/utilitas error.
+- `files/` — helper file/storage lokal.
+- `i18n/` — parser `.po`, catalog loader, `createTranslator`/`t()`, formatter locale-aware (Issue #433; skill `awcms-mini-i18n`).
+- `integration/` — `timeout.ts` (`withTimeout` untuk panggilan keluar, Issue #436; skill `awcms-mini-integration`).
+- `logging/` — `logger.ts` (JSON terstruktur + `setLogSink`), `correlation-response.ts` (propagasi `meta.correlationId`, Issue #447; skill `awcms-mini-observability`).
+- `security/` — `security-headers.ts`, `rate-limit.ts`, `theme-init-script.ts` (Issue #437; skill `awcms-mini-security-hardening`).
+- `ui/` — `admin-form-client.ts` (`submitJson`/`showBanner`/`lockElement`, Issue #434).
 
-Implementasi detail masuk issue berikutnya. Semua kode di folder ini wajib Bun-only, tidak menyimpan secret, dan mengikuti lapisan service/repository di doc 10 dan doc 16.
+Semua kode di folder ini wajib Bun-only, tidak menyimpan secret, dan mengikuti lapisan service/repository di doc 10 dan doc 16.
 
 ## `database/` (Issue 0.2, 10.2)
 


### PR DESCRIPTION
Closes #450.

## Ringkasan

Base sudah di v0.23.5 (seluruh 18 issue backlog doc06 + M9 tuntas), tapi beberapa dokumen aktif masih terbaca seolah proyek masih di tengah foundation ("modul tenant/auth/RBAC/sync/deployment belum diimplementasikan", "Kerjakan Issue 0.1" sebagai pekerjaan baru) — bahaya onboarding nyata, coding agent bisa membangun ulang kontrol yang sudah ada.

## Dokumen aktif diperbarui

- **`AGENTS.md`** — blockquote status ditulis ulang ke "base generik selesai (v0.23.5)"; §Mulai dari sini mengganti blok "Kerjakan Issue 0.1" dengan dua jalur nyata (bangun aplikasi turunan via rantai skill new-module/migration/endpoint/..., atau perawatan base via skill peningkatan); catatan "Perintah standar (target)" diperbarui dari "deployment readiness masuk issue berikutnya" ke daftar script yang kini tersedia.
- **`docs/awcms-mini/README.md`** — §Langkah berikutnya mengganti titik mulai "Issue 0.1" dengan alur build aplikasi turunan 9-langkah berbasis skill nyata, plus jalur perawatan.
- **`docs/ARCHITECTURE.md`** — future-tense "modul ... ditambahkan pada issue berikutnya" → present state (sudah ada, base selesai).
- **`src/lib/README.md`** — buang baris usang "implementasi detail masuk issue berikutnya"; lengkapi daftar folder (sebelumnya kurang `integration/`, `security/`, `ui/` dari #436/#437/#434), tiap folder diberi anotasi isi + skill pemilik.

## Arsip historis dipertahankan (bukan dihapus)

Blok "final coding instruction" di doc 12 (generator prompt) dan doc 13 (traceability) tetap mencatat cara base di-bootstrap dari Issue 0.1, tapi masing-masing kini punya banner status yang menandainya arsip dan mengarahkan ke AGENTS.md §Mulai dari sini. Snapshot/backlog docs (`github/`, `06_github_issues_detail`, `01_canvas_induk`, AUDIT log) dan referensi historis faktual "sejak Issue 0.1" tidak disentuh.

## Verifikasi

Tidak ada kode aplikasi/migration/kontrak berubah. `bun run check` bersih (lint/check:docs/api:spec:check/typecheck/test/build). Tidak ada changeset (docs-only, tidak ada perilaku yang dirilis berubah).

🤖 Generated with [Claude Code](https://claude.com/claude-code)