### PR TITLE
feat(email): add bulk announcement/notification workflows

### DIFF
--- a/.claude/skills/awcms-mini-email/SKILL.md
+++ b/.claude/skills/awcms-mini-email/SKILL.md
@@ -28,16 +28,24 @@ Ikuti `src/modules/email/README.md` (arsitektur lengkap: kontrak provider, adapt
    (`{templateKey, name, subjectTemplate: {en, id?}, textBodyTemplate?, htmlBodyTemplate?}`)
    atau `seedDefaultEmailTemplates` untuk kategori base bawaan
    (`bun run email:templates:seed-defaults -- --tenant=<id> --actor=<tenantUserId>`).
-3. **Enqueue** — INSERT langsung ke `awcms_mini_email_messages` (`sql/020`)
-   di dalam transaksi bisnis Anda sendiri (ADR-0006: pemanggilan provider
-   **tidak boleh** di dalam transaction — outbox pattern yang memisahkan
-   ini). Isi `to_address`/`to_address_hash`/`to_address_masked` pakai
-   `normalizeIdentifier("email", ...)`/`hashIdentifier`/`maskIdentifier`
-   (`profile-identity/domain/identifier.ts` — reuse, jangan bikin ulang),
-   `template_key` = kategori Anda, `variables` (jsonb) = hanya nilai yang
-   akan lolos allowlist kategori itu (nilai lain diam-diam tidak pernah
-   disubstitusi saat render), `subject` = subjek final (dirender/ditentukan
-   saat enqueue, bukan saat dispatch).
+3. **Enqueue** — dua opsi:
+   - **Bulk/announcement ke user/role/tenant** — pakai
+     `POST /api/v1/email/announcements` (Issue #497) alih-alih menulis
+     manual: sudah menangani targeting (`{type: "users"|"role"|"tenant"}`),
+     filter suppression list, ABAC dua-tingkat, `Idempotency-Key` wajib,
+     dan audit satu baris per request. `POST .../preview` untuk dry-run
+     (jumlah + sampel render, tidak pernah daftar penerima nyata).
+   - **Kasus lain (mis. modul domain turunan sendiri)** — INSERT langsung
+     ke `awcms_mini_email_messages` (`sql/020`) di dalam transaksi bisnis
+     Anda sendiri (ADR-0006: pemanggilan provider **tidak boleh** di dalam
+     transaction — outbox pattern yang memisahkan ini). Isi
+     `to_address`/`to_address_hash`/`to_address_masked` pakai
+     `normalizeIdentifier("email", ...)`/`hashIdentifier`/`maskIdentifier`
+     (`profile-identity/domain/identifier.ts` — reuse, jangan bikin ulang),
+     `template_key` = kategori Anda, `variables` (jsonb) = hanya nilai yang
+     akan lolos allowlist kategori itu (nilai lain diam-diam tidak pernah
+     disubstitusi saat render), `subject` = subjek final
+     (dirender/ditentukan saat enqueue, bukan saat dispatch).
 4. **Dispatcher** (`bun run email:dispatch`, dijadwalkan cron/systemd
    timer/k8s CronJob) yang mengirim sungguhan — Anda tidak pernah memanggil
    provider langsung.
@@ -76,7 +84,9 @@ Ikuti `src/modules/email/README.md` (arsitektur lengkap: kontrak provider, adapt
 
 `awcms-mini-integration` (pola outbox/retry/circuit-breaker generik),
 `awcms-mini-sensitive-data` (normalize/hash/mask alamat email),
-`awcms-mini-idempotency` (Issue #496/#497's endpoint enqueue akan
-membutuhkan ini untuk mutation high-risk), `awcms-mini-abac-guard`
-(permission `email.template.*` sudah diseed, ikuti pola guard yang sama
-untuk endpoint baru).
+`awcms-mini-idempotency` (`POST /email/announcements` mewajibkan
+`Idempotency-Key` di setiap request, bukan hanya bulk), `awcms-mini-abac-guard`
+(permission `email.template.*`/`email.notification.create`/
+`email.announcement.create` sudah diseed — `announcement.create` **selalu
+tambahan** di atas `notification.create` untuk target role/tenant, contoh
+nyata pola "permission bertingkat untuk aksi bulk vs tunggal").

--- a/asyncapi/awcms-mini-domain-events.asyncapi.yaml
+++ b/asyncapi/awcms-mini-domain-events.asyncapi.yaml
@@ -33,6 +33,39 @@ channels:
       from `withTenant` (`src/lib/database/tenant-context.ts`), consistent
       with how AsyncAPI events have been documented since Issue 0.3 without
       requiring a live producer.
+  awcms-mini.email.message.queued:
+    address: awcms-mini.email.message.queued
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      An email message was enqueued into `awcms_mini_email_messages` (Issue
+      #494/#497). Documented contract only, same convention as
+      `database.pool.saturated` above — the concrete producer is the
+      structured JSON logger, invoked from
+      `email/application/announcement-directory.ts`'s `enqueueAnnouncement`
+      (`email.message.queued` log line).
+  awcms-mini.email.message.sent:
+    address: awcms-mini.email.message.sent
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      The email dispatcher (Issue #495, `bun run email:dispatch`)
+      successfully delivered a message through the configured provider.
+      Documented contract only; producer is the structured JSON logger
+      (`email/application/email-dispatch.ts`'s `email.dispatch.sent` log
+      line).
+  awcms-mini.email.message.failed:
+    address: awcms-mini.email.message.failed
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      The email dispatcher exhausted retries (or hit a non-retryable
+      failure) for a queued message. Documented contract only; producer is
+      the structured JSON logger (`email/application/email-dispatch.ts`'s
+      `email.dispatch.failed` log line).
 operations:
   publishSyncPushRequested:
     action: send
@@ -46,6 +79,24 @@ operations:
       $ref: "#/channels/awcms-mini.database.pool.saturated"
     messages:
       - $ref: "#/channels/awcms-mini.database.pool.saturated/messages/DomainEvent"
+  publishEmailMessageQueued:
+    action: send
+    channel:
+      $ref: "#/channels/awcms-mini.email.message.queued"
+    messages:
+      - $ref: "#/channels/awcms-mini.email.message.queued/messages/DomainEvent"
+  publishEmailMessageSent:
+    action: send
+    channel:
+      $ref: "#/channels/awcms-mini.email.message.sent"
+    messages:
+      - $ref: "#/channels/awcms-mini.email.message.sent/messages/DomainEvent"
+  publishEmailMessageFailed:
+    action: send
+    channel:
+      $ref: "#/channels/awcms-mini.email.message.failed"
+    messages:
+      - $ref: "#/channels/awcms-mini.email.message.failed/messages/DomainEvent"
 components:
   securitySchemes:
     syncHmac:

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -2431,6 +2431,110 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/email/announcements:
+    post:
+      tags:
+        - Email Announcements
+      summary: >-
+        Enqueue a notification/announcement to an explicit user list, a
+        role, or the whole tenant
+      operationId: emailAnnouncementsCreate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AnnouncementRequest"
+      responses:
+        "200":
+          description: Announcement enqueued.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AnnouncementCreateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: No active template found for the given templateKey.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: Idempotency-Key reused with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/email/announcements/preview:
+    post:
+      tags:
+        - Email Announcements
+      summary: >-
+        Dry-run: resolves the same targeting criteria as a real send and
+        returns a recipient count plus a synthetic-data sample render —
+        never the actual recipient list
+      operationId: emailAnnouncementsPreview
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AnnouncementRequest"
+      responses:
+        "200":
+          description: Preview result.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AnnouncementPreviewResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: No active template found for the given templateKey.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/health:
     get:
       tags:
@@ -4513,6 +4617,77 @@ components:
           type: string
         htmlBody:
           type: string
+    AnnouncementTarget:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum: [users, role, tenant]
+        userIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: Required when type is "users".
+        roleId:
+          type: string
+          format: uuid
+          description: Required when type is "role".
+    AnnouncementRequest:
+      type: object
+      required:
+        - templateKey
+        - target
+      additionalProperties: false
+      properties:
+        templateKey:
+          type: string
+          description: A recognized base category or registered "derived.*" category.
+        variables:
+          type: object
+          additionalProperties:
+            type: string
+        target:
+          $ref: "#/components/schemas/AnnouncementTarget"
+        locale:
+          type: string
+    AnnouncementCreateResponse:
+      type: object
+      required:
+        - recipientCount
+        - correlationId
+      additionalProperties: false
+      properties:
+        recipientCount:
+          type: integer
+        correlationId:
+          type: string
+    AnnouncementPreviewResponse:
+      type: object
+      required:
+        - matchedCount
+        - sample
+      additionalProperties: false
+      properties:
+        matchedCount:
+          type: integer
+          description: >-
+            Recipient count only — the actual recipient list/addresses are
+            never returned.
+        sample:
+          type: object
+          required:
+            - subject
+          additionalProperties: false
+          properties:
+            subject:
+              type: string
+            textBody:
+              type: string
+            htmlBody:
+              type: string
 security:
   - bearerAuth: []
     tenantHeader: []

--- a/sql/023_awcms_mini_email_announcement_permission_schema.sql
+++ b/sql/023_awcms_mini_email_announcement_permission_schema.sql
@@ -1,0 +1,21 @@
+-- Issue #497 (epic #492, follows #493-#496/#498) — announcement/notification
+-- email workflows. No new tables: targeting/enqueue logic reads existing
+-- tables (`awcms_mini_tenant_users`, `awcms_mini_access_assignments`,
+-- `awcms_mini_identities`, `awcms_mini_profiles`, `awcms_mini_email_
+-- suppression_list`) and writes existing `awcms_mini_email_messages`
+-- (`sql/020`) — one row per resolved recipient, sharing a correlation_id,
+-- per the "no fan-out shape" decision already documented there.
+--
+-- Two permissions, not one — issue's own acceptance criteria: "Bulk
+-- announcement should require stronger permission than ordinary
+-- notification enqueue." `email.notification.create` gates sending to an
+-- explicit, caller-chosen list of users (bounded, lower risk);
+-- `email.announcement.create` is REQUIRED IN ADDITION when targeting a
+-- role or the whole tenant (unbounded, higher risk) — a role granted only
+-- `notification.create` can message specific people it already knows
+-- about, but cannot blast every user in a role/tenant.
+INSERT INTO awcms_mini_permissions (module_key, activity_code, action, description)
+VALUES
+  ('email', 'notification', 'create', 'Enqueue an email notification to an explicit set of users'),
+  ('email', 'announcement', 'create', 'Enqueue a bulk email announcement to a role or the whole tenant')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/modules/email/README.md
+++ b/src/modules/email/README.md
@@ -1,11 +1,14 @@
 # Email
 
-Implementasi Issue #493-#496, #498 (epic #492) — arsitektur modul email
+Implementasi Issue #493-#498 (epic #492) — arsitektur modul email
 reusable, skema/RLS/delivery queue (`sql/020`/`021`), adapter Mailketing
 nyata + dispatcher, template management (CRUD, i18n, allowlist, preview),
-dan caller nyata pertama (`POST /api/v1/auth/password/forgot`/`reset`,
-`src/modules/identity-access/README.md` §Password reset). **Belum ada**
-announcement/notification workflow — itu Issue #497 (lihat §Roadmap).
+flow forgot/reset password (`POST /api/v1/auth/password/forgot`/`reset`,
+`src/modules/identity-access/README.md` §Password reset), dan
+announcement/notification bulk workflow (`POST /api/v1/email/
+announcements[/preview]`, lihat §Announcement/notification workflows di
+bawah). Semua sub-issue epic #492 sudah selesai kecuali #499/#500 (lihat
+§Roadmap).
 
 ## Kenapa modul ini ada — hubungan dengan historical issue #390
 
@@ -48,8 +51,9 @@ tempat lain.
 
 **Ditegakkan sejak Issue #495** (ADR-0006, doc 16 §Transactional outbox):
 pemanggilan provider (Mailketing) **tidak boleh** terjadi di dalam DB
-transaction. Alur nyata: caller (Issue #496/#497, belum ada) menulis baris
-`awcms_mini_email_messages` (`sql/020`) di dalam transaksi bisnisnya
+transaction. Alur nyata: caller (Issue #496's password reset, #497's
+announcements) menulis baris `awcms_mini_email_messages` (`sql/020`) di
+dalam transaksi bisnisnya
 sendiri; dispatcher terpisah (`application/email-dispatch.ts`, `bun run
 email:dispatch`) meng-claim baris dalam transaksi pendek
 (`FOR UPDATE SKIP LOCKED`, reuse `next_attempt_at` sebagai lease — pola
@@ -187,16 +191,69 @@ memang tidak mencoba. Deployment offline/LAN-first berjalan penuh tanpa
 email terkirim; begitu online dan diaktifkan, pesan yang sudah antre
 diproses dispatcher pada run berikutnya.
 
+## Announcement/notification workflows (Issue #497)
+
+`POST /api/v1/email/announcements` (bulk-capable enqueue) dan
+`POST /api/v1/email/announcements/preview` (dry-run), di
+`application/announcement-directory.ts` + `domain/announcement-validation.ts`.
+
+- **Targeting** — `target: {type: "users", userIds}` (daftar eksplisit
+  tenant_user, di-bind via `tx.array(ids, "uuid")` — bukan interpolasi
+  array langsung, gotcha `Bun.SQL` yang sudah terdokumentasi), `{type:
+"role", roleId}` (semua tenant_user aktif ber-role itu), atau `{type:
+"tenant"}` (seluruh tenant). Setiap target di-resolve hanya identity
+  **aktif** dan **tidak** ada di `awcms_mini_email_suppression_list`
+  (Issue #494's suppression list, konsumen nyata pertama).
+- **ABAC dua-tingkat** (acceptance criteria: "Bulk announcement should
+  require stronger permission than ordinary notification enqueue") —
+  `email.notification.create` wajib untuk **semua** request; `target.type
+= "role"`/`"tenant"` (unbounded) **tambahan** wajib
+  `email.announcement.create`. Role yang cuma punya permission dasar bisa
+  mengirim ke user tertentu yang sudah diketahuinya, tapi tidak bisa
+  membanjiri satu role/tenant penuh.
+- **Idempotency wajib** — `Idempotency-Key` selalu diminta (bukan hanya
+  saat bulk), reuse `_shared/idempotency.ts` (pola sama
+  `workflows/tasks/{id}/decisions.ts`).
+- **Preview aman** — resolve target yang SAMA seperti kirim nyata tapi
+  hanya mengembalikan **jumlah** (`matchedCount`) + rendering sampel data
+  sintetis (`buildSyntheticSampleVariables`, Issue #498) — tidak pernah
+  daftar/alamat penerima nyata, dan **tidak menyentuh**
+  `email_messages`/antrean sama sekali.
+- **Satu baris `email_messages` per penerima**, berbagi `correlation_id`
+  yang sama untuk satu request bulk — bukan fan-out (keputusan `sql/020`
+  di Issue #494, dikonfirmasi ulang di sini sebagai konsumen bulk nyata
+  pertamanya). Subjek dirender per-penerima (variabel `userName` = nama
+  tampilan penerima) saat enqueue, bukan saat dispatch.
+- **Audit satu baris per request** (bukan per penerima — hindari spam
+  audit untuk bulk send): `action: "announcement_sent"`, `attributes`
+  berisi `targetType`, `templateKey`, `recipientCount`, `correlationId`,
+  `dispatchStatus: "queued"` — **tidak pernah** daftar penerima nyata.
+- **Kategori baru** `system.maintenance` ditambahkan (allowlist:
+  `userName`, `maintenanceWindow`, `expectedDuration`,
+  `impactDescription`) plus default template EN/ID — kategori
+  `system.security_notice`/`workflow.task_assigned`/
+  `workflow.decision_required`/`derived.transactional` yang relevan sudah
+  ada sejak Issue #498.
+- **Event AsyncAPI** `awcms-mini.email.message.{queued,sent,failed}` —
+  dokumentasi kontrak saja (pola sama `database.pool.saturated`, doc 05),
+  produser nyatanya structured logger: `email.message.queued`
+  (`announcement-directory.ts`), `email.dispatch.sent`/`.failed`
+  (`email-dispatch.ts`, baris log baru ditambahkan issue ini — sebelumnya
+  hanya `email.dispatch.claimed` yang ada sejak Issue #495).
+
 ## Keamanan
 
 Tidak pernah mencatat (log) secret provider, isi lengkap `to`/subject/body,
-atau raw token apa pun terkait email (mis. token reset password, Issue
-#496, belum ada) — hanya alamat yang **di-mask** (log provider) dan respons
-provider yang sudah **diredaksi** (`domain/email-log-redaction.ts`,
-menutup pola email di teks bebas sebelum disimpan ke
-`email_delivery_attempts`/dicatat log) yang pernah tersimpan/tercatat.
-Selaras ISO/IEC 27001 Annex A (manajemen secret/config) dan ISO/IEC 27002
-(kontrol operasional).
+atau raw token apa pun terkait email (token reset password di-hash saat
+disimpan, Issue #496) — hanya alamat yang **di-mask** (log provider) dan
+respons provider yang sudah **diredaksi**
+(`domain/email-log-redaction.ts`, menutup pola email di teks bebas
+sebelum disimpan ke `email_delivery_attempts`/dicatat log) yang pernah
+tersimpan/tercatat. Selaras ISO/IEC 27001 Annex A (manajemen
+secret/config) dan ISO/IEC 27002 (kontrol operasional). Announcement
+(Issue #497) menegakkan data minimization UU PDP secara struktural:
+preview tidak pernah mengembalikan daftar penerima, audit hanya mencatat
+jumlah bukan daftar, dan targeting selalu memfilter suppression list.
 
 ## Roadmap (epic #492)
 
@@ -206,7 +263,8 @@ Selaras ISO/IEC 27001 Annex A (manajemen secret/config) dan ISO/IEC 27002
 - ~~**#496**~~ — flow forgot/reset password (caller pertama yang benar-benar
   meng-enqueue baris `email_messages`). **Selesai** — lihat
   `identity-access/README.md` §Password reset.
-- **#497** — announcement/notification workflow.
+- ~~**#497**~~ — announcement/notification bulk workflow. **Selesai** —
+  lihat §Announcement/notification workflows di atas.
 - **#499** — observability, security test, production readiness gate
   (termasuk automated purge job untuk `email_messages`/`_delivery_attempts`
   terminal-state, didokumentasikan di doc 04 tapi belum diimplementasikan).

--- a/src/modules/email/application/announcement-directory.ts
+++ b/src/modules/email/application/announcement-directory.ts
@@ -1,0 +1,223 @@
+/**
+ * Announcement/notification targeting + enqueue (Issue #497, epic #492).
+ * Reuses `awcms_mini_email_messages` (`sql/020`) exactly as the password
+ * reset flow (#496) does — one row per resolved recipient, sharing a
+ * `correlation_id` for a bulk send rather than a fan-out shape (the
+ * `email_recipients` table proposed in #494 was deliberately not built;
+ * this is the first real bulk-send caller that confirms that decision).
+ * Provider calls never happen here — enqueue only, dispatcher (#495)
+ * sends later, outside any transaction.
+ */
+import { log } from "../../../lib/logging/logger";
+import {
+  hashIdentifier,
+  maskIdentifier,
+  normalizeIdentifier
+} from "../../profile-identity/domain/identifier";
+import { buildSyntheticSampleVariables } from "../domain/email-template-preview";
+import { renderEmailTemplate } from "../domain/email-template-render";
+import { fetchActiveEmailTemplateByKey } from "./email-template-directory";
+import type { AnnouncementTarget } from "../domain/announcement-validation";
+
+const MODULE_KEY = "email";
+
+export type ResolvedRecipient = {
+  tenantUserId: string;
+  loginIdentifier: string;
+  displayName: string;
+};
+
+type TargetRow = {
+  tenant_user_id: string;
+  login_identifier: string;
+  display_name: string;
+};
+
+/**
+ * Active tenant_user + active identity only (skips deactivated accounts),
+ * and always excludes anyone on `awcms_mini_email_suppression_list`
+ * (bounce/complaint/manual/unsubscribe — built in #494, this is its first
+ * real consumer).
+ */
+export async function resolveAnnouncementTargets(
+  tx: Bun.SQL,
+  tenantId: string,
+  target: AnnouncementTarget
+): Promise<ResolvedRecipient[]> {
+  let rows: TargetRow[];
+
+  if (target.type === "tenant") {
+    rows = (await tx`
+      SELECT tu.id AS tenant_user_id, i.login_identifier, p.display_name
+      FROM awcms_mini_tenant_users tu
+      JOIN awcms_mini_identities i
+        ON i.id = tu.identity_id AND i.tenant_id = tu.tenant_id
+      JOIN awcms_mini_profiles p
+        ON p.id = i.profile_id AND p.tenant_id = tu.tenant_id
+      WHERE tu.tenant_id = ${tenantId} AND tu.status = 'active' AND i.status = 'active'
+    `) as TargetRow[];
+  } else if (target.type === "role") {
+    rows = (await tx`
+      SELECT tu.id AS tenant_user_id, i.login_identifier, p.display_name
+      FROM awcms_mini_access_assignments aa
+      JOIN awcms_mini_tenant_users tu
+        ON tu.id = aa.tenant_user_id AND tu.tenant_id = aa.tenant_id
+      JOIN awcms_mini_identities i
+        ON i.id = tu.identity_id AND i.tenant_id = tu.tenant_id
+      JOIN awcms_mini_profiles p
+        ON p.id = i.profile_id AND p.tenant_id = tu.tenant_id
+      WHERE aa.tenant_id = ${tenantId} AND aa.role_id = ${target.roleId}
+        AND tu.status = 'active' AND i.status = 'active'
+    `) as TargetRow[];
+  } else {
+    // `tx.array(...)` — direct `= ANY(${array})` interpolation fails with
+    // Bun.SQL (documented gotcha); array bind values must go through
+    // `tx.array(values, "type")`.
+    rows = (await tx`
+      SELECT tu.id AS tenant_user_id, i.login_identifier, p.display_name
+      FROM awcms_mini_tenant_users tu
+      JOIN awcms_mini_identities i
+        ON i.id = tu.identity_id AND i.tenant_id = tu.tenant_id
+      JOIN awcms_mini_profiles p
+        ON p.id = i.profile_id AND p.tenant_id = tu.tenant_id
+      WHERE tu.tenant_id = ${tenantId}
+        AND tu.id = ANY(${tx.array(target.userIds, "uuid")})
+        AND tu.status = 'active' AND i.status = 'active'
+    `) as TargetRow[];
+  }
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const suppressedRows = (await tx`
+    SELECT recipient_hash FROM awcms_mini_email_suppression_list
+    WHERE tenant_id = ${tenantId}
+  `) as { recipient_hash: string }[];
+  const suppressedHashes = new Set(
+    suppressedRows.map((row) => row.recipient_hash)
+  );
+
+  return rows
+    .filter((row) => {
+      const normalized = normalizeIdentifier("email", row.login_identifier);
+      return !suppressedHashes.has(hashIdentifier(normalized));
+    })
+    .map((row) => ({
+      tenantUserId: row.tenant_user_id,
+      loginIdentifier: row.login_identifier,
+      displayName: row.display_name
+    }));
+}
+
+export type AnnouncementPreviewResult = {
+  matchedCount: number;
+  sample: {
+    subject: string;
+    textBody?: string;
+    htmlBody?: string;
+  };
+};
+
+/** Never returns the resolved recipient list/addresses — count only, plus a rendered sample using synthetic data merged with any caller-supplied variables (still allowlist-filtered by `renderEmailTemplate`). */
+export async function previewAnnouncement(
+  tx: Bun.SQL,
+  tenantId: string,
+  templateKey: string,
+  variables: Record<string, string>,
+  target: AnnouncementTarget,
+  locale = "en"
+): Promise<AnnouncementPreviewResult | null> {
+  const template = await fetchActiveEmailTemplateByKey(
+    tx,
+    tenantId,
+    templateKey
+  );
+
+  if (!template) {
+    return null;
+  }
+
+  const recipients = await resolveAnnouncementTargets(tx, tenantId, target);
+  const sampleVariables = {
+    ...buildSyntheticSampleVariables(templateKey),
+    ...variables
+  };
+  const rendered = renderEmailTemplate(
+    template,
+    sampleVariables,
+    templateKey,
+    locale
+  );
+
+  return { matchedCount: recipients.length, sample: rendered };
+}
+
+export type EnqueueAnnouncementResult = {
+  recipientCount: number;
+  correlationId: string;
+};
+
+/**
+ * Returns `null` if `templateKey` has no active template — callers must
+ * check this before enqueuing (mirrors the dispatcher's own
+ * missing-template handling, #495).
+ */
+export async function enqueueAnnouncement(
+  tx: Bun.SQL,
+  tenantId: string,
+  templateKey: string,
+  variables: Record<string, string>,
+  target: AnnouncementTarget,
+  correlationId: string,
+  locale = "en"
+): Promise<EnqueueAnnouncementResult | null> {
+  const template = await fetchActiveEmailTemplateByKey(
+    tx,
+    tenantId,
+    templateKey
+  );
+
+  if (!template) {
+    return null;
+  }
+
+  const recipients = await resolveAnnouncementTargets(tx, tenantId, target);
+  const priority = target.type === "tenant" ? "normal" : "high";
+
+  for (const recipient of recipients) {
+    const normalized = normalizeIdentifier("email", recipient.loginIdentifier);
+    const recipientVariables = {
+      ...variables,
+      userName: recipient.displayName
+    };
+    const rendered = renderEmailTemplate(
+      template,
+      recipientVariables,
+      templateKey,
+      locale
+    );
+
+    await tx`
+      INSERT INTO awcms_mini_email_messages
+        (tenant_id, correlation_id, category, template_key, to_address,
+         to_address_hash, to_address_masked, subject, variables, priority)
+      VALUES (
+        ${tenantId}, ${correlationId}, ${templateKey}, ${templateKey},
+        ${normalized}, ${hashIdentifier(normalized)},
+        ${maskIdentifier("email", normalized)}, ${rendered.subject},
+        ${recipientVariables}, ${priority}
+      )
+    `;
+  }
+
+  log("info", "email.message.queued", {
+    correlationId,
+    tenantId,
+    moduleKey: MODULE_KEY,
+    category: templateKey,
+    count: recipients.length
+  });
+
+  return { recipientCount: recipients.length, correlationId };
+}

--- a/src/modules/email/application/email-dispatch.ts
+++ b/src/modules/email/application/email-dispatch.ts
@@ -378,6 +378,12 @@ export async function dispatchEmailQueue(
         env.EMAIL_PROVIDER ?? "unknown",
         deliveryResult.providerMessageId
       );
+      log("info", "email.dispatch.sent", {
+        correlationId: messageCorrelationId,
+        tenantId,
+        moduleKey: MODULE_KEY,
+        category: entry.category
+      });
       result.sent += 1;
       continue;
     }
@@ -409,8 +415,24 @@ export async function dispatchEmailQueue(
     );
 
     if (finalized.eligible) {
+      log("warning", "email.dispatch.retry_scheduled", {
+        correlationId: messageCorrelationId,
+        tenantId,
+        moduleKey: MODULE_KEY,
+        category: entry.category,
+        retryCount: retryCount + 1,
+        error: safeError
+      });
       result.retried += 1;
     } else {
+      log("error", "email.dispatch.failed", {
+        correlationId: messageCorrelationId,
+        tenantId,
+        moduleKey: MODULE_KEY,
+        category: entry.category,
+        retryCount: retryCount + 1,
+        error: safeError
+      });
       result.failed += 1;
     }
   }

--- a/src/modules/email/domain/announcement-validation.ts
+++ b/src/modules/email/domain/announcement-validation.ts
@@ -1,0 +1,173 @@
+/**
+ * Pure validation for the announcement/notification endpoints (Issue #497).
+ * Same shape/style as `email-template-validation.ts` — no I/O here;
+ * existence checks (does `roleId`/each `userId` actually exist) happen in
+ * the application layer against the database.
+ */
+import { isKnownEmailTemplateCategory } from "./email-template-categories";
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+type Result<T> =
+  { valid: true; value: T } | { valid: false; errors: ValidationError[] };
+
+export type AnnouncementTarget =
+  | { type: "users"; userIds: string[] }
+  | { type: "role"; roleId: string }
+  | { type: "tenant" };
+
+export type AnnouncementInput = {
+  templateKey: string;
+  variables: Record<string, string>;
+  target: AnnouncementTarget;
+  locale?: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_EXPLICIT_USER_IDS = 500;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateTarget(
+  value: unknown,
+  errors: ValidationError[]
+): AnnouncementTarget | undefined {
+  if (!isPlainObject(value)) {
+    errors.push({
+      field: "target",
+      message: 'target is required, e.g. { "type": "tenant" }.'
+    });
+    return undefined;
+  }
+
+  if (value.type === "tenant") {
+    return { type: "tenant" };
+  }
+
+  if (value.type === "role") {
+    if (typeof value.roleId !== "string" || !UUID_PATTERN.test(value.roleId)) {
+      errors.push({
+        field: "target.roleId",
+        message: 'target.roleId must be a UUID when target.type is "role".'
+      });
+      return undefined;
+    }
+    return { type: "role", roleId: value.roleId };
+  }
+
+  if (value.type === "users") {
+    if (
+      !Array.isArray(value.userIds) ||
+      value.userIds.length === 0 ||
+      value.userIds.length > MAX_EXPLICIT_USER_IDS ||
+      !value.userIds.every(
+        (id) => typeof id === "string" && UUID_PATTERN.test(id)
+      )
+    ) {
+      errors.push({
+        field: "target.userIds",
+        message: `target.userIds must be a non-empty array of up to ${MAX_EXPLICIT_USER_IDS} UUIDs when target.type is "users".`
+      });
+      return undefined;
+    }
+    return { type: "users", userIds: value.userIds as string[] };
+  }
+
+  errors.push({
+    field: "target.type",
+    message: 'target.type must be one of "users", "role", "tenant".'
+  });
+  return undefined;
+}
+
+function validateVariables(
+  value: unknown,
+  errors: ValidationError[]
+): Record<string, string> | undefined {
+  if (value === undefined) {
+    return {};
+  }
+
+  if (!isPlainObject(value)) {
+    errors.push({
+      field: "variables",
+      message: "variables must be an object of string values."
+    });
+    return undefined;
+  }
+
+  const result: Record<string, string> = {};
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "string") {
+      errors.push({
+        field: "variables",
+        message: `variables.${key} must be a string.`
+      });
+      continue;
+    }
+    result[key] = entry;
+  }
+
+  return errors.length === 0 ? result : undefined;
+}
+
+export function validateAnnouncementInput(
+  body: unknown
+): Result<AnnouncementInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  let templateKey: string | undefined;
+  if (
+    typeof record.templateKey !== "string" ||
+    record.templateKey.trim().length === 0
+  ) {
+    errors.push({ field: "templateKey", message: "templateKey is required." });
+  } else if (!isKnownEmailTemplateCategory(record.templateKey)) {
+    errors.push({
+      field: "templateKey",
+      message: `templateKey "${record.templateKey}" is not a recognized category.`
+    });
+  } else {
+    templateKey = record.templateKey;
+  }
+
+  const variables = validateVariables(record.variables, errors);
+  const target = validateTarget(record.target, errors);
+
+  let locale: string | undefined;
+  if (record.locale !== undefined) {
+    if (
+      typeof record.locale !== "string" ||
+      record.locale.trim().length === 0
+    ) {
+      errors.push({
+        field: "locale",
+        message: "locale must be a non-empty string."
+      });
+    } else {
+      locale = record.locale;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      templateKey: templateKey!,
+      variables: variables!,
+      target: target!,
+      locale
+    }
+  };
+}

--- a/src/modules/email/domain/email-default-templates.ts
+++ b/src/modules/email/domain/email-default-templates.ts
@@ -58,6 +58,18 @@ export const DEFAULT_EMAIL_TEMPLATES: readonly DefaultEmailTemplate[] = [
     }
   },
   {
+    templateKey: "system.maintenance",
+    name: "Scheduled maintenance",
+    subjectTemplate: {
+      en: "Scheduled maintenance: {{maintenanceWindow}}",
+      id: "Pemeliharaan terjadwal: {{maintenanceWindow}}"
+    },
+    textBodyTemplate: {
+      en: "Hi {{userName}},\n\nWe will be performing scheduled maintenance during {{maintenanceWindow}} (expected duration: {{expectedDuration}}).\n\n{{impactDescription}}\n\nWe apologize for any inconvenience.",
+      id: "Halo {{userName}},\n\nKami akan melakukan pemeliharaan terjadwal pada {{maintenanceWindow}} (perkiraan durasi: {{expectedDuration}}).\n\n{{impactDescription}}\n\nMohon maaf atas ketidaknyamanannya."
+    }
+  },
+  {
     templateKey: "workflow.task_assigned",
     name: "Task assigned",
     subjectTemplate: {

--- a/src/modules/email/domain/email-template-categories.ts
+++ b/src/modules/email/domain/email-template-categories.ts
@@ -17,6 +17,7 @@ export const BASE_EMAIL_TEMPLATE_CATEGORIES = [
   "auth.password_reset",
   "system.announcement",
   "system.security_notice",
+  "system.maintenance",
   "workflow.task_assigned",
   "workflow.decision_required",
   "derived.transactional"
@@ -30,6 +31,12 @@ const BASE_CATEGORY_ALLOWLISTS: Readonly<Record<string, readonly string[]>> = {
     "eventDescription",
     "occurredAt",
     "ipAddress"
+  ],
+  "system.maintenance": [
+    "userName",
+    "maintenanceWindow",
+    "expectedDuration",
+    "impactDescription"
   ],
   "workflow.task_assigned": [
     "userName",

--- a/src/modules/email/module.ts
+++ b/src/modules/email/module.ts
@@ -3,13 +3,21 @@ import { defineModule } from "../_shared/module-contract";
 export const emailModule = defineModule({
   key: "email",
   name: "Email",
-  version: "0.3.0",
+  version: "0.4.0",
   status: "active",
   description:
-    "Reusable, provider-neutral email service (Issues #493-#495, #498, epic #492): message/recipient/attachment DTOs, an `EmailProvider` port, Mailketing configuration validation, the tenant-scoped schema/RLS/delivery queue (`sql/020`/`021`), the real Mailketing adapter, the claim/send/finalize dispatcher (`bun run email:dispatch`), and template management (CRUD + soft-delete/restore, per-category variable allowlists, i18n locale variants, admin preview) at `/api/v1/email/templates`. Generic infrastructure — analogous to `sync_storage`'s object-storage port — for password reset, system announcements, and workflow notifications; not a domain-specific 'send a receipt' feature (see README §Relationship to historical issue #390). No endpoint yet actually enqueues a message (Issues #496/#497).",
-  dependencies: ["tenant_admin", "profile_identity"],
+    "Reusable, provider-neutral email service (Issues #493-#498, epic #492): message/recipient/attachment DTOs, an `EmailProvider` port, Mailketing configuration validation, the tenant-scoped schema/RLS/delivery queue (`sql/020`/`021`), the real Mailketing adapter, the claim/send/finalize dispatcher (`bun run email:dispatch`), template management (CRUD + soft-delete/restore, per-category variable allowlists, i18n locale variants, admin preview) at `/api/v1/email/templates`, password reset (`/api/v1/auth/password/{forgot,reset}`), and bulk announcement/notification workflows (`/api/v1/email/announcements`, tenant/role/explicit-user targeting, two-tier ABAC, idempotent). Generic infrastructure — analogous to `sync_storage`'s object-storage port — for password reset, system announcements, and workflow notifications; not a domain-specific 'send a receipt' feature (see README §Relationship to historical issue #390).",
+  dependencies: ["tenant_admin", "profile_identity", "identity_access"],
   api: {
     openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
     basePath: "/api/v1/email"
+  },
+  events: {
+    asyncApiPath: "asyncapi/awcms-mini-domain-events.asyncapi.yaml",
+    publishes: [
+      "awcms-mini.email.message.queued",
+      "awcms-mini.email.message.sent",
+      "awcms-mini.email.message.failed"
+    ]
   }
 });

--- a/src/pages/api/v1/email/announcements/index.ts
+++ b/src/pages/api/v1/email/announcements/index.ts
@@ -1,0 +1,198 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../modules/_shared/idempotency";
+import { enqueueAnnouncement } from "../../../../../modules/email/application/announcement-directory";
+import { validateAnnouncementInput } from "../../../../../modules/email/domain/announcement-validation";
+
+const NOTIFICATION_GUARD = {
+  moduleKey: "email",
+  activityCode: "notification",
+  action: "create" as const
+};
+
+const ANNOUNCEMENT_GUARD = {
+  moduleKey: "email",
+  activityCode: "announcement",
+  action: "create" as const
+};
+
+const IDEMPOTENCY_SCOPE = "email_announcement_create";
+
+/**
+ * `POST /api/v1/email/announcements` — enqueue a notification/announcement
+ * to an explicit user list, a role, or the whole tenant. High-risk
+ * (bulk-capable) mutation: always requires `Idempotency-Key` (doc 10
+ * §Idempotency wrapper rules), same replay/conflict shape as
+ * `workflows/tasks/{id}/decisions.ts`.
+ *
+ * Two-tier ABAC (Issue #497 §Access control — "Bulk announcement should
+ * require stronger permission than ordinary notification enqueue"):
+ * `email.notification.create` is required for every request;
+ * `email.announcement.create` is ADDITIONALLY required when
+ * `target.type` is `"role"` or `"tenant"` (unbounded) — a role granted
+ * only the base permission can message specific users it already knows
+ * about, but cannot blast an entire role/tenant.
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const validation = validateAnnouncementInput(
+    await request.json().catch(() => null)
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Announcement request is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const isBulk = input.target.type === "role" || input.target.type === "tenant";
+  const requestHash = computeRequestHash(input);
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId ?? crypto.randomUUID();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      NOTIFICATION_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    if (isBulk) {
+      const bulkAuth = await authorizeInTransaction(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        ANNOUNCEMENT_GUARD
+      );
+
+      if (!bulkAuth.allowed) {
+        return bulkAuth.denied;
+      }
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const result = await enqueueAnnouncement(
+      tx,
+      tenantId,
+      input.templateKey,
+      input.variables,
+      input.target,
+      correlationId,
+      input.locale
+    );
+
+    if (!result) {
+      return fail(
+        404,
+        "TEMPLATE_NOT_FOUND",
+        `No active template found for templateKey "${input.templateKey}".`
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "email",
+      action: "announcement_sent",
+      resourceType: "email_announcement",
+      severity: isBulk ? "warning" : "info",
+      message: `Announcement enqueued: ${input.templateKey} to ${result.recipientCount} recipient(s).`,
+      attributes: {
+        targetType: input.target.type,
+        templateKey: input.templateKey,
+        recipientCount: result.recipientCount,
+        correlationId: result.correlationId,
+        dispatchStatus: "queued"
+      },
+      correlationId
+    });
+
+    const responseBody = ok({
+      recipientCount: result.recipientCount,
+      correlationId: result.correlationId
+    });
+    const responseJson = await responseBody.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      responseJson
+    );
+
+    return responseBody;
+  });
+};

--- a/src/pages/api/v1/email/announcements/preview.ts
+++ b/src/pages/api/v1/email/announcements/preview.ts
@@ -1,0 +1,112 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import { previewAnnouncement } from "../../../../../modules/email/application/announcement-directory";
+import { validateAnnouncementInput } from "../../../../../modules/email/domain/announcement-validation";
+
+const NOTIFICATION_GUARD = {
+  moduleKey: "email",
+  activityCode: "notification",
+  action: "create" as const
+};
+
+const ANNOUNCEMENT_GUARD = {
+  moduleKey: "email",
+  activityCode: "announcement",
+  action: "create" as const
+};
+
+/**
+ * `POST /api/v1/email/announcements/preview` — dry-run: resolves the same
+ * targeting criteria as the real send (Issue #497 §"Require preview/
+ * dry-run before high-volume sends") and returns only a recipient COUNT
+ * plus a rendered sample using synthetic data — never the actual
+ * recipient list/addresses. Guarded by the same two-tier permission the
+ * real send uses, so a caller can only preview what it could actually
+ * send.
+ */
+export const POST: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const validation = validateAnnouncementInput(
+    await request.json().catch(() => null)
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Announcement request is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const isBulk = input.target.type === "role" || input.target.type === "tenant";
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      NOTIFICATION_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    if (isBulk) {
+      const bulkAuth = await authorizeInTransaction(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        ANNOUNCEMENT_GUARD
+      );
+
+      if (!bulkAuth.allowed) {
+        return bulkAuth.denied;
+      }
+    }
+
+    const preview = await previewAnnouncement(
+      tx,
+      tenantId,
+      input.templateKey,
+      input.variables,
+      input.target,
+      input.locale
+    );
+
+    if (!preview) {
+      return fail(
+        404,
+        "TEMPLATE_NOT_FOUND",
+        `No active template found for templateKey "${input.templateKey}".`
+      );
+    }
+
+    return ok(preview);
+  });
+};

--- a/tests/announcement-validation.test.ts
+++ b/tests/announcement-validation.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateAnnouncementInput } from "../src/modules/email/domain/announcement-validation";
+
+const VALID_USER_ID = "11111111-1111-1111-1111-111111111111";
+const VALID_ROLE_ID = "22222222-2222-2222-2222-222222222222";
+
+describe("validateAnnouncementInput", () => {
+  test("accepts a tenant-wide announcement", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "system.announcement",
+      variables: { title: "Hi", body: "Body", actionUrl: "https://x" },
+      target: { type: "tenant" }
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts a role-targeted announcement", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "system.maintenance",
+      variables: {},
+      target: { type: "role", roleId: VALID_ROLE_ID }
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts an explicit-users notification", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "workflow.task_assigned",
+      variables: {},
+      target: { type: "users", userIds: [VALID_USER_ID] }
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects an unrecognized templateKey", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "not.a.category",
+      variables: {},
+      target: { type: "tenant" }
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects target.type = role without a valid roleId", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "system.announcement",
+      variables: {},
+      target: { type: "role", roleId: "not-a-uuid" }
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects target.type = users with an empty userIds array", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "system.announcement",
+      variables: {},
+      target: { type: "users", userIds: [] }
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects target.type = users with a non-UUID entry", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "system.announcement",
+      variables: {},
+      target: { type: "users", userIds: ["not-a-uuid"] }
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an unrecognized target.type", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "system.announcement",
+      variables: {},
+      target: { type: "everyone" }
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a missing target", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "system.announcement",
+      variables: {}
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects non-string variable values", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "system.announcement",
+      variables: { title: 123 },
+      target: { type: "tenant" }
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  test("defaults variables to an empty object when omitted", () => {
+    const result = validateAnnouncementInput({
+      templateKey: "system.announcement",
+      target: { type: "tenant" }
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.variables).toEqual({});
+    }
+  });
+});

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -58,7 +58,7 @@ describe("soft delete helper", () => {
 });
 
 describe("module registry", () => {
-  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, and email are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#495", () => {
+  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, and email are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498", () => {
     expect(listModules()).toHaveLength(9);
     expect(getModuleByKey("tenant_admin")).toMatchObject({
       key: "tenant_admin",
@@ -102,7 +102,7 @@ describe("module registry", () => {
     expect(getModuleByKey("email")).toMatchObject({
       key: "email",
       status: "active",
-      dependencies: ["tenant_admin", "profile_identity"]
+      dependencies: ["tenant_admin", "profile_identity", "identity_access"]
     });
     expect(getModuleByKey("unknown_module")).toBeUndefined();
   });
@@ -205,7 +205,8 @@ describe("database migration runner helpers", () => {
       "019_awcms_mini_form_drafts_schema.sql",
       "020_awcms_mini_email_schema.sql",
       "021_awcms_mini_email_template_i18n_schema.sql",
-      "022_awcms_mini_password_reset_schema.sql"
+      "022_awcms_mini_password_reset_schema.sql",
+      "023_awcms_mini_email_announcement_permission_schema.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/email-announcements.integration.test.ts
+++ b/tests/integration/email-announcements.integration.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Integration tests for announcement/notification email workflows (Issue
+ * #497, epic #492). Exercises the real handlers against a real
+ * PostgreSQL: targeting (explicit users/role/tenant), the two-tier ABAC
+ * (bulk requires a stronger permission than an explicit-user send),
+ * idempotency on the bulk-capable create endpoint, preview (count-only,
+ * no queue writes), suppression-list exclusion, and audit.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { POST as createAnnouncement } from "../../src/pages/api/v1/email/announcements/index";
+import { POST as previewAnnouncement } from "../../src/pages/api/v1/email/announcements/preview";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import { seedDefaultEmailTemplates } from "../../src/modules/email/application/email-template-directory";
+import { DEFAULT_EMAIL_TEMPLATES } from "../../src/modules/email/domain/email-default-templates";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string; tenantUserId: string };
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const loginIdentifier = `${tenantCode}-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  const admin = getAdminSql();
+  const tenantUserRows = (await admin`
+    SELECT tu.id FROM awcms_mini_tenant_users tu
+    JOIN awcms_mini_identities i ON i.id = tu.identity_id
+    WHERE tu.tenant_id = ${setup.body.data.tenantId} AND i.login_identifier = ${loginIdentifier}
+  `) as { id: string }[];
+  const tenantUserId = tenantUserRows[0]!.id;
+
+  // The announcement endpoints render an existing template — seed the base
+  // defaults (Issue #498) for this tenant so "system.announcement"/
+  // "workflow.task_assigned" resolve to a real, active template.
+  await withTenant(admin, setup.body.data.tenantId, (tx) =>
+    seedDefaultEmailTemplates(
+      tx,
+      setup.body.data.tenantId,
+      tenantUserId,
+      DEFAULT_EMAIL_TEMPLATES
+    )
+  );
+
+  return {
+    tenantId: setup.body.data.tenantId,
+    token: login.body.data.token,
+    tenantUserId
+  };
+}
+
+function authHeaders(
+  owner: Bootstrap,
+  extra?: Record<string, string>
+): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": owner.tenantId,
+    authorization: `Bearer ${owner.token}`,
+    ...extra
+  };
+}
+
+/** Provisions a second identity in the SAME tenant granted only `email.notification.create` (no `email.announcement.create`) — proves the two-tier ABAC. */
+async function provisionNotificationOnlyUser(
+  tenantId: string
+): Promise<{ token: string }> {
+  const password = "integration-test-notification-only-password";
+  const admin = getAdminSql();
+  const passwordHash = await Bun.password.hash(password);
+
+  await admin.begin(async (tx) => {
+    await tx.unsafe(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+    const profile = (await tx`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', 'Notification Only') RETURNING id
+    `) as { id: string }[];
+    const identity = (await tx`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profile[0]!.id}, 'notification-only@example.com', ${passwordHash})
+      RETURNING id
+    `) as { id: string }[];
+    const tenantUser = (await tx`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${tenantId}, ${identity[0]!.id}) RETURNING id
+    `) as { id: string }[];
+    const role = (await tx`
+      INSERT INTO awcms_mini_roles (tenant_id, role_code, role_name)
+      VALUES (${tenantId}, 'notifier', 'Notifier') RETURNING id
+    `) as { id: string }[];
+    const permission = (await tx`
+      SELECT id FROM awcms_mini_permissions
+      WHERE module_key = 'email' AND activity_code = 'notification' AND action = 'create'
+    `) as { id: string }[];
+
+    await tx`
+      INSERT INTO awcms_mini_role_permissions (tenant_id, role_id, permission_id)
+      VALUES (${tenantId}, ${role[0]!.id}, ${permission[0]!.id})
+    `;
+    await tx`
+      INSERT INTO awcms_mini_access_assignments (tenant_id, tenant_user_id, role_id)
+      VALUES (${tenantId}, ${tenantUser[0]!.id}, ${role[0]!.id})
+    `;
+  });
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier: "notification-only@example.com", password },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { token: login.body.data.token };
+}
+
+const ANNOUNCEMENT_BODY = {
+  templateKey: "system.announcement",
+  variables: {
+    title: "Big news",
+    body: "Something happened.",
+    actionUrl: "https://example.com"
+  },
+  target: { type: "tenant" }
+};
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("email announcements API", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("preview returns a count and sample without touching the message queue", async () => {
+    const owner = await bootstrap();
+
+    const preview = await invoke<{
+      data: { matchedCount: number; sample: { subject: string } };
+    }>(previewAnnouncement, {
+      method: "POST",
+      path: "/api/v1/email/announcements/preview",
+      headers: authHeaders(owner),
+      body: ANNOUNCEMENT_BODY
+    });
+
+    expect(preview.status).toBe(200);
+    expect(preview.body.data.matchedCount).toBe(1);
+    expect(preview.body.data.sample.subject).toBe("Big news");
+
+    const admin = getAdminSql();
+    const messageRows = (await admin`
+      SELECT count(*)::int AS count FROM awcms_mini_email_messages
+    `) as { count: number }[];
+    expect(messageRows[0]?.count).toBe(0);
+  });
+
+  test("create with an explicit user list enqueues one message and requires only the base permission", async () => {
+    const owner = await bootstrap();
+    const notifier = await provisionNotificationOnlyUser(owner.tenantId);
+
+    const result = await invoke<{
+      data: { recipientCount: number; correlationId: string };
+    }>(createAnnouncement, {
+      method: "POST",
+      path: "/api/v1/email/announcements",
+      headers: authHeaders(
+        { ...owner, token: notifier.token },
+        { "idempotency-key": "test-key-1" }
+      ),
+      body: {
+        templateKey: "workflow.task_assigned",
+        variables: {
+          taskTitle: "Review PR",
+          assignedBy: "Owner",
+          dueAt: "tomorrow",
+          taskUrl: "https://example.com/task"
+        },
+        target: { type: "users", userIds: [owner.tenantUserId] }
+      }
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.recipientCount).toBe(1);
+
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT category, template_key, priority, correlation_id
+      FROM awcms_mini_email_messages
+      WHERE tenant_id = ${owner.tenantId}
+    `) as {
+      category: string;
+      template_key: string;
+      priority: string;
+      correlation_id: string;
+    }[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.category).toBe("workflow.task_assigned");
+    expect(rows[0]!.priority).toBe("high");
+    expect(rows[0]!.correlation_id).toBe(result.body.data.correlationId);
+  });
+
+  test("a bulk (tenant-wide) send is denied for a role with only the base notification permission", async () => {
+    const owner = await bootstrap();
+    const notifier = await provisionNotificationOnlyUser(owner.tenantId);
+
+    const result = await invoke(createAnnouncement, {
+      method: "POST",
+      path: "/api/v1/email/announcements",
+      headers: authHeaders(
+        { ...owner, token: notifier.token },
+        { "idempotency-key": "test-key-bulk-denied" }
+      ),
+      body: ANNOUNCEMENT_BODY
+    });
+
+    expect(result.status).toBe(403);
+  });
+
+  test("a bulk (tenant-wide) send succeeds for the owner (has both permissions) and enqueues one row per active user", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{ data: { recipientCount: number } }>(
+      createAnnouncement,
+      {
+        method: "POST",
+        path: "/api/v1/email/announcements",
+        headers: authHeaders(owner, { "idempotency-key": "test-key-bulk-ok" }),
+        body: ANNOUNCEMENT_BODY
+      }
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.recipientCount).toBe(1);
+  });
+
+  test("missing Idempotency-Key is rejected", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke(createAnnouncement, {
+      method: "POST",
+      path: "/api/v1/email/announcements",
+      headers: authHeaders(owner),
+      body: ANNOUNCEMENT_BODY
+    });
+
+    expect(result.status).toBe(400);
+  });
+
+  test("idempotency: replaying the same key+body returns the same response without a duplicate enqueue", async () => {
+    const owner = await bootstrap();
+    const headers = authHeaders(owner, { "idempotency-key": "replay-key" });
+
+    const first = await invoke<{ data: { recipientCount: number } }>(
+      createAnnouncement,
+      {
+        method: "POST",
+        path: "/api/v1/email/announcements",
+        headers,
+        body: ANNOUNCEMENT_BODY
+      }
+    );
+    expect(first.status).toBe(200);
+
+    const second = await invoke<{ data: { recipientCount: number } }>(
+      createAnnouncement,
+      {
+        method: "POST",
+        path: "/api/v1/email/announcements",
+        headers,
+        body: ANNOUNCEMENT_BODY
+      }
+    );
+    expect(second.status).toBe(200);
+    expect(second.body).toEqual(first.body);
+
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT count(*)::int AS count FROM awcms_mini_email_messages
+      WHERE tenant_id = ${owner.tenantId}
+    `) as { count: number }[];
+    expect(rows[0]?.count).toBe(1);
+  });
+
+  test("same Idempotency-Key with a different body conflicts (409)", async () => {
+    const owner = await bootstrap();
+    const headers = authHeaders(owner, { "idempotency-key": "conflict-key" });
+
+    const first = await invoke(createAnnouncement, {
+      method: "POST",
+      path: "/api/v1/email/announcements",
+      headers,
+      body: ANNOUNCEMENT_BODY
+    });
+    expect(first.status).toBe(200);
+
+    const second = await invoke(createAnnouncement, {
+      method: "POST",
+      path: "/api/v1/email/announcements",
+      headers,
+      body: { ...ANNOUNCEMENT_BODY, variables: { title: "Different" } }
+    });
+    expect(second.status).toBe(409);
+  });
+
+  test("a suppressed recipient is excluded from targeting", async () => {
+    const owner = await bootstrap();
+    const admin = getAdminSql();
+
+    // The suppression list stores a hash, not the raw identifier — insert
+    // the real hash via the same normalize/hash pipeline the app uses
+    // (`resolveAnnouncementTargets`), not the raw login_identifier.
+    const identityRows = (await admin`
+      SELECT i.login_identifier FROM awcms_mini_tenant_users tu
+      JOIN awcms_mini_identities i ON i.id = tu.identity_id
+      WHERE tu.id = ${owner.tenantUserId}
+    `) as { login_identifier: string }[];
+    const normalized = identityRows[0]!.login_identifier.trim().toLowerCase();
+    const hash = `sha256:${new Bun.CryptoHasher("sha256").update(normalized).digest("hex")}`;
+
+    await admin`
+      INSERT INTO awcms_mini_email_suppression_list
+        (tenant_id, recipient_hash, recipient_masked, reason)
+      VALUES (${owner.tenantId}, ${hash}, 'o***@example.com', 'manual')
+    `;
+
+    const preview = await invoke<{ data: { matchedCount: number } }>(
+      previewAnnouncement,
+      {
+        method: "POST",
+        path: "/api/v1/email/announcements/preview",
+        headers: authHeaders(owner),
+        body: ANNOUNCEMENT_BODY
+      }
+    );
+
+    expect(preview.body.data.matchedCount).toBe(0);
+  });
+
+  test("audit event records target type, template key, and recipient count", async () => {
+    const owner = await bootstrap();
+
+    await invoke(createAnnouncement, {
+      method: "POST",
+      path: "/api/v1/email/announcements",
+      headers: authHeaders(owner, { "idempotency-key": "audit-key" }),
+      body: ANNOUNCEMENT_BODY
+    });
+
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT action, resource_type, attributes
+      FROM awcms_mini_audit_events
+      WHERE tenant_id = ${owner.tenantId} AND action = 'announcement_sent'
+    `) as {
+      action: string;
+      resource_type: string;
+      attributes: Record<string, unknown>;
+    }[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.resource_type).toBe("email_announcement");
+    expect(rows[0]!.attributes.targetType).toBe("tenant");
+    expect(rows[0]!.attributes.templateKey).toBe("system.announcement");
+    expect(rows[0]!.attributes.recipientCount).toBe(1);
+  });
+});

--- a/tests/integration/email-schema.integration.test.ts
+++ b/tests/integration/email-schema.integration.test.ts
@@ -180,7 +180,9 @@ suite("email schema — RLS isolation", () => {
     `) as { activity_code: string; action: string }[];
 
     expect(rows.map((row) => `${row.activity_code}.${row.action}`)).toEqual([
+      "announcement.create",
       "message.read",
+      "notification.create",
       "suppression.create",
       "suppression.delete",
       "suppression.read",


### PR DESCRIPTION
## Summary
- Closes #497 (epic #492, follows #493-#496/#498 — the last of the epic's three planned email-sending flows). Adds `POST /api/v1/email/announcements` (bulk-capable enqueue) and `POST /api/v1/email/announcements/preview` (dry-run).
- **Targeting**: `{type: "users", userIds}` (explicit tenant_user list), `{type: "role", roleId}` (all active tenant_users with that role), or `{type: "tenant"}` (whole tenant). Each resolved recipient becomes its own `awcms_mini_email_messages` row sharing one `correlation_id` — confirms the #494 one-row-per-recipient decision with its first real bulk caller. Always excludes anyone on the suppression list (#494, first real consumer).
- **Two-tier ABAC** per the issue's own acceptance criteria ("Bulk announcement should require stronger permission than ordinary notification enqueue"): `email.notification.create` gates every request; `email.announcement.create` is required *in addition* when `target.type` is `"role"` or `"tenant"` (unbounded). A role with only the base permission can message specific users it already knows about but cannot blast a whole role/tenant.
- **Idempotency-Key always required** (not just for bulk) — reuses `_shared/idempotency.ts`, same replay/conflict shape as `workflows/tasks/{id}/decisions.ts`.
- **Preview is genuinely safe**: resolves the identical targeting criteria as a real send but returns only a recipient *count* plus a rendered sample using synthetic data (#498's `buildSyntheticSampleVariables`) — never the actual recipient list, and never writes to `email_messages`.
- **Audit**: one event per *request* (not per recipient, to avoid audit spam on bulk sends) recording target type, template key, recipient count, correlation ID, dispatch status — never a raw recipient list.
- New `system.maintenance` template category (with EN/ID default copy) for the "system maintenance" notification type the issue calls out.
- Closed a real gap in #495's dispatcher: added the missing `email.dispatch.sent`/`.retry_scheduled`/`.failed` structured log lines (previously only `.claimed` existed) — these back three newly-documented AsyncAPI channels (`awcms-mini.email.message.{queued,sent,failed}`), contract-only per the same `database.pool.saturated` convention (no live pub/sub dispatcher exists in this repo; the structured logger is the documented producer).

## Out of scope (per issue #497)
- Full marketing automation, campaign analytics, CRM segmentation, unsubscribe center, newsletter builder (explicitly excluded).
- Admin UI for composing announcements (API-layer only, matching #496's UI deferral).

## Test plan
- [x] Unit tests: `announcement-validation.test.ts` (11 tests — all three target types, malformed roleId/userIds, unrecognized templateKey/target.type, variable type validation).
- [x] New `tests/integration/email-announcements.integration.test.ts` (9 tests) live against real PostgreSQL: preview returns count+sample with zero queue writes, explicit-user send with only the base permission, bulk send denied for a role lacking `announcement.create` (403), bulk send succeeds for a role with both permissions, missing-Idempotency-Key rejection, idempotent replay (same key+body → same response, no duplicate row), conflicting replay (different body → 409), suppressed-recipient exclusion, and audit event content.
- [x] Full integration suite (90 tests across 13 files) re-run live — zero regressions (one pre-existing permission-catalog assertion updated for the 2 new permissions).
- [x] `bun test`, `bun run api:spec:check`, `bun run check` all green.