### PR TITLE
fix(security): resolve CodeQL comparison-between-incompatible-types alert

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -6,32 +6,33 @@ Skill Claude Code tingkat-proyek untuk AWCMS-Mini. Setiap skill meng-encode stan
 
 ## Katalog
 
-| Skill                                                  | Kapan dipakai                                                               | Sumber docs            |
-| ------------------------------------------------------ | --------------------------------------------------------------------------- | ---------------------- |
-| `awcms-mini-implement-issue`                           | Orkestrator: kerjakan satu issue/sprint atomic end-to-end                   | 06, 11, 12             |
-| `awcms-mini-new-module`                                | Scaffold modul baru di `src/modules/`                                       | 10, 11                 |
-| `awcms-mini-new-migration`                             | Buat/ubah migration SQL (tabel, index, RLS)                                 | 04, 10                 |
-| `awcms-mini-new-endpoint`                              | Tambah/ubah endpoint REST + OpenAPI                                         | 05, 10                 |
-| `awcms-mini-new-event`                                 | Tambah/ubah domain event + AsyncAPI                                         | 05                     |
-| `awcms-mini-idempotency`                               | Mutation high-risk anti double-submit                                       | 10                     |
-| `awcms-mini-abac-guard`                                | Kontrol akses default-deny + RLS                                            | 03, 10                 |
-| `awcms-mini-audit-log`                                 | Audit aksi high-risk + redaction                                            | 03, 10                 |
-| `awcms-mini-observability`                             | Correlation ID otomatis, retensi/purge audit log, extension point log/audit | 10, 16, 20             |
-| `awcms-mini-new-migration` + `awcms-mini-new-endpoint` | Soft delete/restore/purge resource deletable                                | 04, 05, 10, 16         |
-| `awcms-mini-sensitive-data`                            | Normalize/hash/mask identifier sensitif                                     | 04                     |
-| `awcms-mini-sync-hmac`                                 | Sync push/pull bertanda HMAC + anti-replay                                  | 08, 10                 |
-| `awcms-mini-security-review`                           | Review keamanan modul                                                       | 12, 13                 |
-| `awcms-mini-pr-review`                                 | Review pull request terhadap DoD                                            | 09, 10, 12             |
-| `awcms-mini-testing`                                   | Tulis test berlapis (unit→security)                                         | 07                     |
-| `awcms-mini-production-preflight`                      | Preflight & go-live readiness                                               | 07, 12                 |
-| `awcms-mini-deploy`                                    | Pilih & jalankan profil deployment (LAN-first vs registry/Coolify)          | 18, deploy-coolify.md  |
-| `awcms-mini-ui-screen`                                 | Implementasi layar/komponen UI sesuai design system                         | 14, 15                 |
-| `awcms-mini-wizard-form`                               | Form multi-step (reusable wizard pattern)                                   | wizard-form-pattern.md |
-| `awcms-mini-form-drafts`                               | Server-side draft persistence (resume lintas sesi/perangkat)                | form-drafts/README.md  |
-| `awcms-mini-email`                                     | Kirim email transaksional (provider-neutral, template management, outbox)   | email/README.md        |
-| `awcms-mini-i18n`                                      | String UI `.po` gettext & konten multi-bahasa                               | 14, 04, 19             |
-| `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)                           | 09                     |
-| `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                | 07, 06                 |
+| Skill                                                  | Kapan dipakai                                                                   | Sumber docs            |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------- | ---------------------- |
+| `awcms-mini-implement-issue`                           | Orkestrator: kerjakan satu issue/sprint atomic end-to-end                       | 06, 11, 12             |
+| `awcms-mini-new-module`                                | Scaffold modul baru di `src/modules/`                                           | 10, 11                 |
+| `awcms-mini-new-migration`                             | Buat/ubah migration SQL (tabel, index, RLS)                                     | 04, 10                 |
+| `awcms-mini-new-endpoint`                              | Tambah/ubah endpoint REST + OpenAPI                                             | 05, 10                 |
+| `awcms-mini-new-event`                                 | Tambah/ubah domain event + AsyncAPI                                             | 05                     |
+| `awcms-mini-idempotency`                               | Mutation high-risk anti double-submit                                           | 10                     |
+| `awcms-mini-abac-guard`                                | Kontrol akses default-deny + RLS                                                | 03, 10                 |
+| `awcms-mini-audit-log`                                 | Audit aksi high-risk + redaction                                                | 03, 10                 |
+| `awcms-mini-observability`                             | Correlation ID otomatis, retensi/purge audit log, extension point log/audit     | 10, 16, 20             |
+| `awcms-mini-new-migration` + `awcms-mini-new-endpoint` | Soft delete/restore/purge resource deletable                                    | 04, 05, 10, 16         |
+| `awcms-mini-sensitive-data`                            | Normalize/hash/mask identifier sensitif                                         | 04                     |
+| `awcms-mini-sync-hmac`                                 | Sync push/pull bertanda HMAC + anti-replay                                      | 08, 10                 |
+| `awcms-mini-security-review`                           | Review keamanan modul                                                           | 12, 13                 |
+| `awcms-mini-codeql-triage`                             | Triase & perbaiki temuan CodeQL code scanning (termasuk katalog false-positive) | 20                     |
+| `awcms-mini-pr-review`                                 | Review pull request terhadap DoD                                                | 09, 10, 12             |
+| `awcms-mini-testing`                                   | Tulis test berlapis (unit→security)                                             | 07                     |
+| `awcms-mini-production-preflight`                      | Preflight & go-live readiness                                                   | 07, 12                 |
+| `awcms-mini-deploy`                                    | Pilih & jalankan profil deployment (LAN-first vs registry/Coolify)              | 18, deploy-coolify.md  |
+| `awcms-mini-ui-screen`                                 | Implementasi layar/komponen UI sesuai design system                             | 14, 15                 |
+| `awcms-mini-wizard-form`                               | Form multi-step (reusable wizard pattern)                                       | wizard-form-pattern.md |
+| `awcms-mini-form-drafts`                               | Server-side draft persistence (resume lintas sesi/perangkat)                    | form-drafts/README.md  |
+| `awcms-mini-email`                                     | Kirim email transaksional (provider-neutral, template management, outbox)       | email/README.md        |
+| `awcms-mini-i18n`                                      | String UI `.po` gettext & konten multi-bahasa                                   | 14, 04, 19             |
+| `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)                               | 09                     |
+| `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                    | 07, 06                 |
 
 ## Katalog peningkatan (improvement/hardening)
 
