### PR TITLE
fix(github-snapshot): don't report in-progress CodeQL run as Failure

### DIFF
--- a/scripts/github-snapshot-refresh.ts
+++ b/scripts/github-snapshot-refresh.ts
@@ -72,6 +72,7 @@ type WorkflowRun = {
   conclusion: string | null;
   headSha: string;
   createdAt: string;
+  status: string;
 };
 
 /** Runs `gh` and returns stdout. Never logs args that could contain a token — this script never passes one. */
@@ -174,7 +175,7 @@ async function fetchLiveState(repo: string) {
     "--limit",
     "1",
     "--json",
-    "conclusion,headSha,createdAt"
+    "conclusion,headSha,createdAt,status"
   ])?.[0];
 
   return {
@@ -404,7 +405,7 @@ async function main() {
     const file = path.join(DOCS_DIR, "security.md");
     let content = readFileSync(file, "utf8");
     content = content.replace(/^Snapshot: .*$/m, `Snapshot: ${snapshotAt}`);
-    if (state.latestCodeQlRun) {
+    if (state.latestCodeQlRun?.status === "completed") {
       const shortSha = state.latestCodeQlRun.headSha.slice(0, 7);
       const status =
         state.latestCodeQlRun.conclusion === "success" ? "Success" : "Failure";
@@ -412,6 +413,13 @@ async function main() {
         content,
         "Latest CodeQL run",
         `${status} pada \`main\` commit \`${shortSha}\` (${state.latestCodeQlRun.createdAt})`
+      );
+    } else if (state.latestCodeQlRun) {
+      // Run hasn't finished yet (queued/in_progress) — `conclusion` would be
+      // null/empty here, which would otherwise be misread as "Failure". Leave
+      // the row as whatever it currently says rather than guess.
+      console.log(
+        "Latest CodeQL run belum selesai (status bukan 'completed') — baris 'Latest CodeQL run' TIDAK diperbarui, tinjau ulang nanti."
       );
     }
     if (state.dependabotOpen !== null && state.dependabotAll !== null) {


### PR DESCRIPTION
## Summary
- Found live while running the refresh for Issue #472: right after a merge to `main`, the script fetched the "latest" CodeQL run before it had finished, wrote "Failure" into `security.md`, then a few minutes later `gh run list` showed that same run as `completed`/`success`. The ternary `conclusion === "success" ? "Success" : "Failure"` treated an in-progress run's null `conclusion` as a failure — a false negative in generated security-audit docs.
- Fetch `status` alongside `conclusion`; only update the "Latest CodeQL run" row when `status === "completed"`. Otherwise leave the row untouched and log that it was skipped, rather than guessing.
- Verified live: re-running the script now correctly writes "Success" for the completed run.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run github:snapshot:refresh` (live) — confirmed `security.md`'s "Latest CodeQL run" row now correctly shows "Success" for the completed run
- [x] `bun run check` (lint, check:docs, api:spec:check, typecheck, 319 tests, build) — all green
- [x] Generated docs from this verification run reverted on this branch (`git checkout --`) — this PR only ships the script fix; the actual snapshot refresh ships separately in #472

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)