### PR TITLE
feat: add server-side form draft persistence

### DIFF
--- a/.changeset/form-draft-persistence.md
+++ b/.changeset/form-draft-persistence.md
@@ -1,0 +1,18 @@
+---
+"awcms-mini": minor
+---
+
+Add generic server-side form draft persistence: a new
+`awcms_mini_form_drafts` table (tenant-scoped, RLS FORCE'd) and
+`src/modules/form-drafts/` module with `GET/POST /api/v1/form-drafts`,
+`GET/PATCH/DELETE /api/v1/form-drafts/{id}`, and
+`POST /api/v1/form-drafts/{id}/submit` (Idempotency-Key required). Lets a
+multi-step wizard (Issue #479/#480) resume across sessions/devices instead
+of only holding progress in memory. Payload is denylist-validated against
+secret-shaped fields (password/token/secret/credential/apiKey/privateKey)
+and capped at 32KB; a scheduled `bun run form-drafts:purge` expires
+overdue drafts and purges old expired/abandoned ones. Piloted in
+`admin/examples/wizard.astro` — no domain-specific behavior added to the
+base itself. See `src/modules/form-drafts/README.md` and
+`docs/awcms-mini/examples/wizard-form-pattern.md` §Server-side draft
+(Issue #484).

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -27,6 +27,7 @@ Skill Claude Code tingkat-proyek untuk AWCMS-Mini. Setiap skill meng-encode stan
 | `awcms-mini-deploy`                                    | Pilih & jalankan profil deployment (LAN-first vs registry/Coolify)          | 18, deploy-coolify.md  |
 | `awcms-mini-ui-screen`                                 | Implementasi layar/komponen UI sesuai design system                         | 14, 15                 |
 | `awcms-mini-wizard-form`                               | Form multi-step (reusable wizard pattern)                                   | wizard-form-pattern.md |
+| `awcms-mini-form-drafts`                               | Server-side draft persistence (resume lintas sesi/perangkat)                | form-drafts/README.md  |
 | `awcms-mini-i18n`                                      | String UI `.po` gettext & konten multi-bahasa                               | 14, 04, 19             |
 | `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)                           | 09                     |
 | `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                | 07, 06                 |
@@ -72,6 +73,9 @@ flowchart TD
   UI --> WIZ[awcms-mini-wizard-form]
   WIZ --> IDEM
   WIZ --> I18N
+  WIZ --> DRAFT[awcms-mini-form-drafts]
+  DRAFT --> IDEM
+  DRAFT --> ABAC
   II --> LEG[awcms-mini-legacy-migration]
   II --> PR[awcms-mini-pr-review]
   PR --> SEC[awcms-mini-security-review]

--- a/.claude/skills/awcms-mini-form-drafts/SKILL.md
+++ b/.claude/skills/awcms-mini-form-drafts/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: awcms-mini-form-drafts
+description: Simpan progress form/wizard di server (resume lintas sesi/perangkat) memakai API generik form-drafts AWCMS-Mini. Gunakan saat wizard-client.ts's in-memory state saja tidak cukup — user perlu melanjutkan draft setelah menutup tab, ganti perangkat, atau payload draft mengandung lebih dari UX scratch state murni. Sesuai src/modules/form-drafts/README.md.
+---
+
+# AWCMS-Mini — Server-Side Form Draft Persistence
+
+Ikuti `src/modules/form-drafts/README.md` (modul) dan
+`docs/awcms-mini/examples/wizard-form-pattern.md` §Server-side draft
+(kapan ini vs client-only state). Contoh pemakaian nyata:
+`src/pages/admin/examples/wizard.astro` (pilot, Issue #484).
+
+## Kapan pakai ini vs client-only `wizard-client.ts` state
+
+Server-side draft **hanya** bila: user perlu resume lintas sesi/tab/
+perangkat, atau ada kebutuhan audit/observability atas progress form
+(bukan sekadar UX). Jangan default ke ini untuk setiap wizard — form
+pendek yang selesai dalam satu duduk cukup pakai state in-memory
+`wizard-client.ts` (skill `awcms-mini-wizard-form`) tanpa network round-trip
+tambahan.
+
+## API
+
+`GET/POST /api/v1/form-drafts`, `GET/PATCH/DELETE /api/v1/form-drafts/{id}`,
+`POST /api/v1/form-drafts/{id}/submit`. Guard
+`form_drafts.draft.{read,create,update,delete}` — permission generik,
+tidak per `moduleKey` pembuat draft (RLS sudah isolasi tenant).
+
+## Aturan wajib
+
+1. **`moduleKey`/`wizardKey`/`resourceType` milik modul Anda sendiri** —
+   format lowercase snake_case (`^[a-z][a-z0-9_]{1,63}$`), unik per
+   modul/wizard supaya query resume-on-load (`?moduleKey=&wizardKey=`)
+   tidak bentrok dengan modul lain.
+2. **Payload tidak boleh berisi field yang menyerupai secret**
+   (`password`/`token`/`secret`/`credential`/`apiKey`/`privateKey`,
+   dicek rekursif) — ditolak `400 VALIDATION_ERROR`, bukan direduksi
+   diam-diam. Jangan simpan data sensitif di draft sama sekali, bukan
+   hanya menghindari nama field yang jelas menyerupai secret.
+3. **Payload maksimum 32KB serialized** (`MAX_PAYLOAD_BYTES`) — draft
+   adalah scratch state form, bukan penyimpan dokumen/lampiran.
+4. **Create/update/delete TIDAK butuh `Idempotency-Key`** — create
+   worst-case menghasilkan draft duplikat berisiko rendah, update/delete
+   idempotent secara struktural. **Submit WAJIB `Idempotency-Key`** —
+   transisi status yang berarti, sama seperti mutation high-risk lain
+   (skill `awcms-mini-idempotency`).
+5. **Hanya draft `status = 'draft'` yang editable** — submitted/
+   abandoned/expired mengembalikan `404` dari PATCH, bukan mengizinkan
+   edit riwayat.
+6. **Resume-on-load lewat application layer langsung dari SSR**
+   (`listFormDrafts(tx, tenantId, {moduleKey, wizardKey, status: "draft"})`),
+   bukan round-trip HTTP ke endpoint sendiri — pola sama seperti
+   `admin/index.astro`'s dashboard reports.
+7. **Retensi** — jadwalkan `bun run form-drafts:purge` (cron/systemd
+   timer/k8s CronJob, tidak lewat HTTP) untuk expire draft overdue lalu
+   purge draft expired/abandoned lama. Default retention 30 hari,
+   override `--retention-days=<n>` atau env `FORM_DRAFT_RETENTION_DAYS`.
+
+## Verifikasi
+
+`tests/form-draft-validation.test.ts` (denylist, format, ukuran payload).
+`tests/integration/form-drafts.integration.test.ts` (CRUD+submit
+end-to-end, RLS tenant isolation, ABAC default-deny, submit idempotency,
+retention/expiry) — jalankan terhadap Postgres nyata sebelum PR yang
+menyentuh modul ini dianggap selesai.
+
+## Skill terkait
+
+`awcms-mini-wizard-form` (komponen UI wizard yang biasanya memakai ini),
+`awcms-mini-idempotency` (submit), `awcms-mini-abac-guard`,
+`awcms-mini-observability` (pola retensi/purge terjadwal yang sama).

--- a/.claude/skills/awcms-mini-wizard-form/SKILL.md
+++ b/.claude/skills/awcms-mini-wizard-form/SKILL.md
@@ -49,10 +49,10 @@ murni: `createWizardState`, `advanceWizard`, `rewindWizard`,
    memperbarui state stepper via JS setelah render awal (SSR-only, tidak
    reaktif sendiri).
 7. **Draft client-side hanya data non-sensitif**, dan tidak persisten
-   (tidak ada `localStorage`). Data sensitif/butuh resume lintas sesi →
-   itu scope server-side draft persistence (Issue #484, **belum
-   dikerjakan** — gate: dipakai minimal 2 modul domain nyata atau
-   disetujui maintainer lebih awal).
+   (tidak ada `localStorage`). Butuh resume lintas sesi/perangkat, atau
+   payload mengandung apa pun yang lebih dari UX scratch state? Pakai
+   server-side draft persistence — skill `awcms-mini-form-drafts`
+   (tersedia sejak Issue #484, `/api/v1/form-drafts`).
 
 ## Verifikasi
 
@@ -65,4 +65,5 @@ keyboard-only.
 
 `awcms-mini-ui-screen` (pola layar/token/a11y umum), `awcms-mini-i18n`
 (katalog `.po`), `awcms-mini-idempotency` (submit final high-risk),
-`awcms-mini-new-endpoint` (endpoint domain target submit).
+`awcms-mini-new-endpoint` (endpoint domain target submit),
+`awcms-mini-form-drafts` (resume-on-load lintas sesi via server).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ AWCMS-Mini menyediakan **skill Claude Code tingkat-proyek** yang meng-encode sta
 | Pilih & jalankan profil deployment (LAN-first vs registry/Coolify) | `awcms-mini-deploy`               |
 | Layar/komponen UI sesuai design system                             | `awcms-mini-ui-screen`            |
 | Form multi-step (reusable wizard pattern)                          | `awcms-mini-wizard-form`          |
+| Server-side draft persistence (resume lintas sesi/perangkat)       | `awcms-mini-form-drafts`          |
 | String UI `.po` gettext & konten multi-bahasa                      | `awcms-mini-i18n`                 |
 | Rilis versi (Changesets, tag, CHANGELOG)                           | `awcms-mini-release`              |
 | Migrasi data legacy (dry-run, backfill)                            | `awcms-mini-legacy-migration`     |
@@ -149,6 +150,8 @@ flowchart LR
   UI2 --> I18N[i18n]
   UI2 --> WIZ[wizard-form]
   WIZ --> IDEM
+  WIZ --> DRAFT[form-drafts]
+  DRAFT --> IDEM
   EP --> PERF[performance]
   EP --> INT[integration]
   SEC --> HARD[security-hardening]
@@ -227,7 +230,7 @@ awcms-mini/
 ├── AGENTS.md                # file ini
 ├── CHANGELOG.md             # versioning (Changesets)
 ├── .changeset/              # config + changeset entries
-├── .claude/skills/          # 25 skill proyek (implement-issue, new-migration, dst.)
+├── .claude/skills/          # 26 skill proyek (implement-issue, new-migration, dst.)
 ├── .claude/agents/          # subagents (coder, reviewer, security-auditor)
 ├── README.md
 ├── package.json

--- a/docs/awcms-mini/13_final_master_index_traceability.md
+++ b/docs/awcms-mini/13_final_master_index_traceability.md
@@ -205,6 +205,7 @@ flowchart LR
 | Profil deployment (LAN-first/Coolify) | `awcms-mini-deploy`                                                                                    |
 | UI/design system/a11y                 | `awcms-mini-ui-screen`                                                                                 |
 | Form multi-step (wizard)              | `awcms-mini-wizard-form`                                                                               |
+| Server-side draft persistence         | `awcms-mini-form-drafts`                                                                               |
 | Rilis/CHANGELOG                       | `awcms-mini-release`                                                                                   |
 | Legacy migration                      | `awcms-mini-legacy-migration`                                                                          |
 | Implementasi issue                    | skill `awcms-mini-implement-issue` + agent `awcms-mini-coder`                                          |
@@ -324,7 +325,7 @@ Alasan:
 - `AGENTS.md`
 - `README.md`
 - `CHANGELOG.md` + `.changeset/` (versioning via Changesets)
-- `.claude/skills/` (25 skill proyek + katalog README)
+- `.claude/skills/` (26 skill proyek + katalog README)
 - `.claude/agents/` (3 subagent: coder, reviewer, security-auditor)
 - `package.json`
 - `astro.config.mjs`

--- a/docs/awcms-mini/derived-application-guide.md
+++ b/docs/awcms-mini/derived-application-guide.md
@@ -6,21 +6,22 @@
 
 Sebelum menulis kode apa pun, pahami batasnya: base menyediakan infrastruktur dan kontrak yang **dipakai ulang tanpa diubah**; aplikasi turunan hanya menambah **modul domain baru** di atasnya.
 
-| Reusable (base — jangan diubah)                                                                                                      | Domain-specific (aplikasi turunan — Anda tambahkan)                              |
-| ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
-| Modular monolith + module contract (`src/modules/_shared/module-contract.ts`, doc 10/11)                                             | Modul domain baru di `src/modules/<domain>/`                                     |
-| RBAC + ABAC default-deny + RLS (ADR-0003/0004, `src/modules/identity-access/`)                                                       | Permission/role/policy spesifik domain (doc 17 pola, bukan isinya)               |
-| Migration runner checksum-based, konvensi `NNN_awcms_mini_<area>_<desc>.sql`                                                         | Skema tabel domain (skill `awcms-mini-new-migration`)                            |
-| Kontrak OpenAPI/AsyncAPI wajib + `api:spec:check` (ADR-0007/0008)                                                                    | Endpoint/event domain (skill `awcms-mini-new-endpoint`/`awcms-mini-new-event`)   |
-| Soft delete + immutability posted (ADR-0005)                                                                                         | Kebijakan resource domain mana yang boleh restore/purge                          |
-| Audit trail generik (`awcms_mini_audit_events`) + retensi/purge + correlation ID (Issue 10.1/#447, skill `awcms-mini-observability`) | Aksi high-risk spesifik domain yang wajib diaudit (skill `awcms-mini-audit-log`) |
-| Idempotency ledger generik (`awcms_mini_idempotency_keys`)                                                                           | Mutation high-risk domain mana yang wajib `Idempotency-Key`                      |
-| Structured logger + extension point (`setLogSink`/`setAuditExportHook`)                                                              | Consumer log/audit nyata (SIEM, alerting) — base hanya sediakan titik pasang     |
-| Design system, token, state pattern, i18n (doc 14, skill `awcms-mini-i18n`)                                                          | Layar admin/operator/portal domain (skill `awcms-mini-ui-screen`)                |
-| Offline-first sync (outbox/inbox, HMAC, conflict tracking, object queue dispatcher — Issue 6.1-6.3/#436)                             | Payload event domain yang disinkronkan lewat outbox yang sama                    |
-| Connection pooling + work-class backpressure + circuit breaker (Issue 10.2, per-provider sejak #436)                                 | Provider eksternal domain (WA/email/AI/pajak) di belakang flag + outbox          |
-| Production readiness tooling (`db:pool:health`, `security:readiness`, `production:preflight`)                                        | Item checklist domain tambahan (mis. tax data masking untuk aplikasi pajak)      |
-| Skill proyek `.claude/skills/`                                                                                                       | —                                                                                |
+| Reusable (base — jangan diubah)                                                                                                      | Domain-specific (aplikasi turunan — Anda tambahkan)                                |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Modular monolith + module contract (`src/modules/_shared/module-contract.ts`, doc 10/11)                                             | Modul domain baru di `src/modules/<domain>/`                                       |
+| RBAC + ABAC default-deny + RLS (ADR-0003/0004, `src/modules/identity-access/`)                                                       | Permission/role/policy spesifik domain (doc 17 pola, bukan isinya)                 |
+| Migration runner checksum-based, konvensi `NNN_awcms_mini_<area>_<desc>.sql`                                                         | Skema tabel domain (skill `awcms-mini-new-migration`)                              |
+| Kontrak OpenAPI/AsyncAPI wajib + `api:spec:check` (ADR-0007/0008)                                                                    | Endpoint/event domain (skill `awcms-mini-new-endpoint`/`awcms-mini-new-event`)     |
+| Soft delete + immutability posted (ADR-0005)                                                                                         | Kebijakan resource domain mana yang boleh restore/purge                            |
+| Audit trail generik (`awcms_mini_audit_events`) + retensi/purge + correlation ID (Issue 10.1/#447, skill `awcms-mini-observability`) | Aksi high-risk spesifik domain yang wajib diaudit (skill `awcms-mini-audit-log`)   |
+| Idempotency ledger generik (`awcms_mini_idempotency_keys`)                                                                           | Mutation high-risk domain mana yang wajib `Idempotency-Key`                        |
+| Server-side form draft persistence generik (`awcms_mini_form_drafts`, `/api/v1/form-drafts`, Issue #484)                             | Apa isi `payload` draft dan `moduleKey`/`wizardKey`/`resourceType` spesifik domain |
+| Structured logger + extension point (`setLogSink`/`setAuditExportHook`)                                                              | Consumer log/audit nyata (SIEM, alerting) — base hanya sediakan titik pasang       |
+| Design system, token, state pattern, i18n (doc 14, skill `awcms-mini-i18n`)                                                          | Layar admin/operator/portal domain (skill `awcms-mini-ui-screen`)                  |
+| Offline-first sync (outbox/inbox, HMAC, conflict tracking, object queue dispatcher — Issue 6.1-6.3/#436)                             | Payload event domain yang disinkronkan lewat outbox yang sama                      |
+| Connection pooling + work-class backpressure + circuit breaker (Issue 10.2, per-provider sejak #436)                                 | Provider eksternal domain (WA/email/AI/pajak) di belakang flag + outbox            |
+| Production readiness tooling (`db:pool:health`, `security:readiness`, `production:preflight`)                                        | Item checklist domain tambahan (mis. tax data masking untuk aplikasi pajak)        |
+| Skill proyek `.claude/skills/`                                                                                                       | —                                                                                  |
 
 Prinsip: **pertahankan** kolom kiri apa adanya; **tambahkan** kolom kanan mengikuti pola yang sudah mapan. Jangan menulis ulang RLS/ABAC/audit/idempotency Anda sendiri — base sudah menyediakannya, cukup dipakai.
 

--- a/docs/awcms-mini/examples/wizard-derived-module-example.md
+++ b/docs/awcms-mini/examples/wizard-derived-module-example.md
@@ -16,8 +16,12 @@ nyata, bukan sekadar daftar tanggung jawab komponen.
 Ikuti kriteria di `wizard-form-pattern.md` §Kapan memakai wizard. Contoh
 konkret di sini: form registrasi aset dengan tiga kategori data (identitas
 aset, lokasi, kategori/kondisi) — cukup panjang untuk manfaat dari step
-terpisah, tapi tidak butuh lampiran/draft/resume (jadi tetap MVP, bukan
-alasan untuk server-side draft persistence — lihat #484).
+terpisah, tapi tidak butuh lampiran/draft/resume di contoh ini secara
+spesifik. Server-side draft persistence generik memang tersedia
+(`/api/v1/form-drafts`, Issue #484) bila modul domain Anda membutuhkannya —
+lihat §6 di bawah untuk pola submit yang sama, dan
+[`wizard-form-pattern.md`](wizard-form-pattern.md) §Server-side draft
+untuk API lengkap.
 
 ## 1. Import komponen dan helper
 

--- a/docs/awcms-mini/examples/wizard-form-pattern.md
+++ b/docs/awcms-mini/examples/wizard-form-pattern.md
@@ -183,13 +183,21 @@ Pola ini wajib mengikuti guardrail AWCMS-Mini:
 9. Provider eksternal seperti R2, email, WhatsApp, atau AI tidak boleh dipanggil
    di dalam transaksi database.
 
-## Server-side draft: follow-up, bukan MVP
+## Server-side draft — tersedia (Issue #484)
 
-Issue #479 sengaja tidak langsung membangun draft persistence agar scope tetap
-kecil dan tidak over-engineering. Setelah pattern dipakai minimal oleh dua modul
-domain nyata, buat issue lanjutan untuk server-side draft.
+Issue #479 sengaja tidak langsung membangun draft persistence agar scope MVP
+tetap kecil. Setelah #482 (contoh pemakaian derived module) dan #483
+(fixture nyata) landed, maintainer meng-unblock follow-up ini dengan pilot
+plan konkret — sekarang tersedia sebagai modul generik
+`src/modules/form-drafts/` (lihat README modul itu untuk detail lengkap:
+endpoint, model idempotency per-aksi, retensi/expiry, dan alasan tiap
+keputusan desain).
 
-Tabel draft yang disarankan:
+Skema final (`sql/019_awcms_mini_form_drafts_schema.sql`) — satu
+perbedaan dari rancangan awal di bawah: `resource_id` bertipe `text`,
+bukan `uuid`, disamakan dengan `awcms_mini_workflow_instances`/
+`awcms_mini_audit_events.resource_id` supaya draft bisa menunjuk resource
+yang belum ada atau identifier non-UUID:
 
 ```sql
 CREATE TABLE awcms_mini_form_drafts (
@@ -198,7 +206,7 @@ CREATE TABLE awcms_mini_form_drafts (
   module_key text NOT NULL,
   wizard_key text NOT NULL,
   resource_type text NOT NULL,
-  resource_id uuid,
+  resource_id text,
   current_step text NOT NULL,
   payload jsonb NOT NULL,
   status text NOT NULL CHECK (status IN ('draft', 'submitted', 'abandoned', 'expired')),
@@ -215,16 +223,11 @@ CREATE TABLE awcms_mini_form_drafts (
 );
 ```
 
-Follow-up server-side draft wajib menambah:
-
-- migration SQL berurutan;
-- RLS policy tenant-scoped;
-- repository dan service layer;
-- OpenAPI endpoint;
-- audit log untuk create/update/submit/delete draft;
-- retention/expiry policy;
-- test RLS dan permission;
-- dokumentasi operasi.
+Pemakaian dari modul domain turunan: lihat
+[`wizard-derived-module-example.md`](wizard-derived-module-example.md)
+§6-7 (submit `Idempotency-Key`, anti-double-submit) — pola create/
+update/submit/delete draft mengikuti API `/api/v1/form-drafts` yang sama
+persis dipakai `admin/examples/wizard.astro` sebagai pilot.
 
 ## Contoh definisi step
 

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -577,4 +577,10 @@ msgid "admin.examples.wizard.validation_category_required"
 msgstr "Category is required."
 
 msgid "admin.examples.wizard.submit_success_message"
-msgstr "Submitted (dummy — nothing was actually saved)."
+msgstr "Submitted — draft saved via the form-drafts API (no domain action was taken)."
+
+msgid "admin.examples.wizard.draft_save_error"
+msgstr "Could not save your progress. Your entries are still here — try again."
+
+msgid "admin.examples.wizard.draft_resumed_notice"
+msgstr "Resumed your saved draft."

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -577,4 +577,10 @@ msgid "admin.examples.wizard.validation_category_required"
 msgstr "Kategori wajib diisi."
 
 msgid "admin.examples.wizard.submit_success_message"
-msgstr "Terkirim (dummy — tidak ada yang benar-benar disimpan)."
+msgstr "Terkirim — draft disimpan lewat API form-drafts (tidak ada aksi domain yang dijalankan)."
+
+msgid "admin.examples.wizard.draft_save_error"
+msgstr "Progres tidak bisa disimpan. Isian Anda masih ada — coba lagi."
+
+msgid "admin.examples.wizard.draft_resumed_notice"
+msgstr "Draft tersimpan Anda dilanjutkan."

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -43,6 +43,12 @@ tags:
       decisions). Only the decision API is public (doc 17 seed grants no
       create/configure action for workflow.approval) — no
       create-definition/start-instance endpoint by design.
+  - name: Form Drafts
+    description: >-
+      Generic, domain-agnostic server-side draft store for the reusable
+      wizard pattern (Issue #484) — create/update/read/submit/delete a
+      tenant-scoped JSONB payload. No domain-specific meaning; a derived
+      module decides what a draft's payload contains.
 paths:
   /api/v1/sync/push:
     post:
@@ -1689,6 +1695,302 @@ paths:
           description: >-
             Idempotency-Key reused with a different request, or the task's
             decision has already been recorded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/form-drafts:
+    get:
+      tags:
+        - Form Drafts
+      summary: List the caller's tenant's non-deleted form drafts
+      operationId: formDraftsList
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: moduleKey
+          in: query
+          schema:
+            type: string
+        - name: wizardKey
+          in: query
+          schema:
+            type: string
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [draft, submitted, abandoned, expired]
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Form drafts for the caller's tenant (limit 100, newest first).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/FormDraftListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      tags:
+        - Form Drafts
+      summary: Create a new form draft
+      operationId: formDraftsCreate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFormDraftRequest"
+      responses:
+        "200":
+          description: Form draft created.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/FormDraftItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/form-drafts/{id}:
+    get:
+      tags:
+        - Form Drafts
+      summary: Read one form draft (resume-on-load)
+      operationId: formDraftsGet
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: The requested form draft.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/FormDraftItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    patch:
+      tags:
+        - Form Drafts
+      summary: Update a form draft's step/payload/expiry
+      operationId: formDraftsUpdate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateFormDraftRequest"
+      responses:
+        "200":
+          description: Form draft updated.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/FormDraftItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: >-
+            Form draft not found, deleted, or no longer editable (already
+            submitted/abandoned/expired).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    delete:
+      tags:
+        - Form Drafts
+      summary: Soft-delete (abandon) a form draft
+      operationId: formDraftsDelete
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                reason:
+                  type: string
+      responses:
+        "200":
+          description: Form draft deleted.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        type: object
+                        additionalProperties: false
+                        required:
+                          - id
+                          - deleted
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                          deleted:
+                            type: boolean
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/form-drafts/{id}/submit:
+    post:
+      tags:
+        - Form Drafts
+      summary: Submit a form draft (transitions draft -> submitted)
+      operationId: formDraftsSubmit
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/IdempotencyKey"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Form draft submitted.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/FormDraftItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: >-
+            Form draft not found, already submitted, or no longer editable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: Idempotency-Key reused with a different request.
           content:
             application/json:
               schema:
@@ -3444,6 +3746,135 @@ components:
         nextStepOrder:
           type: integer
           minimum: 1
+          nullable: true
+    FormDraftItem:
+      type: object
+      required:
+        - id
+        - tenantId
+        - moduleKey
+        - wizardKey
+        - resourceType
+        - resourceId
+        - currentStep
+        - payload
+        - status
+        - createdBy
+        - updatedBy
+        - submittedBy
+        - expiresAt
+        - createdAt
+        - updatedAt
+        - submittedAt
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        moduleKey:
+          type: string
+        wizardKey:
+          type: string
+        resourceType:
+          type: string
+        resourceId:
+          type: string
+          nullable: true
+        currentStep:
+          type: string
+        payload:
+          type: object
+        status:
+          type: string
+          enum:
+            - draft
+            - submitted
+            - abandoned
+            - expired
+        createdBy:
+          type: string
+          format: uuid
+        updatedBy:
+          type: string
+          format: uuid
+        submittedBy:
+          type: string
+          format: uuid
+          nullable: true
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        submittedAt:
+          type: string
+          format: date-time
+          nullable: true
+    FormDraftListResponse:
+      type: object
+      required:
+        - drafts
+      additionalProperties: false
+      properties:
+        drafts:
+          type: array
+          items:
+            $ref: "#/components/schemas/FormDraftItem"
+    CreateFormDraftRequest:
+      type: object
+      required:
+        - moduleKey
+        - wizardKey
+        - resourceType
+        - currentStep
+        - payload
+      additionalProperties: false
+      properties:
+        moduleKey:
+          type: string
+          pattern: "^[a-z][a-z0-9_]{1,63}$"
+        wizardKey:
+          type: string
+          pattern: "^[a-z][a-z0-9_]{1,63}$"
+        resourceType:
+          type: string
+          pattern: "^[a-z][a-z0-9_]{1,63}$"
+        resourceId:
+          type: string
+          maxLength: 128
+        currentStep:
+          type: string
+          maxLength: 64
+        payload:
+          type: object
+          description: >-
+            Arbitrary JSON scratch state up to 32KB serialized. Must never
+            contain a field resembling a secret (password, token, credential,
+            apiKey, privateKey) — rejected with 400 VALIDATION_ERROR if found.
+        expiresAt:
+          type: string
+          format: date-time
+    UpdateFormDraftRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        currentStep:
+          type: string
+          maxLength: 64
+        payload:
+          type: object
+          description: Same constraints as CreateFormDraftRequest.payload.
+        expiresAt:
+          type: string
+          format: date-time
           nullable: true
 security:
   - bearerAuth: []

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "db:pool:health": "bun scripts/db-pool-health.ts",
     "sync:objects:dispatch": "bun scripts/object-sync-dispatch.ts",
     "logs:audit:purge": "bun scripts/audit-log-purge.ts",
+    "form-drafts:purge": "bun scripts/form-draft-purge.ts",
     "security:readiness": "bun scripts/security-readiness.ts",
     "config:validate": "bun scripts/validate-env.ts",
     "production:preflight": "bun scripts/production-preflight.ts",

--- a/scripts/form-draft-purge.ts
+++ b/scripts/form-draft-purge.ts
@@ -1,0 +1,116 @@
+/**
+ * form-draft-purge.ts — `bun run form-drafts:purge`.
+ *
+ * Issue #484. Internal worker entrypoint mirroring
+ * `scripts/audit-log-purge.ts` (Issue #447) — not exposed over HTTP, run on
+ * a schedule (cron/systemd timer/k8s CronJob). Two passes per tenant:
+ *
+ *   1. `expireOverdueFormDrafts` — flips overdue `draft` rows to `expired`.
+ *   2. `purgeExpiredFormDrafts` — physically deletes `expired`/`abandoned`
+ *      rows older than the retention cutoff.
+ *
+ * Both loop in bounded batches per tenant until a pass does nothing or
+ * `MAX_PASSES_PER_TENANT` is hit, same safety bound as the audit-log job.
+ *
+ * Retention (for step 2 only — step 1 always uses each draft's own
+ * `expires_at`) is configurable in this priority order: `--retention-
+ * days=<n>` CLI flag, then `FORM_DRAFT_RETENTION_DAYS` env var, then
+ * `FORM_DRAFT_DEFAULT_RETENTION_DAYS` (30 days).
+ */
+import { getDatabaseClient } from "../src/lib/database/client";
+import {
+  FORM_DRAFT_DEFAULT_RETENTION_DAYS,
+  expireOverdueFormDrafts,
+  purgeExpiredFormDrafts
+} from "../src/modules/form-drafts/application/form-draft-purge";
+
+const MAX_PASSES_PER_TENANT = 50;
+
+type TenantRow = { id: string };
+
+function resolveRetentionDays(): number {
+  const flag = process.argv.find((arg) => arg.startsWith("--retention-days="));
+
+  if (flag) {
+    const parsed = Number(flag.split("=")[1]);
+
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  const envValue = process.env.FORM_DRAFT_RETENTION_DAYS;
+
+  if (envValue) {
+    const parsed = Number(envValue);
+
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  return FORM_DRAFT_DEFAULT_RETENTION_DAYS;
+}
+
+async function main() {
+  const sql = getDatabaseClient();
+  const correlationId = crypto.randomUUID();
+  const retentionDays = resolveRetentionDays();
+
+  try {
+    const tenants = (await sql`
+      SELECT id FROM awcms_mini_tenants WHERE status = 'active'
+    `) as TenantRow[];
+
+    let totalExpired = 0;
+    let totalPurged = 0;
+    const now = new Date();
+    let cutoffIso = "";
+
+    for (const tenant of tenants) {
+      for (let pass = 0; pass < MAX_PASSES_PER_TENANT; pass += 1) {
+        const result = await expireOverdueFormDrafts(sql, tenant.id, {
+          now,
+          correlationId
+        });
+
+        totalExpired += result.expiredCount;
+
+        if (result.expiredCount === 0) {
+          break;
+        }
+      }
+
+      for (let pass = 0; pass < MAX_PASSES_PER_TENANT; pass += 1) {
+        const result = await purgeExpiredFormDrafts(sql, tenant.id, {
+          retentionDays,
+          now,
+          correlationId
+        });
+
+        totalPurged += result.purgedCount;
+        cutoffIso = result.cutoff.toISOString();
+
+        if (result.purgedCount === 0) {
+          break;
+        }
+      }
+    }
+
+    console.log(
+      `form-drafts:purge complete — correlationId=${correlationId} ` +
+        `retentionDays=${retentionDays} cutoff=${cutoffIso} ` +
+        `tenants=${tenants.length} expired=${totalExpired} purged=${totalPurged}`
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(`form-drafts:purge FAILED — ${detail}`);
+    process.exitCode = 1;
+  } finally {
+    await sql.close({ timeout: 1 });
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/sql/019_awcms_mini_form_drafts_schema.sql
+++ b/sql/019_awcms_mini_form_drafts_schema.sql
@@ -1,0 +1,93 @@
+-- Issue #484 — Add server-side form draft persistence.
+--
+-- Generic, domain-agnostic draft store for the reusable wizard pattern
+-- (Issue #479/#480, docs/awcms-mini/examples/wizard-form-pattern.md
+-- §Server-side draft: follow-up, bukan MVP — that section's own suggested
+-- schema is the starting point for this table). Deliberately deferred until
+-- there was real evidence the pattern needed it: #482 (derived-module usage
+-- example) and #483 (a real fixture in the admin shell) both landed first,
+-- and the maintainer explicitly unblocked this issue afterward with a
+-- concrete pilot plan (settings-form / admin/examples/wizard).
+--
+-- `resource_id` is `text`, not `uuid` as the doc's rough draft suggested —
+-- reconciled here to match `awcms_mini_workflow_instances.resource_id` and
+-- `awcms_mini_audit_events.resource_id` (both `text`), so a draft can
+-- reference a not-yet-created resource or a non-UUID external identifier
+-- without a type mismatch against the audit/workflow tables it sits next to.
+--
+-- No `restored_at`/`restored_by` columns (unlike the workflow tables) —
+-- drafts are ephemeral scratch state, not an audited resource where restore
+-- has meaning; `deleted_at`/`deleted_by`/`delete_reason` alone is enough for
+-- the standard soft-delete convention.
+--
+-- FORCE RLS is applied inline in this same migration (not deferred to a
+-- follow-up like migration 013 had to be) — every migration after 013 that
+-- adds a new tenant-scoped table is expected to ENABLE+FORCE it immediately,
+-- since the least-privilege `awcms_mini_app` role and its default DML grants
+-- (`ALTER DEFAULT PRIVILEGES ... GRANT ... ON TABLES`, migration 013) already
+-- exist and auto-apply to this new table — no separate GRANT statement
+-- needed here.
+CREATE TABLE IF NOT EXISTS awcms_mini_form_drafts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  module_key text NOT NULL,
+  wizard_key text NOT NULL,
+  resource_type text NOT NULL,
+  resource_id text,
+  current_step text NOT NULL,
+  payload jsonb NOT NULL,
+  status text NOT NULL DEFAULT 'draft',
+  created_by uuid NOT NULL,
+  updated_by uuid NOT NULL,
+  submitted_by uuid,
+  expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  submitted_at timestamptz,
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_mini_form_drafts_status_check
+    CHECK (status IN ('draft', 'submitted', 'abandoned', 'expired')),
+  CONSTRAINT awcms_mini_form_drafts_module_key_format_check
+    CHECK (module_key ~ '^[a-z][a-z0-9_]{1,63}$'),
+  CONSTRAINT awcms_mini_form_drafts_wizard_key_format_check
+    CHECK (wizard_key ~ '^[a-z][a-z0-9_]{1,63}$')
+);
+
+-- Listing "my active drafts for this wizard" is the primary read path (the
+-- pilot's resume-on-load query) — index the tuple it filters on.
+CREATE INDEX IF NOT EXISTS awcms_mini_form_drafts_tenant_wizard_idx
+  ON awcms_mini_form_drafts (tenant_id, module_key, wizard_key, status);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_form_drafts_tenant_idx
+  ON awcms_mini_form_drafts (tenant_id);
+
+-- Retention job's query shape: WHERE tenant_id = ? AND status = 'draft' AND
+-- expires_at < now() — see application/form-draft-purge.ts.
+CREATE INDEX IF NOT EXISTS awcms_mini_form_drafts_tenant_expiry_idx
+  ON awcms_mini_form_drafts (tenant_id, status, expires_at)
+  WHERE expires_at IS NOT NULL;
+
+ALTER TABLE awcms_mini_form_drafts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_form_drafts FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_form_drafts_tenant_isolation
+  ON awcms_mini_form_drafts
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Permission model is generic infra, not gated per producing module_key —
+-- same reasoning as awcms_mini_idempotency_keys (migration 012): RLS
+-- already isolates by tenant; ABAC here answers "can this user use the
+-- form-drafts API at all", not "can this user touch drafts belonging to
+-- module X specifically". Module key shortened to "form_drafts" (matches
+-- the table name), consistent with the "workflow"/"logging"/"reporting"
+-- precedent of using a short base module key in code rather than doc 17's
+-- domain-illustrative naming.
+INSERT INTO awcms_mini_permissions (module_key, activity_code, action, description)
+VALUES
+  ('form_drafts', 'draft', 'read', 'Read own tenant form drafts'),
+  ('form_drafts', 'draft', 'create', 'Create a form draft'),
+  ('form_drafts', 'draft', 'update', 'Update or submit a form draft'),
+  ('form_drafts', 'draft', 'delete', 'Delete (abandon) a form draft')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/modules/form-drafts/README.md
+++ b/src/modules/form-drafts/README.md
@@ -1,0 +1,104 @@
+# Form Drafts
+
+Implementasi Issue #484 — server-side draft persistence untuk reusable
+wizard pattern (Issue #479/#480,
+`docs/awcms-mini/examples/wizard-form-pattern.md` §Server-side draft:
+follow-up, bukan MVP). Deliberately deferred sampai ada bukti nyata
+kebutuhannya: #482 (contoh pemakaian derived module) dan #483 (fixture
+nyata di admin shell) lebih dulu landed, baru maintainer meng-unblock issue
+ini dengan pilot plan konkret.
+
+## Scope
+
+Satu tabel generik, domain-agnostic: `awcms_mini_form_drafts`
+(`sql/019_awcms_mini_form_drafts_schema.sql`) — `tenant_id`, `module_key`,
+`wizard_key`, `resource_type`, `resource_id` (nullable, `text` — bukan
+`uuid`, disamakan dengan `awcms_mini_workflow_instances`/
+`awcms_mini_audit_events.resource_id` supaya draft bisa menunjuk resource
+yang belum ada atau identifier non-UUID), `current_step`, `payload` (jsonb),
+`status` (`draft → submitted | abandoned | expired`), `expires_at`, kolom
+soft-delete standar (`deleted_at`/`deleted_by`/`delete_reason` — tanpa
+`restored_at`/`restored_by`, draft adalah scratch state, bukan resource
+yang restore-nya bermakna).
+
+Modul ini **tidak tahu apa isi payload-nya** — itu keputusan modul domain
+turunan sepenuhnya. Satu-satunya kontrak yang ditegakkan di sini:
+`module_key`/`wizard_key`/`resource_type` harus format lowercase
+snake_case (`^[a-z][a-z0-9_]{1,63}$`, dicek constraint SQL **dan**
+validator domain), `payload` maksimum 32KB serialized, dan `payload` tidak
+boleh mengandung field yang menyerupai secret (`password`, `token`,
+`secret`, `credential`, `apiKey`, `privateKey` — dicek rekursif di semua
+kedalaman nesting, case-insensitive, toleran terhadap separator umum).
+
+## Endpoint publik
+
+Bearer session atau cookie SSR (`authorizeInTransaction`/
+`resolveAuthInputs`, `identity-access/application/access-guard.ts`), guard
+`form_drafts.draft.{read,create,update,delete}` — permission generik,
+**tidak** digerbangi per `module_key` pembuat draft (RLS sudah
+mengisolasi per tenant; ABAC di sini menjawab "bisakah user ini memakai
+API form-drafts sama sekali", bukan "bisakah user ini menyentuh draft milik
+modul X").
+
+- **`GET /api/v1/form-drafts`** — daftar draft tenant (non-deleted, limit
+  100, terbaru dulu), filter opsional `?moduleKey=&wizardKey=&status=`.
+- **`POST /api/v1/form-drafts`** — buat draft baru. Bukan idempotent
+  (tidak wajib `Idempotency-Key`) — worst-case retry jaringan adalah satu
+  baris scratch tambahan yang bisa dihapus user, bukan efek domain.
+- **`GET /api/v1/form-drafts/{id}`** — baca satu draft (resume-on-load).
+- **`PATCH /api/v1/form-drafts/{id}`** — perbarui `currentStep`/`payload`/
+  `expiresAt`. Hanya draft `status = 'draft'` yang bisa diedit — draft yang
+  sudah submitted/abandoned/expired mengembalikan `404` (riwayat, bukan
+  resource hidup). Idempotent secara alami (payload sama → state akhir
+  sama), tidak butuh `Idempotency-Key`.
+- **`DELETE /api/v1/form-drafts/{id}`** — soft-delete ("abandon"). `reason`
+  opsional (beda dari `DELETE /api/v1/profiles/{id}` yang mewajibkannya —
+  draft adalah scratch state berisiko rendah, bukan record bisnis).
+  Idempotent-safe: memanggil ulang pada draft yang sudah dihapus
+  mengembalikan `404`, bukan menulis ulang `deleted_at`.
+- **`POST /api/v1/form-drafts/{id}/submit`** — transisi `draft →
+submitted`. Memakai ulang action ABAC `update` (bukan action baru — sama
+  seperti `workflow.approval.approve` dipakai untuk approve **dan**
+  reject). **High-risk**: wajib `Idempotency-Key`, pola replay/conflict
+  identik `workflows/tasks/{id}/decisions.ts`.
+
+## Kenapa create/update/delete tidak butuh Idempotency-Key, tapi submit butuh
+
+`create` menambah baris scratch bernilai rendah — retry jaringan
+menghasilkan draft duplikat yang bisa dihapus user, bukan efek domain.
+`update`/`delete` idempotent secara struktural (payload sama → state akhir
+sama; `deleted_at IS NULL` guard mencegah tulis ulang). `submit` adalah
+transisi status yang benar-benar berarti (dan pada modul domain turunan
+nyata kemungkinan memicu efek lanjutan) — retry jaringan yang menyebabkan
+submit ganda adalah bug nyata, bukan sekadar baris scratch berlebih,
+sehingga wajib idempotency key sesuai doc 10 §Idempotency wrapper rules.
+
+## Retensi/expiry
+
+Dua tahap terpisah (`application/form-draft-purge.ts`,
+`bun run form-drafts:purge` — mirip `logs:audit:purge`, Issue #447):
+
+1. **`expireOverdueFormDrafts`** — draft `status='draft'` yang
+   `expires_at`-nya lewat ditransisikan ke `status='expired'` (transisi
+   lunak, bukan delete — baris + payload tetap ada untuk audit/debug,
+   hanya tidak lagi resumable/editable).
+2. **`purgeExpiredFormDrafts`** — hapus fisik draft `expired`/`abandoned`
+   yang lebih tua dari retention cutoff (`updated_at`, default 30 hari,
+   override `--retention-days=<n>` atau env `FORM_DRAFT_RETENTION_DAYS`).
+
+Tidak ada FK child pada tabel ini, jadi DELETE fisik di tahap 2 tidak
+pernah memutus foreign key (alasan sama seperti `audit_events`, migration
+011). Kedua tahap mencatat aksinya sendiri sebagai audit event
+(`recordAuditEvent`, `action: "expire"`/`"purge"`) — tidak pernah purge
+diam-diam, sama seperti `audit-purge.ts`.
+
+## Pilot: `admin/examples/wizard.astro`
+
+`moduleKey: "admin_examples"`, `wizardKey: "wizard_fixture"`,
+`resourceType: "fixture"` — SSR meng-query draft aktif via application
+layer langsung (pola sama seperti `admin/index.astro`'s dashboard
+reports, bukan round-trip HTTP ke API sendiri), client script menyimpan
+progress via `POST`/`PATCH` setiap kali step berpindah, dan submit final
+memakai `Idempotency-Key` nyata. Lihat komentar di berkas itu untuk detail
+wiring; `wizard-derived-module-example.md` (Issue #482) menunjukkan pola
+yang sama untuk modul domain turunan sungguhan.

--- a/src/modules/form-drafts/application/form-draft-directory.ts
+++ b/src/modules/form-drafts/application/form-draft-directory.ts
@@ -1,0 +1,209 @@
+import type {
+  CreateFormDraftInput,
+  UpdateFormDraftInput
+} from "../domain/form-draft-validation";
+
+export type FormDraftView = {
+  id: string;
+  tenantId: string;
+  moduleKey: string;
+  wizardKey: string;
+  resourceType: string;
+  resourceId: string | null;
+  currentStep: string;
+  payload: Record<string, unknown>;
+  status: "draft" | "submitted" | "abandoned" | "expired";
+  createdBy: string;
+  updatedBy: string;
+  submittedBy: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  submittedAt: string | null;
+};
+
+type FormDraftRow = {
+  id: string;
+  tenant_id: string;
+  module_key: string;
+  wizard_key: string;
+  resource_type: string;
+  resource_id: string | null;
+  current_step: string;
+  payload: Record<string, unknown>;
+  status: "draft" | "submitted" | "abandoned" | "expired";
+  created_by: string;
+  updated_by: string;
+  submitted_by: string | null;
+  expires_at: string | null;
+  created_at: string;
+  updated_at: string;
+  submitted_at: string | null;
+};
+
+function toView(row: FormDraftRow): FormDraftView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    moduleKey: row.module_key,
+    wizardKey: row.wizard_key,
+    resourceType: row.resource_type,
+    resourceId: row.resource_id,
+    currentStep: row.current_step,
+    payload: row.payload,
+    status: row.status,
+    createdBy: row.created_by,
+    updatedBy: row.updated_by,
+    submittedBy: row.submitted_by,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    submittedAt: row.submitted_at
+  };
+}
+
+export async function createFormDraft(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  input: CreateFormDraftInput
+): Promise<FormDraftView> {
+  const rows = (await tx`
+    INSERT INTO awcms_mini_form_drafts
+      (tenant_id, module_key, wizard_key, resource_type, resource_id,
+       current_step, payload, created_by, updated_by, expires_at)
+    VALUES (
+      ${tenantId}, ${input.moduleKey}, ${input.wizardKey}, ${input.resourceType},
+      ${input.resourceId ?? null}, ${input.currentStep}, ${input.payload},
+      ${actorTenantUserId}, ${actorTenantUserId}, ${input.expiresAt ?? null}
+    )
+    RETURNING id, tenant_id, module_key, wizard_key, resource_type, resource_id,
+      current_step, payload, status, created_by, updated_by, submitted_by,
+      expires_at, created_at, updated_at, submitted_at
+  `) as FormDraftRow[];
+
+  return toView(rows[0]!);
+}
+
+/** Only non-deleted rows are readable — a soft-deleted draft is gone from every read path, matching the base soft-delete convention (default filter `deleted_at IS NULL`). */
+export async function fetchActiveFormDraft(
+  tx: Bun.SQL,
+  tenantId: string,
+  draftId: string
+): Promise<FormDraftView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, module_key, wizard_key, resource_type, resource_id,
+      current_step, payload, status, created_by, updated_by, submitted_by,
+      expires_at, created_at, updated_at, submitted_at
+    FROM awcms_mini_form_drafts
+    WHERE tenant_id = ${tenantId} AND id = ${draftId} AND deleted_at IS NULL
+  `) as FormDraftRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export type ListFormDraftsFilter = {
+  moduleKey?: string;
+  wizardKey?: string;
+  status?: "draft" | "submitted" | "abandoned" | "expired";
+};
+
+/** `LIMIT 100`, newest first — mirrors `workflows/tasks`'s bounded-list convention (no pagination cursor for a generic scratch-data table). */
+export async function listFormDrafts(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: ListFormDraftsFilter = {}
+): Promise<FormDraftView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, module_key, wizard_key, resource_type, resource_id,
+      current_step, payload, status, created_by, updated_by, submitted_by,
+      expires_at, created_at, updated_at, submitted_at
+    FROM awcms_mini_form_drafts
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+      AND (${filter.moduleKey ?? null}::text IS NULL OR module_key = ${filter.moduleKey ?? null})
+      AND (${filter.wizardKey ?? null}::text IS NULL OR wizard_key = ${filter.wizardKey ?? null})
+      AND (${filter.status ?? null}::text IS NULL OR status = ${filter.status ?? null})
+    ORDER BY updated_at DESC
+    LIMIT 100
+  `) as FormDraftRow[];
+
+  return rows.map(toView);
+}
+
+export async function updateFormDraft(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  draftId: string,
+  input: UpdateFormDraftInput
+): Promise<FormDraftView | null> {
+  const existing = await fetchActiveFormDraft(tx, tenantId, draftId);
+
+  if (!existing || existing.status !== "draft") {
+    return null;
+  }
+
+  const rows = (await tx`
+    UPDATE awcms_mini_form_drafts
+    SET current_step = COALESCE(${input.currentStep ?? null}, current_step),
+        payload = COALESCE(${input.payload ?? null}, payload),
+        expires_at = CASE
+          WHEN ${input.expiresAt === undefined} THEN expires_at
+          ELSE ${input.expiresAt ?? null}
+        END,
+        updated_by = ${actorTenantUserId},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${draftId} AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, wizard_key, resource_type, resource_id,
+      current_step, payload, status, created_by, updated_by, submitted_by,
+      expires_at, created_at, updated_at, submitted_at
+  `) as FormDraftRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/** Transitions a `draft` to `submitted`. Returns `null` if the draft doesn't exist, is already deleted, or isn't in `draft` status (already submitted — the caller's idempotency check is expected to have already handled the replay case before reaching here). */
+export async function submitFormDraft(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  draftId: string
+): Promise<FormDraftView | null> {
+  const rows = (await tx`
+    UPDATE awcms_mini_form_drafts
+    SET status = 'submitted',
+        submitted_by = ${actorTenantUserId},
+        submitted_at = now(),
+        updated_by = ${actorTenantUserId},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${draftId}
+      AND deleted_at IS NULL AND status = 'draft'
+    RETURNING id, tenant_id, module_key, wizard_key, resource_type, resource_id,
+      current_step, payload, status, created_by, updated_by, submitted_by,
+      expires_at, created_at, updated_at, submitted_at
+  `) as FormDraftRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/** Soft-deletes ("abandons") a draft. Idempotent by construction — the `deleted_at IS NULL` guard means calling this twice is a safe no-op the second time, no `Idempotency-Key` needed. */
+export async function deleteFormDraft(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  draftId: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_mini_form_drafts
+    SET deleted_at = now(),
+        deleted_by = ${actorTenantUserId},
+        delete_reason = ${reason},
+        status = CASE WHEN status = 'draft' THEN 'abandoned' ELSE status END,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${draftId} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}

--- a/src/modules/form-drafts/application/form-draft-purge.ts
+++ b/src/modules/form-drafts/application/form-draft-purge.ts
@@ -1,0 +1,152 @@
+import { withTenant } from "../../../lib/database/tenant-context";
+import { recordAuditEvent } from "../../logging/application/audit-log";
+
+/**
+ * Retention for `awcms_mini_form_drafts` (Issue #484), same bounded-batch +
+ * self-auditing shape as `logging/application/audit-purge.ts`. Two distinct
+ * steps, run separately so a caller can schedule them independently:
+ *
+ * 1. `expireOverdueFormDrafts` — a `draft` whose caller-supplied
+ *    `expires_at` has passed transitions to `status = 'expired'` (soft
+ *    transition, not a delete — the row and its payload are still there for
+ *    audit/debugging, just no longer resumable/editable).
+ * 2. `purgeExpiredFormDrafts` — physically deletes rows that have been
+ *    `expired`/`abandoned` for longer than `retentionDays`, the same
+ *    age-based cutoff `purgeExpiredAuditEvents` uses (no `expires_at`-only
+ *    cutoff here since `abandoned` drafts never had one).
+ *
+ * Neither drafts nor the columns they touch have FK children, so a physical
+ * DELETE in step 2 can never break a foreign key (same reasoning as audit
+ * events, migration 011).
+ */
+export const FORM_DRAFT_DEFAULT_RETENTION_DAYS = 30;
+export const FORM_DRAFT_PURGE_BATCH_LIMIT = 5000;
+
+export type ExpireFormDraftsOptions = {
+  /** Defaults to `new Date()`. Injectable for deterministic tests. */
+  now?: Date;
+  /** Defaults to `FORM_DRAFT_PURGE_BATCH_LIMIT`. */
+  batchLimit?: number;
+  correlationId?: string;
+};
+
+export type ExpireFormDraftsResult = {
+  expiredCount: number;
+};
+
+type IdRow = { id: string };
+
+/** Transitions one batch of overdue `draft` rows to `status = 'expired'`. */
+export async function expireOverdueFormDrafts(
+  sql: Bun.SQL,
+  tenantId: string,
+  options: ExpireFormDraftsOptions = {}
+): Promise<ExpireFormDraftsResult> {
+  const now = options.now ?? new Date();
+  const batchLimit = options.batchLimit ?? FORM_DRAFT_PURGE_BATCH_LIMIT;
+
+  const expiredCount = await withTenant(
+    sql,
+    tenantId,
+    async (tx) => {
+      const expired = (await tx`
+        UPDATE awcms_mini_form_drafts
+        SET status = 'expired', updated_at = ${now}
+        WHERE id IN (
+          SELECT id FROM awcms_mini_form_drafts
+          WHERE tenant_id = ${tenantId} AND status = 'draft'
+            AND expires_at IS NOT NULL AND expires_at < ${now}
+          ORDER BY expires_at ASC
+          LIMIT ${batchLimit}
+        )
+        RETURNING id
+      `) as IdRow[];
+
+      if (expired.length > 0) {
+        await recordAuditEvent(tx, {
+          tenantId,
+          moduleKey: "form_drafts",
+          action: "expire",
+          resourceType: "form_draft",
+          severity: "info",
+          message: `Expired ${expired.length} form draft(s) past their expires_at.`,
+          attributes: { expiredCount: expired.length },
+          correlationId: options.correlationId
+        });
+      }
+
+      return expired.length;
+    },
+    { workClass: "maintenance" }
+  );
+
+  return { expiredCount };
+}
+
+export type PurgeFormDraftsOptions = {
+  /** Defaults to `FORM_DRAFT_DEFAULT_RETENTION_DAYS`. */
+  retentionDays?: number;
+  /** Defaults to `FORM_DRAFT_PURGE_BATCH_LIMIT`. */
+  batchLimit?: number;
+  now?: Date;
+  correlationId?: string;
+};
+
+export type PurgeFormDraftsResult = {
+  purgedCount: number;
+  cutoff: Date;
+};
+
+/** Physically deletes one batch of `expired`/`abandoned` drafts older than the retention cutoff (by `updated_at`, the moment they stopped being editable). */
+export async function purgeExpiredFormDrafts(
+  sql: Bun.SQL,
+  tenantId: string,
+  options: PurgeFormDraftsOptions = {}
+): Promise<PurgeFormDraftsResult> {
+  const retentionDays =
+    options.retentionDays ?? FORM_DRAFT_DEFAULT_RETENTION_DAYS;
+  const batchLimit = options.batchLimit ?? FORM_DRAFT_PURGE_BATCH_LIMIT;
+  const now = options.now ?? new Date();
+  const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+
+  const purgedCount = await withTenant(
+    sql,
+    tenantId,
+    async (tx) => {
+      const deleted = (await tx`
+        DELETE FROM awcms_mini_form_drafts
+        WHERE id IN (
+          SELECT id FROM awcms_mini_form_drafts
+          WHERE tenant_id = ${tenantId}
+            AND status IN ('expired', 'abandoned')
+            AND updated_at < ${cutoff}
+          ORDER BY updated_at ASC
+          LIMIT ${batchLimit}
+        )
+        RETURNING id
+      `) as IdRow[];
+
+      if (deleted.length > 0) {
+        await recordAuditEvent(tx, {
+          tenantId,
+          moduleKey: "form_drafts",
+          action: "purge",
+          resourceType: "form_draft",
+          severity: "warning",
+          message: `Purged ${deleted.length} expired/abandoned form draft(s) older than the retention cutoff.`,
+          attributes: {
+            retentionDays,
+            cutoffIso: cutoff.toISOString(),
+            purgedCount: deleted.length
+          },
+          correlationId: options.correlationId
+        });
+      }
+
+      return deleted.length;
+    },
+    { workClass: "maintenance" }
+  );
+
+  return { purgedCount, cutoff };
+}

--- a/src/modules/form-drafts/domain/form-draft-validation.ts
+++ b/src/modules/form-drafts/domain/form-draft-validation.ts
@@ -1,0 +1,282 @@
+/**
+ * Pure validation for the form-drafts endpoints (Issue #484). Same
+ * shape/style as `tenant-admin/domain/settings-validation.ts` — no I/O here.
+ */
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+type Result<T> =
+  { valid: true; value: T } | { valid: false; errors: ValidationError[] };
+
+export type CreateFormDraftInput = {
+  moduleKey: string;
+  wizardKey: string;
+  resourceType: string;
+  resourceId?: string;
+  currentStep: string;
+  payload: Record<string, unknown>;
+  expiresAt?: string;
+};
+
+export type UpdateFormDraftInput = {
+  currentStep?: string;
+  payload?: Record<string, unknown>;
+  expiresAt?: string | null;
+};
+
+// Mirrors the SQL CHECK constraints in migration 019 — keep both in sync.
+const KEY_FORMAT = /^[a-z][a-z0-9_]{1,63}$/;
+const MAX_RESOURCE_ID_LENGTH = 128;
+const MAX_CURRENT_STEP_LENGTH = 64;
+
+/**
+ * Payload cannot exceed this size (Issue #484 acceptance criteria: "payload
+ * memiliki ukuran maksimum yang eksplisit"). 32KB is generous for a form's
+ * worth of scratch field values while still bounding worst-case row/index
+ * bloat — this is draft scratch state, not a document/file store.
+ */
+export const MAX_PAYLOAD_BYTES = 32 * 1024;
+
+/**
+ * Field names that must never be persisted in a draft payload (Issue #484:
+ * "field yang dilarang ... harus ditolak"). Matched case-insensitively
+ * against every key at every nesting depth, tolerant of common separators
+ * (apiKey, api_key, api-key all match) — rejecting outright rather than
+ * silently redacting, so a caller can't mistake a stripped field for a
+ * saved one.
+ */
+const FORBIDDEN_PAYLOAD_KEY_PATTERNS: readonly RegExp[] = [
+  /password/i,
+  /token/i,
+  /secret/i,
+  /credential/i,
+  /api[_-]?key/i,
+  /private[_-]?key/i
+];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Recursively walks a JSON-serializable value looking for a forbidden key at
+ * any depth (including inside arrays of objects). Returns the first
+ * offending key path found, or `null` if none.
+ */
+export function findForbiddenPayloadKey(
+  value: unknown,
+  path: string = ""
+): string | null {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      const found = findForbiddenPayloadKey(value[i], `${path}[${i}]`);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  if (isPlainObject(value)) {
+    for (const [key, nested] of Object.entries(value)) {
+      if (FORBIDDEN_PAYLOAD_KEY_PATTERNS.some((pattern) => pattern.test(key))) {
+        return path ? `${path}.${key}` : key;
+      }
+      const found = findForbiddenPayloadKey(
+        nested,
+        path ? `${path}.${key}` : key
+      );
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+/** Validates a payload value is a plain JSON object, within size limits, and free of forbidden keys. */
+function validatePayload(
+  value: unknown,
+  errors: ValidationError[]
+): Record<string, unknown> | undefined {
+  if (!isPlainObject(value)) {
+    errors.push({
+      field: "payload",
+      message: "payload must be a JSON object."
+    });
+    return undefined;
+  }
+
+  const serialized = JSON.stringify(value);
+
+  if (serialized.length > MAX_PAYLOAD_BYTES) {
+    errors.push({
+      field: "payload",
+      message: `payload must not exceed ${MAX_PAYLOAD_BYTES} bytes when serialized.`
+    });
+    return undefined;
+  }
+
+  const forbiddenKey = findForbiddenPayloadKey(value);
+
+  if (forbiddenKey) {
+    errors.push({
+      field: "payload",
+      message: `payload must not contain a field resembling a secret (found "${forbiddenKey}"). Never persist passwords, tokens, credentials, or keys in a draft.`
+    });
+    return undefined;
+  }
+
+  return value;
+}
+
+function validateKeyFormat(
+  field: string,
+  value: unknown,
+  errors: ValidationError[]
+): string | undefined {
+  if (typeof value !== "string" || !KEY_FORMAT.test(value)) {
+    errors.push({
+      field,
+      message: `${field} must be lowercase snake_case, 2-64 characters, starting with a letter.`
+    });
+    return undefined;
+  }
+  return value;
+}
+
+export function validateCreateFormDraftInput(
+  body: unknown
+): Result<CreateFormDraftInput> {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+
+  const moduleKey = validateKeyFormat("moduleKey", record.moduleKey, errors);
+  const wizardKey = validateKeyFormat("wizardKey", record.wizardKey, errors);
+  const resourceType = validateKeyFormat(
+    "resourceType",
+    record.resourceType,
+    errors
+  );
+
+  let resourceId: string | undefined;
+  if (record.resourceId !== undefined) {
+    if (
+      typeof record.resourceId !== "string" ||
+      record.resourceId.trim().length === 0 ||
+      record.resourceId.length > MAX_RESOURCE_ID_LENGTH
+    ) {
+      errors.push({
+        field: "resourceId",
+        message: `resourceId must be a non-empty string up to ${MAX_RESOURCE_ID_LENGTH} characters.`
+      });
+    } else {
+      resourceId = record.resourceId.trim();
+    }
+  }
+
+  let currentStep: string | undefined;
+  if (
+    typeof record.currentStep !== "string" ||
+    record.currentStep.trim().length === 0 ||
+    record.currentStep.length > MAX_CURRENT_STEP_LENGTH
+  ) {
+    errors.push({
+      field: "currentStep",
+      message: `currentStep is required and must be up to ${MAX_CURRENT_STEP_LENGTH} characters.`
+    });
+  } else {
+    currentStep = record.currentStep.trim();
+  }
+
+  const payload = validatePayload(record.payload, errors);
+
+  let expiresAt: string | undefined;
+  if (record.expiresAt !== undefined) {
+    if (
+      typeof record.expiresAt !== "string" ||
+      Number.isNaN(Date.parse(record.expiresAt))
+    ) {
+      errors.push({
+        field: "expiresAt",
+        message: "expiresAt must be a valid ISO 8601 timestamp."
+      });
+    } else {
+      expiresAt = record.expiresAt;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      moduleKey: moduleKey!,
+      wizardKey: wizardKey!,
+      resourceType: resourceType!,
+      resourceId,
+      currentStep: currentStep!,
+      payload: payload!,
+      expiresAt
+    }
+  };
+}
+
+export function validateUpdateFormDraftInput(
+  body: unknown
+): Result<UpdateFormDraftInput> {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+  const value: UpdateFormDraftInput = {};
+
+  if (record.currentStep !== undefined) {
+    if (
+      typeof record.currentStep !== "string" ||
+      record.currentStep.trim().length === 0 ||
+      record.currentStep.length > MAX_CURRENT_STEP_LENGTH
+    ) {
+      errors.push({
+        field: "currentStep",
+        message: `currentStep must be a non-empty string up to ${MAX_CURRENT_STEP_LENGTH} characters.`
+      });
+    } else {
+      value.currentStep = record.currentStep.trim();
+    }
+  }
+
+  if (record.payload !== undefined) {
+    const payload = validatePayload(record.payload, errors);
+    if (payload !== undefined) {
+      value.payload = payload;
+    }
+  }
+
+  if (record.expiresAt !== undefined) {
+    if (
+      record.expiresAt !== null &&
+      (typeof record.expiresAt !== "string" ||
+        Number.isNaN(Date.parse(record.expiresAt)))
+    ) {
+      errors.push({
+        field: "expiresAt",
+        message: "expiresAt must be a valid ISO 8601 timestamp or null."
+      });
+    } else {
+      value.expiresAt = record.expiresAt;
+    }
+  }
+
+  if (errors.length === 0 && Object.keys(value).length === 0) {
+    errors.push({
+      field: "body",
+      message: "Provide at least one of currentStep, payload, expiresAt."
+    });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/form-drafts/module.ts
+++ b/src/modules/form-drafts/module.ts
@@ -1,0 +1,15 @@
+import { defineModule } from "../_shared/module-contract";
+
+export const formDraftsModule = defineModule({
+  key: "form_drafts",
+  name: "Form Drafts",
+  version: "1.0.0",
+  status: "active",
+  description:
+    "Generic, domain-agnostic server-side draft store for the reusable wizard pattern (create/update/read/submit/delete a tenant-scoped JSONB payload, denylist-validated against secret-shaped fields). No domain-specific logic — a derived module owns what a draft's payload actually means.",
+  dependencies: ["identity_access"],
+  api: {
+    openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
+    basePath: "/api/v1/form-drafts"
+  }
+});

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,4 +1,5 @@
 import type { ModuleDescriptor } from "./_shared/module-contract";
+import { formDraftsModule } from "./form-drafts/module";
 import { identityAccessModule } from "./identity-access/module";
 import { loggingModule } from "./logging/module";
 import { profileIdentityModule } from "./profile-identity/module";
@@ -14,7 +15,8 @@ export const modules: ModuleDescriptor[] = [
   syncStorageModule,
   reportingModule,
   loggingModule,
-  workflowApprovalModule
+  workflowApprovalModule,
+  formDraftsModule
 ];
 
 export function getModuleByKey(

--- a/src/pages/admin/examples/wizard.astro
+++ b/src/pages/admin/examples/wizard.astro
@@ -1,22 +1,35 @@
 ---
 /**
- * Wizard fixture page (Issue #483) — non-domain, dummy-data example
+ * Wizard fixture page (Issue #483/#484) — non-domain, dummy-data example
  * exercising the reusable wizard pattern (Issue #479/#480,
  * `docs/awcms-mini/examples/wizard-form-pattern.md`) end-to-end inside the
  * real admin shell. Not linked from `AdminLayout.astro`'s nav (it's a
  * fixture for developers building a derived module, not a shipped admin
  * feature) — reachable directly at `/admin/examples/wizard`.
  *
- * Submit is a local mock (`setTimeout`, no `fetch`) — no new endpoint,
- * schema, or migration, per the issue's explicit scope. A real derived
- * module wires the same wizard-client.ts helper to an actual endpoint;
- * see `wizard-derived-module-example.md` (Issue #482) for that version.
+ * Draft save/resume/submit wired to the real `/api/v1/form-drafts` API
+ * (Issue #484's pilot integration) — `moduleKey: "admin_examples"`,
+ * `wizardKey: "wizard_fixture"`. This is the only thing that changed from
+ * #483's original local-mock version; a real derived module follows the
+ * exact same pattern against its own `moduleKey`/`wizardKey`/`resourceType`
+ * — see `wizard-derived-module-example.md` (Issue #482).
  */
 import AdminLayout from "../../../layouts/AdminLayout.astro";
 import WizardStepper from "../../../components/ui/WizardStepper.astro";
 import WizardPanel from "../../../components/ui/WizardPanel.astro";
 import WizardActions from "../../../components/ui/WizardActions.astro";
 import { createTranslator } from "../../../lib/i18n/translate";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { listFormDrafts } from "../../../modules/form-drafts/application/form-draft-directory";
+
+// Kept in sync with the identical constants in the client `<script>` below
+// (frontmatter and client script are separate bundles — this SSR side only
+// needs moduleKey/wizardKey to query for a resumable draft; resourceType is
+// only needed when the client script creates one).
+const FORM_DRAFT_MODULE_KEY = "admin_examples";
+const FORM_DRAFT_WIZARD_KEY = "wizard_fixture";
 
 const context = Astro.locals.ssrContext;
 
@@ -34,6 +47,27 @@ const steps = [
   { key: "review", title: t("admin.examples.wizard.step_review_title") }
 ];
 
+// Resume-on-load: SSR fetch via the application layer directly (same
+// pattern as `admin/index.astro`'s dashboard reports) rather than an HTTP
+// round-trip to this page's own API. Permission-gated the same way — if the
+// caller somehow lacks `form_drafts.draft.read` (shouldn't happen for the
+// owner role, which gets every permission at setup), the fixture just
+// starts fresh instead of failing the whole page.
+const canReadDrafts = context.permissions.has(
+  permissionKey("form_drafts", "draft", "read")
+);
+
+const existingDraft = canReadDrafts
+  ? await withTenant(getDatabaseClient(), context.tenantId, async (tx) => {
+      const drafts = await listFormDrafts(tx, context.tenantId, {
+        moduleKey: FORM_DRAFT_MODULE_KEY,
+        wizardKey: FORM_DRAFT_WIZARD_KEY,
+        status: "draft"
+      });
+      return drafts[0] ?? null;
+    })
+  : null;
+
 const clientStrings = {
   stepperLabel: t("admin.examples.wizard.stepper_label"),
   stepCurrent: t("admin.examples.wizard.step_current"),
@@ -43,7 +77,15 @@ const clientStrings = {
   titleRequired: t("admin.examples.wizard.validation_title_required"),
   categoryRequired: t("admin.examples.wizard.validation_category_required"),
   pleaseWait: t("common.please_wait"),
-  submitSuccess: t("admin.examples.wizard.submit_success_message")
+  submitSuccess: t("admin.examples.wizard.submit_success_message"),
+  draftSaveError: t("admin.examples.wizard.draft_save_error"),
+  draftResumedNotice: t("admin.examples.wizard.draft_resumed_notice")
+};
+
+const initialDraft = existingDraft && {
+  id: existingDraft.id,
+  currentStep: existingDraft.currentStep,
+  payload: existingDraft.payload
 };
 ---
 
@@ -57,6 +99,12 @@ const clientStrings = {
       type="application/json"
       id="i18n-strings"
       set:html={JSON.stringify(clientStrings)}
+    />
+
+    <script
+      type="application/json"
+      id="initial-draft"
+      set:html={JSON.stringify(initialDraft ?? null)}
     />
 
     <WizardStepper
@@ -223,6 +271,7 @@ const clientStrings = {
   } from "../../../lib/ui/admin-form-client";
   import {
     advanceWizard,
+    createWizardIdempotencyKey,
     createWizardState,
     rewindWizard,
     toFieldErrorMap,
@@ -242,9 +291,22 @@ const clientStrings = {
     categoryRequired: string;
     pleaseWait: string;
     submitSuccess: string;
+    draftSaveError: string;
+    draftResumedNotice: string;
   }
 
+  type InitialDraft = {
+    id: string;
+    currentStep: string;
+    payload: Record<string, unknown>;
+  } | null;
+
   const strings = readClientStrings<FixtureStrings>();
+  const initialDraft = readClientStrings<InitialDraft>("initial-draft");
+
+  const FORM_DRAFT_MODULE_KEY = "admin_examples";
+  const FORM_DRAFT_WIZARD_KEY = "wizard_fixture";
+  const FORM_DRAFT_RESOURCE_TYPE = "fixture";
 
   const steps: WizardStepDefinition[] = [
     { key: "basic", title: "basic", fields: ["title", "category"] },
@@ -252,7 +314,8 @@ const clientStrings = {
     { key: "review", title: "review", fields: [] }
   ];
 
-  let state: WizardState = createWizardState(steps);
+  let state: WizardState = createWizardState(steps, initialDraft?.currentStep);
+  let draftId: string | null = initialDraft?.id ?? null;
 
   const form = document.getElementById(
     "wizard-fixture-form"
@@ -267,6 +330,62 @@ const clientStrings = {
       category: data.get("category"),
       notes: data.get("notes")
     };
+  }
+
+  function applyPayloadToForm(payload: Record<string, unknown>): void {
+    if (!form) return;
+    const title = form.querySelector<HTMLInputElement>('[name="title"]');
+    const category = form.querySelector<HTMLSelectElement>('[name="category"]');
+    const notes = form.querySelector<HTMLTextAreaElement>('[name="notes"]');
+    if (title && typeof payload.title === "string") title.value = payload.title;
+    if (category && typeof payload.category === "string")
+      category.value = payload.category;
+    if (notes && typeof payload.notes === "string") notes.value = payload.notes;
+  }
+
+  /**
+   * Persists the wizard's current step + payload — creates the draft on the
+   * first save, `PATCH`es it on every save after. Fire-and-forget from the
+   * caller's perspective (navigation isn't blocked on this), but failures
+   * are surfaced via the banner rather than swallowed silently, since a
+   * failed save means progress genuinely wasn't saved.
+   */
+  async function saveDraftProgress(stepKey: string): Promise<void> {
+    const payload = currentPayload();
+
+    try {
+      if (!draftId) {
+        const res = await fetch("/api/v1/form-drafts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({
+            moduleKey: FORM_DRAFT_MODULE_KEY,
+            wizardKey: FORM_DRAFT_WIZARD_KEY,
+            resourceType: FORM_DRAFT_RESOURCE_TYPE,
+            currentStep: stepKey,
+            payload
+          })
+        });
+        const json = await res.json();
+        if (!res.ok) throw new Error(json?.error?.message ?? "create failed");
+        draftId = json.data.id as string;
+        return;
+      }
+
+      const res = await fetch(`/api/v1/form-drafts/${draftId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
+        body: JSON.stringify({ currentStep: stepKey, payload })
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        throw new Error(json?.error?.message ?? "update failed");
+      }
+    } catch {
+      showBanner("action-banner", strings.draftSaveError, "error");
+    }
   }
 
   const validateFixtureStep: WizardValidator<Record<string, unknown>> = (
@@ -364,7 +483,7 @@ const clientStrings = {
     );
   }
 
-  function showActiveStep(): void {
+  function showActiveStep(options: { focus?: boolean } = {}): void {
     const activeKey = steps[state.activeStepIndex]!.key;
     for (const step of steps) {
       const panel = document.getElementById(`step-${step.key}`);
@@ -372,7 +491,18 @@ const clientStrings = {
     }
     renderStepper();
     if (activeKey === "review") renderReviewSummary();
-    focusPanelHeading(activeKey);
+    if (options.focus !== false) focusPanelHeading(activeKey);
+  }
+
+  // Resume-on-load (Issue #484): if an active draft was found server-side,
+  // pre-fill the form and jump straight to where the user left off — no
+  // focus steal, since the user didn't just take a navigation action.
+  if (initialDraft) {
+    applyPayloadToForm(initialDraft.payload);
+    if (initialDraft.currentStep !== "basic") {
+      showActiveStep({ focus: false });
+    }
+    showBanner("action-banner", strings.draftResumedNotice, "success");
   }
 
   form?.addEventListener("click", (event) => {
@@ -396,12 +526,14 @@ const clientStrings = {
       state = result.state;
       renderFieldErrors(activeKeyBeforeAdvance, []);
       showActiveStep();
+      void saveDraftProgress(steps[state.activeStepIndex]!.key);
     }
 
     if (target.closest("[data-wizard-back]")) {
       event.preventDefault();
       state = rewindWizard(state);
       showActiveStep();
+      void saveDraftProgress(steps[state.activeStepIndex]!.key);
     }
 
     if (target.closest("[data-wizard-submit]")) {
@@ -411,14 +543,36 @@ const clientStrings = {
       ) as HTMLButtonElement;
       if (button.disabled) return;
 
+      if (!draftId) {
+        // Reached review without a single successful Next (shouldn't
+        // happen through normal navigation) — nothing to submit yet.
+        showBanner("action-banner", strings.draftSaveError, "error");
+        return;
+      }
+
       const unlock = lockElement(button, strings.pleaseWait);
-      // Local mock — no fetch, no new endpoint/schema (Issue #483 scope).
-      // A real derived module submits with an Idempotency-Key against its
-      // own endpoint instead — see wizard-derived-module-example.md.
-      setTimeout(() => {
-        unlock();
-        showBanner("action-banner", strings.submitSuccess, "success");
-      }, 400);
+      const idempotencyKey = createWizardIdempotencyKey(
+        "wizard-fixture-submit"
+      );
+
+      fetch(`/api/v1/form-drafts/${draftId}/submit`, {
+        method: "POST",
+        headers: { "Idempotency-Key": idempotencyKey },
+        credentials: "same-origin"
+      })
+        .then(async (res) => {
+          const json = await res.json().catch(() => null);
+          if (!res.ok) {
+            throw new Error(json?.error?.message ?? "submit failed");
+          }
+          showBanner("action-banner", strings.submitSuccess, "success");
+        })
+        .catch(() => {
+          showBanner("action-banner", strings.draftSaveError, "error");
+        })
+        .finally(() => {
+          unlock();
+        });
     }
   });
 </script>

--- a/src/pages/api/v1/form-drafts/[id].ts
+++ b/src/pages/api/v1/form-drafts/[id].ts
@@ -1,0 +1,231 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  deleteFormDraft,
+  fetchActiveFormDraft,
+  updateFormDraft
+} from "../../../../modules/form-drafts/application/form-draft-directory";
+import { validateUpdateFormDraftInput } from "../../../../modules/form-drafts/domain/form-draft-validation";
+
+const READ_GUARD = {
+  moduleKey: "form_drafts",
+  activityCode: "draft",
+  action: "read" as const
+};
+
+const UPDATE_GUARD = {
+  moduleKey: "form_drafts",
+  activityCode: "draft",
+  action: "update" as const
+};
+
+const DELETE_GUARD = {
+  moduleKey: "form_drafts",
+  activityCode: "draft",
+  action: "delete" as const
+};
+
+/** `GET /api/v1/form-drafts/{id}` — read one draft (resume-on-load). */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const draftId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!draftId) {
+    return fail(400, "VALIDATION_ERROR", "Form draft id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const draft = await fetchActiveFormDraft(tx, tenantId, draftId);
+
+    if (!draft) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Form draft not found.");
+    }
+
+    return ok(draft);
+  });
+};
+
+/**
+ * `PATCH /api/v1/form-drafts/{id}` — update `currentStep`/`payload`/
+ * `expiresAt`. Only a draft still in `status = 'draft'` is editable; a
+ * submitted/abandoned/expired draft returns `404` (it's history now, not a
+ * live resource this endpoint mutates). Naturally idempotent — retrying the
+ * same PATCH body produces the same end state, so no `Idempotency-Key`.
+ */
+export const PATCH: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const draftId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!draftId) {
+    return fail(400, "VALIDATION_ERROR", "Form draft id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const validation = validateUpdateFormDraftInput(
+    await request.json().catch(() => null)
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Form draft update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      UPDATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const draft = await updateFormDraft(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      draftId,
+      input
+    );
+
+    if (!draft) {
+      return fail(
+        404,
+        "RESOURCE_NOT_FOUND",
+        "Form draft not found or no longer editable."
+      );
+    }
+
+    return ok(draft);
+  });
+};
+
+/**
+ * `DELETE /api/v1/form-drafts/{id}` — soft-delete ("abandon") a draft.
+ * `reason` is optional (unlike `DELETE /api/v1/profiles/{id}`, which
+ * requires one) — a draft is low-stakes scratch state a user discards
+ * routinely, not a business record where the reason matters for audit; a
+ * default is recorded instead of forcing every caller to supply one.
+ * Idempotent — repeating the call on an already-deleted draft is a
+ * `404`, not an error, and never double-writes `deleted_at`.
+ */
+export const DELETE: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const draftId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!draftId) {
+    return fail(400, "VALIDATION_ERROR", "Form draft id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const body = await request.json().catch(() => null);
+  const reasonRaw = (body as { reason?: unknown } | null)?.reason;
+  const reason =
+    typeof reasonRaw === "string" && reasonRaw.trim().length > 0
+      ? reasonRaw.trim()
+      : "Abandoned by user.";
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DELETE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const deleted = await deleteFormDraft(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      draftId,
+      reason
+    );
+
+    if (!deleted) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Form draft not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "form_drafts",
+      action: "delete",
+      resourceType: "form_draft",
+      resourceId: draftId,
+      severity: "info",
+      message: "Form draft deleted.",
+      attributes: { reason }
+    });
+
+    return ok({ id: draftId, deleted: true });
+  });
+};

--- a/src/pages/api/v1/form-drafts/[id]/submit.ts
+++ b/src/pages/api/v1/form-drafts/[id]/submit.ts
@@ -1,0 +1,157 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import { submitFormDraft } from "../../../../../modules/form-drafts/application/form-draft-directory";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../modules/_shared/idempotency";
+
+const SUBMIT_GUARD = {
+  moduleKey: "form_drafts",
+  activityCode: "draft",
+  action: "update" as const
+};
+
+const IDEMPOTENCY_SCOPE = "form_draft_submit";
+
+/**
+ * `POST /api/v1/form-drafts/{id}/submit` (Issue #484) — transitions a draft
+ * from `status = 'draft'` to `'submitted'`. Reuses the `update` ABAC action
+ * (submitting is a state transition on an existing draft, not a distinct
+ * permission — same reasoning `workflow.approval.approve` uses for both
+ * approve/reject).
+ *
+ * High-risk mutation: requires `Idempotency-Key`, same replay/conflict shape
+ * as `workflows/tasks/{id}/decisions.ts` — a network retry after the
+ * transition already committed must return the original response, not a
+ * second submission or a confusing error.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const draftId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!draftId) {
+    return fail(400, "VALIDATION_ERROR", "Form draft id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ draftId });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(
+    sql,
+    tenantId,
+    async (tx) => {
+      const auth = await authorizeInTransaction(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        SUBMIT_GUARD
+      );
+
+      if (!auth.allowed) {
+        return auth.denied;
+      }
+
+      const existingIdempotency = await findIdempotencyRecord(
+        tx,
+        tenantId,
+        IDEMPOTENCY_SCOPE,
+        idempotencyKey
+      );
+
+      if (existingIdempotency) {
+        if (existingIdempotency.requestHash !== requestHash) {
+          return fail(
+            409,
+            "IDEMPOTENCY_CONFLICT",
+            "Idempotency-Key was already used with a different request."
+          );
+        }
+
+        return jsonResponse(existingIdempotency.responseBody, {
+          status: existingIdempotency.responseStatus
+        });
+      }
+
+      const draft = await submitFormDraft(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        draftId
+      );
+
+      if (!draft) {
+        return fail(
+          404,
+          "RESOURCE_NOT_FOUND",
+          "Form draft not found, already submitted, or no longer editable."
+        );
+      }
+
+      await recordAuditEvent(tx, {
+        tenantId,
+        actorTenantUserId: auth.context.tenantUserId,
+        moduleKey: "form_drafts",
+        action: "submit",
+        resourceType: "form_draft",
+        resourceId: draftId,
+        severity: "warning",
+        message: `Form draft submitted for ${draft.moduleKey}/${draft.wizardKey}.`,
+        attributes: { moduleKey: draft.moduleKey, wizardKey: draft.wizardKey },
+        correlationId
+      });
+
+      const successResponse = ok(draft);
+      const successBody = await successResponse.clone().json();
+
+      await saveIdempotencyRecord(
+        tx,
+        tenantId,
+        IDEMPOTENCY_SCOPE,
+        idempotencyKey,
+        requestHash,
+        200,
+        successBody
+      );
+
+      return successResponse;
+    },
+    { workClass: "interactive" }
+  );
+};

--- a/src/pages/api/v1/form-drafts/index.ts
+++ b/src/pages/api/v1/form-drafts/index.ts
@@ -1,0 +1,163 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  createFormDraft,
+  listFormDrafts
+} from "../../../../modules/form-drafts/application/form-draft-directory";
+import { validateCreateFormDraftInput } from "../../../../modules/form-drafts/domain/form-draft-validation";
+
+const READ_GUARD = {
+  moduleKey: "form_drafts",
+  activityCode: "draft",
+  action: "read" as const
+};
+
+const CREATE_GUARD = {
+  moduleKey: "form_drafts",
+  activityCode: "draft",
+  action: "create" as const
+};
+
+const VALID_STATUSES = new Set(["draft", "submitted", "abandoned", "expired"]);
+
+/**
+ * `GET /api/v1/form-drafts` (Issue #484) — list the caller's own tenant's
+ * non-deleted drafts, optionally filtered by `moduleKey`/`wizardKey`/
+ * `status` query params (e.g. a page resuming its own wizard queries
+ * `?moduleKey=admin_examples&wizardKey=wizard_fixture&status=draft`).
+ */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const statusParam = url.searchParams.get("status");
+
+  if (statusParam && !VALID_STATUSES.has(statusParam)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "status must be one of draft, submitted, abandoned, expired."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const drafts = await listFormDrafts(tx, tenantId, {
+      moduleKey: url.searchParams.get("moduleKey") ?? undefined,
+      wizardKey: url.searchParams.get("wizardKey") ?? undefined,
+      status:
+        (statusParam as
+          "draft" | "submitted" | "abandoned" | "expired" | null) ?? undefined
+    });
+
+    return ok({ drafts });
+  });
+};
+
+/**
+ * `POST /api/v1/form-drafts` — create a new draft. Not treated as high-risk
+ * (no `Idempotency-Key` required): worst case for a network retry is one
+ * extra low-value scratch row the caller can delete, not a domain-level
+ * side effect — unlike `submit`, which really does need one (see
+ * `[id]/submit.ts`).
+ */
+export const POST: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const validation = validateCreateFormDraftInput(
+    await request.json().catch(() => null)
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Form draft input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CREATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const draft = await createFormDraft(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      input
+    );
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "form_drafts",
+      action: "create",
+      resourceType: "form_draft",
+      resourceId: draft.id,
+      severity: "info",
+      message: `Form draft created for ${input.moduleKey}/${input.wizardKey}.`,
+      attributes: {
+        moduleKey: input.moduleKey,
+        wizardKey: input.wizardKey,
+        resourceType: input.resourceType
+      }
+    });
+
+    return ok(draft);
+  });
+};

--- a/tests/form-draft-validation.test.ts
+++ b/tests/form-draft-validation.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  MAX_PAYLOAD_BYTES,
+  findForbiddenPayloadKey,
+  validateCreateFormDraftInput,
+  validateUpdateFormDraftInput
+} from "../src/modules/form-drafts/domain/form-draft-validation";
+
+describe("findForbiddenPayloadKey", () => {
+  test("finds a forbidden key at the top level", () => {
+    expect(findForbiddenPayloadKey({ password: "x" })).toBe("password");
+  });
+
+  test("finds a forbidden key nested inside an object", () => {
+    expect(findForbiddenPayloadKey({ auth: { apiKey: "x" } })).toBe(
+      "auth.apiKey"
+    );
+  });
+
+  test("finds a forbidden key nested inside an array of objects", () => {
+    expect(
+      findForbiddenPayloadKey({ items: [{ title: "ok" }, { token: "x" }] })
+    ).toBe("items[1].token");
+  });
+
+  test("matches common separator variants (api_key, api-key, apiKey)", () => {
+    expect(findForbiddenPayloadKey({ api_key: "x" })).toBe("api_key");
+    expect(findForbiddenPayloadKey({ "api-key": "x" })).toBe("api-key");
+    expect(findForbiddenPayloadKey({ privateKey: "x" })).toBe("privateKey");
+  });
+
+  test("returns null for a payload with no forbidden keys", () => {
+    expect(
+      findForbiddenPayloadKey({ title: "Demo", category: "general" })
+    ).toBeNull();
+  });
+
+  test("does not flag a benign key that merely contains a similar substring boundary safely", () => {
+    // "keyword" contains "key" but not as a secret-shaped field name on its
+    // own — this documents current (intentionally simple, pattern-based)
+    // behavior rather than asserting a stricter semantic boundary.
+    expect(findForbiddenPayloadKey({ keyword: "x" })).toBeNull();
+  });
+});
+
+describe("validateCreateFormDraftInput", () => {
+  const validBody = {
+    moduleKey: "admin_examples",
+    wizardKey: "wizard_fixture",
+    resourceType: "fixture",
+    currentStep: "basic",
+    payload: { title: "Demo" }
+  };
+
+  test("accepts a well-formed create request", () => {
+    const result = validateCreateFormDraftInput(validBody);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.moduleKey).toBe("admin_examples");
+      expect(result.value.payload).toEqual({ title: "Demo" });
+    }
+  });
+
+  test("rejects a moduleKey that isn't lowercase snake_case", () => {
+    const result = validateCreateFormDraftInput({
+      ...validBody,
+      moduleKey: "Admin-Examples"
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "moduleKey")).toBe(true);
+    }
+  });
+
+  test("rejects a payload containing a forbidden field", () => {
+    const result = validateCreateFormDraftInput({
+      ...validBody,
+      payload: { title: "Demo", password: "hunter2" }
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors[0]!.field).toBe("payload");
+      expect(result.errors[0]!.message).toContain("password");
+    }
+  });
+
+  test("rejects a payload larger than the max size", () => {
+    const result = validateCreateFormDraftInput({
+      ...validBody,
+      payload: { blob: "x".repeat(MAX_PAYLOAD_BYTES) }
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors[0]!.field).toBe("payload");
+    }
+  });
+
+  test("rejects a missing currentStep", () => {
+    const { currentStep: _omit, ...withoutStep } = validBody;
+    const result = validateCreateFormDraftInput(withoutStep);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.field === "currentStep")).toBe(true);
+    }
+  });
+
+  test("rejects a non-object payload", () => {
+    const result = validateCreateFormDraftInput({
+      ...validBody,
+      payload: "not-an-object"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("accepts an optional resourceId and expiresAt", () => {
+    const result = validateCreateFormDraftInput({
+      ...validBody,
+      resourceId: "draft-target-1",
+      expiresAt: "2026-08-01T00:00:00.000Z"
+    });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.resourceId).toBe("draft-target-1");
+      expect(result.value.expiresAt).toBe("2026-08-01T00:00:00.000Z");
+    }
+  });
+
+  test("rejects an invalid expiresAt", () => {
+    const result = validateCreateFormDraftInput({
+      ...validBody,
+      expiresAt: "not-a-date"
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("validateUpdateFormDraftInput", () => {
+  test("accepts a partial update with only payload", () => {
+    const result = validateUpdateFormDraftInput({ payload: { title: "New" } });
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects an empty body", () => {
+    const result = validateUpdateFormDraftInput({});
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a payload with a forbidden field on update too", () => {
+    const result = validateUpdateFormDraftInput({
+      payload: { token: "abc" }
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("accepts explicit null to clear expiresAt", () => {
+    const result = validateUpdateFormDraftInput({ expiresAt: null });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.expiresAt).toBeNull();
+    }
+  });
+});

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -58,8 +58,8 @@ describe("soft delete helper", () => {
 });
 
 describe("module registry", () => {
-  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, and workflow are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, and 11.1", () => {
-    expect(listModules()).toHaveLength(7);
+  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, and form_drafts are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, and #484", () => {
+    expect(listModules()).toHaveLength(8);
     expect(getModuleByKey("tenant_admin")).toMatchObject({
       key: "tenant_admin",
       status: "active"
@@ -93,6 +93,11 @@ describe("module registry", () => {
       key: "workflow",
       status: "active",
       dependencies: ["tenant_admin", "identity_access"]
+    });
+    expect(getModuleByKey("form_drafts")).toMatchObject({
+      key: "form_drafts",
+      status: "active",
+      dependencies: ["identity_access"]
     });
     expect(getModuleByKey("unknown_module")).toBeUndefined();
   });
@@ -191,7 +196,8 @@ describe("database migration runner helpers", () => {
       "015_awcms_mini_tenant_settings_management_permission_schema.sql",
       "016_awcms_mini_tenant_default_locale_english_schema.sql",
       "017_awcms_mini_sync_queue_conflict_performance_indexes.sql",
-      "018_awcms_mini_object_sync_queue_dispatcher_schema.sql"
+      "018_awcms_mini_object_sync_queue_dispatcher_schema.sql",
+      "019_awcms_mini_form_drafts_schema.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/form-drafts.integration.test.ts
+++ b/tests/integration/form-drafts.integration.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Integration tests for the Form Drafts API (Issue #484). Exercises the real
+ * handlers against a real PostgreSQL via the shared harness — CRUD + submit
+ * flow, RLS tenant isolation, ABAC default-deny, denylist rejection at the
+ * endpoint level (not just the pure validator), submit idempotency, and the
+ * retention/expiry application functions (not exposed over HTTP, so called
+ * directly like `audit-purge.test.ts` presumably does for its own job).
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import {
+  GET as listDrafts,
+  POST as createDraft
+} from "../../src/pages/api/v1/form-drafts/index";
+import {
+  DELETE as deleteDraft,
+  GET as getDraft,
+  PATCH as updateDraft
+} from "../../src/pages/api/v1/form-drafts/[id]";
+import { POST as submitDraft } from "../../src/pages/api/v1/form-drafts/[id]/submit";
+import {
+  expireOverdueFormDrafts,
+  purgeExpiredFormDrafts
+} from "../../src/modules/form-drafts/application/form-draft-purge";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string };
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: `${tenantCode}-${OWNER_LOGIN}`,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: {
+      loginIdentifier: `${tenantCode}-${OWNER_LOGIN}`,
+      password: OWNER_PASSWORD
+    },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId, token: login.body.data.token };
+}
+
+function authHeaders(b: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": b.tenantId,
+    authorization: `Bearer ${b.token}`
+  };
+}
+
+type DraftBody = {
+  id: string;
+  moduleKey: string;
+  wizardKey: string;
+  currentStep: string;
+  payload: Record<string, unknown>;
+  status: string;
+};
+
+async function createTestDraft(b: Bootstrap): Promise<DraftBody> {
+  const res = await invoke<{ data: DraftBody }>(createDraft, {
+    method: "POST",
+    path: "/api/v1/form-drafts",
+    headers: authHeaders(b),
+    body: {
+      moduleKey: "admin_examples",
+      wizardKey: "wizard_fixture",
+      resourceType: "fixture",
+      currentStep: "basic",
+      payload: { title: "Demo" }
+    }
+  });
+  expect(res.status).toBe(200);
+  return res.body.data;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("Form Drafts API (real Postgres)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("creates, reads, updates, and lists a draft", async () => {
+    const b = await bootstrap();
+    const draft = await createTestDraft(b);
+
+    expect(draft.status).toBe("draft");
+    expect(draft.payload).toEqual({ title: "Demo" });
+
+    const read = await invoke<{ data: DraftBody }>(getDraft, {
+      method: "GET",
+      path: `/api/v1/form-drafts/${draft.id}`,
+      headers: authHeaders(b),
+      params: { id: draft.id }
+    });
+    expect(read.status).toBe(200);
+    expect(read.body.data.currentStep).toBe("basic");
+
+    const updated = await invoke<{ data: DraftBody }>(updateDraft, {
+      method: "PATCH",
+      path: `/api/v1/form-drafts/${draft.id}`,
+      headers: authHeaders(b),
+      params: { id: draft.id },
+      body: { currentStep: "details", payload: { title: "Demo", notes: "x" } }
+    });
+    expect(updated.status).toBe(200);
+    expect(updated.body.data.currentStep).toBe("details");
+    expect(updated.body.data.payload).toEqual({ title: "Demo", notes: "x" });
+
+    const list = await invoke<{ data: { drafts: DraftBody[] } }>(listDrafts, {
+      method: "GET",
+      path: "/api/v1/form-drafts?moduleKey=admin_examples&wizardKey=wizard_fixture",
+      headers: authHeaders(b)
+    });
+    expect(list.status).toBe(200);
+    expect(list.body.data.drafts).toHaveLength(1);
+    expect(list.body.data.drafts[0]!.id).toBe(draft.id);
+  });
+
+  test("rejects a create request whose payload contains a forbidden field", async () => {
+    const b = await bootstrap();
+
+    const res = await invoke<{ error: { code: string; details: unknown } }>(
+      createDraft,
+      {
+        method: "POST",
+        path: "/api/v1/form-drafts",
+        headers: authHeaders(b),
+        body: {
+          moduleKey: "admin_examples",
+          wizardKey: "wizard_fixture",
+          resourceType: "fixture",
+          currentStep: "basic",
+          payload: { title: "Demo", password: "hunter2" }
+        }
+      }
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  test("submit transitions draft->submitted and is idempotent on retry with the same key", async () => {
+    const b = await bootstrap();
+    const draft = await createTestDraft(b);
+    const idempotencyKey = "test-submit-key-0001";
+
+    const first = await invoke<{ data: DraftBody }>(submitDraft, {
+      method: "POST",
+      path: `/api/v1/form-drafts/${draft.id}/submit`,
+      headers: { ...authHeaders(b), "idempotency-key": idempotencyKey },
+      params: { id: draft.id }
+    });
+    expect(first.status).toBe(200);
+    expect(first.body.data.status).toBe("submitted");
+
+    // Retry with the same key -> replay, not a second transition/error.
+    const retry = await invoke<{ data: DraftBody }>(submitDraft, {
+      method: "POST",
+      path: `/api/v1/form-drafts/${draft.id}/submit`,
+      headers: { ...authHeaders(b), "idempotency-key": idempotencyKey },
+      params: { id: draft.id }
+    });
+    expect(retry.status).toBe(200);
+    expect(retry.body.data.id).toBe(draft.id);
+
+    // A second, genuinely new submit attempt on an already-submitted draft
+    // (different key) is rejected — nothing left to transition.
+    const secondAttempt = await invoke<{ error: { code: string } }>(
+      submitDraft,
+      {
+        method: "POST",
+        path: `/api/v1/form-drafts/${draft.id}/submit`,
+        headers: { ...authHeaders(b), "idempotency-key": "different-key" },
+        params: { id: draft.id }
+      }
+    );
+    expect(secondAttempt.status).toBe(404);
+  });
+
+  test("submit requires an Idempotency-Key header", async () => {
+    const b = await bootstrap();
+    const draft = await createTestDraft(b);
+
+    const res = await invoke<{ error: { code: string } }>(submitDraft, {
+      method: "POST",
+      path: `/api/v1/form-drafts/${draft.id}/submit`,
+      headers: authHeaders(b),
+      params: { id: draft.id }
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("IDEMPOTENCY_REQUIRED");
+  });
+
+  test("delete (abandon) is idempotent-safe — repeating it returns 404, not a duplicate side effect", async () => {
+    const b = await bootstrap();
+    const draft = await createTestDraft(b);
+
+    const first = await invoke<{ data: { deleted: boolean } }>(deleteDraft, {
+      method: "DELETE",
+      path: `/api/v1/form-drafts/${draft.id}`,
+      headers: authHeaders(b),
+      params: { id: draft.id }
+    });
+    expect(first.status).toBe(200);
+    expect(first.body.data.deleted).toBe(true);
+
+    const second = await invoke<{ error: { code: string } }>(deleteDraft, {
+      method: "DELETE",
+      path: `/api/v1/form-drafts/${draft.id}`,
+      headers: authHeaders(b),
+      params: { id: draft.id }
+    });
+    expect(second.status).toBe(404);
+  });
+
+  test("a deleted/submitted draft is no longer editable via PATCH", async () => {
+    const b = await bootstrap();
+    const draft = await createTestDraft(b);
+
+    await invoke(deleteDraft, {
+      method: "DELETE",
+      path: `/api/v1/form-drafts/${draft.id}`,
+      headers: authHeaders(b),
+      params: { id: draft.id }
+    });
+
+    const patch = await invoke<{ error: { code: string } }>(updateDraft, {
+      method: "PATCH",
+      path: `/api/v1/form-drafts/${draft.id}`,
+      headers: authHeaders(b),
+      params: { id: draft.id },
+      body: { currentStep: "details" }
+    });
+    expect(patch.status).toBe(404);
+  });
+
+  test("tenant A cannot read, update, or list tenant B's draft (RLS FORCE)", async () => {
+    // `POST /setup/initialize` is a once-per-database singleton lock (see
+    // `awcms_mini_setup_state`) — it cannot be called twice to create a
+    // second tenant. Tenant B is inserted directly as the admin/superuser
+    // role instead, same as `settings.integration.test.ts`'s cross-tenant
+    // test does, bypassing RLS on purpose to seed the fixture.
+    const a = await bootstrap("acme", "Acme");
+
+    const admin = getAdminSql();
+    const tenantBId = crypto.randomUUID();
+    await admin`
+      INSERT INTO awcms_mini_tenants (id, tenant_code, tenant_name)
+      VALUES (${tenantBId}, 'beta', 'Beta')
+    `;
+    const draftBRows = (await admin`
+      INSERT INTO awcms_mini_form_drafts
+        (tenant_id, module_key, wizard_key, resource_type, current_step, payload, created_by, updated_by)
+      VALUES (
+        ${tenantBId}, 'admin_examples', 'wizard_fixture', 'fixture', 'basic',
+        ${{ title: "Beta secret draft" }}, ${crypto.randomUUID()}, ${crypto.randomUUID()}
+      )
+      RETURNING id
+    `) as { id: string }[];
+    const draftB = { id: draftBRows[0]!.id };
+
+    const readAsA = await invoke<{ error: { code: string } }>(getDraft, {
+      method: "GET",
+      path: `/api/v1/form-drafts/${draftB.id}`,
+      headers: authHeaders(a),
+      params: { id: draftB.id }
+    });
+    expect(readAsA.status).toBe(404);
+
+    const listAsA = await invoke<{ data: { drafts: DraftBody[] } }>(
+      listDrafts,
+      {
+        method: "GET",
+        path: "/api/v1/form-drafts",
+        headers: authHeaders(a)
+      }
+    );
+    expect(listAsA.body.data.drafts).toHaveLength(0);
+
+    // Confirm tenant B's row genuinely still exists (RLS filtered it from A,
+    // rather than it never having been created).
+    const rows = (await admin`
+      SELECT id FROM awcms_mini_form_drafts WHERE id = ${draftB.id}
+    `) as { id: string }[];
+    expect(rows).toHaveLength(1);
+  });
+
+  test("default-deny: a role-less user cannot use any form-drafts endpoint", async () => {
+    const b = await bootstrap();
+
+    const sql = getAdminSql();
+    const passwordHash = await Bun.password.hash("norole-password-123456");
+    await sql.begin(async (tx) => {
+      await tx.unsafe(`SET LOCAL app.current_tenant_id = '${b.tenantId}'`);
+      const profile = (await tx`
+        INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+        VALUES (${b.tenantId}, 'person', 'No Role') RETURNING id
+      `) as { id: string }[];
+      const identity = (await tx`
+        INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+        VALUES (${b.tenantId}, ${profile[0]!.id}, 'norole-drafts@example.com', ${passwordHash})
+        RETURNING id
+      `) as { id: string }[];
+      await tx`
+        INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+        VALUES (${b.tenantId}, ${identity[0]!.id})
+      `;
+    });
+
+    const login = await invoke<{ data: { token: string } }>(authLogin, {
+      method: "POST",
+      path: "/api/v1/auth/login",
+      headers: {
+        "content-type": "application/json",
+        "x-awcms-mini-tenant-id": b.tenantId
+      },
+      body: {
+        loginIdentifier: "norole-drafts@example.com",
+        password: "norole-password-123456"
+      },
+      cookies: createCookieJar()
+    });
+    expect(login.status).toBe(200);
+    const headers = {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": b.tenantId,
+      authorization: `Bearer ${login.body.data.token}`
+    };
+
+    const list = await invoke<{ error: { code: string } }>(listDrafts, {
+      method: "GET",
+      path: "/api/v1/form-drafts",
+      headers
+    });
+    expect(list.status).toBe(403);
+
+    const create = await invoke<{ error: { code: string } }>(createDraft, {
+      method: "POST",
+      path: "/api/v1/form-drafts",
+      headers,
+      body: {
+        moduleKey: "admin_examples",
+        wizardKey: "wizard_fixture",
+        resourceType: "fixture",
+        currentStep: "basic",
+        payload: {}
+      }
+    });
+    expect(create.status).toBe(403);
+  });
+
+  test("expireOverdueFormDrafts transitions an overdue draft to expired and audits it", async () => {
+    const b = await bootstrap();
+    const draft = await createTestDraft(b);
+
+    const admin = getAdminSql();
+    await admin`
+      UPDATE awcms_mini_form_drafts
+      SET expires_at = now() - interval '1 hour'
+      WHERE id = ${draft.id}
+    `;
+
+    const result = await expireOverdueFormDrafts(admin, b.tenantId);
+    expect(result.expiredCount).toBe(1);
+
+    const rows = (await admin`
+      SELECT status FROM awcms_mini_form_drafts WHERE id = ${draft.id}
+    `) as { status: string }[];
+    expect(rows[0]!.status).toBe("expired");
+
+    const auditRows = (await admin`
+      SELECT action FROM awcms_mini_audit_events
+      WHERE tenant_id = ${b.tenantId} AND module_key = 'form_drafts' AND action = 'expire'
+    `) as { action: string }[];
+    expect(auditRows).toHaveLength(1);
+  });
+
+  test("purgeExpiredFormDrafts physically deletes an old expired draft past retention, and audits the purge", async () => {
+    const b = await bootstrap();
+    const draft = await createTestDraft(b);
+
+    const admin = getAdminSql();
+    await admin`
+      UPDATE awcms_mini_form_drafts
+      SET status = 'expired', updated_at = now() - interval '31 days'
+      WHERE id = ${draft.id}
+    `;
+
+    const result = await purgeExpiredFormDrafts(admin, b.tenantId, {
+      retentionDays: 30
+    });
+    expect(result.purgedCount).toBe(1);
+
+    const rows = (await admin`
+      SELECT id FROM awcms_mini_form_drafts WHERE id = ${draft.id}
+    `) as { id: string }[];
+    expect(rows).toHaveLength(0);
+
+    const auditRows = (await admin`
+      SELECT action FROM awcms_mini_audit_events
+      WHERE tenant_id = ${b.tenantId} AND module_key = 'form_drafts' AND action = 'purge'
+    `) as { action: string }[];
+    expect(auditRows).toHaveLength(1);
+  });
+
+  test("purgeExpiredFormDrafts does not delete a recently-expired draft still within retention", async () => {
+    const b = await bootstrap();
+    const draft = await createTestDraft(b);
+
+    const admin = getAdminSql();
+    await admin`
+      UPDATE awcms_mini_form_drafts
+      SET status = 'expired', updated_at = now() - interval '1 day'
+      WHERE id = ${draft.id}
+    `;
+
+    const result = await purgeExpiredFormDrafts(admin, b.tenantId, {
+      retentionDays: 30
+    });
+    expect(result.purgedCount).toBe(0);
+
+    const rows = (await admin`
+      SELECT id FROM awcms_mini_form_drafts WHERE id = ${draft.id}
+    `) as { id: string }[];
+    expect(rows).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Issue #484's own dependency gate ("wizard pattern used by 2 real domain modules") was explicitly waived by the maintainer after #482/#483 landed, with a concrete pilot plan. Chose the wizard fixture as the pilot (lower risk than touching the production settings screen) while still proving the full loop end-to-end.
- **Migration 019**: `awcms_mini_form_drafts` (tenant-scoped, `ENABLE`+`FORCE RLS` inline, format-check constraints on `module_key`/`wizard_key`). `resource_id` is `text` (not the doc's original `uuid` suggestion) — reconciled to match `workflow_instances`/`audit_events` precedent.
- **`src/modules/form-drafts/`**: domain validation (recursive secret-shaped-field denylist, 32KB payload cap, key format) + application layer (CRUD/submit + two-stage retention mirroring `audit-purge.ts`'s bounded-batch-plus-self-audit shape).
- **Five endpoints** under `/api/v1/form-drafts`, ABAC-guarded. Only `submit` requires `Idempotency-Key` — create/update/delete are each idempotent by construction, so a key there would be friction with no safety benefit.
- **`bun run form-drafts:purge`**, OpenAPI paths/schemas, and a new `awcms-mini-form-drafts` skill (split from `awcms-mini-wizard-form`, same as idempotency/audit-log each having their own).
- **Pilot wiring** in `admin/examples/wizard.astro`: SSR resume-on-load via the application layer directly, autosave on Next/Back, real `Idempotency-Key` submit replacing #483's local mock.

## Testing
- [x] `bun run check` (lint, check:docs, api:spec:check, typecheck, 357 unit tests, build) — all green
- [x] **Live end-to-end verification against real PostgreSQL 18.4** (not just the test suite): ran migration 019, then exercised create → resume-on-reload → update → submit → idempotent-replay → denylist-rejection → retention-purge through the actual running server and real HTTP requests (Astro's `checkOrigin` CSRF guard included, confirmed it correctly blocks a cross-origin-looking `POST` without an `Origin` header)
- [x] **11 integration tests** against the same live database: RLS FORCE (tenant isolation), ABAC default-deny, submit idempotency + replay, delete idempotent-safety, retention expire + purge — all pass
- [x] Fixed a real bug found while writing the RLS test: `POST /setup/initialize` is a once-per-database singleton lock, so bootstrapping a second tenant needs a direct admin-SQL insert (matching `settings.integration.test.ts`'s existing pattern), not a second `bootstrap()` call
- [x] Updated two pre-existing unit tests (module-registry count 7→8, migration-list assertion) for the new module/migration — legitimate updates, not test-weakening
- Not applicable: 2 unrelated `check-docs-integration.test.mjs` failures seen only inside a throwaway Docker container running the suite (missing `git` binary in the minimal `oven/bun:1` image) — confirmed passing on host where `git` is available; not a regression

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)