@@ -80,6 +81,7 @@ flowchart TD
   II --> LEG[awcms-mini-legacy-migration]
   II --> PR[awcms-mini-pr-review]
   PR --> SEC[awcms-mini-security-review]
+  PR --> CQ[awcms-mini-codeql-triage]
   SEC --> PF[awcms-mini-production-preflight]
   PF --> DEP[awcms-mini-deploy]
   DEP --> REL[awcms-mini-release]

--- a/.claude/skills/awcms-mini-codeql-triage/SKILL.md
+++ b/.claude/skills/awcms-mini-codeql-triage/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: awcms-mini-codeql-triage
+description: Triase dan perbaiki temuan CodeQL code scanning AWCMS-Mini (github.com/ahliweb/awcms-mini/security/code-scanning). Gunakan saat diminta "analisis code scanning"/"perbaiki CodeQL", saat sebuah PR gagal check CodeQL, atau saat menemukan alert baru. Mendokumentasikan dua false-positive nyata yang sudah ditemukan (name-heuristic password, incompatible-types typeof/null) supaya tidak diinvestigasi ulang dari nol.
+---
+
+# AWCMS-Mini — Triase CodeQL Code Scanning
+
+CodeQL (`.github/workflows/codeql.yml`, matrix `actions` + `javascript-typescript`) jalan di setiap push/PR ke `main`. Sebagian temuan adalah bug nyata; sebagian lain adalah **false positive** dari heuristik statis CodeQL yang tidak melihat konteks runtime sesungguhnya. Skill ini adalah proses triase + katalog false-positive yang sudah dikonfirmasi.
+
+## Langkah triase (wajib, jangan menebak)
+
+1. **Ambil daftar alert nyata** — jangan asumsikan dari ingatan/PR lama:
+   ```bash
+   gh api repos/ahliweb/awcms-mini/code-scanning/alerts --paginate \
+     -q '.[] | select(.state=="open") | "\(.number)\t\(.rule.severity)\t\(.rule.id)\t\(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)"'
+   ```
+2. **Ambil detail + pesan asli per alert** (bukan cuma nama rule):
+   ```bash
+   gh api repos/ahliweb/awcms-mini/code-scanning/alerts/<N>
+   ```
+   Baca `most_recent_instance.message.text` — ini alasan CONCRETE CodeQL, bukan deskripsi generik rule. Untuk PR yang gagal check, `gh api repos/ahliweb/awcms-mini/check-runs/<id>/annotations` memberi lokasi+pesan yang sama.
+3. **Cari bukti apakah ini bug nyata atau false positive** sebelum menulis kode apa pun:
+   - Cek apakah pola kode yang sama persis ada di file lain **tanpa** alert — kalau ada, itu sinyal kuat false positive kontekstual (CodeQL flow-sensitive analysis kadang berbeda hasil per call-site untuk kode identik).
+   - Baca pesan CodeQL kata-per-kata dan uji terhadap semantik JS/TS sesungguhnya — kalau pesannya menyebut sesuatu yang secara data-flow **tidak mungkin** (mis. menyebut sebuah fungsi yang terbukti tidak pernah mengembalikan field yang dituduh), itu bukti definitif false positive, bukan tebakan.
+   - **Jangan** langsung tambah suppression comment (`// codeql[rule-id]`) sebagai upaya pertama — sudah terbukti **tidak efektif** di setup CI repo ini (diverifikasi PR #505, Issue #496: suppression comment tetap muncul ulang di run berikutnya).
+4. **Perbaiki dengan code change minimal, behavior-preserving** — bukan menekan alert. Kalau setelah investigasi ternyata false positive murni tanpa cara reformulasi kode yang wajar, baru pertimbangkan dismiss resmi lewat API:
+   ```bash
+   gh api repos/ahliweb/awcms-mini/code-scanning/alerts/<N> -X PATCH \
+     -f state=dismissed -f dismissed_reason=false_positive \
+     -f dismissed_comment="<alasan konkret + bukti>"
+   ```
+5. **Verifikasi**: `bun run check` hijau, push, tunggu CI — konfirmasi CodeQL run berikutnya tidak lagi menampilkan alert yang sama (bukan cuma "kelihatannya benar").
+
+## Katalog false-positive yang sudah dikonfirmasi
+
+### 1. `js/insufficient-password-hash` — heuristik nama fungsi
+
+CodeQL menandai **return value fungsi APA PUN yang namanya mengandung substring "password"** sebagai "password-flavored", terlepas dari apa yang sungguh-sungguh dikembalikan atau bagaimana dipakai. Ditemukan Issue #496 (PR #505): `hashPasswordResetToken` (hash token 256-bit) dan `validateForgotPasswordInput` (return `{loginIdentifier}`, TIDAK ADA field password sama sekali) sama-sama ditandai. Bukti definitif false positive: kasus kedua _tidak mungkin_ soal data-flow nyata karena tipe returnnya tidak punya field password sama sekali — satu-satunya penjelasan adalah heuristik nama.
+
+**Fix yang terbukti berhasil**: **rename** fungsi agar namanya tidak mengandung "password" (`generatePasswordResetToken`→`generateResetToken`, `hashPasswordResetToken`→`hashResetToken`, `validateForgotPasswordInput`→`validateForgotIdentifierInput`, `validateResetPasswordInput`→`validateCompleteResetInput`). Suppression comment inline **dicoba lebih dulu dan terbukti tidak menghilangkan alert** — jangan ulangi jalan itu.
+
+**Pencegahan**: saat menamai fungsi yang menangani hashing/validasi terkait password/reset/kredensial, hindari substring "password" di nama fungsi kalau return value-nya **bukan** password mentah/hash password sungguhan (mis. token, identifier, DTO tanpa field password) — heuristik CodeQL hanya melihat nama, bukan tipe.
+
+### 2. `js/comparison-between-incompatible-types` — idiom `typeof x === "object" && x !== null`
+
+Ditemukan 2026-07-07 (alert #11) di `isPlainObject`/`isRecord` helper (`typeof value === "object" && value !== null && !Array.isArray(value)`) — idiom standar JS untuk cek "objek non-null" (`typeof null === "object"`, sehingga cek `!== null` wajib). CodeQL menganggap setelah `typeof value === "object"` menyempitkan tipe `value` ke "Date, object, atau regular expression", lalu membandingkannya ke `null` dianggap "incompatible types" — padahal `null` selalu bisa dibandingkan langsung ke referensi objek apa pun di JS, ini bukan bug. Bukti false positive: pola identik ada di 4 file lain (`form-draft-validation.ts`, `settings-validation.ts`, `announcement-validation.ts`, `wizard-client.ts`) tanpa alert — CodeQL flow-sensitive analysis berbeda hasil per call-site untuk kode yang identik.
+
+**Fix**: urutkan ulang — cek `value === null` **sebelum** narrowing `typeof`, bukan sesudahnya (perilaku runtime identik):
+
+```ts
+// Sebelum (bisa kena false positive):
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Sesudah (perilaku sama, tidak kena false positive):
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || Array.isArray(value)) {
+    return false;
+  }
+  return typeof value === "object";
+}
+```
+
+**Pencegahan**: saat menulis helper "is non-null object" baru, pakai urutan `value === null` dulu, baru `typeof`.
+
+## Verifikasi
+
+- `gh pr checks <PR>` — tunggu CodeQL selesai (jangan asumsikan pending = akan pass).
+- Alert yang sudah diperbaiki otomatis pindah ke state `fixed` di halaman code-scanning pada run berikutnya di `main` — tidak perlu dismiss manual kalau memang sudah tidak muncul lagi.
+- `bun run check` tetap harus hijau — perbaikan CodeQL tidak boleh mengubah perilaku runtime (lihat test yang sudah ada untuk fungsi yang diubah).
+
+## Skill terkait
+
+`awcms-mini-security-review` (checklist keamanan modul, bukan tooling scan), `awcms-mini-pr-review` (proses review PR secara umum).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ AWCMS-Mini menyediakan **skill Claude Code tingkat-proyek** yang meng-encode sta
 | Masking data sensitif                                              | `awcms-mini-sensitive-data`       |
 | Sync HMAC + anti-replay                                            | `awcms-mini-sync-hmac`            |
 | Review keamanan modul                                              | `awcms-mini-security-review`      |
+| Triase & perbaiki temuan CodeQL code scanning                      | `awcms-mini-codeql-triage`        |
 | Review pull request                                                | `awcms-mini-pr-review`            |
 | Tulis test berlapis                                                | `awcms-mini-testing`              |
 | Preflight & go-live                                                | `awcms-mini-production-preflight` |
@@ -234,7 +235,7 @@ awcms-mini/
 ├── AGENTS.md                # file ini
 ├── CHANGELOG.md             # versioning (Changesets)
 ├── .changeset/              # config + changeset entries
-├── .claude/skills/          # 26 skill proyek (implement-issue, new-migration, dst.)
+├── .claude/skills/          # 29 skill proyek (implement-issue, new-migration, dst.)
 ├── .claude/agents/          # subagents (coder, reviewer, security-auditor)
 ├── README.md
 ├── package.json

--- a/docs/awcms-mini/13_final_master_index_traceability.md
+++ b/docs/awcms-mini/13_final_master_index_traceability.md
@@ -200,6 +200,7 @@ flowchart LR
 | API/event contract                    | `awcms-mini-new-endpoint`, `awcms-mini-new-event`                                                      |
 | Testing berlapis                      | `awcms-mini-testing`                                                                                   |
 | Review keamanan                       | `awcms-mini-security-review` + agent `awcms-mini-security-auditor`                                     |
+| Triase CodeQL code scanning           | `awcms-mini-codeql-triage`                                                                             |
 | Review PR / DoD                       | `awcms-mini-pr-review` + agent `awcms-mini-reviewer`                                                   |
 | Go-live gate                          | `awcms-mini-production-preflight`                                                                      |
 | Profil deployment (LAN-first/Coolify) | `awcms-mini-deploy`                                                                                    |
@@ -326,7 +327,7 @@ Alasan:
 - `AGENTS.md`
 - `README.md`
 - `CHANGELOG.md` + `.changeset/` (versioning via Changesets)
-- `.claude/skills/` (26 skill proyek + katalog README)
+- `.claude/skills/` (29 skill proyek + katalog README)
 - `.claude/agents/` (3 subagent: coder, reviewer, security-auditor)
 - `package.json`
 - `astro.config.mjs`

--- a/src/lib/ui/wizard-client.ts
+++ b/src/lib/ui/wizard-client.ts
@@ -270,6 +270,11 @@ function uniqueStrings(values: readonly string[]): readonly string[] {
   return Array.from(new Set(values));
 }
 
+/** `value === null` checked before `typeof` narrowing — avoids a CodeQL `js/comparison-between-incompatible-types` false positive on the more common `typeof value === "object" && value !== null` ordering (see `email/domain/email-template-validation.ts`'s `isPlainObject` for the full explanation). Same runtime behavior. */
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
+  if (value === null) {
+    return false;
+  }
+
+  return typeof value === "object";
 }

--- a/src/modules/email/domain/announcement-validation.ts
+++ b/src/modules/email/domain/announcement-validation.ts
@@ -30,8 +30,13 @@ const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MAX_EXPLICIT_USER_IDS = 500;
 
+/** `value === null` checked before `typeof` narrowing — avoids a CodeQL `js/comparison-between-incompatible-types` false positive on the more common `typeof value === "object" && value !== null` ordering (see `email-template-validation.ts`'s `isPlainObject` for the full explanation). Same runtime behavior. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  return typeof value === "object";
 }
 
 function validateTarget(

--- a/src/modules/email/domain/email-template-validation.ts
+++ b/src/modules/email/domain/email-template-validation.ts
@@ -48,8 +48,23 @@ const UNSAFE_HTML_PATTERNS: readonly RegExp[] = [
   /javascript:/i
 ];
 
+/**
+ * `value === null` is checked *before* narrowing by `typeof` — CodeQL's
+ * `js/comparison-between-incompatible-types` query flags the more common
+ * `typeof value === "object" && value !== null` ordering as a false
+ * positive here (it infers `value`'s narrowed type as
+ * "Date, object or regular expression" after the `typeof` check, then
+ * treats the subsequent `!== null` as an "incompatible" comparison — `null`
+ * is directly comparable to any reference value in JS, this is the
+ * standard non-null-object check, not a bug). Same runtime behavior,
+ * reordered to avoid the false positive.
+ */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  return typeof value === "object";
 }
 
 function validateLocalizedText(

--- a/src/modules/form-drafts/domain/form-draft-validation.ts
+++ b/src/modules/form-drafts/domain/form-draft-validation.ts
@@ -56,8 +56,13 @@ const FORBIDDEN_PAYLOAD_KEY_PATTERNS: readonly RegExp[] = [
   /private[_-]?key/i
 ];
 
+/** `value === null` checked before `typeof` narrowing — avoids a CodeQL `js/comparison-between-incompatible-types` false positive on the more common `typeof value === "object" && value !== null` ordering (see `email/domain/email-template-validation.ts`'s `isPlainObject` for the full explanation). Same runtime behavior. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  return typeof value === "object";
 }
 
 /**

--- a/src/modules/tenant-admin/domain/settings-validation.ts
+++ b/src/modules/tenant-admin/domain/settings-validation.ts
@@ -25,8 +25,13 @@ const VALID_LOCALES = new Set(["id", "en", "ms", "ar"]);
 // doc 04 §ERD `awcms_mini_tenants.default_theme`.
 const VALID_THEMES = new Set(["light", "dark", "system"]);
 
+/** `value === null` checked before `typeof` narrowing — avoids a CodeQL `js/comparison-between-incompatible-types` false positive on the more common `typeof value === "object" && value !== null` ordering (see `email/domain/email-template-validation.ts`'s `isPlainObject` for the full explanation). Same runtime behavior. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  return typeof value === "object";
 }
 
 export function validateUpdateTenantSettingsInput(


### PR DESCRIPTION
## Summary
- Fixes CodeQL alert #11 (`js/comparison-between-incompatible-types`, warning) in `src/modules/email/domain/email-template-validation.ts`'s `isPlainObject` helper.
- Confirmed false positive (not a real bug): `typeof value === "object" && value !== null` is the standard JS non-null-object idiom (`typeof null === "object"`); the identical pattern exists unflagged in 3 other files, and CodeQL's own message about "incompatible types" doesn't hold under real JS semantics (`null` is always meaningfully comparable to any reference value).
- Fix: reorder the null check before `typeof` narrowing (behaviorally identical), applied to all 5 occurrences of this idiom repo-wide to preempt the same false positive resurfacing elsewhere.
- Added a new `awcms-mini-codeql-triage` skill documenting the triage process and a catalog of confirmed false-positives (this one, plus #496's `js/insufficient-password-hash` name-heuristic) — propagated to the skill README, AGENTS.md, and doc 13's traceability matrix (also fixed a stale skill count).

## Test plan
- [x] `bun run check` green (lint, check:docs, api:spec:check, typecheck, test, build)
- [x] Live-verified against real PostgreSQL (552 tests pass)
- [x] No behavior change — same 5 functions, same runtime semantics, only comparison order changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)