### PR TITLE
docs(github): refresh GitHub issue and security snapshots (Issue #461)

### DIFF
--- a/docs/awcms-mini/github/README.md
+++ b/docs/awcms-mini/github/README.md
@@ -5,20 +5,20 @@ Dokumen ini mencatat snapshot live repository GitHub `ahliweb/awcms-mini`. Folde
 | Metadata     | Nilai                           |
 | ------------ | ------------------------------- |
 | Repository   | `ahliweb/awcms-mini`            |
-| Snapshot     | 2026-07-05T19:20:00Z            |
-| Total issue  | 38                              |
-| Open issue   | 0                               |
-| Closed issue | 38                              |
+| Snapshot     | 2026-07-06T13:39:59Z            |
+| Total issue  | 55                              |
+| Open issue   | 5                               |
+| Closed issue | 50                              |
 | Labels       | 98 (25 doc 06 + 73 peninggalan) |
-| Milestones   | 24 (5 doc 06 + 19 peninggalan)  |
+| Milestones   | 25 (6 doc 06 + 19 peninggalan)  |
 
 ## File snapshot
 
 | State           | File                                         |                                         Jumlah issue |
 | --------------- | -------------------------------------------- | ---------------------------------------------------: |
-| OPEN            | [issues-open-001.md](issues-open-001.md)     |                                                    0 |
-| CLOSED          | [issues-closed-001.md](issues-closed-001.md) |                                                   38 |
-| LABEL/MILESTONE | [labels-milestones.md](labels-milestones.md) |                             98 labels, 24 milestones |
+| OPEN            | [issues-open-001.md](issues-open-001.md)     |                                                    5 |
+| CLOSED          | [issues-closed-001.md](issues-closed-001.md) |                                                   50 |
+| LABEL/MILESTONE | [labels-milestones.md](labels-milestones.md) |                             98 labels, 25 milestones |
 | SECURITY        | [security.md](security.md)                   | Security policy, Dependabot, secret scanning, CodeQL |
 
 ## Aturan pencatatan
@@ -42,10 +42,34 @@ Setelah data diambil, regenerate file di folder ini dengan pembagian state dan b
 
 ## Ringkasan state saat snapshot
 
-| State  | Jumlah | Catatan                                                                                                                                                                                                                                                   |
-| ------ | -----: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| OPEN   |      0 | **Tidak ada issue open** — seluruh 18 issue backlog base generik `docs/awcms-mini/06_github_issues_detail.md` sudah `completed`.                                                                                                                          |
-| CLOSED |     38 | 20 issue domain ditutup `not planned`; #371-#373, #376-#379, #391-#393, #398, #401, #403-#406, #407, dan #408 ditutup `completed` setelah Issue 0.1-0.3, epic M2 (2.1-2.4), 12.1, epic M5 (6.1-6.3), epic M7 (8.1-9.1), 10.1, 10.2, 10.3, 11.1, dan 12.2. |
+| State  | Jumlah | Catatan                                                                                                                                                                                                                                                                                                   |
+| ------ | -----: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OPEN   |      5 | #461-#465 — issue docs/tooling/planning pasca-analisis lanjutan (refresh snapshot, tooling snapshot, panduan deploy Coolify, contoh modul domain minimal, rencana pilot aplikasi turunan). Bukan bagian backlog doc06 (18 issue itu sudah `completed` seluruhnya).                                        |
+| CLOSED |     50 | 20 issue domain ditutup `not planned`; 18 issue backlog doc06 (#371-#373, #376-#379, #391-#393, #398, #401, #403-#408) ditutup `completed`; epic M9 (#433-#438, #447, 7 issue) dan 5 issue pasca-analisis lanjutan pertama (#450-#454) ditutup `completed` di luar backlog doc06 — lihat bagian di bawah. |
+
+### Issue pasca-analisis #450-#454 completed (2026-07-06)
+
+Lima issue perbaikan/perluasan di luar backlog doc06, dibuat setelah analisis repo pasca-M9 dan semuanya ditutup `completed` pada hari yang sama:
+
+- **[#450](https://github.com/ahliweb/awcms-mini/issues/450)** — sinkronisasi `AGENTS.md`/`docs/awcms-mini/README.md`/`docs/ARCHITECTURE.md`/`src/lib/README.md` agar tidak lagi terbaca seolah base masih di tengah foundation ("Kerjakan Issue 0.1", "modul belum diimplementasikan"); arsip bootstrap di doc 12/13 diberi banner status, bukan dihapus.
+- **[#451](https://github.com/ahliweb/awcms-mini/issues/451)** — ADR-0008: tiga skema SemVer independen (rilis package, kontrak OpenAPI/AsyncAPI, module descriptor). Kontrak dinaikkan `0.1.0` → `1.0.0`; ketujuh module descriptor `experimental` → `active`. `api:spec:check` kini memvalidasi `info.version` berbentuk SemVer.
+- **[#452](https://github.com/ahliweb/awcms-mini/issues/452)** — CodeQL matrix diperluas dari `actions` saja menjadi `actions` + `javascript-typescript` (`build-mode: none`, Bun-only). Dua temuan nyata dari scan pertama (`js/unused-local-variable`, `js/file-system-race`) diperbaiki dan dikonfirmasi `state: fixed` — lihat `security.md`.
+- **[#453](https://github.com/ahliweb/awcms-mini/issues/453)** — `docs/awcms-mini/derived-application-guide.md` baru: tabel base-reusable vs domain-specific, alur 9 langkah berbasis skill nyata, 5 contoh aplikasi turunan ilustratif, checklist keamanan.
+- **[#454](https://github.com/ahliweb/awcms-mini/issues/454)** — `Dockerfile.production` opsional (registry-based deployment, berdampingan dengan `docker-compose.yml` LAN-first) — diverifikasi nyata: `docker build` + `docker run` terhadap Postgres nyata, non-root user dikonfirmasi, `GET /api/v1/health` → 200, `POST /setup/initialize` menulis baris nyata.
+
+### Epic M9 — Peningkatan & Hardening pasca-backlog tuntas (2026-07-06)
+
+Milestone M9 (5 anak issue peningkatan pasca-backlog v0.22.0, epic [#438](https://github.com/ahliweb/awcms-mini/issues/438)) dan satu issue lanjutan berdiri sendiri di milestone yang sama, seluruhnya `completed`:
+
+- **[#433](https://github.com/ahliweb/awcms-mini/issues/433)** — runtime i18n (katalog `.po` gettext, default `en`, min en+id).
+- **[#434](https://github.com/ahliweb/awcms-mini/issues/434)** — audit UX/UI & aksesibilitas WCAG 2.1 AA atas layar admin yang sudah ada.
+- **[#435](https://github.com/ahliweb/awcms-mini/issues/435)** — audit performa (index RLS-aware, N+1 dihilangkan, keyset pagination — diukur `EXPLAIN ANALYZE` sebelum/sesudah).
+- **[#436](https://github.com/ahliweb/awcms-mini/issues/436)** — dispatcher object sync queue nyata + kerasan integrasi eksternal (circuit breaker per-provider, timeout).
+- **[#437](https://github.com/ahliweb/awcms-mini/issues/437)** — security hardening berbasis standar (matrix kepatuhan OWASP Top 10/ASVS/ISO 27001).
+- **[#438](https://github.com/ahliweb/awcms-mini/issues/438)** — epic tracking, ditutup setelah 5/5 anak issue selesai.
+- **[#447](https://github.com/ahliweb/awcms-mini/issues/447)** — aktivasi sistem log & manajemennya (correlation ID otomatis lintas endpoint, retensi/purge audit log terjadwal, extension point observability) — issue berdiri sendiri, bukan bagian 5 anak epic #438.
+
+Detail lengkap tiap issue: `CHANGELOG.md` (versi 0.23.0-0.23.5) dan `docs/awcms-mini/AUDIT_STANDAR_PENGEMBANGAN_2026-07-04.md` §Perawatan pasca-backlog.
 
 ### Offline/LAN deployment profile 12.2 completed — seluruh backlog base generik tuntas (2026-07-05)
 

--- a/docs/awcms-mini/github/issues-closed-001.md
+++ b/docs/awcms-mini/github/issues-closed-001.md
@@ -1,16 +1,18 @@
 # GitHub Issues Closed 001
 
-| Metadata           | Nilai                |
-| ------------------ | -------------------- |
-| Repository         | `ahliweb/awcms-mini` |
-| Snapshot           | 2026-07-05T19:20:00Z |
-| State              | `CLOSED`             |
-| File page          | 1/1                  |
-| Max issue per file | 100                  |
-| Issue dalam file   | 38                   |
-| Range              | #371-#408            |
+| Metadata           | Nilai                                                                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Repository         | `ahliweb/awcms-mini`                                                                                                                     |
+| Snapshot           | 2026-07-06T13:39:59Z                                                                                                                     |
+| State              | `CLOSED`                                                                                                                                 |
+| File page          | 1/1                                                                                                                                      |
+| Max issue per file | 100                                                                                                                                      |
+| Issue dalam file   | 50                                                                                                                                       |
+| Range              | #371-#454 (#409-#432, #439-#446, #448-#449, #455-#460 adalah nomor PR, bukan issue — issue/PR berbagi satu urutan nomor per repo GitHub) |
 
 > File ini adalah snapshot dari GitHub. Refresh dengan proses di `docs/awcms-mini/github/README.md` bila state issue berubah.
+
+Baris #371-#408 (38 issue) adalah backlog doc06 original — lihat narasi lengkap di bawah tabel dan di `docs/awcms-mini/github/README.md`. Baris #433-#454 (12 issue) adalah epic M9 + issue pasca-analisis lanjutan, **di luar** backlog doc06 — ringkasan singkat di bawah, detail lengkap di `CHANGELOG.md` dan `docs/awcms-mini/AUDIT_STANDAR_PENGEMBANGAN_2026-07-04.md` §Perawatan pasca-backlog.
 
 Seluruh issue di bawah ditutup dengan reason `not planned` pada 2026-07-04: kontennya spesifik domain POS/retail (katalog, stok, checkout, warehouse, pajak/Coretax, CRM receipt, AI business analyst) yang tidak sesuai konteks AWCMS-Mini sebagai contoh repo pengembangan umum. Konten dipindahkan ke aplikasi turunan contoh (mis. AWPOS), bukan dihapus riwayatnya.
 
@@ -56,3 +58,22 @@ Issue [#371](https://github.com/ahliweb/awcms-mini/issues/371), [#372](https://g
 | [#406](https://github.com/ahliweb/awcms-mini/issues/406) | 11.1 — Add Workflow Approval Engine                               | M8 — Security, Performance, Production |
 | [#407](https://github.com/ahliweb/awcms-mini/issues/407) | 12.1 — Add Initial Setup Wizard API                               | M0 — Repository Foundation             |
 | [#408](https://github.com/ahliweb/awcms-mini/issues/408) | 12.2 — Add Offline/LAN Deployment Profile                         | M8 — Security, Performance, Production |
+
+## Epic M9 + issue pasca-analisis lanjutan (di luar backlog doc06)
+
+Ditutup `completed` pada 2026-07-06, setelah seluruh 18 issue backlog doc06 di atas tuntas. Ringkasan per issue ada di `docs/awcms-mini/github/README.md` §Epic M9/§Issue pasca-analisis #450-#454; detail teknis lengkap di `CHANGELOG.md` (versi 0.23.0-0.23.5) dan `docs/awcms-mini/AUDIT_STANDAR_PENGEMBANGAN_2026-07-04.md` §Perawatan pasca-backlog.
+
+|                                                        # | Judul                                                                                                                               | Milestone (saat dibuat)                      |
+| -------------------------------------------------------: | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| [#433](https://github.com/ahliweb/awcms-mini/issues/433) | Peningkatan: implementasi i18n / multi-bahasa (.po gettext, default EN, min EN+ID)                                                  | M9 — Peningkatan & Hardening (pasca-backlog) |
+| [#434](https://github.com/ahliweb/awcms-mini/issues/434) | Peningkatan: audit & tingkatkan UX/UI (usability, aksesibilitas AA, konsistensi)                                                    | M9 — Peningkatan & Hardening (pasca-backlog) |
+| [#435](https://github.com/ahliweb/awcms-mini/issues/435) | Peningkatan: performa aplikasi & database (query, index, pagination, pooling)                                                       | M9 — Peningkatan & Hardening (pasca-backlog) |
+| [#436](https://github.com/ahliweb/awcms-mini/issues/436) | Peningkatan: kerasan backend & integrasi eksternal (outbox, resiliensi, observability)                                              | M9 — Peningkatan & Hardening (pasca-backlog) |
+| [#437](https://github.com/ahliweb/awcms-mini/issues/437) | Peningkatan: security hardening berbasis standar (OWASP Top 10, ASVS, ISO 27001)                                                    | M9 — Peningkatan & Hardening (pasca-backlog) |
+| [#438](https://github.com/ahliweb/awcms-mini/issues/438) | [EPIC] M9 — Peningkatan & Hardening pasca-backlog (UX, performa, integrasi, security, i18n)                                         | M9 — Peningkatan & Hardening (pasca-backlog) |
+| [#447](https://github.com/ahliweb/awcms-mini/issues/447) | Peningkatan: aktivasi sistem log & manajemennya (correlation ID end-to-end, retensi/purge audit log, extension point observability) | M9 — Peningkatan & Hardening (pasca-backlog) |
+| [#450](https://github.com/ahliweb/awcms-mini/issues/450) | docs: sync AGENTS and docs README with completed base state                                                                         | -                                            |
+| [#451](https://github.com/ahliweb/awcms-mini/issues/451) | chore(versioning): define and align package, API, AsyncAPI, and module versions                                                     | -                                            |
+| [#452](https://github.com/ahliweb/awcms-mini/issues/452) | security(ci): add CodeQL javascript-typescript analysis                                                                             | -                                            |
+| [#453](https://github.com/ahliweb/awcms-mini/issues/453) | docs: add derived application implementation guide                                                                                  | -                                            |
+| [#454](https://github.com/ahliweb/awcms-mini/issues/454) | build(deploy): add optional production Dockerfile for registry-based deployment                                                     | -                                            |

--- a/docs/awcms-mini/github/issues-open-001.md
+++ b/docs/awcms-mini/github/issues-open-001.md
@@ -3,13 +3,21 @@
 | Metadata           | Nilai                |
 | ------------------ | -------------------- |
 | Repository         | `ahliweb/awcms-mini` |
-| Snapshot           | 2026-07-05T19:20:00Z |
+| Snapshot           | 2026-07-06T13:39:59Z |
 | State              | `OPEN`               |
 | File page          | 1/1                  |
 | Max issue per file | 100                  |
-| Issue dalam file   | 0                    |
-| Range              | -                    |
+| Issue dalam file   | 5                    |
+| Range              | #461-#465            |
 
 > File ini adalah snapshot dari GitHub. Refresh dengan proses di `docs/awcms-mini/github/README.md` bila state issue berubah.
 
-**Tidak ada issue open.** Seluruh 18 issue backlog base generik dari `docs/awcms-mini/06_github_issues_detail.md` sudah `completed` — lihat `issues-closed-001.md`. Issue baru untuk base ini (perbaikan/perluasan di luar backlog awal) akan muncul di sini saat dibuka.
+Seluruh 18 issue backlog base generik dari `docs/awcms-mini/06_github_issues_detail.md` tetap `completed` (lihat `issues-closed-001.md`) — lima issue di bawah adalah perbaikan/perluasan **di luar** backlog awal, dibuka 2026-07-06 sebagai tindak lanjut analisis repo pasca-M9 (bukan berlabel/milestone doc06; tidak ada label/milestone yang di-assign saat dibuat).
+
+|                                                        # | Judul                                                                                | Tipe     |
+| -------------------------------------------------------: | ------------------------------------------------------------------------------------ | -------- |
+| [#461](https://github.com/ahliweb/awcms-mini/issues/461) | docs(github): refresh GitHub issue and security snapshots after post-analysis issues | docs     |
+| [#462](https://github.com/ahliweb/awcms-mini/issues/462) | docs(deploy): add Coolify deployment guide for Dockerfile.production                 | docs     |
+| [#463](https://github.com/ahliweb/awcms-mini/issues/463) | docs(examples): add minimal domain module implementation example                     | docs     |
+| [#464](https://github.com/ahliweb/awcms-mini/issues/464) | tooling(github): add reproducible GitHub snapshot refresh script                     | tooling  |
+| [#465](https://github.com/ahliweb/awcms-mini/issues/465) | planning(derived-app): define first real derived application pilot plan              | planning |

--- a/docs/awcms-mini/github/labels-milestones.md
+++ b/docs/awcms-mini/github/labels-milestones.md
@@ -3,9 +3,9 @@
 | Metadata         | Nilai                |
 | ---------------- | -------------------- |
 | Repository       | `ahliweb/awcms-mini` |
-| Snapshot         | 2026-07-05T00:05:58Z |
+| Snapshot         | 2026-07-06T13:39:59Z |
 | Total labels     | 98                   |
-| Total milestones | 24                   |
+| Total milestones | 25                   |
 
 Label diurutkan menjadi dua kelompok: **taksonomi doc 06** (dipakai backlog issue atomic base generik) dan **peninggalan proyek sebelumnya** (SIKESRA/governance-overlay, dibiarkan apa adanya, tidak dihapus/diubah).
 
@@ -119,15 +119,16 @@ Dibuat sebelum refaktor standar base sebagai label/milestone peninggalan proyek 
 | `wontfix`                   | This will not be worked on                           | `#ffffff` |
 | `workflow:issue-driven`     | Work must be implemented through an issue-based flow | `#5319e7` |
 
-## Milestone taksonomi doc 06 (5)
+## Milestone taksonomi doc 06 (6)
 
-|   # | Milestone                              | Deskripsi                                                                                 | State  |
-| --: | -------------------------------------- | ----------------------------------------------------------------------------------------- | ------ |
-|  20 | M0 — Repository Foundation             | Skeleton, migration runner, OpenAPI/AsyncAPI baseline (doc 06 Epic 0)                     | `open` |
-|  22 | M2 — Identity, Tenant, Profile         | Tenant, profile, auth, access control dasar (doc 06 Epic 2)                               | `open` |
-|  25 | M5 — Sync Storage                      | Offline sync outbox/inbox, conflict resolution, R2 object queue (doc 06 Epic 6)           | `open` |
-|  27 | M7 — UI/UX & Reporting                 | Admin layout shell, management reporting views (doc 06 Epic 8-9, generic)                 | `open` |
-|  28 | M8 — Security, Performance, Production | Logging, pooling, workflow approval, security readiness, deployment (doc 06 Epic 10-12.2) | `open` |
+|   # | Milestone                                    | Deskripsi                                                                                                                                                 | State  |
+| --: | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+|  20 | M0 — Repository Foundation                   | Skeleton, migration runner, OpenAPI/AsyncAPI baseline (doc 06 Epic 0)                                                                                     | `open` |
+|  22 | M2 — Identity, Tenant, Profile               | Tenant, profile, auth, access control dasar (doc 06 Epic 2)                                                                                               | `open` |
+|  25 | M5 — Sync Storage                            | Offline sync outbox/inbox, conflict resolution, R2 object queue (doc 06 Epic 6)                                                                           | `open` |
+|  27 | M7 — UI/UX & Reporting                       | Admin layout shell, management reporting views (doc 06 Epic 8-9, generic)                                                                                 | `open` |
+|  28 | M8 — Security, Performance, Production       | Logging, pooling, workflow approval, security readiness, deployment (doc 06 Epic 10-12.2)                                                                 | `open` |
+|  29 | M9 — Peningkatan & Hardening (pasca-backlog) | Peningkatan pasca-backlog v0.22.0: i18n, UX/a11y, performa, integrasi, security hardening, observability (bukan bagian backlog doc06 — dibuat 2026-07-06) | `open` |
 
 ## Milestone peninggalan proyek sebelumnya (19)
 

--- a/docs/awcms-mini/github/security.md
+++ b/docs/awcms-mini/github/security.md
@@ -1,8 +1,8 @@
 # GitHub Security Setup AWCMS-Mini
 
-Snapshot: 2026-07-05T00:05:58Z
+Snapshot: 2026-07-06T13:39:59Z
 
-Dokumen ini mencatat konfigurasi GitHub Security untuk `ahliweb/awcms-mini`: Bun + Astro 7 + PostgreSQL, base generik selesai (v0.23.5). Baris konfigurasi diperbarui saat setup berubah (baris CodeQL code scanning disegarkan untuk Issue #452 — coverage `javascript-typescript`); metrik point-in-time (alert count, commit run) mengikuti timestamp snapshot di atas dan disegarkan lewat §Proses Refresh.
+Dokumen ini mencatat konfigurasi GitHub Security untuk `ahliweb/awcms-mini`: Bun + Astro 7 + PostgreSQL, base generik selesai (v0.23.5). Baris konfigurasi diperbarui saat setup berubah (baris CodeQL code scanning disegarkan untuk Issue #452 — coverage `javascript-typescript`); metrik point-in-time (alert count, commit run) mengikuti timestamp snapshot di atas dan disegarkan lewat §Proses Refresh. Refresh 2026-07-06 (Issue #461): dua temuan nyata dari scan `javascript-typescript` pertama (alert #8 `js/file-system-race`, #9 `js/unused-local-variable`) diperbaiki dan dikonfirmasi `state: fixed` via API — lihat §Alert Count Saat Setup.
 
 ## Ringkasan Live State
 
@@ -20,15 +20,15 @@ Dokumen ini mencatat konfigurasi GitHub Security untuk `ahliweb/awcms-mini`: Bun
 | Secret scanning validity checks       | Disabled pada GitHub saat setup                                                                                                                                                                                     |
 | Code scanning                         | Enabled lewat `.github/workflows/codeql.yml` untuk GitHub Actions **dan** `javascript-typescript` (source TypeScript/Astro, Issue #452); default setup `not-configured` agar tidak konflik dengan advanced workflow |
 | Private vulnerability reporting       | Enabled; gunakan link GitHub advisory di `SECURITY.md`                                                                                                                                                              |
-| Latest CodeQL run                     | Success pada `main` commit `17a851f`                                                                                                                                                                                |
+| Latest CodeQL run                     | Success pada `main` commit `d7fba32` (2026-07-06T13:01:20Z)                                                                                                                                                         |
 
 ## Alert Count Saat Setup
 
-| Alert type      | Open | Fixed / historical | Catatan                                                                                                          |
-| --------------- | ---: | -----------------: | ---------------------------------------------------------------------------------------------------------------- |
-| Dependabot      |    0 |                 40 | Semua alert yang terambil dari API berstatus `fixed`.                                                            |
-| Code scanning   |    0 |                  7 | Semua alert yang terambil dari API berstatus `fixed`; #7 `actions/unpinned-tag` fixed pada 2026-07-05T00:05:32Z. |
-| Secret scanning |    0 |                  0 | Tidak ada alert saat setup.                                                                                      |
+| Alert type      | Open | Fixed / historical | Catatan                                                                                                                                                                                                                                                                             |
+| --------------- | ---: | -----------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Dependabot      |    0 |                 40 | Semua alert yang terambil dari API berstatus `fixed`.                                                                                                                                                                                                                               |
+| Code scanning   |    0 |                  9 | Semua alert yang terambil dari API berstatus `fixed`; #7 `actions/unpinned-tag` fixed pada 2026-07-05T00:05:32Z; #8 `js/file-system-race` dan #9 `js/unused-local-variable` (temuan pertama scan `javascript-typescript`, Issue #452) fixed pada 2026-07-06T13:02:21Z (Issue #461). |
+| Secret scanning |    0 |                  0 | Tidak ada alert saat setup.                                                                                                                                                                                                                                                         |
 
 ## File Yang Menjadi Standar
 


### PR DESCRIPTION
Closes #461.

## Ringkasan

`docs/awcms-mini/github/` belum di-refresh sejak `2026-07-05T19:20:00Z` (38 total issue, 0 open, 24 milestone) — seluruh epic M9 (#433-438, #447) sampai batch pasca-analisis pertama (#450-454) mendarat tanpa pernah menyentuh snapshot ini, dan milestone M9 sendiri (#29) belum ada saat snapshot terakhir dibuat.

Disegarkan terhadap state live GitHub (`gh issue list`/`label list`/`api milestones`, `gh api code-scanning`/`dependabot`/`secret-scanning` alerts, `gh run list` untuk run CodeQL terbaru) per `2026-07-06T13:39:59Z`:

- **README.md**: tabel metadata (38→55 total, 0→5 open, 38→50 closed, 24→25 milestone), plus dua section narasi baru (paling-baru-di-atas, mengikuti gaya file yang sudah ada) mencakup batch #450-454 dan epic M9 + #447, tiap issue diringkas apa yang benar-benar dikirim dengan cross-reference ke `CHANGELOG.md`/`AUDIT_STANDAR_PENGEMBANGAN.md` untuk detail lengkap, bukan menarasikan ulang di sini.
- **issues-open-001.md**: kini mencatat 5 issue open saat ini (#461-465, batch ini) menggantikan klaim basi "tidak ada issue open".
- **issues-closed-001.md**: ditambah section tabel baru untuk 12 issue yang baru ditutup (#433-438, #447, #450-454), dengan catatan eksplisit bahwa gap nomor di rentang #371-454 adalah nomor PR, bukan issue yang hilang (diverifikasi tiap nomor 409-454 satu per satu via API — issue dan PR berbagi satu urutan nomor per repo GitHub, sumber kebingungan nyata yang tidak diberi catatan sebelumnya).
- **labels-milestones.md**: menambah baris milestone M9 (#29) yang hilang, jumlah section 5→6.
- **security.md**: run CodeQL terbaru diperbarui ke HEAD `main` saat ini (`d7fba32`, merge yang menutup fix alert #8/#9), dan jumlah alert code scanning dikoreksi dari 7 menjadi 9 fixed dengan catatan bahwa #8 (`js/file-system-race`) dan #9 (`js/unused-local-variable`) — temuan pertama dari matrix `javascript-typescript` (#452) — kini dikonfirmasi `state: fixed` via API, bukan sekadar diasumsikan closed.

## Verifikasi

`bun run check` bersih (lint/check:docs/api:spec:check/typecheck/test/build) — `check:docs` secara spesifik memvalidasi setiap tautan internal di kelima file masih resolve. Tidak ada changeset (docs-only snapshot internal, tidak ada perilaku aplikasi berubah).

🤖 Generated with [Claude Code](https://claude.com/claude-code)