### PR TITLE
chore: add changeset for reusable wizard form pattern

### DIFF
--- a/.changeset/reusable-wizard-form-pattern.md
+++ b/.changeset/reusable-wizard-form-pattern.md
@@ -1,0 +1,12 @@
+---
+"awcms-mini": minor
+---
+
+Add a reusable multi-step wizard form pattern for derived-application admin
+screens: `WizardStepper`/`WizardPanel`/`WizardActions` Astro components and
+a pure `src/lib/ui/wizard-client.ts` state helper (step navigation, per-step
+validation, field-error mapping, and idempotency-key generation for the
+final submit). No schema or API change — server-side validation, ABAC/RLS,
+audit, and idempotency remain the authoritative controls for any domain
+module that adopts this pattern. See
+`docs/awcms-mini/examples/wizard-form-pattern.md` (Issue #479, PR #480).


### PR DESCRIPTION
## Summary
- PR #480 added a new reusable capability (wizard UI components + client state helper) but shipped without a changeset.
- Added a minor-bump changeset summarizing the addition, noting no schema/API change, and that server-side validation/ABAC/RLS/audit/idempotency remain authoritative for any domain module adopting the pattern.

## Test plan
- [x] `bun run lint`
- [x] `bun run check:docs`
- [x] `bun run changeset:status` — confirms `awcms-mini` bumped at minor
- No runtime behavior change

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)