### PR TITLE
test: add accessibility coverage for reusable wizard components

### DIFF
--- a/docs/awcms-mini/examples/wizard-form-pattern.md
+++ b/docs/awcms-mini/examples/wizard-form-pattern.md
@@ -286,6 +286,39 @@ pemanggil, dengan implementasi referensi nyata di
   mengorkestrasi transisi step, persis seperti fungsi
   `focusPanelHeading()` di fixture di atas.
 
+### Regression guard otomatis
+
+`tests/wizard-accessibility.test.ts` (Issue #485) menegaskan atribut di
+atas tetap ada di markup/CSS komponen — bukan pengganti pengujian
+assistive-tech nyata, hanya mencegah atribut aksesibilitas terhapus diam-diam
+saat edit berikutnya (pola yang sama seperti guard hash
+`theme-init-script.test.ts`).
+
+### Walkthrough manual keyboard-only
+
+Jalankan di `src/pages/admin/examples/wizard.astro` (`/admin/examples/wizard`,
+Issue #483) — buka halaman, lalu **jangan sentuh mouse**:
+
+1. `Tab` dari luar halaman ke dalam — fokus harus mendarat di skip-link
+   (bila ada) lalu tombol/field pertama halaman dalam urutan visual.
+2. Isi field step "Basic info" hanya dengan keyboard; tekan `Enter`/klik
+   `Next` (via `Space`/`Enter` saat tombol fokus) dengan salah satu field
+   kosong — fokus harus tetap di step yang sama, error field + ringkasan
+   error muncul dan terbaca (uji dengan screen reader: `role="alert"`
+   harus terumumkan otomatis tanpa perlu fokus berpindah manual).
+3. Isi field wajib, tekan `Next` lagi — step berpindah ke "Details", dan
+   fokus harus berpindah ke judul panel baru (`focusPanelHeading()`),
+   bukan tetap di tombol `Next` step sebelumnya (elemen itu kini `hidden`).
+4. Dari step "Details", `Tab` ke tombol `Back` lalu `Next` — urutan tab
+   harus Back sebelum Next (`wizard-actions-secondary` sebelum
+   `wizard-actions-primary` di markup).
+5. Lanjut ke step "Review", tekan `Submit` — tombol harus terlihat
+   `aria-busy="true"` dan disabled selama mock delay (~400ms), lalu
+   banner sukses muncul dan terbaca.
+6. Ulangi langkah 1-5 memakai screen reader (VoiceOver/NVDA) untuk
+   memverifikasi step aktif, status (Current/Completed/Pending), dan
+   error summary benar-benar diumumkan, bukan hanya terlihat visual.
+
 ## Testing checklist
 
 - Step awal selalu valid secara state dan tidak melewati daftar step.

--- a/tests/wizard-accessibility.test.ts
+++ b/tests/wizard-accessibility.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Accessibility regression guard for the reusable wizard components (Issue
+ * #485). These are static Astro components with no client-side reactivity
+ * of their own (Issue #479/#480) — there is no jsdom/component-rendering
+ * harness in this repo to mount them, so this asserts directly on the
+ * source markup/CSS instead. That's a deliberate, narrow scope: this
+ * guards against someone *silently removing* an accessibility attribute
+ * during a future edit (same spirit as `theme-init-script.test.ts`'s
+ * hash-drift guard), not a substitute for real assistive-tech testing.
+ *
+ * See `docs/awcms-mini/examples/wizard-form-pattern.md` §Accessibility
+ * checklist for the full checklist this test covers, and
+ * `src/pages/admin/examples/wizard.astro` (Issue #483) for a manual
+ * keyboard-only walkthrough script.
+ */
+
+const COMPONENTS_DIR = path.resolve(
+  import.meta.dirname,
+  "../src/components/ui"
+);
+
+function readComponent(name: string): string {
+  return readFileSync(path.join(COMPONENTS_DIR, name), "utf8");
+}
+
+describe("WizardStepper accessibility", () => {
+  const source = readComponent("WizardStepper.astro");
+
+  test("marks the active step with aria-current=step", () => {
+    expect(source).toContain('aria-current={isActive ? "step" : undefined}');
+  });
+
+  test("accepts a translatable label prop for the nav landmark (not hardcoded, per i18n policy)", () => {
+    expect(source).toMatch(/label\?:\s*string/);
+    expect(source).toContain("aria-label={label}");
+  });
+
+  test("status is conveyed via text, not color alone", () => {
+    // stateLabel (Current/Completed/Pending, all translatable props) is
+    // rendered as visible text alongside the marker — color is additive,
+    // not the sole signal.
+    expect(source).toContain(
+      '<span class="wizard-stepper-status">{stateLabel}</span>'
+    );
+    expect(source).toMatch(/currentLabel\?:\s*string/);
+    expect(source).toMatch(/completedLabel\?:\s*string/);
+    expect(source).toMatch(/pendingLabel\?:\s*string/);
+  });
+
+  test("exposes a per-item selector so client scripts can update state after initial render", () => {
+    // Issue #483 found this was missing entirely; without it, no calling
+    // page can keep the stepper in sync after a Next/Back transition.
+    expect(source).toContain("data-step-key={step.key}");
+  });
+});
+
+describe("WizardPanel accessibility", () => {
+  const source = readComponent("WizardPanel.astro");
+
+  test("error summary uses role=alert so assistive tech announces it", () => {
+    expect(source).toContain('<div class="wizard-panel-errors" role="alert">');
+  });
+
+  test("error summary heading is an overridable prop, not hardcoded (i18n policy)", () => {
+    expect(source).toMatch(/errorSummaryHeading\?:\s*string/);
+  });
+
+  test("panel is labelled by its own heading for screen readers", () => {
+    expect(source).toContain("aria-labelledby={`${id}-title`}");
+  });
+});
+
+describe("WizardActions accessibility", () => {
+  const source = readComponent("WizardActions.astro");
+
+  test("busy/submitting state is exposed via aria-busy and disables buttons", () => {
+    expect(source).toContain('aria-busy={busy ? "true" : "false"}');
+    expect(source.match(/disabled={busy}/g)?.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test("buttons meet the 44px minimum touch target", () => {
+    expect(source).toMatch(/min-height:\s*44px/);
+  });
+
+  test("buttons have a visible focus indicator", () => {
+    expect(source).toContain(".wizard-action:focus-visible");
+  });
+
+  test("secondary actions (Back) render before primary actions (Next/Submit) in source order, matching logical Back-then-forward tab order", () => {
+    const backIndex = source.indexOf("wizard-actions-secondary");
+    const primaryIndex = source.indexOf("wizard-actions-primary");
+    expect(backIndex).toBeGreaterThan(-1);
+    expect(primaryIndex).toBeGreaterThan(backIndex);
+  });
+});


### PR DESCRIPTION
## Summary
- The wizard components (#479/#480) had no automated check that their accessibility attributes stay intact through future edits, and no documented keyboard-only walkthrough despite #483's fixture now existing to run one against.
- Add `tests/wizard-accessibility.test.ts`: asserts directly on the three components' source — `aria-current`, translatable stepper labels, status conveyed via text not color alone, `role="alert"` error summary, `aria-labelledby`, `aria-busy`+`disabled` on all four action buttons, 44px touch targets, `:focus-visible`, and Back-before-Next source order. Same regression-guard spirit as `theme-init-script.test.ts`'s hash-drift check — there's no component-rendering test harness for Astro components in this repo, so this can't substitute for real assistive-tech testing, only catch a future edit silently dropping an attribute.
- Added a manual keyboard-only walkthrough procedure to `wizard-form-pattern.md` referencing the `#483` fixture, covering tab order, per-step validation blocking, focus moving to the new panel heading, and busy-state announcement.

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` — 339 tests pass (11 new)
- [x] `bun run build`
- Manual keyboard-only smoke test: documented as a repeatable procedure in the doc (see above), not personally executed in this PR — no browser automation tool is available in this session; noted explicitly rather than claimed.

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)