### PR TITLE
build(deploy): add optional production Dockerfile for registry-based deployment (Issue #454)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# .dockerignore (Issue #454) — keeps secrets and local artifacts out of
+# the build context entirely, so they can never end up cached in a layer
+# even by accident.
+
+# Secrets — never send to the Docker daemon (doc 10/18 "secrets only from
+# environment", same rule CI's Repo hygiene job enforces for git commits).
+.env
+.env.*
+!.env.example
+
+# Local build artifacts — regenerated inside the image by `bun run build`;
+# copying a stale host-built dist/ would shadow the in-image build output.
+dist/
+node_modules/
+
+# Runtime data, never part of the image.
+storage/
+
+# VCS/editor/CI metadata irrelevant to the build.
+.git/
+.github/
+.claude/
+.changeset/
+*.md
+!README.md
+
+# Test artifacts and coverage.
+coverage/

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,71 @@
+# Dockerfile.production — optional registry-based deployment image
+# (Issue #454, doc 18 §Profil per-environment "production (online)").
+#
+# This is OPTIONAL and does NOT replace `docker-compose.yml`, which stays
+# the recommended path for the LAN-first/offline single-server topology
+# (bind-mount + `bun install && bun run build` at container start — see
+# that file's own top-of-file comment for why). This Dockerfile instead
+# targets a registry-based flow (build once in CI, push an image, pull +
+# run identically across environments) where build-at-startup is
+# undesirable: slower cold start, and the image should be immutable once
+# built rather than re-installing/rebuilding from a live bind mount.
+#
+# Bun-only (AGENTS.md rule 14): base image is `oven/bun:1`, never `node`.
+#
+# Usage:
+#   docker build -f Dockerfile.production -t awcms-mini:prod .
+#   docker run -d --name awcms-mini \
+#     -p 4321:4321 \
+#     -e DATABASE_URL=postgres://awcms_mini_app:<password>@<db-host>:5432/awcms-mini \
+#     -e AUTH_JWT_SECRET=<secret> \
+#     -e AUTH_COOKIE_SECURE=true \
+#     -e APP_ENV=production \
+#     awcms-mini:prod
+#   curl http://localhost:4321/api/v1/health
+#
+# Secrets (DATABASE_URL, AUTH_JWT_SECRET, AWCMS_MINI_SYNC_HMAC_SECRET, R2
+# credentials, etc.) are supplied at `docker run`/orchestrator level
+# (env vars, secret store, or an env file passed via `--env-file`) — never
+# baked into the image. `.dockerignore` excludes `.env`/`.env.*` from the
+# build context so a local `.env` can never accidentally end up in a layer.
+#
+# Migrations are NOT run by this image — `bun run db:migrate` needs the
+# privileged DB role this image's runtime user does not have (two-role
+# model, see docs/awcms-mini/deployment-profiles.md §Model dua-peran). Run
+# migrations as a separate one-shot step (CI job, `docker run` with the
+# privileged DATABASE_URL, or plain `bun run db:migrate` from a checkout)
+# before starting this container against a fresh database.
+
+FROM oven/bun:1 AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+FROM oven/bun:1 AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN bun run build
+
+# Fresh production-only install — keeps devDependencies (typescript,
+# prettier, changesets, etc.) out of the final image entirely, rather than
+# copying the `deps` stage's full node_modules forward.
+FROM oven/bun:1 AS prod-deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+FROM oven/bun:1 AS runtime
+WORKDIR /app
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+
+# `oven/bun:1` ships a built-in non-root `bun` user (uid 1000) for exactly
+# this purpose — never run the server as root.
+USER bun
+
+EXPOSE 4321
+ENV HOST=0.0.0.0 PORT=4321
+
+CMD ["bun", "./dist/server/entry.mjs"]

--- a/docs/awcms-mini/deployment-profiles.md
+++ b/docs/awcms-mini/deployment-profiles.md
@@ -99,6 +99,55 @@ sebagai peran least-privilege — jadi `docker compose up` mengurut sendiri:
 `db` init membuat peran → `migrate` menerapkan skema + FORCE RLS + grant →
 `app` mulai.
 
+### production (online) — image registry (`Dockerfile.production`, opsional)
+
+`docker-compose.yml` di atas **tetap jadi jalur yang direkomendasikan**
+untuk topologi LAN-first satu-server (bind-mount + `bun install && bun run
+build` saat container start — praktis untuk operator yang `git
+pull`/rebuild in-place, lihat komentar header berkas itu). `Dockerfile.production`
+adalah jalur **opsional lain**, untuk deployment berbasis image registry
+(build sekali di CI, push image, pull+run identik di tiap environment) —
+dipakai saat build-saat-startup tidak diinginkan (cold start lebih lambat,
+image ingin immutable) atau saat orkestrator (Coolify, k8s, ECS, dsb.)
+mengharapkan image siap-pakai, bukan bind-mount sumber.
+
+Perbedaan kunci vs `docker-compose.yml`'s `app` service:
+
+| Aspek       | `docker-compose.yml` (`app`)                                | `Dockerfile.production`                                                    |
+| ----------- | ----------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Sumber kode | Bind-mount repo langsung (`volumes: - .:/app`)              | `COPY` ke dalam image saat build — immutable setelah dibuat                |
+| Build       | Saat container start (`bun install && bun run build`)       | Saat `docker build` (multi-stage) — start container jadi instan            |
+| User        | Host user (`APP_UID`/`APP_GID`) — perlu bind-mount writable | User bawaan image `oven/bun:1`, `bun` (non-root, uid 1000)                 |
+| Migration   | Service `migrate` terpisah dalam compose yang sama          | Tidak disertakan — jalankan `bun run db:migrate` terpisah (lihat di bawah) |
+| Cocok untuk | LAN-first satu server, operator `git pull` in-place         | Registry/CI-push, orkestrator container (Coolify/k8s/ECS)                  |
+
+Build dan jalankan:
+
+```bash
+docker build -f Dockerfile.production -t awcms-mini:prod .
+docker run -d --name awcms-mini \
+  -p 4321:4321 \
+  -e DATABASE_URL=postgres://awcms_mini_app:<password>@<db-host>:5432/awcms-mini \
+  -e AUTH_JWT_SECRET=<secret> \
+  -e AUTH_COOKIE_SECURE=true \
+  -e APP_ENV=production \
+  awcms-mini:prod
+curl http://localhost:4321/api/v1/health
+```
+
+Secret (`DATABASE_URL`, `AUTH_JWT_SECRET`, HMAC sync, kredensial R2, dst.)
+**selalu** disuntikkan saat `docker run`/lewat orkestrator (env var, secret
+store, atau `--env-file`) — **tidak pernah** dibakar ke dalam image.
+`.dockerignore` mengecualikan `.env`/`.env.*` dari build context sehingga
+`.env` lokal operator tidak mungkin ikut ter-cache di satu layer.
+
+Image ini **tidak** menjalankan migration — peran runtime-nya
+(`awcms_mini_app`, least-privilege) tidak punya hak DDL/GRANT yang
+migration butuhkan (model dua-peran di bawah). Jalankan `bun run
+db:migrate` sebagai langkah terpisah (job CI, atau `docker run` sekali
+pakai dengan `DATABASE_URL` privileged) terhadap database baru sebelum
+container ini pertama kali dijalankan.
+
 ## Model dua-peran basis data (RLS enforcement)
 
 Isolasi antar-tenant memakai PostgreSQL Row-Level Security (ADR-0003).


### PR DESCRIPTION
Closes #454.

## Ringkasan

`docker-compose.yml`'s `app` service sengaja build saat container start (bind-mount + `bun install && bun run build`) — cocok untuk target LAN-first satu-server, tapi bentuk yang salah untuk alur registry-based (build sekali di CI, push image, pull+run identik di mana pun): cold start lebih lambat, dan image tidak bisa dianggap immutable kalau rebuild dari mount hidup setiap kali.

Ditambahkan `Dockerfile.production` sebagai jalur kedua yang **eksplisit opsional**, berdampingan dengan (bukan menggantikan) `docker-compose.yml`:

- **4-stage build**: `deps` (`bun install --frozen-lockfile`, full deps untuk build) → `build` (`bun run build`) → `prod-deps` (install ulang segar `--production` supaya devDependencies tidak pernah masuk image final, bukan membawa maju node_modules penuh dari stage `deps`) → `runtime` (copy hanya `dist/`, node_modules production-only, dan `package.json`).
- Jalan sebagai user non-root bawaan `oven/bun:1`, `bun` (uid 1000) — dikonfirmasi memang ada di base image, bukan menciptakan `useradd`/`addgroup` untuk distro dasar yang tidak pasti.
- **Tidak menjalankan migration** — runtime konek sebagai peran least-privilege `awcms_mini_app` (model dua-peran) yang tidak punya hak DDL/GRANT yang `bun run db:migrate` butuhkan. Didokumentasikan sebagai langkah terpisah wajib sebelum run pertama terhadap database baru.
- Secret (`DATABASE_URL`, `AUTH_JWT_SECRET`, dst.) runtime-only, tidak pernah dibakar ke image — `.dockerignore` (baru) mengecualikan `.env`/`.env.*` dari build context.

`docs/awcms-mini/deployment-profiles.md`: subsection baru di bawah "production (online)" dengan tabel perbandingan vs `app` service `docker-compose.yml` (sumber kode, waktu build, user, langkah migration, cocok untuk), plus contoh build/run. Eksplisit bahwa compose tetap jalur direkomendasikan LAN-first, ini alternatif untuk alur registry/orkestrator (Coolify/k8s/ECS).

## Verifikasi (nyata, bukan cuma build)

- `docker build -f Dockerfile.production -t awcms-mini-prod-test .` sukses (image final 397MB).
- Container dijalankan (`--network host`) terhadap `postgres:18.4` nyata yang baru dimigrasi (`bun run db:migrate` penuh, 18 migration applied).
- `docker exec ... whoami` → `bun` (non-root dikonfirmasi).
- `GET /api/v1/health` → `200` dengan payload 7-modul yang benar.
- `POST /api/v1/setup/initialize` sukses end-to-end lewat koneksi DB container (baris nyata ditulis sebagai peran least-privilege, bukan cuma health check statis).
- Container, image, db, dan `.env` dibongkar setelah verifikasi.

`bun run check` bersih. Tidak ada changeset (aset deployment opsional + docs, tidak ada perilaku runtime aplikasi yang berubah untuk jalur `docker-compose.yml` yang ada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)