### PR TITLE
feat: add reusable wizard form pattern

### DIFF
--- a/docs/awcms-mini/examples/wizard-form-pattern.md
+++ b/docs/awcms-mini/examples/wizard-form-pattern.md
@@ -89,6 +89,38 @@ Tanggung jawab:
 - mencegah loncat step yang belum selesai;
 - membuat `Idempotency-Key` untuk submit final high-risk.
 
+## Pola i18n
+
+Konsisten dengan `StateNotice.astro`/`WizardActions.astro`: komponen wizard
+**tidak pernah** memanggil translator sendiri atau membaca locale dari
+request — semua string yang tampak ke user diterima sebagai prop, dan
+halaman pemanggil yang bertanggung jawab memanggil
+`createTranslator(locale)` (`src/lib/i18n/translate.ts`) di frontmatter lalu
+meneruskan hasil `t(key)` sebagai prop. Default prop (bila ada) berbahasa
+Inggris hanya sebagai fallback aman, bukan nilai yang dianggap final untuk
+production — halaman pemanggil wajib selalu mengisi prop ini dari katalog:
+
+| Komponen        | Prop yang wajib diisi dari `t(key)`                       |
+| --------------- | --------------------------------------------------------- |
+| `WizardStepper` | `label`, `currentLabel`, `completedLabel`, `pendingLabel` |
+| `WizardPanel`   | `title`, `description`, `errorSummaryHeading`             |
+| `WizardActions` | `backLabel`, `nextLabel`, `submitLabel`, `saveDraftLabel` |
+
+```astro
+---
+const t = await createTranslator(locale);
+---
+
+<WizardStepper
+  steps={steps}
+  activeStepKey={activeStepKey}
+  label={t("wizard.stepper.label")}
+  currentLabel={t("wizard.stepper.current")}
+  completedLabel={t("wizard.stepper.completed")}
+  pendingLabel={t("wizard.stepper.pending")}
+/>
+```
+
 ## Flow standar
 
 ```mermaid
@@ -197,26 +229,26 @@ export const dutyTravelWizardSteps: WizardStep[] = [
     key: "basic",
     title: "Data dasar",
     description: "Judul, jenis, tanggal, dan tujuan tugas.",
-    fields: ["title", "assignmentType", "startDate", "endDate"],
+    fields: ["title", "assignmentType", "startDate", "endDate"]
   },
   {
     key: "participants",
     title: "Peserta",
     description: "Pegawai yang ditugaskan dan perannya.",
-    fields: ["participants"],
+    fields: ["participants"]
   },
   {
     key: "destination",
     title: "Tujuan",
     description: "Lokasi, instansi tujuan, dan uraian tugas.",
-    fields: ["destinationName", "destinationAddress", "taskDescription"],
+    fields: ["destinationName", "destinationAddress", "taskDescription"]
   },
   {
     key: "review",
     title: "Review",
     description: "Periksa kembali sebelum submit.",
-    fields: [],
-  },
+    fields: []
+  }
 ];
 ```
 
