### PR TITLE
docs: add derived application implementation guide (Issue #453)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ flowchart LR
 
 ### Mulai dari
 
-Backlog base generik ada di [`docs/awcms-mini/06_github_issues_detail.md`](docs/awcms-mini/06_github_issues_detail.md) — **seluruh 18 issue-nya kini tuntas**: foundation (**0.1-0.3**), epic M2 Tenant/Identity/Profile (**2.1-2.4**), **12.1** (setup wizard), epic M5 Sync Storage (**6.1-6.3**), epic M7 UI/UX & Reporting (**8.1**, **9.1**), dan epic M8 Security/Performance/Production (**10.1-10.3**, **11.1**, **12.2**). Base ini siap dipakai sebagai fondasi aplikasi turunan — lihat paket dokumen AWPOS sebagai contoh pola menambah modul domain di atas base ini (§Reusable vs domain turunan di [`docs/awcms-mini/README.md`](docs/awcms-mini/README.md)).
+Backlog base generik ada di [`docs/awcms-mini/06_github_issues_detail.md`](docs/awcms-mini/06_github_issues_detail.md) — **seluruh 18 issue-nya kini tuntas**: foundation (**0.1-0.3**), epic M2 Tenant/Identity/Profile (**2.1-2.4**), **12.1** (setup wizard), epic M5 Sync Storage (**6.1-6.3**), epic M7 UI/UX & Reporting (**8.1**, **9.1**), dan epic M8 Security/Performance/Production (**10.1-10.3**, **11.1**, **12.2**). Base ini siap dipakai sebagai fondasi aplikasi turunan — panduan langkah-demi-langkah (9 langkah berbasis skill nyata, 5 contoh aplikasi ilustratif, checklist keamanan): [`docs/awcms-mini/derived-application-guide.md`](docs/awcms-mini/derived-application-guide.md).
 
 ## Keamanan
 

--- a/docs/awcms-mini/README.md
+++ b/docs/awcms-mini/README.md
@@ -116,13 +116,14 @@ Dokumen dikelompokkan mengikuti alur pengembangan agar mudah diimplementasi.
 
 ### Lapisan E — Operasi & referensi
 
-|  No | File                                       | Isi                                                                                                  |
-| --: | ------------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-|   8 | `08_sop_operasional_user_guide.md`         | SOP operasional dan user guide                                                                       |
-|  19 | `19_glossary_terminology.md`               | Glossary & terminologi lintas dokumen                                                                |
-|  20 | `20_threat_model_security_architecture.md` | Threat model (STRIDE), trust boundary, kontrol keamanan berlapis (dokumen base, bukan contoh domain) |
-|   – | `database-migrations.md`                   | Panduan runner migrasi PostgreSQL Bun-native                                                         |
-|   – | `../../openapi/` dan `../../asyncapi/`     | Baseline kontrak OpenAPI/AsyncAPI dan validator `api:spec:check`                                     |
+|  No | File                                       | Isi                                                                                                    |
+| --: | ------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+|   8 | `08_sop_operasional_user_guide.md`         | SOP operasional dan user guide                                                                         |
+|  19 | `19_glossary_terminology.md`               | Glossary & terminologi lintas dokumen                                                                  |
+|  20 | `20_threat_model_security_architecture.md` | Threat model (STRIDE), trust boundary, kontrol keamanan berlapis (dokumen base, bukan contoh domain)   |
+|   – | `database-migrations.md`                   | Panduan runner migrasi PostgreSQL Bun-native                                                           |
+|   – | `derived-application-guide.md`             | Panduan membangun aplikasi turunan di atas base (9 langkah + 5 contoh ilustratif + checklist keamanan) |
+|   – | `../../openapi/` dan `../../asyncapi/`     | Baseline kontrak OpenAPI/AsyncAPI dan validator `api:spec:check`                                       |
 
 ### Architecture Decision Records
 
@@ -175,7 +176,7 @@ AWCMS-Mini sengaja disusun agar bisa dipakai sebagai **template/contoh** untuk m
 | Skill proyek `.claude/skills/`                                     | —                                             |
 | Standar commit/roadmap/preflight (09, 07)                          | —                                             |
 
-Untuk membangun aplikasi baru di atas AWCMS-Mini: pertahankan lapisan reusable, ganti lapisan spesifik domain dengan kebutuhan aplikasi Anda, dan ikuti alur dokumen 01 → 20 (plus ADR di [`../adr/`](../adr/README.md)).
+Untuk membangun aplikasi baru di atas AWCMS-Mini: pertahankan lapisan reusable, ganti lapisan spesifik domain dengan kebutuhan aplikasi Anda, dan ikuti alur dokumen 01 → 20 (plus ADR di [`../adr/`](../adr/README.md)). Panduan langkah-demi-langkah (9 langkah berbasis skill nyata + 5 contoh aplikasi turunan + checklist keamanan): [`derived-application-guide.md`](derived-application-guide.md).
 
 ## Versioning
 

--- a/docs/awcms-mini/derived-application-guide.md
+++ b/docs/awcms-mini/derived-application-guide.md
@@ -1,0 +1,82 @@
+# Panduan Implementasi Aplikasi Turunan
+
+> **Dokumen base (bukan contoh domain).** Dokumen ini menjelaskan cara membangun aplikasi turunan **di atas** AWCMS-Mini setelah base generik selesai (v0.23.5, seluruh 18 issue backlog doc06 + peningkatan pasca-backlog M9 tuntas — lihat [`README.md`](README.md) §Langkah berikutnya dan [`AGENTS.md`](../../AGENTS.md) §Mulai dari sini). Lima contoh aplikasi di §Contoh aplikasi turunan adalah **ilustrasi**, bukan modul yang ditambahkan ke base ini.
+
+## Base reusable vs domain-specific extension
+
+Sebelum menulis kode apa pun, pahami batasnya: base menyediakan infrastruktur dan kontrak yang **dipakai ulang tanpa diubah**; aplikasi turunan hanya menambah **modul domain baru** di atasnya.
+
+| Reusable (base — jangan diubah)                                                                                                      | Domain-specific (aplikasi turunan — Anda tambahkan)                              |
+| ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| Modular monolith + module contract (`src/modules/_shared/module-contract.ts`, doc 10/11)                                             | Modul domain baru di `src/modules/<domain>/`                                     |
+| RBAC + ABAC default-deny + RLS (ADR-0003/0004, `src/modules/identity-access/`)                                                       | Permission/role/policy spesifik domain (doc 17 pola, bukan isinya)               |
+| Migration runner checksum-based, konvensi `NNN_awcms_mini_<area>_<desc>.sql`                                                         | Skema tabel domain (skill `awcms-mini-new-migration`)                            |
+| Kontrak OpenAPI/AsyncAPI wajib + `api:spec:check` (ADR-0007/0008)                                                                    | Endpoint/event domain (skill `awcms-mini-new-endpoint`/`awcms-mini-new-event`)   |
+| Soft delete + immutability posted (ADR-0005)                                                                                         | Kebijakan resource domain mana yang boleh restore/purge                          |
+| Audit trail generik (`awcms_mini_audit_events`) + retensi/purge + correlation ID (Issue 10.1/#447, skill `awcms-mini-observability`) | Aksi high-risk spesifik domain yang wajib diaudit (skill `awcms-mini-audit-log`) |
+| Idempotency ledger generik (`awcms_mini_idempotency_keys`)                                                                           | Mutation high-risk domain mana yang wajib `Idempotency-Key`                      |
+| Structured logger + extension point (`setLogSink`/`setAuditExportHook`)                                                              | Consumer log/audit nyata (SIEM, alerting) — base hanya sediakan titik pasang     |
+| Design system, token, state pattern, i18n (doc 14, skill `awcms-mini-i18n`)                                                          | Layar admin/operator/portal domain (skill `awcms-mini-ui-screen`)                |
+| Offline-first sync (outbox/inbox, HMAC, conflict tracking, object queue dispatcher — Issue 6.1-6.3/#436)                             | Payload event domain yang disinkronkan lewat outbox yang sama                    |
+| Connection pooling + work-class backpressure + circuit breaker (Issue 10.2, per-provider sejak #436)                                 | Provider eksternal domain (WA/email/AI/pajak) di belakang flag + outbox          |
+| Production readiness tooling (`db:pool:health`, `security:readiness`, `production:preflight`)                                        | Item checklist domain tambahan (mis. tax data masking untuk aplikasi pajak)      |
+| Skill proyek `.claude/skills/`                                                                                                       | —                                                                                |
+
+Prinsip: **pertahankan** kolom kiri apa adanya; **tambahkan** kolom kanan mengikuti pola yang sudah mapan. Jangan menulis ulang RLS/ABAC/audit/idempotency Anda sendiri — base sudah menyediakannya, cukup dipakai.
+
+## Alur membangun aplikasi turunan (9 langkah)
+
+Setiap langkah dipetakan ke skill nyata (`.claude/skills/`) — panggil skill itu, jangan menebak polanya sendiri.
+
+1. **Definisikan PRD/SRS domain** — pola doc 02/03 (isi generik-nya sudah base; entitas retail/POS di dalamnya adalah contoh AWPOS, ganti dengan domain Anda). Tentukan entitas, aktor, dan alur bisnis inti.
+2. **Scaffold modul domain** — `src/modules/<domain-key>/` dengan struktur `domain/application/infrastructure/api` + `module.ts` + `README.md`. Skill: `awcms-mini-new-module`. Modul baru mulai `version: "0.1.0"`, `status: "experimental"` (ADR-0008) — naik ke `active`/`1.0.0` setelah matang (lihat §Definisi "matang" di bawah).
+3. **Migration PostgreSQL + RLS** — tabel tenant-scoped **wajib** `tenant_id`, `ENABLE`+`FORCE ROW LEVEL SECURITY`, policy `app.current_tenant_id`, index berprefiks `(tenant_id, …)`. Skill: `awcms-mini-new-migration`.
+4. **Seed RBAC/ABAC domain** — permission/role/policy baru mengikuti pola doc 17 (bukan menyalin isi ilustratifnya); evaluator ABAC yang sudah ada (`evaluateAccess`, default-deny) dipakai ulang, bukan ditulis ulang. Skill: `awcms-mini-abac-guard`.
+5. **Endpoint REST + OpenAPI, domain event + AsyncAPI** — route tipis (auth → tenant context → ABAC guard → validasi → idempotency bila high-risk → service+transaction → response helper standar). Skill: `awcms-mini-new-endpoint` (REST), `awcms-mini-new-event` (event domain). Mutation high-risk wajib `Idempotency-Key` — skill `awcms-mini-idempotency`.
+6. **UI/admin screen** — token desain, 4-state pattern (loading/empty/error/ready), a11y WCAG 2.1 AA, string via katalog `.po` (bukan hardcode). Skill: `awcms-mini-ui-screen` (layar baru), `awcms-mini-i18n` (katalog terjemahan), `awcms-mini-ux-review` (audit layar yang sudah jadi).
+7. **Audit & observability** — aksi high-risk domain (approve, price change, transaksi posted/cancel, dst.) wajib `recordAuditEvent`. Skill: `awcms-mini-audit-log` (apa yang diaudit), `awcms-mini-observability` (correlation ID otomatis, retensi/purge, extension point bila aplikasi turunan butuh forward ke SIEM eksternal).
+8. **Test berlapis + security review** — unit (domain logic murni), integration (endpoint terhadap Postgres nyata), kontrak (`api:spec:check`), keamanan (ABAC default-deny, RLS FORCE, redaksi). Skill: `awcms-mini-testing`, `awcms-mini-security-review` (checklist DoD per modul), `awcms-mini-security-hardening` (audit OWASP/ASVS/ISO bila menjelang audit eksternal/go-live besar).
+9. **Deployment & go-live** — `bun run production:preflight` (orkestrasi migrate → api:spec:check → test → build → db:pool:health → security:readiness). Skill: `awcms-mini-production-preflight`. Pilih profil deployment (doc `deployment-profiles.md`): LAN-first (`docker-compose.yml`) atau registry-based (`Dockerfile.production`, Issue #454).
+
+Orkestrasi satu unit kerja penuh (baca docs → implementasi → migration/OpenAPI/AsyncAPI/test/docs → laporan): skill `awcms-mini-implement-issue`.
+
+### Kapan modul dianggap "matang" (`active`, ADR-0008)
+
+Modul naik dari `experimental` ke `active` ketika: endpoint/domain logic-nya nyata dipakai (bukan scaffold kosong), RLS+ABAC terpasang dan diuji, test berlapis lulus, dan sudah melalui `awcms-mini-security-review`. Jangan tandai `active` sebelum itu — status ini metadata deskriptif yang dibaca kontributor lain untuk menilai kematangan modul, bukan gerbang runtime.
+
+## Contoh aplikasi turunan (ilustratif — bukan bagian base)
+
+Lima contoh berikut menunjukkan bagaimana base yang sama melayani domain yang sangat berbeda. **Tidak satu pun** dari modul/entitas di bawah ada di `src/modules/` base ini — ini murni ilustrasi untuk membantu Anda memetakan domain Anda sendiri ke pola di atas.
+
+| Aplikasi                                  | Domain                                                 | Modul domain ilustratif (bukan bagian base)             | Contoh entitas tenant-scoped                          |
+| ----------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------- | ----------------------------------------------------- |
+| **AWPOS** (retail/POS)                    | Penjualan ritel, gudang, pajak, CRM                    | `sales`, `inventory`, `tax-coretax`, `crm`              | Produk, transaksi, stok, pelanggan                    |
+| **Satu Sehat Kobar** (internal kesehatan) | Integrasi data kesehatan internal per fasilitas        | `health-records`, `satu-sehat-sync`                     | Rekam kunjungan, faskes, petugas                      |
+| **Sistem Manajemen Mutu Faskes**          | Audit mutu, insiden, akreditasi                        | `quality-audit`, `incident-report`, `accreditation`     | Temuan audit, insiden keselamatan, dokumen akreditasi |
+| **Smart School Portal**                   | Akademik, kehadiran, nilai, komunikasi ortu            | `academic`, `attendance`, `grading`, `parent-portal`    | Siswa, kelas, jadwal, nilai                           |
+| **Sistem Pengaduan Publik**               | Pengaduan warga, disposisi, tindak lanjut lintas dinas | `complaint-intake`, `disposition`, `follow-up-tracking` | Pengaduan, unit penerima, status tindak lanjut        |
+
+Setiap aplikasi di atas **tetap** memakai identity/login, RBAC/ABAC, RLS, audit trail, i18n, dan admin shell base yang sama — modul domain di atas hanya menambah entitas + endpoint + layar yang spesifik pada domainnya, mengikuti 9 langkah di atas.
+
+## Checklist keamanan & kepatuhan praktis
+
+Wajib dipenuhi modul domain baru sebelum dianggap siap produksi (turunan dari doc 10/12/13, skill `awcms-mini-security-review`):
+
+- [ ] **Tenant context** — setiap query tenant-scoped lewat `withTenant()`/`SET LOCAL app.current_tenant_id`; tidak ada `WHERE tenant_id` yang dilewati manual dari input.
+- [ ] **ABAC default-deny** — endpoint non-public dicek `evaluateAccess()`; permission baru diseed eksplisit, tidak ada grant implisit.
+- [ ] **RLS** — tabel tenant-scoped baru `ENABLE`+`FORCE ROW LEVEL SECURITY` + policy isolasi; index berprefiks `(tenant_id, …)`.
+- [ ] **Audit** — aksi high-risk domain (soft delete/restore/purge, approval, perubahan harga/status kritis, dst.) menghasilkan `awcms_mini_audit_events` row via `recordAuditEvent`.
+- [ ] **Idempotency** — mutation high-risk domain menerima `Idempotency-Key`, aman diulang.
+- [ ] **Redaksi/masking** — identifier sensitif domain (NIK, nomor rekam medis, dst. — pola sama seperti NPWP/NIK/email di base) di-hash+mask sebelum disimpan/ditampilkan/di-log.
+- [ ] **Kontrak sinkron** — `bun run api:spec:check` hijau untuk setiap endpoint/event domain baru.
+- [ ] **Test berlapis** — unit (domain logic), integration (Postgres nyata), keamanan (RLS/ABAC dipaksa gagal untuk membuktikan gate benar-benar memblokir, bukan hanya "pass" diam-diam).
+- [ ] **`bun run production:preflight`** hijau sebelum go-live.
+
+## Referensi
+
+- [`AGENTS.md`](../../AGENTS.md) §Mulai dari sini — entry point kontributor.
+- [`README.md`](README.md) §Langkah berikutnya — ringkasan alur yang sama, versi singkat.
+- [`docs/adr/`](../adr/README.md) — keputusan arsitektural base (ADR-0001 s.d. 0008).
+- `docs/awcms-mini/01` s.d. `20` — paket dokumen master (§Peta dokumen di README ini).
+- [`deployment-profiles.md`](deployment-profiles.md) — profil deployment (development/staging/production/offline-LAN, LAN-first compose vs registry image).
+- `.claude/skills/README.md` — katalog skill lengkap + peta pemakaian.


### PR DESCRIPTION
Closes #453.

## Ringkasan

Base punya banyak dokumen standar (01-20) tapi tidak ada satu tempat yang langsung menjawab "bagaimana cara membangun AWPOS/portal sekolah/sistem pengaduan di atas ini" — developer harus merangkai sendiri dari 20 dokumen + katalog skill.

Ditambahkan `docs/awcms-mini/derived-application-guide.md`:

- **Tabel base-reusable vs domain-specific**: 13 baris memasangkan yang tetap tak disentuh (module contract, RBAC+ABAC+RLS, migration runner, kontrak OpenAPI/AsyncAPI, soft delete, audit trail + retensi + correlation ID, idempotency ledger, extension point logging, design system + i18n, offline-first sync, pooling/circuit-breaker, tooling production readiness, katalog skill) dengan apa yang ditambahkan aplikasi turunan di baris yang sama.
- **Alur 9 langkah**, tiap langkah dipetakan ke skill nyata yang ADA sekarang di `.claude/skills/` (new-module, new-migration, abac-guard, new-endpoint/new-event, idempotency, ui-screen/i18n/ux-review, audit-log/observability, testing/security-review/security-hardening, production-preflight), plus catatan singkat kriteria maturitas modul `active`/`experimental` dari ADR-0008.
- **5 contoh aplikasi turunan ilustratif** (AWPOS retail/POS, Satu Sehat Kobar internal, Sistem Manajemen Mutu Faskes, Smart School Portal, Sistem Pengaduan Publik) dengan modul domain & entitas masing-masing — ditandai eksplisit sebagai ilustrasi saja, tidak satu pun ada di `src/modules/` base ini.
- **Checklist keamanan/kepatuhan praktis** (tenant context via `withTenant`, ABAC default-deny, RLS FORCE, audit aksi high-risk, idempotency, redaksi/masking identifier sensitif, kontrak sinkron, test berlapis, `production:preflight`) mencerminkan checklist skill `awcms-mini-security-review` yang sudah ada, bukan checklist paralel baru.

Ditautkan dari `README.md` §"Mulai dari" dan `docs/awcms-mini/README.md` (paragraf "Untuk membangun aplikasi baru" + tabel referensi Lapisan E).

## Verifikasi

`bun run check:docs` dan `bun run check` bersih (lint/check:docs/api:spec:check/typecheck/test/build) — validasi mermaid/tautan internal memastikan setiap cross-reference (skill, ADR, dokumen lain) benar-benar resolve. Tidak ada changeset (docs-only, tidak ada perilaku aplikasi berubah).

🤖 Generated with [Claude Code](https://claude.com/claude-code)