### PR TITLE
docs: add derived module wizard usage example

### DIFF
--- a/docs/awcms-mini/README.md
+++ b/docs/awcms-mini/README.md
@@ -116,18 +116,20 @@ Dokumen dikelompokkan mengikuti alur pengembangan agar mudah diimplementasi.
 
 ### Lapisan E — Operasi & referensi
 
-|  No | File                                       | Isi                                                                                                    |
-| --: | ------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-|   8 | `08_sop_operasional_user_guide.md`         | SOP operasional dan user guide                                                                         |
-|  19 | `19_glossary_terminology.md`               | Glossary & terminologi lintas dokumen                                                                  |
-|  20 | `20_threat_model_security_architecture.md` | Threat model (STRIDE), trust boundary, kontrol keamanan berlapis (dokumen base, bukan contoh domain)   |
-|   – | `database-migrations.md`                   | Panduan runner migrasi PostgreSQL Bun-native                                                           |
-|   – | `deployment-profiles.md`                   | Profil deployment (development/staging/production/offline-LAN) dan model dua-peran basis data          |
-|   – | `deploy-coolify.md`                        | Panduan deploy Coolify: single-VPS, multi-aplikasi, opsi PostgreSQL, checklist keamanan (Issue #462)   |
-|   – | `derived-application-guide.md`             | Panduan membangun aplikasi turunan di atas base (9 langkah + 5 contoh ilustratif + checklist keamanan) |
-|   – | `examples/minimal-domain-module.md`        | Contoh konkret satu modul domain minimal (Issue #463)                                                  |
-|   – | `derived-app-pilot-plan.md`                | Rencana pilot aplikasi turunan pertama — rekomendasi AWPOS (Issue #465)                                |
-|   – | `../../openapi/` dan `../../asyncapi/`     | Baseline kontrak OpenAPI/AsyncAPI dan validator `api:spec:check`                                       |
+|  No | File                                        | Isi                                                                                                    |
+| --: | ------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+|   8 | `08_sop_operasional_user_guide.md`          | SOP operasional dan user guide                                                                         |
+|  19 | `19_glossary_terminology.md`                | Glossary & terminologi lintas dokumen                                                                  |
+|  20 | `20_threat_model_security_architecture.md`  | Threat model (STRIDE), trust boundary, kontrol keamanan berlapis (dokumen base, bukan contoh domain)   |
+|   – | `database-migrations.md`                    | Panduan runner migrasi PostgreSQL Bun-native                                                           |
+|   – | `deployment-profiles.md`                    | Profil deployment (development/staging/production/offline-LAN) dan model dua-peran basis data          |
+|   – | `deploy-coolify.md`                         | Panduan deploy Coolify: single-VPS, multi-aplikasi, opsi PostgreSQL, checklist keamanan (Issue #462)   |
+|   – | `derived-application-guide.md`              | Panduan membangun aplikasi turunan di atas base (9 langkah + 5 contoh ilustratif + checklist keamanan) |
+|   – | `examples/minimal-domain-module.md`         | Contoh konkret satu modul domain minimal (Issue #463)                                                  |
+|   – | `examples/wizard-form-pattern.md`           | Reusable multi-step wizard form pattern: komponen, helper, pola i18n (Issue #479)                      |
+|   – | `examples/wizard-derived-module-example.md` | Contoh pemakaian wizard end-to-end pada modul domain turunan (Issue #482)                              |
+|   – | `derived-app-pilot-plan.md`                 | Rencana pilot aplikasi turunan pertama — rekomendasi AWPOS (Issue #465)                                |
+|   – | `../../openapi/` dan `../../asyncapi/`      | Baseline kontrak OpenAPI/AsyncAPI dan validator `api:spec:check`                                       |
 
 ### Architecture Decision Records
 

--- a/docs/awcms-mini/examples/wizard-derived-module-example.md
+++ b/docs/awcms-mini/examples/wizard-derived-module-example.md
@@ -1,0 +1,258 @@
+# Contoh Pemakaian Wizard di Modul Domain Turunan
+
+Issue #482. Contoh end-to-end memakai
+[reusable wizard form pattern](wizard-form-pattern.md) (Issue #479/#480)
+pada satu modul domain turunan — melengkapi dokumen itu dengan pemakaian
+nyata, bukan sekadar daftar tanggung jawab komponen.
+
+> **Payload di dokumen ini seluruhnya dummy/non-sensitif.** Domain contoh
+> memakai `asset-register` yang sama seperti
+> [`minimal-domain-module.md`](minimal-domain-module.md) agar konsisten
+> lintas dokumen — ganti nama domain/entitas/field sesuai kebutuhan Anda,
+> jangan salin apa adanya ke production.
+
+## Kapan memakai wizard di modul domain
+
+Ikuti kriteria di `wizard-form-pattern.md` §Kapan memakai wizard. Contoh
+konkret di sini: form registrasi aset dengan tiga kategori data (identitas
+aset, lokasi, kategori/kondisi) — cukup panjang untuk manfaat dari step
+terpisah, tapi tidak butuh lampiran/draft/resume (jadi tetap MVP, bukan
+alasan untuk server-side draft persistence — lihat #484).
+
+## 1. Import komponen dan helper
+
+```astro
+---
+// src/pages/admin/assets/register.astro (ilustrasi — sesuaikan path modul Anda)
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import WizardStepper from "../../../components/ui/WizardStepper.astro";
+import WizardPanel from "../../../components/ui/WizardPanel.astro";
+import WizardActions from "../../../components/ui/WizardActions.astro";
+import { createTranslator } from "../../../lib/i18n/translate";
+import {
+  createWizardState,
+  getActiveWizardStep,
+  getWizardProgress,
+  type WizardStepDefinition
+} from "../../../lib/ui/wizard-client";
+---
+```
+
+## 2. Deklarasikan `WizardStepDefinition[]`
+
+```ts
+const assetRegisterSteps: WizardStepDefinition[] = [
+  {
+    key: "identity",
+    title: "Identitas aset",
+    description: "Kode aset dan nama.",
+    fields: ["assetCode", "name"]
+  },
+  {
+    key: "location",
+    title: "Lokasi",
+    description: "Lokasi fisik aset saat ini.",
+    fields: ["officeId", "roomLabel"]
+  },
+  {
+    key: "review",
+    title: "Review",
+    description: "Periksa kembali sebelum submit.",
+    fields: []
+  }
+];
+```
+
+## 3. `createTranslator(locale)` dan label i18n sebagai prop
+
+Sesuai `wizard-form-pattern.md` §Pola i18n — komponen wizard tidak pernah
+menerjemahkan sendiri, jadi halaman pemanggil wajib mengisi setiap prop
+string dari katalog:
+
+```astro
+---
+const t = await createTranslator(Astro.locals.locale);
+const state = createWizardState(assetRegisterSteps);
+const progress = getWizardProgress(state);
+---
+
+<WizardStepper
+  steps={assetRegisterSteps}
+  activeStepKey={progress.activeStep.key}
+  label={t("asset_register.wizard.stepper_label")}
+  currentLabel={t("asset_register.wizard.step_current")}
+  completedLabel={t("asset_register.wizard.step_completed")}
+  pendingLabel={t("asset_register.wizard.step_pending")}
+/>
+
+<WizardPanel
+  id="step-identity"
+  title={t("asset_register.wizard.step_identity_title")}
+  description={t("asset_register.wizard.step_identity_description")}
+  errorSummaryHeading={t("asset_register.wizard.error_summary_heading")}
+>
+  <!-- field identitas aset di sini -->
+</WizardPanel>
+
+<WizardActions
+  backLabel={t("common.back")}
+  nextLabel={t("common.next")}
+  submitLabel={t("common.submit")}
+/>
+```
+
+## 4. Validasi per-step memakai `wizard-client.ts`
+
+Validator murni, tanpa I/O — dipanggil dari script sisi klien sebelum
+`advanceWizard` mengizinkan lanjut ke step berikutnya:
+
+```ts
+import {
+  advanceWizard,
+  type WizardFieldError,
+  type WizardValidator
+} from "../../../lib/ui/wizard-client";
+
+const validateAssetRegisterStep: WizardValidator<Record<string, unknown>> = (
+  step,
+  payload
+) => {
+  const errors: WizardFieldError[] = [];
+
+  if (step.key === "identity") {
+    if (!String(payload.assetCode ?? "").trim()) {
+      errors.push({
+        field: "assetCode",
+        message: t("asset_register.validation.asset_code_required")
+      });
+    }
+    if (!String(payload.name ?? "").trim()) {
+      errors.push({
+        field: "name",
+        message: t("asset_register.validation.name_required")
+      });
+    }
+  }
+
+  if (step.key === "location" && !payload.officeId) {
+    errors.push({
+      field: "officeId",
+      message: t("asset_register.validation.office_required")
+    });
+  }
+
+  return errors;
+};
+
+// Dipanggil saat user menekan "Next":
+const result = advanceWizard(state, formPayload, validateAssetRegisterStep);
+if (!result.advanced) {
+  // render result.errors ke field terkait (lihat §5) — jangan lanjut step.
+}
+```
+
+## 5. Mapping error validasi server ke field error
+
+Endpoint domain (`POST /api/v1/assets`, pola sama seperti
+`minimal-domain-module.md`) tetap memvalidasi payload lengkap di server —
+respons `400 VALIDATION_ERROR` dipetakan balik ke field yang sama lewat
+`mapValidationDetailsToFieldErrors`, bukan divalidasi ulang secara terpisah:
+
+```ts
+import { mapValidationDetailsToFieldErrors } from "../../../lib/ui/wizard-client";
+
+const res = await fetch("/api/v1/assets", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  credentials: "same-origin",
+  body: JSON.stringify(payload)
+});
+const json = await res.json();
+
+if (!res.ok && json.error?.code === "VALIDATION_ERROR") {
+  const fieldErrors = mapValidationDetailsToFieldErrors(json.error.details);
+  // render fieldErrors ke WizardPanel yang relevan; jangan hapus payload/state.
+}
+```
+
+## 6. Submit final memakai `Idempotency-Key`
+
+Mutation registrasi aset dianggap high-risk (menulis baris baru) — kunci
+idempotency dibuat sekali per attempt submit, bukan per klik tombol
+(supaya retry jaringan dengan payload sama tidak membuat baris duplikat):
+
+```ts
+import { createWizardIdempotencyKey } from "../../../lib/ui/wizard-client";
+
+const idempotencyKey = createWizardIdempotencyKey("asset-register");
+
+const res = await fetch("/api/v1/assets", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Idempotency-Key": idempotencyKey
+  },
+  credentials: "same-origin",
+  body: JSON.stringify(finalPayload)
+});
+```
+
+Simpan `idempotencyKey` yang sama di closure/state selama percobaan submit
+berlangsung — jangan generate ulang saat retry otomatis untuk request yang
+sama, atau server akan melihatnya sebagai request baru yang berbeda.
+
+## 7. Anti-double-submit dengan helper existing
+
+Pakai `lockElement`/`submitJson` yang sudah ada
+(`src/lib/ui/admin-form-client.ts`, dipakai `admin/settings.astro` dkk.)
+untuk mengunci tombol submit selama request in-flight — komponen
+`WizardActions` sendiri hanya menampilkan state `busy`/`disabled`, bukan
+yang mengelola siklus fetch:
+
+```ts
+import {
+  lockElement,
+  readClientStrings
+} from "../../../lib/ui/admin-form-client";
+
+const strings = readClientStrings<{ pleaseWait: string }>();
+const submitButton = document.querySelector<HTMLButtonElement>(
+  "[data-wizard-submit]"
+);
+const unlock = submitButton
+  ? lockElement(submitButton, strings.pleaseWait)
+  : null;
+
+try {
+  // fetch submit final (§6) di sini
+} finally {
+  unlock?.();
+}
+```
+
+## Checklist keamanan modul turunan
+
+Turunan dari `wizard-form-pattern.md` §Keamanan, diterapkan ke contoh ini:
+
+- [ ] Endpoint `POST /api/v1/assets` tetap memvalidasi payload lengkap di
+      server — validasi client (§4) hanya untuk UX cepat.
+- [ ] Endpoint memakai tenant context + ABAC default-deny + RLS (pola
+      `minimal-domain-module.md`), bukan mengandalkan wizard client-side.
+- [ ] `Idempotency-Key` (§6) unik per attempt submit, bukan per klik tombol.
+- [ ] Aksi registrasi aset diaudit via `recordAuditEvent` di endpoint.
+- [ ] Tidak ada payload disimpan ke `localStorage`/`sessionStorage` — state
+      wizard hanya hidup di memori JS selama halaman terbuka (MVP, lihat
+      §Server-side draft: follow-up di `wizard-form-pattern.md`).
+- [ ] Semua string user-facing (§3) berasal dari `t(key)`, tidak ada
+      hardcode production.
+- [ ] Error server (§5) ditampilkan apa adanya dari `ERROR_CODE_KEYS`
+      (`src/lib/i18n/error-messages.ts`) — tidak menampilkan stack trace.
+
+## Lihat juga
+
+- [`wizard-form-pattern.md`](wizard-form-pattern.md) — spesifikasi
+  komponen, pola i18n lengkap, dan rancangan follow-up server-side draft.
+- [`minimal-domain-module.md`](minimal-domain-module.md) — pola endpoint
+  domain (`asset-register`) yang dipakai sebagai target submit di atas.
+- `src/lib/ui/admin-form-client.ts` — `submitJson`/`lockElement`/
+  `readClientStrings` yang dipakai bersama pola wizard ini.

--- a/docs/awcms-mini/examples/wizard-form-pattern.md
+++ b/docs/awcms-mini/examples/wizard-form-pattern.md
@@ -8,6 +8,11 @@ ditampilkan sebagai satu form besar.
 Issue pelacak:
 [#479 — UX: Add reusable multi-step wizard form pattern](https://github.com/ahliweb/awcms-mini/issues/479).
 
+Contoh pemakaian end-to-end pada modul domain turunan (import, deklarasi
+step, i18n, validasi, submit `Idempotency-Key`, anti-double-submit):
+[`wizard-derived-module-example.md`](wizard-derived-module-example.md)
+(Issue #482).
+
 ## Tujuan
 
 1. Membagi form panjang menjadi beberapa langkah yang mudah dipahami operator.


### PR DESCRIPTION
## Summary
- `wizard-form-pattern.md` documented each component's responsibility but not how to wire them together end-to-end in a real domain module.
- Add `docs/awcms-mini/examples/wizard-derived-module-example.md`: a concrete walkthrough using a dummy `asset-register` domain (same as `minimal-domain-module.md`, for consistency) covering component imports, `WizardStepDefinition` declaration, `createTranslator()` + i18n prop wiring, per-step validation via `wizard-client.ts`, mapping `VALIDATION_ERROR` details to field errors, an `Idempotency-Key` final submit, and anti-double-submit via the existing `admin-form-client.ts` helpers (`lockElement`/`submitJson`).
- All payload dummy/non-sensitive; ends with a security checklist restating that server validation/ABAC/RLS/audit remain authoritative.
- Linked from `wizard-form-pattern.md` and added to the docs index — along with `wizard-form-pattern.md` itself, which had never been indexed there.
- Docs-only — no endpoint/migration/admin page added.

## Test plan
- [x] `bun run format`
- [x] `bun run check:docs` — OK, internal links valid
- [x] `bun run check` (lint, check:docs, api:spec:check, typecheck, 328 tests, build) — all green
- [x] Manual review: every referenced helper (`createWizardState`, `advanceWizard`, `mapValidationDetailsToFieldErrors`, `createWizardIdempotencyKey`, `lockElement`, `readClientStrings`) confirmed to exist with matching signatures in the current codebase
- Not applicable: no DB-dependent runtime code touched, docs-only change

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)