### PR TITLE
docs(skills): document in-progress CodeQL run behavior in github-snapshot skill

### DIFF
--- a/.claude/skills/awcms-mini-github-snapshot/SKILL.md
+++ b/.claude/skills/awcms-mini-github-snapshot/SKILL.md
@@ -38,6 +38,13 @@ mekanis lewat `gh` CLI (tidak pernah membaca/menyimpan token sendiri):
 Tinjau bagian-bagian ini manual setelah menjalankan script bila ada
 issue/label/milestone baru yang butuh konteks naratif.
 
+**Catatan (Issue #475):** bila CodeQL run terbaru untuk `main` masih
+`in_progress`/`queued` (mis. baru saja push/merge), baris "Latest CodeQL
+run" di `security.md` **sengaja tidak diperbarui** — script mencetak
+peringatan di console dan membiarkan nilai lama, bukan menebak status
+run yang belum selesai sebagai `Failure`. Jalankan ulang script beberapa
+menit kemudian bila baris itu perlu nilai terbaru.
+
 ## Alur
 
 ```mermaid


### PR DESCRIPTION
## Summary
- `awcms-mini-github-snapshot` skill didn't mention the behavior #475 just introduced (skip updating "Latest CodeQL run" when the run hasn't completed yet, instead of guessing "Failure"). Added a short note so anyone running the skill right after a merge understands why that one row might not update.
- Ran a repo-wide `bun run format` sweep — no other files needed reformatting.
- Swept docs for stale skill-count/issue-count references after today's #472/#473/#475 batch — none found.
- No new skill needed this round: #472/#473/#475 were all fixes/refresh to already-cataloged tooling (`awcms-mini-github-snapshot`, added last session), not new capability.

## Test plan
- [x] `bun run format` — only the skill file changed
- [x] `bun run check:docs` — OK
- [x] `bun run check` (lint, check:docs, api:spec:check, typecheck, 319 tests, build) — all green
- [x] Grepped docs for stale counts (`22 skill`, old issue counts) — none found
- Not applicable: no runtime application changes, docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)