### PR TITLE
fix(github-snapshot): use dynamic repo URL in issue table rows

### DIFF
--- a/scripts/github-snapshot-refresh.ts
+++ b/scripts/github-snapshot-refresh.ts
@@ -263,8 +263,16 @@ function replaceBetweenMarkers(
   return `${before}\n\n${replacement}\n\n${after}`;
 }
 
-function issueTableRow(issue: Issue, milestoneFallback = "-"): string {
-  const url = `https://github.com/ahliweb/awcms-mini/issues/${issue.number}`;
+// `repo` comes from the same `owner/repo` argument fetchLiveState() was
+// called with — keeps generated issue links pointing at the repo actually
+// being processed instead of hardcoding this repo, so this script stays a
+// valid pattern to copy into a derived repo (e.g. AWPOS) unchanged.
+function issueTableRow(
+  issue: Issue,
+  repo: string,
+  milestoneFallback = "-"
+): string {
+  const url = `https://github.com/${repo}/issues/${issue.number}`;
   const milestone = issue.milestone?.title ?? milestoneFallback;
   return `| [#${issue.number}](${url}) | ${issue.title} | ${milestone} |`;
 }
@@ -345,7 +353,7 @@ async function main() {
         ? [
             "|                                                        # | Judul | Milestone (saat dibuat) |",
             "| -------------------------------------------------------: | ----- | ----------------------- |",
-            ...sorted.map((issue) => issueTableRow(issue))
+            ...sorted.map((issue) => issueTableRow(issue, repo))
           ].join("\n")
         : "**Tidak ada issue open.**";
     content = replaceBetweenMarkers(content, "open-issues", table);
@@ -370,7 +378,7 @@ async function main() {
     const table = [
       "|                                                        # | Judul | Milestone (saat dibuat) |",
       "| -------------------------------------------------------: | ----- | ----------------------- |",
-      ...postDoc06.map((issue) => issueTableRow(issue))
+      ...postDoc06.map((issue) => issueTableRow(issue, repo))
     ].join("\n");
     content = replaceBetweenMarkers(content, "closed-issues-post-doc06", table);
     writeFileSync(file, content);


### PR DESCRIPTION
## Summary
- `issueTableRow()` in `scripts/github-snapshot-refresh.ts` hardcoded `https://github.com/ahliweb/awcms-mini/issues/<number>` regardless of the `owner/repo` argument the script was invoked with.
- Threaded the resolved `repo` through to `issueTableRow()` at both call sites (open issues table, closed issues post-doc06 table) so generated links match whichever repo is actually being processed — matters if this script is ever copied into a derived repo (e.g. AWPOS) with a different repo argument, which is the whole point of it being a reusable pattern.
- Default repo (`ahliweb/awcms-mini`) output is unchanged.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run github:snapshot:refresh` (live run against `ahliweb/awcms-mini`, default repo) — confirmed generated URLs still point at `ahliweb/awcms-mini`
- [x] `bun run lint` / `bun run check` (lint, check:docs, api:spec:check, typecheck, 319 tests, build) — all green
- Not applicable: no DB-dependent runtime code touched

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)