@@ -228,8 +260,17 @@ export const dutyTravelWizardSteps: WizardStep[] = [
 - Urutan tab mengikuti urutan visual.
 - Target sentuh minimal 44px pada layar kecil.
 - Status step tidak hanya ditandai warna; tambahkan teks atau ikon.
-- Fokus berpindah ke judul panel step setelah user menekan `Next`.
 - Submit state memakai `aria-busy="true"`.
+
+Belum diimplementasikan di komponen MVP ini — jadi tanggung jawab
+halaman pemanggil, bukan jaminan `WizardPanel`/`WizardStepper` itu sendiri
+(komponen ini tidak menyertakan `<script>` client apa pun):
+
+- Pindahkan fokus ke judul panel (`#${id}-title`) setiap kali step aktif
+  berubah (mis. setelah `Next`/`Back`/jump), supaya pembaca layar
+  mengumumkan step baru. Panggil `document.getElementById(...).focus()`
+  (dengan `tabindex="-1"` pada elemen judul) dari script halaman yang
+  mengorkestrasi transisi step.
 
 ## Testing checklist
 

--- a/docs/awcms-mini/examples/wizard-form-pattern.md
+++ b/docs/awcms-mini/examples/wizard-form-pattern.md
@@ -1,16 +1,21 @@
 # Reusable Wizard Form Pattern
 
-Dokumen ini menjelaskan pola **multi-step wizard form** untuk AWCMS-Mini sebagai alternatif form input biasa. Pattern ini ditujukan untuk aplikasi turunan yang membutuhkan input data panjang, bertahap, dan rawan salah jika ditampilkan sebagai satu form besar.
+Dokumen ini menjelaskan pola **multi-step wizard form** untuk AWCMS-Mini
+sebagai alternatif form input biasa. Pattern ini ditujukan untuk aplikasi
+turunan yang membutuhkan input data panjang, bertahap, dan rawan salah jika
+ditampilkan sebagai satu form besar.
 
-Issue pelacak: [#479 — UX: Add reusable multi-step wizard form pattern](https://github.com/ahliweb/awcms-mini/issues/479).
+Issue pelacak:
+[#479 — UX: Add reusable multi-step wizard form pattern](https://github.com/ahliweb/awcms-mini/issues/479).
 
 ## Tujuan
 
 1. Membagi form panjang menjadi beberapa langkah yang mudah dipahami operator.
-2. Menyediakan validasi per langkah sebelum user lanjut ke langkah berikutnya.
+2. Menyediakan validasi per langkah sebelum user lanjut.
 3. Menyediakan ringkasan akhir sebelum submit final.
-4. Memakai pola UI, i18n, accessibility, dan keamanan AWCMS-Mini.
-5. Tetap menjaga server validation, ABAC, RLS, audit, dan idempotency sebagai kontrol utama.
+4. Memakai pola UI, i18n, aksesibilitas, dan keamanan AWCMS-Mini.
+5. Tetap menjaga server validation, ABAC, RLS, audit, dan idempotency sebagai
+   kontrol utama.
 
 ## Kapan memakai wizard
 
@@ -19,23 +24,26 @@ Gunakan wizard bila form memenuhi salah satu kondisi berikut:
 - memiliki banyak field lintas kategori;
 - membutuhkan urutan input yang jelas;
 - perlu review akhir sebelum submit;
-- memiliki lampiran/bukti pendukung;
-- rawan salah input bila seluruh field ditampilkan sekaligus;
+- memiliki lampiran atau bukti pendukung;
+- rawan salah input bila semua field ditampilkan sekaligus;
 - membutuhkan draft/resume pada tahap lanjutan.
 
 Contoh cocok:
 
-1. Surat Tugas/SPPD: identitas tugas → peserta → tujuan → biaya/SPM → lampiran → review.
-2. SIKESRA: wilayah → identitas keluarga → anggota keluarga → indikator → bukti → review.
-3. Master faskes: identitas → wilayah/alamat → koordinat → layanan → kontak → review.
-4. Sistem manajemen mutu: audit → klausul → temuan → tindakan korektif → bukti → review.
-5. Produk AWPOS: identitas produk → kategori/SKU → harga/pajak → stok awal → review.
+| Domain                | Step yang disarankan                                                         |
+| --------------------- | ---------------------------------------------------------------------------- |
+| Surat Tugas/SPPD      | Identitas tugas → peserta → tujuan → biaya/SPM → lampiran → review           |
+| SIKESRA               | Wilayah → identitas keluarga → anggota keluarga → indikator → bukti → review |
+| Master faskes         | Identitas → wilayah/alamat → koordinat → layanan → kontak → review           |
+| Sistem manajemen mutu | Audit → klausul → temuan → tindakan korektif → bukti → review                |
+| Produk AWPOS          | Identitas produk → kategori/SKU → harga/pajak → stok awal → review           |
 
-Tetap gunakan form biasa bila input hanya sederhana, misalnya ganti nama role, ubah status, atau pengaturan singkat.
+Tetap gunakan form biasa bila input hanya sederhana, misalnya ganti nama role,
+ubah status, atau pengaturan singkat.
 
 ## Komponen target
 
-Implementasi issue #479 sebaiknya menambah komponen berikut:
+Implementasi issue #479 menambahkan komponen berikut:
 
 ```text
 src/components/ui/WizardStepper.astro
@@ -49,9 +57,7 @@ src/lib/ui/wizard-client.ts
 Tanggung jawab:
 
 - menampilkan daftar langkah;
-- menandai step aktif;
-- menandai step selesai;
-- mendukung keyboard navigation;
+- menandai step aktif dan selesai;
 - memakai `aria-current="step"` pada step aktif;
 - tidak memakai warna sebagai satu-satunya indikator status.
 
@@ -60,7 +66,7 @@ Tanggung jawab:
 Tanggung jawab:
 
 - membungkus konten per step;
-- menyembunyikan step yang tidak aktif tanpa kehilangan state form;
+- menyembunyikan step tidak aktif tanpa menghapus state form;
 - menyediakan region yang dapat dibaca assistive technology;
 - menampilkan ringkasan error step.
 
@@ -68,8 +74,8 @@ Tanggung jawab:
 
 Tanggung jawab:
 
-- tombol `Back`, `Next`, `Save Draft` bila tersedia, dan `Submit`;
-- disable tombol selama mutation in-flight;
+- menyediakan tombol `Back`, `Next`, `Save Draft` bila tersedia, dan `Submit`;
+- men-disable tombol selama mutation in-flight;
 - menyampaikan state loading/submitting secara aksesibel;
 - tidak menghapus input ketika server menolak request.
 
@@ -80,8 +86,8 @@ Tanggung jawab:
 - menyimpan state step aktif;
 - menjalankan validasi per step;
 - mapping `VALIDATION_ERROR.details` ke field error;
-- mengunci submit final;
-- integrasi dengan helper existing `submitJson`, `showBanner`, dan `lockElement` dari `src/lib/ui/admin-form-client.ts`.
+- mencegah loncat step yang belum selesai;
+- membuat `Idempotency-Key` untuk submit final high-risk.
 
 ## Flow standar
 
@@ -111,10 +117,11 @@ Minimal validasi:
 
 - field wajib per step;
 - format dasar seperti tanggal, angka, email, kode, atau UUID;
-- cross-field rule sederhana, misalnya tanggal selesai tidak boleh sebelum tanggal mulai;
+- cross-field rule sederhana;
 - review step menampilkan data final yang akan dikirim.
 
-Endpoint domain tetap wajib memvalidasi payload lengkap, termasuk field dari step sebelumnya. UI tidak boleh dianggap sebagai kontrol keamanan utama.
+Endpoint domain tetap wajib memvalidasi payload lengkap, termasuk field dari step
+sebelumnya. UI tidak boleh dianggap sebagai kontrol keamanan utama.
 
 ## Keamanan
 
@@ -125,14 +132,18 @@ Pola ini wajib mengikuti guardrail AWCMS-Mini:
 3. Mutation berbasis cookie mengikuti kebijakan CSRF repository.
 4. Draft client-side hanya boleh untuk data non-sensitif.
 5. Data sensitif atau PII tidak boleh disimpan di `localStorage`.
-6. Jika draft berisi data sensitif, gunakan server-side draft dengan RLS, audit, retention, masking, dan soft delete.
+6. Jika draft berisi data sensitif, gunakan server-side draft dengan RLS, audit,
+   retention, masking, dan soft delete.
 7. Jangan memakai `innerHTML` untuk data user tanpa sanitasi.
 8. Error harus user-friendly dan tidak mengekspos stack trace.
-9. Provider eksternal seperti R2, email, WhatsApp, atau AI tidak boleh dipanggil di dalam transaksi database.
+9. Provider eksternal seperti R2, email, WhatsApp, atau AI tidak boleh dipanggil
+   di dalam transaksi database.
 
 ## Server-side draft: follow-up, bukan MVP
 
-Issue #479 sengaja tidak langsung membangun draft persistence agar scope tetap kecil dan tidak over-engineering. Setelah pattern dipakai minimal oleh dua modul domain nyata, buat issue lanjutan untuk server-side draft.
+Issue #479 sengaja tidak langsung membangun draft persistence agar scope tetap
+kecil dan tidak over-engineering. Setelah pattern dipakai minimal oleh dua modul
+domain nyata, buat issue lanjutan untuk server-side draft.
 
 Tabel draft yang disarankan:
 
@@ -186,67 +197,33 @@ export const dutyTravelWizardSteps: WizardStep[] = [
     key: "basic",
     title: "Data dasar",
     description: "Judul, jenis, tanggal, dan tujuan tugas.",
-    fields: ["title", "assignmentType", "startDate", "endDate"]
+    fields: ["title", "assignmentType", "startDate", "endDate"],
   },
   {
     key: "participants",
     title: "Peserta",
     description: "Pegawai yang ditugaskan dan perannya.",
-    fields: ["participants"]
+    fields: ["participants"],
   },
   {
     key: "destination",
     title: "Tujuan",
     description: "Lokasi, instansi tujuan, dan uraian tugas.",
-    fields: ["destinationName", "destinationAddress", "taskDescription"]
+    fields: ["destinationName", "destinationAddress", "taskDescription"],
   },
   {
     key: "review",
     title: "Review",
     description: "Periksa kembali sebelum submit.",
-    fields: []
-  }
+    fields: [],
+  },
 ];
-```
-
-## Contoh validasi per step
-
-```ts
-export type FieldError = {
-  field: string;
-  message: string;
-};
-
-export function validateStep(
-  stepKey: string,
-  payload: Record<string, unknown>
-): FieldError[] {
-  const errors: FieldError[] = [];
-
-  if (stepKey === "basic") {
-    if (typeof payload.title !== "string" || payload.title.trim() === "") {
-      errors.push({ field: "title", message: "Judul wajib diisi." });
-    }
-
-    if (!payload.startDate) {
-      errors.push({ field: "startDate", message: "Tanggal mulai wajib diisi." });
-    }
-  }
-
-  if (stepKey === "participants") {
-    if (!Array.isArray(payload.participants) || payload.participants.length === 0) {
-      errors.push({ field: "participants", message: "Minimal satu peserta wajib dipilih." });
-    }
-  }
-
-  return errors;
-}
 ```
 
 ## Accessibility checklist
 
 - Step aktif memakai `aria-current="step"`.
-- Error summary memakai `role="alert"` atau `aria-live="polite"` sesuai konteks.
+- Error summary memakai `role="alert"` atau `aria-live="polite"`.
 - Tombol dapat difokus dan dioperasikan dengan keyboard.
 - Urutan tab mengikuti urutan visual.
 - Target sentuh minimal 44px pada layar kecil.

--- a/docs/awcms-mini/examples/wizard-form-pattern.md
+++ b/docs/awcms-mini/examples/wizard-form-pattern.md
@@ -1,0 +1,276 @@
+# Reusable Wizard Form Pattern
+
+Dokumen ini menjelaskan pola **multi-step wizard form** untuk AWCMS-Mini sebagai alternatif form input biasa. Pattern ini ditujukan untuk aplikasi turunan yang membutuhkan input data panjang, bertahap, dan rawan salah jika ditampilkan sebagai satu form besar.
+
+Issue pelacak: [#479 — UX: Add reusable multi-step wizard form pattern](https://github.com/ahliweb/awcms-mini/issues/479).
+
+## Tujuan
+
+1. Membagi form panjang menjadi beberapa langkah yang mudah dipahami operator.
+2. Menyediakan validasi per langkah sebelum user lanjut ke langkah berikutnya.
+3. Menyediakan ringkasan akhir sebelum submit final.
+4. Memakai pola UI, i18n, accessibility, dan keamanan AWCMS-Mini.
+5. Tetap menjaga server validation, ABAC, RLS, audit, dan idempotency sebagai kontrol utama.
+
+## Kapan memakai wizard
+
+Gunakan wizard bila form memenuhi salah satu kondisi berikut:
+
+- memiliki banyak field lintas kategori;
+- membutuhkan urutan input yang jelas;
+- perlu review akhir sebelum submit;
+- memiliki lampiran/bukti pendukung;
+- rawan salah input bila seluruh field ditampilkan sekaligus;
+- membutuhkan draft/resume pada tahap lanjutan.
+
+Contoh cocok:
+
+1. Surat Tugas/SPPD: identitas tugas → peserta → tujuan → biaya/SPM → lampiran → review.
+2. SIKESRA: wilayah → identitas keluarga → anggota keluarga → indikator → bukti → review.
+3. Master faskes: identitas → wilayah/alamat → koordinat → layanan → kontak → review.
+4. Sistem manajemen mutu: audit → klausul → temuan → tindakan korektif → bukti → review.
+5. Produk AWPOS: identitas produk → kategori/SKU → harga/pajak → stok awal → review.
+
+Tetap gunakan form biasa bila input hanya sederhana, misalnya ganti nama role, ubah status, atau pengaturan singkat.
+
+## Komponen target
+
+Implementasi issue #479 sebaiknya menambah komponen berikut:
+
+```text
+src/components/ui/WizardStepper.astro
+src/components/ui/WizardPanel.astro
+src/components/ui/WizardActions.astro
+src/lib/ui/wizard-client.ts
+```
+
+### `WizardStepper.astro`
+
+Tanggung jawab:
+
+- menampilkan daftar langkah;
+- menandai step aktif;
+- menandai step selesai;
+- mendukung keyboard navigation;
+- memakai `aria-current="step"` pada step aktif;
+- tidak memakai warna sebagai satu-satunya indikator status.
+
+### `WizardPanel.astro`
+
+Tanggung jawab:
+
+- membungkus konten per step;
+- menyembunyikan step yang tidak aktif tanpa kehilangan state form;
+- menyediakan region yang dapat dibaca assistive technology;
+- menampilkan ringkasan error step.
+
+### `WizardActions.astro`
+
+Tanggung jawab:
+
+- tombol `Back`, `Next`, `Save Draft` bila tersedia, dan `Submit`;
+- disable tombol selama mutation in-flight;
+- menyampaikan state loading/submitting secara aksesibel;
+- tidak menghapus input ketika server menolak request.
+
+### `wizard-client.ts`
+
+Tanggung jawab:
+
+- menyimpan state step aktif;
+- menjalankan validasi per step;
+- mapping `VALIDATION_ERROR.details` ke field error;
+- mengunci submit final;
+- integrasi dengan helper existing `submitJson`, `showBanner`, dan `lockElement` dari `src/lib/ui/admin-form-client.ts`.
+
+## Flow standar
+
+```mermaid
+flowchart LR
+  A[Start] --> B[Step 1: data dasar]
+  B --> C{Valid?}
+  C -- Tidak --> B
+  C -- Ya --> D[Step 2: detail]
+  D --> E{Valid?}
+  E -- Tidak --> D
+  E -- Ya --> F[Step 3: lampiran / bukti]
+  F --> G[Review]
+  G --> H{Konfirmasi user}
+  H -- Revisi --> B
+  H -- Submit --> I[POST/PATCH endpoint domain]
+  I --> J{Server valid?}
+  J -- Tidak --> K[Tampilkan field error + preserve input]
+  J -- Ya --> L[Success state / redirect]
+```
+
+## Prinsip validasi
+
+Validasi client hanya untuk UX cepat. Server tetap sumber kebenaran.
+
+Minimal validasi:
+
+- field wajib per step;
+- format dasar seperti tanggal, angka, email, kode, atau UUID;
+- cross-field rule sederhana, misalnya tanggal selesai tidak boleh sebelum tanggal mulai;
+- review step menampilkan data final yang akan dikirim.
+
+Endpoint domain tetap wajib memvalidasi payload lengkap, termasuk field dari step sebelumnya. UI tidak boleh dianggap sebagai kontrol keamanan utama.
+
+## Keamanan
+
+Pola ini wajib mengikuti guardrail AWCMS-Mini:
+
+1. Backend tetap memakai ABAC default-deny dan RLS untuk data tenant-scoped.
+2. Submit final high-risk memakai `Idempotency-Key`.
+3. Mutation berbasis cookie mengikuti kebijakan CSRF repository.
+4. Draft client-side hanya boleh untuk data non-sensitif.
+5. Data sensitif atau PII tidak boleh disimpan di `localStorage`.
+6. Jika draft berisi data sensitif, gunakan server-side draft dengan RLS, audit, retention, masking, dan soft delete.
+7. Jangan memakai `innerHTML` untuk data user tanpa sanitasi.
+8. Error harus user-friendly dan tidak mengekspos stack trace.
+9. Provider eksternal seperti R2, email, WhatsApp, atau AI tidak boleh dipanggil di dalam transaksi database.
+
+## Server-side draft: follow-up, bukan MVP
+
+Issue #479 sengaja tidak langsung membangun draft persistence agar scope tetap kecil dan tidak over-engineering. Setelah pattern dipakai minimal oleh dua modul domain nyata, buat issue lanjutan untuk server-side draft.
+
+Tabel draft yang disarankan:
+
+```sql
+CREATE TABLE awcms_mini_form_drafts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  module_key text NOT NULL,
+  wizard_key text NOT NULL,
+  resource_type text NOT NULL,
+  resource_id uuid,
+  current_step text NOT NULL,
+  payload jsonb NOT NULL,
+  status text NOT NULL CHECK (status IN ('draft', 'submitted', 'abandoned', 'expired')),
+  created_by uuid NOT NULL,
+  updated_by uuid NOT NULL,
+  submitted_by uuid,
+  expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  submitted_at timestamptz,
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text
+);
+```
+
+Follow-up server-side draft wajib menambah:
+
+- migration SQL berurutan;
+- RLS policy tenant-scoped;
+- repository dan service layer;
+- OpenAPI endpoint;
+- audit log untuk create/update/submit/delete draft;
+- retention/expiry policy;
+- test RLS dan permission;
+- dokumentasi operasi.
+
+## Contoh definisi step
+
+```ts
+export type WizardStep = {
+  key: string;
+  title: string;
+  description?: string;
+  fields: string[];
+};
+
+export const dutyTravelWizardSteps: WizardStep[] = [
+  {
+    key: "basic",
+    title: "Data dasar",
+    description: "Judul, jenis, tanggal, dan tujuan tugas.",
+    fields: ["title", "assignmentType", "startDate", "endDate"]
+  },
+  {
+    key: "participants",
+    title: "Peserta",
+    description: "Pegawai yang ditugaskan dan perannya.",
+    fields: ["participants"]
+  },
+  {
+    key: "destination",
+    title: "Tujuan",
+    description: "Lokasi, instansi tujuan, dan uraian tugas.",
+    fields: ["destinationName", "destinationAddress", "taskDescription"]
+  },
+  {
+    key: "review",
+    title: "Review",
+    description: "Periksa kembali sebelum submit.",
+    fields: []
+  }
+];
+```
+
+## Contoh validasi per step
+
+```ts
+export type FieldError = {
+  field: string;
+  message: string;
+};
+
+export function validateStep(
+  stepKey: string,
+  payload: Record<string, unknown>
+): FieldError[] {
+  const errors: FieldError[] = [];
+
+  if (stepKey === "basic") {
+    if (typeof payload.title !== "string" || payload.title.trim() === "") {
+      errors.push({ field: "title", message: "Judul wajib diisi." });
+    }
+
+    if (!payload.startDate) {
+      errors.push({ field: "startDate", message: "Tanggal mulai wajib diisi." });
+    }
+  }
+
+  if (stepKey === "participants") {
+    if (!Array.isArray(payload.participants) || payload.participants.length === 0) {
+      errors.push({ field: "participants", message: "Minimal satu peserta wajib dipilih." });
+    }
+  }
+
+  return errors;
+}
+```
+
+## Accessibility checklist
+
+- Step aktif memakai `aria-current="step"`.
+- Error summary memakai `role="alert"` atau `aria-live="polite"` sesuai konteks.
+- Tombol dapat difokus dan dioperasikan dengan keyboard.
+- Urutan tab mengikuti urutan visual.
+- Target sentuh minimal 44px pada layar kecil.
+- Status step tidak hanya ditandai warna; tambahkan teks atau ikon.
+- Fokus berpindah ke judul panel step setelah user menekan `Next`.
+- Submit state memakai `aria-busy="true"`.
+
+## Testing checklist
+
+- Step awal selalu valid secara state dan tidak melewati daftar step.
+- `Next` ditolak jika validasi step gagal.
+- `Back` tidak menghapus input.
+- Submit final tidak bisa double-click.
+- Error server dipetakan ke field terkait.
+- Input tetap dipertahankan saat server error.
+- Stepper dapat dipakai hanya dengan keyboard.
+- `bun run check` lulus sebelum PR siap merge.
+
+## Definition of Done
+
+- Komponen wizard reusable tersedia di `src/components/ui`.
+- Helper state tersedia di `src/lib/ui`.
+- Dokumentasi pattern ini tetap sinkron dengan implementasi.
+- Test helper tersedia.
+- Tidak ada perubahan schema pada MVP.
+- Tidak ada dependency framework baru tanpa alasan kuat.
+- Tidak ada secret atau PII sensitif di client storage.

--- a/src/components/ui/WizardActions.astro
+++ b/src/components/ui/WizardActions.astro
@@ -1,0 +1,139 @@
+---
+interface Props {
+  backLabel?: string;
+  nextLabel?: string;
+  submitLabel?: string;
+  saveDraftLabel?: string;
+  showBack?: boolean;
+  showNext?: boolean;
+  showSubmit?: boolean;
+  showSaveDraft?: boolean;
+  busy?: boolean;
+}
+
+const {
+  backLabel = "Back",
+  nextLabel = "Next",
+  submitLabel = "Submit",
+  saveDraftLabel = "Save draft",
+  showBack = true,
+  showNext = true,
+  showSubmit = false,
+  showSaveDraft = false,
+  busy = false
+} = Astro.props;
+---
+
+<div class="wizard-actions" aria-busy={busy ? "true" : "false"}>
+  <div class="wizard-actions-secondary">
+    {
+      showBack && (
+        <button
+          type="button"
+          class="wizard-action wizard-action-secondary"
+          data-wizard-back
+          disabled={busy}
+        >
+          {backLabel}
+        </button>
+      )
+    }
+    {
+      showSaveDraft && (
+        <button
+          type="button"
+          class="wizard-action wizard-action-secondary"
+          data-wizard-save-draft
+          disabled={busy}
+        >
+          {saveDraftLabel}
+        </button>
+      )
+    }
+  </div>
+
+  <div class="wizard-actions-primary">
+    {
+      showNext && (
+        <button
+          type="button"
+          class="wizard-action wizard-action-primary"
+          data-wizard-next
+          disabled={busy}
+        >
+          {nextLabel}
+        </button>
+      )
+    }
+    {
+      showSubmit && (
+        <button
+          type="submit"
+          class="wizard-action wizard-action-primary"
+          data-wizard-submit
+          disabled={busy}
+        >
+          {submitLabel}
+        </button>
+      )
+    }
+  </div>
+</div>
+
+<style>
+  .wizard-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--sp-3);
+    align-items: center;
+    border-top: 1px solid var(--color-border);
+    padding-top: var(--sp-3);
+  }
+
+  .wizard-actions-secondary,
+  .wizard-actions-primary {
+    display: flex;
+    gap: var(--sp-2);
+    flex-wrap: wrap;
+  }
+
+  .wizard-action {
+    min-height: 44px;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-4);
+    font-size: var(--fs-sm);
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .wizard-action-primary {
+    border: 1px solid var(--color-primary-strong);
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+  }
+
+  .wizard-action-secondary {
+    border: 1px solid var(--color-border);
+    background: var(--color-surface-2);
+    color: var(--color-text);
+  }
+
+  .wizard-action:focus-visible {
+    outline: 3px solid var(--color-focus);
+    outline-offset: 2px;
+  }
+
+  .wizard-action:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  @media (max-width: 640px) {
+    .wizard-actions,
+    .wizard-actions-secondary,
+    .wizard-actions-primary {
+      align-items: stretch;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/src/components/ui/WizardActions.astro
+++ b/src/components/ui/WizardActions.astro
@@ -20,7 +20,7 @@ const {
   showNext = true,
   showSubmit = false,
   showSaveDraft = false,
-  busy = false
+  busy = false,
 } = Astro.props;
 ---
 

--- a/src/components/ui/WizardActions.astro
+++ b/src/components/ui/WizardActions.astro
@@ -20,7 +20,7 @@ const {
   showNext = true,
   showSubmit = false,
   showSaveDraft = false,
-  busy = false,
+  busy = false
 } = Astro.props;
 ---
 

--- a/src/components/ui/WizardPanel.astro
+++ b/src/components/ui/WizardPanel.astro
@@ -5,6 +5,7 @@ interface Props {
   description?: string;
   active?: boolean;
   errorSummary?: readonly string[];
+  errorSummaryHeading?: string;
 }
 
 const {
@@ -13,6 +14,7 @@ const {
   description,
   active = true,
   errorSummary = [],
+  errorSummaryHeading = "Please review the following fields:"
 } = Astro.props;
 ---
 
@@ -31,7 +33,7 @@ const {
   {
     errorSummary.length > 0 && (
       <div class="wizard-panel-errors" role="alert">
-        <strong>Periksa kembali isian berikut:</strong>
+        <strong>{errorSummaryHeading}</strong>
         <ul>
           {errorSummary.map((message) => (
             <li>{message}</li>

--- a/src/components/ui/WizardPanel.astro
+++ b/src/components/ui/WizardPanel.astro
@@ -7,7 +7,13 @@ interface Props {
   errorSummary?: readonly string[];
 }
 
-const { id, title, description, active = true, errorSummary = [] } = Astro.props;
+const {
+  id,
+  title,
+  description,
+  active = true,
+  errorSummary = [],
+} = Astro.props;
 ---
 
 <section

--- a/src/components/ui/WizardPanel.astro
+++ b/src/components/ui/WizardPanel.astro
@@ -1,0 +1,91 @@
+---
+interface Props {
+  id: string;
+  title: string;
+  description?: string;
+  active?: boolean;
+  errorSummary?: readonly string[];
+}
+
+const { id, title, description, active = true, errorSummary = [] } = Astro.props;
+---
+
+<section
+  id={id}
+  class="wizard-panel"
+  data-active={active ? "true" : "false"}
+  aria-labelledby={`${id}-title`}
+  hidden={!active}
+>
+  <header class="wizard-panel-header">
+    <h2 id={`${id}-title`}>{title}</h2>
+    {description && <p>{description}</p>}
+  </header>
+
+  {
+    errorSummary.length > 0 && (
+      <div class="wizard-panel-errors" role="alert">
+        <strong>Periksa kembali isian berikut:</strong>
+        <ul>
+          {errorSummary.map((message) => (
+            <li>{message}</li>
+          ))}
+        </ul>
+      </div>
+    )
+  }
+
+  <div class="wizard-panel-body">
+    <slot />
+  </div>
+</section>
+
+<style>
+  .wizard-panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    padding: var(--sp-4);
+  }
+
+  .wizard-panel-header h2 {
+    margin: 0;
+    font-size: var(--fs-lg);
+  }
+
+  .wizard-panel-header p {
+    margin: var(--sp-1) 0 0;
+    color: var(--color-text-muted);
+    font-size: var(--fs-sm);
+  }
+
+  .wizard-panel-errors {
+    border: 1px solid var(--color-danger-strong);
+    border-radius: var(--radius-sm);
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 12%,
+      var(--color-surface)
+    );
+    padding: var(--sp-3);
+  }
+
+  .wizard-panel-errors strong {
+    display: block;
+    margin-bottom: var(--sp-2);
+  }
+
+  .wizard-panel-errors ul {
+    margin: 0;
+    padding-left: var(--sp-4);
+  }
+
+  .wizard-panel-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+  }
+</style>

--- a/src/components/ui/WizardStepper.astro
+++ b/src/components/ui/WizardStepper.astro
@@ -1,0 +1,140 @@
+---
+import type { WizardStepDefinition } from "../../lib/ui/wizard-client";
+
+interface Props {
+  steps: readonly WizardStepDefinition[];
+  activeStepKey: string;
+  completedStepKeys?: readonly string[];
+  label?: string;
+}
+
+const {
+  steps,
+  activeStepKey,
+  completedStepKeys = [],
+  label = "Wizard steps"
+} = Astro.props;
+---
+
+<nav class="wizard-stepper" aria-label={label}>
+  <ol class="wizard-stepper-list">
+    {
+      steps.map((step, index) => {
+        const isActive = step.key === activeStepKey;
+        const isCompleted = completedStepKeys.includes(step.key);
+        const stateLabel = isActive
+          ? "Current"
+          : isCompleted
+            ? "Completed"
+            : "Pending";
+
+        return (
+          <li
+            class="wizard-stepper-item"
+            data-active={isActive ? "true" : "false"}
+            data-completed={isCompleted ? "true" : "false"}
+          >
+            <span class="wizard-stepper-marker" aria-hidden="true">
+              {isCompleted ? "✓" : index + 1}
+            </span>
+            <span class="wizard-stepper-copy">
+              <span class="wizard-stepper-status">{stateLabel}</span>
+              <span
+                class="wizard-stepper-title"
+                aria-current={isActive ? "step" : undefined}
+              >
+                {step.title}
+              </span>
+              {step.description && (
+                <span class="wizard-stepper-description">
+                  {step.description}
+                </span>
+              )}
+            </span>
+          </li>
+        );
+      })
+    }
+  </ol>
+</nav>
+
+<style>
+  .wizard-stepper {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    padding: var(--sp-3);
+  }
+
+  .wizard-stepper-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: var(--sp-3);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .wizard-stepper-item {
+    display: flex;
+    gap: var(--sp-2);
+    align-items: flex-start;
+    min-width: 0;
+  }
+
+  .wizard-stepper-marker {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 2rem;
+    width: 2rem;
+    height: 2rem;
+    border-radius: var(--radius-full);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    font-weight: 700;
+  }
+
+  .wizard-stepper-item[data-active="true"] .wizard-stepper-marker {
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-primary-strong);
+  }
+
+  .wizard-stepper-item[data-completed="true"] .wizard-stepper-marker {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .wizard-stepper-copy {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    min-width: 0;
+  }
+
+  .wizard-stepper-status {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+
+  .wizard-stepper-title {
+    font-weight: 700;
+  }
+
+  .wizard-stepper-description {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+    line-height: 1.4;
+  }
+
+  @media (max-width: 768px) {
+    .wizard-stepper-list {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/components/ui/WizardStepper.astro
+++ b/src/components/ui/WizardStepper.astro
@@ -12,7 +12,7 @@ const {
   steps,
   activeStepKey,
   completedStepKeys = [],
-  label = "Wizard steps"
+  label = "Wizard steps",
 } = Astro.props;
 ---
 

--- a/src/components/ui/WizardStepper.astro
+++ b/src/components/ui/WizardStepper.astro
@@ -6,6 +6,9 @@ interface Props {
   activeStepKey: string;
   completedStepKeys?: readonly string[];
   label?: string;
+  currentLabel?: string;
+  completedLabel?: string;
+  pendingLabel?: string;
 }
 
 const {
@@ -13,6 +16,9 @@ const {
   activeStepKey,
   completedStepKeys = [],
   label = "Wizard steps",
+  currentLabel = "Current",
+  completedLabel = "Completed",
+  pendingLabel = "Pending"
 } = Astro.props;
 ---
 
@@ -23,10 +29,10 @@ const {
         const isActive = step.key === activeStepKey;
         const isCompleted = completedStepKeys.includes(step.key);
         const stateLabel = isActive
-          ? "Current"
+          ? currentLabel
           : isCompleted
-            ? "Completed"
-            : "Pending";
+            ? completedLabel
+            : pendingLabel;
 
         return (
           <li

--- a/src/lib/ui/wizard-client.ts
+++ b/src/lib/ui/wizard-client.ts
@@ -17,7 +17,7 @@ export type WizardValidationResult = {
 
 export type WizardValidator<TPayload extends Record<string, unknown>> = (
   step: WizardStepDefinition,
-  payload: Readonly<TPayload>
+  payload: Readonly<TPayload>,
 ) => WizardFieldError[];
 
 export type WizardState = {
@@ -33,7 +33,7 @@ export type WizardAdvanceResult =
 
 export function createWizardState(
   steps: readonly WizardStepDefinition[],
-  activeStepKey?: string
+  activeStepKey?: string,
 ): WizardState {
   const normalizedSteps = normalizeWizardSteps(steps);
   const activeStepIndex = activeStepKey
@@ -48,12 +48,12 @@ export function createWizardState(
     steps: normalizedSteps,
     activeStepIndex,
     completedStepKeys: [],
-    fieldErrors: {}
+    fieldErrors: {},
   };
 }
 
 export function normalizeWizardSteps(
-  steps: readonly WizardStepDefinition[]
+  steps: readonly WizardStepDefinition[],
 ): readonly WizardStepDefinition[] {
   if (steps.length === 0) {
     throw new Error("Wizard must define at least one step.");
@@ -78,7 +78,7 @@ export function normalizeWizardSteps(
   return steps.map((step) => ({
     ...step,
     key: step.key.trim(),
-    title: step.title.trim()
+    title: step.title.trim(),
   }));
 }
 
@@ -105,7 +105,7 @@ export function getWizardProgress(state: WizardState): {
     current,
     total,
     percent: Math.round((current / total) * 100),
-    activeStep: getActiveWizardStep(state)
+    activeStep: getActiveWizardStep(state),
   };
 }
 
@@ -117,24 +117,26 @@ export function canGoForward(state: WizardState): boolean {
   return state.activeStepIndex < state.steps.length - 1;
 }
 
-export function validateCurrentWizardStep<TPayload extends Record<string, unknown>>(
+export function validateCurrentWizardStep<
+  TPayload extends Record<string, unknown>,
+>(
   state: WizardState,
   payload: Readonly<TPayload>,
-  validator: WizardValidator<TPayload>
+  validator: WizardValidator<TPayload>,
 ): WizardValidationResult {
   const activeStep = getActiveWizardStep(state);
   const errors = validator(activeStep, payload);
 
   return {
     valid: errors.length === 0,
-    errors
+    errors,
   };
 }
 
 export function advanceWizard<TPayload extends Record<string, unknown>>(
   state: WizardState,
   payload: Readonly<TPayload>,
-  validator: WizardValidator<TPayload>
+  validator: WizardValidator<TPayload>,
 ): WizardAdvanceResult {
   const activeStep = getActiveWizardStep(state);
   const validation = validateCurrentWizardStep(state, payload, validator);
@@ -144,15 +146,15 @@ export function advanceWizard<TPayload extends Record<string, unknown>>(
       advanced: false,
       state: {
         ...state,
-        fieldErrors: toFieldErrorMap(validation.errors)
+        fieldErrors: toFieldErrorMap(validation.errors),
       },
-      errors: validation.errors
+      errors: validation.errors,
     };
   }
 
   const completedStepKeys = uniqueStrings([
     ...state.completedStepKeys,
-    activeStep.key
+    activeStep.key,
   ]);
 
   return {
@@ -163,8 +165,8 @@ export function advanceWizard<TPayload extends Record<string, unknown>>(
         ? state.activeStepIndex + 1
         : state.activeStepIndex,
       completedStepKeys,
-      fieldErrors: {}
-    }
+      fieldErrors: {},
+    },
   };
 }
 
@@ -176,13 +178,13 @@ export function rewindWizard(state: WizardState): WizardState {
   return {
     ...state,
     activeStepIndex: state.activeStepIndex - 1,
-    fieldErrors: {}
+    fieldErrors: {},
   };
 }
 
 export function jumpToWizardStep(
   state: WizardState,
-  stepKey: string
+  stepKey: string,
 ): WizardState {
   const targetIndex = state.steps.findIndex((step) => step.key === stepKey);
 
@@ -202,12 +204,12 @@ export function jumpToWizardStep(
   return {
     ...state,
     activeStepIndex: targetIndex,
-    fieldErrors: {}
+    fieldErrors: {},
   };
 }
 
 export function toFieldErrorMap(
-  errors: readonly WizardFieldError[]
+  errors: readonly WizardFieldError[],
 ): Readonly<Record<string, readonly string[]>> {
   const map: Record<string, string[]> = {};
 
@@ -223,7 +225,7 @@ export function toFieldErrorMap(
 }
 
 export function mapValidationDetailsToFieldErrors(
-  details: unknown
+  details: unknown,
 ): WizardFieldError[] {
   if (!Array.isArray(details)) {
     return [];
@@ -248,7 +250,7 @@ export function mapValidationDetailsToFieldErrors(
 
 export function getFieldErrors(
   state: WizardState,
-  field: string
+  field: string,
 ): readonly string[] {
   return state.fieldErrors[field] ?? [];
 }

--- a/src/lib/ui/wizard-client.ts
+++ b/src/lib/ui/wizard-client.ts
@@ -1,0 +1,273 @@
+export type WizardStepDefinition = {
+  key: string;
+  title: string;
+  description?: string;
+  fields: readonly string[];
+};
+
+export type WizardFieldError = {
+  field: string;
+  message: string;
+};
+
+export type WizardValidationResult = {
+  valid: boolean;
+  errors: WizardFieldError[];
+};
+
+export type WizardValidator<TPayload extends Record<string, unknown>> = (
+  step: WizardStepDefinition,
+  payload: Readonly<TPayload>
+) => WizardFieldError[];
+
+export type WizardState = {
+  steps: readonly WizardStepDefinition[];
+  activeStepIndex: number;
+  completedStepKeys: readonly string[];
+  fieldErrors: Readonly<Record<string, readonly string[]>>;
+};
+
+export type WizardAdvanceResult =
+  | { advanced: true; state: WizardState }
+  | { advanced: false; state: WizardState; errors: WizardFieldError[] };
+
+export function createWizardState(
+  steps: readonly WizardStepDefinition[],
+  activeStepKey?: string
+): WizardState {
+  const normalizedSteps = normalizeWizardSteps(steps);
+  const activeStepIndex = activeStepKey
+    ? normalizedSteps.findIndex((step) => step.key === activeStepKey)
+    : 0;
+
+  if (activeStepIndex < 0) {
+    throw new Error(`Unknown wizard step: ${activeStepKey}`);
+  }
+
+  return {
+    steps: normalizedSteps,
+    activeStepIndex,
+    completedStepKeys: [],
+    fieldErrors: {}
+  };
+}
+
+export function normalizeWizardSteps(
+  steps: readonly WizardStepDefinition[]
+): readonly WizardStepDefinition[] {
+  if (steps.length === 0) {
+    throw new Error("Wizard must define at least one step.");
+  }
+
+  const seen = new Set<string>();
+
+  for (const step of steps) {
+    const key = step.key.trim();
+
+    if (key.length === 0) {
+      throw new Error("Wizard step key is required.");
+    }
+
+    if (seen.has(key)) {
+      throw new Error(`Duplicate wizard step key: ${key}`);
+    }
+
+    seen.add(key);
+  }
+
+  return steps.map((step) => ({
+    ...step,
+    key: step.key.trim(),
+    title: step.title.trim()
+  }));
+}
+
+export function getActiveWizardStep(state: WizardState): WizardStepDefinition {
+  const step = state.steps[state.activeStepIndex];
+
+  if (!step) {
+    throw new Error("Wizard active step index is out of range.");
+  }
+
+  return step;
+}
+
+export function getWizardProgress(state: WizardState): {
+  current: number;
+  total: number;
+  percent: number;
+  activeStep: WizardStepDefinition;
+} {
+  const total = state.steps.length;
+  const current = state.activeStepIndex + 1;
+
+  return {
+    current,
+    total,
+    percent: Math.round((current / total) * 100),
+    activeStep: getActiveWizardStep(state)
+  };
+}
+
+export function canGoBack(state: WizardState): boolean {
+  return state.activeStepIndex > 0;
+}
+
+export function canGoForward(state: WizardState): boolean {
+  return state.activeStepIndex < state.steps.length - 1;
+}
+
+export function validateCurrentWizardStep<TPayload extends Record<string, unknown>>(
+  state: WizardState,
+  payload: Readonly<TPayload>,
+  validator: WizardValidator<TPayload>
+): WizardValidationResult {
+  const activeStep = getActiveWizardStep(state);
+  const errors = validator(activeStep, payload);
+
+  return {
+    valid: errors.length === 0,
+    errors
+  };
+}
+
+export function advanceWizard<TPayload extends Record<string, unknown>>(
+  state: WizardState,
+  payload: Readonly<TPayload>,
+  validator: WizardValidator<TPayload>
+): WizardAdvanceResult {
+  const activeStep = getActiveWizardStep(state);
+  const validation = validateCurrentWizardStep(state, payload, validator);
+
+  if (!validation.valid) {
+    return {
+      advanced: false,
+      state: {
+        ...state,
+        fieldErrors: toFieldErrorMap(validation.errors)
+      },
+      errors: validation.errors
+    };
+  }
+
+  const completedStepKeys = uniqueStrings([
+    ...state.completedStepKeys,
+    activeStep.key
+  ]);
+
+  return {
+    advanced: true,
+    state: {
+      ...state,
+      activeStepIndex: canGoForward(state)
+        ? state.activeStepIndex + 1
+        : state.activeStepIndex,
+      completedStepKeys,
+      fieldErrors: {}
+    }
+  };
+}
+
+export function rewindWizard(state: WizardState): WizardState {
+  if (!canGoBack(state)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    activeStepIndex: state.activeStepIndex - 1,
+    fieldErrors: {}
+  };
+}
+
+export function jumpToWizardStep(
+  state: WizardState,
+  stepKey: string
+): WizardState {
+  const targetIndex = state.steps.findIndex((step) => step.key === stepKey);
+
+  if (targetIndex < 0) {
+    throw new Error(`Unknown wizard step: ${stepKey}`);
+  }
+
+  const targetStep = state.steps[targetIndex]!;
+  const isCurrent = targetIndex === state.activeStepIndex;
+  const isCompleted = state.completedStepKeys.includes(targetStep.key);
+  const isImmediateNext = targetIndex === state.activeStepIndex + 1;
+
+  if (!isCurrent && !isCompleted && !isImmediateNext) {
+    return state;
+  }
+
+  return {
+    ...state,
+    activeStepIndex: targetIndex,
+    fieldErrors: {}
+  };
+}
+
+export function toFieldErrorMap(
+  errors: readonly WizardFieldError[]
+): Readonly<Record<string, readonly string[]>> {
+  const map: Record<string, string[]> = {};
+
+  for (const error of errors) {
+    const field = error.field.trim();
+
+    if (field.length === 0) continue;
+
+    map[field] = [...(map[field] ?? []), error.message];
+  }
+
+  return map;
+}
+
+export function mapValidationDetailsToFieldErrors(
+  details: unknown
+): WizardFieldError[] {
+  if (!Array.isArray(details)) {
+    return [];
+  }
+
+  const errors: WizardFieldError[] = [];
+
+  for (const detail of details) {
+    if (!isRecord(detail)) continue;
+
+    const field = detail.field;
+    const message = detail.message;
+
+    if (typeof field !== "string" || typeof message !== "string") continue;
+    if (field.trim().length === 0 || message.trim().length === 0) continue;
+
+    errors.push({ field: field.trim(), message: message.trim() });
+  }
+
+  return errors;
+}
+
+export function getFieldErrors(
+  state: WizardState,
+  field: string
+): readonly string[] {
+  return state.fieldErrors[field] ?? [];
+}
+
+export function hasFieldError(state: WizardState, field: string): boolean {
+  return getFieldErrors(state, field).length > 0;
+}
+
+export function createWizardIdempotencyKey(prefix = "wizard-submit"): string {
+  const safePrefix = prefix.trim().replace(/[^a-zA-Z0-9:_-]/g, "-");
+  const keyPrefix = safePrefix.length > 0 ? safePrefix : "wizard-submit";
+
+  return `${keyPrefix}:${crypto.randomUUID()}`;
+}
+
+function uniqueStrings(values: readonly string[]): readonly string[] {
+  return Array.from(new Set(values));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/lib/ui/wizard-client.ts
+++ b/src/lib/ui/wizard-client.ts
@@ -17,7 +17,7 @@ export type WizardValidationResult = {
 
 export type WizardValidator<TPayload extends Record<string, unknown>> = (
   step: WizardStepDefinition,
-  payload: Readonly<TPayload>,
+  payload: Readonly<TPayload>
 ) => WizardFieldError[];
 
 export type WizardState = {
@@ -33,7 +33,7 @@ export type WizardAdvanceResult =
 
 export function createWizardState(
   steps: readonly WizardStepDefinition[],
-  activeStepKey?: string,
+  activeStepKey?: string
 ): WizardState {
   const normalizedSteps = normalizeWizardSteps(steps);
   const activeStepIndex = activeStepKey
@@ -48,12 +48,12 @@ export function createWizardState(
     steps: normalizedSteps,
     activeStepIndex,
     completedStepKeys: [],
-    fieldErrors: {},
+    fieldErrors: {}
   };
 }
 
 export function normalizeWizardSteps(
-  steps: readonly WizardStepDefinition[],
+  steps: readonly WizardStepDefinition[]
 ): readonly WizardStepDefinition[] {
   if (steps.length === 0) {
     throw new Error("Wizard must define at least one step.");
@@ -78,7 +78,7 @@ export function normalizeWizardSteps(
   return steps.map((step) => ({
     ...step,
     key: step.key.trim(),
-    title: step.title.trim(),
+    title: step.title.trim()
   }));
 }
 
@@ -105,7 +105,7 @@ export function getWizardProgress(state: WizardState): {
     current,
     total,
     percent: Math.round((current / total) * 100),
-    activeStep: getActiveWizardStep(state),
+    activeStep: getActiveWizardStep(state)
   };
 }
 
@@ -118,25 +118,25 @@ export function canGoForward(state: WizardState): boolean {
 }
 
 export function validateCurrentWizardStep<
-  TPayload extends Record<string, unknown>,
+  TPayload extends Record<string, unknown>
 >(
   state: WizardState,
   payload: Readonly<TPayload>,
-  validator: WizardValidator<TPayload>,
+  validator: WizardValidator<TPayload>
 ): WizardValidationResult {
   const activeStep = getActiveWizardStep(state);
   const errors = validator(activeStep, payload);
 
   return {
     valid: errors.length === 0,
-    errors,
+    errors
   };
 }
 
 export function advanceWizard<TPayload extends Record<string, unknown>>(
   state: WizardState,
   payload: Readonly<TPayload>,
-  validator: WizardValidator<TPayload>,
+  validator: WizardValidator<TPayload>
 ): WizardAdvanceResult {
   const activeStep = getActiveWizardStep(state);
   const validation = validateCurrentWizardStep(state, payload, validator);
@@ -146,15 +146,15 @@ export function advanceWizard<TPayload extends Record<string, unknown>>(
       advanced: false,
       state: {
         ...state,
-        fieldErrors: toFieldErrorMap(validation.errors),
+        fieldErrors: toFieldErrorMap(validation.errors)
       },
-      errors: validation.errors,
+      errors: validation.errors
     };
   }
 
   const completedStepKeys = uniqueStrings([
     ...state.completedStepKeys,
-    activeStep.key,
+    activeStep.key
   ]);
 
   return {
@@ -165,8 +165,8 @@ export function advanceWizard<TPayload extends Record<string, unknown>>(
         ? state.activeStepIndex + 1
         : state.activeStepIndex,
       completedStepKeys,
-      fieldErrors: {},
-    },
+      fieldErrors: {}
+    }
   };
 }
 
@@ -178,13 +178,13 @@ export function rewindWizard(state: WizardState): WizardState {
   return {
     ...state,
     activeStepIndex: state.activeStepIndex - 1,
-    fieldErrors: {},
+    fieldErrors: {}
   };
 }
 
 export function jumpToWizardStep(
   state: WizardState,
-  stepKey: string,
+  stepKey: string
 ): WizardState {
   const targetIndex = state.steps.findIndex((step) => step.key === stepKey);
 
@@ -204,12 +204,12 @@ export function jumpToWizardStep(
   return {
     ...state,
     activeStepIndex: targetIndex,
-    fieldErrors: {},
+    fieldErrors: {}
   };
 }
 
 export function toFieldErrorMap(
-  errors: readonly WizardFieldError[],
+  errors: readonly WizardFieldError[]
 ): Readonly<Record<string, readonly string[]>> {
   const map: Record<string, string[]> = {};
 
@@ -225,7 +225,7 @@ export function toFieldErrorMap(
 }
 
 export function mapValidationDetailsToFieldErrors(
-  details: unknown,
+  details: unknown
 ): WizardFieldError[] {
   if (!Array.isArray(details)) {
     return [];
@@ -250,7 +250,7 @@ export function mapValidationDetailsToFieldErrors(
 
 export function getFieldErrors(
   state: WizardState,
-  field: string,
+  field: string
 ): readonly string[] {
   return state.fieldErrors[field] ?? [];
 }

--- a/tests/wizard-client.test.ts
+++ b/tests/wizard-client.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  advanceWizard,
+  canGoBack,
+  canGoForward,
+  createWizardIdempotencyKey,
+  createWizardState,
+  getActiveWizardStep,
+  getFieldErrors,
+  getWizardProgress,
+  hasFieldError,
+  jumpToWizardStep,
+  mapValidationDetailsToFieldErrors,
+  rewindWizard,
+  toFieldErrorMap,
+  type WizardFieldError,
+  type WizardStepDefinition
+} from "../src/lib/ui/wizard-client";
+
+const steps: WizardStepDefinition[] = [
+  {
+    key: "basic",
+    title: "Basic",
+    fields: ["title"]
+  },
+  {
+    key: "participants",
+    title: "Participants",
+    fields: ["participants"]
+  },
+  {
+    key: "review",
+    title: "Review",
+    fields: []
+  }
+];
+
+describe("wizard client helper", () => {
+  test("creates a valid initial state", () => {
+    const state = createWizardState(steps);
+
+    expect(getActiveWizardStep(state).key).toBe("basic");
+    expect(canGoBack(state)).toBe(false);
+    expect(canGoForward(state)).toBe(true);
+    expect(getWizardProgress(state)).toEqual({
+      current: 1,
+      total: 3,
+      percent: 33,
+      activeStep: steps[0]
+    });
+  });
+
+  test("rejects empty and duplicate step definitions", () => {
+    expect(() => createWizardState([])).toThrow(
+      "Wizard must define at least one step."
+    );
+
+    expect(() =>
+      createWizardState([
+        { key: "basic", title: "Basic", fields: [] },
+        { key: "basic", title: "Duplicate", fields: [] }
+      ])
+    ).toThrow("Duplicate wizard step key: basic");
+  });
+
+  test("blocks advancement and records field errors when current step is invalid", () => {
+    const state = createWizardState(steps);
+    const result = advanceWizard(state, {}, (step): WizardFieldError[] => {
+      if (step.key !== "basic") return [];
+      return [{ field: "title", message: "Title is required." }];
+    });
+
+    expect(result.advanced).toBe(false);
+    expect(getActiveWizardStep(result.state).key).toBe("basic");
+    expect(hasFieldError(result.state, "title")).toBe(true);
+    expect(getFieldErrors(result.state, "title")).toEqual([
+      "Title is required."
+    ]);
+  });
+
+  test("advances and marks current step completed when valid", () => {
+    const state = createWizardState(steps);
+    const result = advanceWizard(state, { title: "Demo" }, () => []);
+
+    expect(result.advanced).toBe(true);
+    expect(getActiveWizardStep(result.state).key).toBe("participants");
+    expect(result.state.completedStepKeys).toEqual(["basic"]);
+    expect(result.state.fieldErrors).toEqual({});
+  });
+
+  test("rewinds without dropping completed step state", () => {
+    const first = advanceWizard(createWizardState(steps), {}, () => []);
+
+    expect(first.advanced).toBe(true);
+
+    const rewound = rewindWizard(first.state);
+
+    expect(getActiveWizardStep(rewound).key).toBe("basic");
+    expect(rewound.completedStepKeys).toEqual(["basic"]);
+  });
+
+  test("does not jump over unfinished steps", () => {
+    const state = createWizardState(steps);
+    const jumped = jumpToWizardStep(state, "review");
+
+    expect(getActiveWizardStep(jumped).key).toBe("basic");
+  });
+
+  test("allows jumping to the immediate next step", () => {
+    const state = createWizardState(steps);
+    const jumped = jumpToWizardStep(state, "participants");
+
+    expect(getActiveWizardStep(jumped).key).toBe("participants");
+  });
+
+  test("maps field errors and server validation details", () => {
+    expect(
+      toFieldErrorMap([
+        { field: "title", message: "Title is required." },
+        { field: "title", message: "Title is too short." },
+        { field: "", message: "Ignored." }
+      ])
+    ).toEqual({
+      title: ["Title is required.", "Title is too short."]
+    });
+
+    expect(
+      mapValidationDetailsToFieldErrors([
+        { field: "title", message: "Title is required." },
+        { field: "ignored", message: "" },
+        { message: "Missing field." },
+        null
+      ])
+    ).toEqual([{ field: "title", message: "Title is required." }]);
+  });
+
+  test("creates a namespaced idempotency key for final submit", () => {
+    const key = createWizardIdempotencyKey("duty-travel");
+
+    expect(key.startsWith("duty-travel:")).toBe(true);
+    expect(key.split(":")[1]).toBeTruthy();
+  });
+});

--- a/tests/wizard-client.test.ts
+++ b/tests/wizard-client.test.ts
@@ -15,25 +15,25 @@ import {
   rewindWizard,
   toFieldErrorMap,
   type WizardFieldError,
-  type WizardStepDefinition
+  type WizardStepDefinition,
 } from "../src/lib/ui/wizard-client";
 
 const steps: WizardStepDefinition[] = [
   {
     key: "basic",
     title: "Basic",
-    fields: ["title"]
+    fields: ["title"],
   },
   {
     key: "participants",
     title: "Participants",
-    fields: ["participants"]
+    fields: ["participants"],
   },
   {
     key: "review",
     title: "Review",
-    fields: []
-  }
+    fields: [],
+  },
 ];
 
 describe("wizard client helper", () => {
@@ -47,20 +47,20 @@ describe("wizard client helper", () => {
       current: 1,
       total: 3,
       percent: 33,
-      activeStep: steps[0]
+      activeStep: steps[0],
     });
   });
 
   test("rejects empty and duplicate step definitions", () => {
     expect(() => createWizardState([])).toThrow(
-      "Wizard must define at least one step."
+      "Wizard must define at least one step.",
     );
 
     expect(() =>
       createWizardState([
         { key: "basic", title: "Basic", fields: [] },
-        { key: "basic", title: "Duplicate", fields: [] }
-      ])
+        { key: "basic", title: "Duplicate", fields: [] },
+      ]),
     ).toThrow("Duplicate wizard step key: basic");
   });
 
@@ -75,7 +75,7 @@ describe("wizard client helper", () => {
     expect(getActiveWizardStep(result.state).key).toBe("basic");
     expect(hasFieldError(result.state, "title")).toBe(true);
     expect(getFieldErrors(result.state, "title")).toEqual([
-      "Title is required."
+      "Title is required.",
     ]);
   });
 
@@ -119,10 +119,10 @@ describe("wizard client helper", () => {
       toFieldErrorMap([
         { field: "title", message: "Title is required." },
         { field: "title", message: "Title is too short." },
-        { field: "", message: "Ignored." }
-      ])
+        { field: "", message: "Ignored." },
+      ]),
     ).toEqual({
-      title: ["Title is required.", "Title is too short."]
+      title: ["Title is required.", "Title is too short."],
     });
 
     expect(
@@ -130,8 +130,8 @@ describe("wizard client helper", () => {
         { field: "title", message: "Title is required." },
         { field: "ignored", message: "" },
         { message: "Missing field." },
-        null
-      ])
+        null,
+      ]),
     ).toEqual([{ field: "title", message: "Title is required." }]);
   });
 

--- a/tests/wizard-client.test.ts
+++ b/tests/wizard-client.test.ts
@@ -15,25 +15,25 @@ import {
   rewindWizard,
   toFieldErrorMap,
   type WizardFieldError,
-  type WizardStepDefinition,
+  type WizardStepDefinition
 } from "../src/lib/ui/wizard-client";
 
 const steps: WizardStepDefinition[] = [
   {
     key: "basic",
     title: "Basic",
-    fields: ["title"],
+    fields: ["title"]
   },
   {
     key: "participants",
     title: "Participants",
-    fields: ["participants"],
+    fields: ["participants"]
   },
   {
     key: "review",
     title: "Review",
-    fields: [],
-  },
+    fields: []
+  }
 ];
 
 describe("wizard client helper", () => {
@@ -47,20 +47,20 @@ describe("wizard client helper", () => {
       current: 1,
       total: 3,
       percent: 33,
-      activeStep: steps[0],
+      activeStep: steps[0]!
     });
   });
 
   test("rejects empty and duplicate step definitions", () => {
     expect(() => createWizardState([])).toThrow(
-      "Wizard must define at least one step.",
+      "Wizard must define at least one step."
     );
 
     expect(() =>
       createWizardState([
         { key: "basic", title: "Basic", fields: [] },
-        { key: "basic", title: "Duplicate", fields: [] },
-      ]),
+        { key: "basic", title: "Duplicate", fields: [] }
+      ])
     ).toThrow("Duplicate wizard step key: basic");
   });
 
@@ -75,7 +75,7 @@ describe("wizard client helper", () => {
     expect(getActiveWizardStep(result.state).key).toBe("basic");
     expect(hasFieldError(result.state, "title")).toBe(true);
     expect(getFieldErrors(result.state, "title")).toEqual([
-      "Title is required.",
+      "Title is required."
     ]);
   });
 
@@ -119,10 +119,10 @@ describe("wizard client helper", () => {
       toFieldErrorMap([
         { field: "title", message: "Title is required." },
         { field: "title", message: "Title is too short." },
-        { field: "", message: "Ignored." },
-      ]),
+        { field: "", message: "Ignored." }
+      ])
     ).toEqual({
-      title: ["Title is required.", "Title is too short."],
+      title: ["Title is required.", "Title is too short."]
     });
 
     expect(
@@ -130,8 +130,8 @@ describe("wizard client helper", () => {
         { field: "title", message: "Title is required." },
         { field: "ignored", message: "" },
         { message: "Missing field." },
-        null,
-      ]),
+        null
+      ])
     ).toEqual([{ field: "title", message: "Title is required." }]);
   });
 


### PR DESCRIPTION
## Summary
- Adds reusable wizard UI components:
  - `src/components/ui/WizardStepper.astro`
  - `src/components/ui/WizardPanel.astro`
  - `src/components/ui/WizardActions.astro`
- Adds `src/lib/ui/wizard-client.ts` for pure wizard state, per-step validation, field-error mapping, safe step navigation, and idempotency key generation.
- Adds `tests/wizard-client.test.ts` to cover helper behavior.
- Adds `docs/awcms-mini/examples/wizard-form-pattern.md` as implementation guidance for derived apps.

## Linked Issue
- Implements MVP scope for #479.

## Security Notes
- No schema change and no new API endpoint.
- Server-side validation remains authoritative.
- The helper only supports client UX/state; endpoint-level ABAC/RLS, audit, CSRF, and idempotency remain mandatory in domain modules.
- The docs explicitly prohibit storing secrets or sensitive PII in localStorage and defer sensitive draft persistence to a future RLS/audit-backed server-side design.

## Testing
- Added unit tests for wizard state transition, validation blocking, field-error mapping, jump restrictions, rewind behavior, and idempotency key prefixing.
- Not run locally: changes were made through GitHub contents API, so CI should run `bun run check` on the PR.

## Follow-up
- After this pattern is used by at least two real derived modules, create a separate issue for server-side draft persistence with migration, RLS, OpenAPI, audit log, retention, and optional sync/offline support.