### PR TITLE
feat(modules): extend module descriptor contract for module management (#511)

### DIFF
--- a/src/modules/_shared/module-contract.ts
+++ b/src/modules/_shared/module-contract.ts
@@ -1,4 +1,31 @@
-export type ModuleStatus = "active" | "experimental" | "deprecated";
+/**
+ * Module descriptor contract (Issue #511, epic #492/#510). Extended for
+ * Module Management: richer trusted metadata about each module, while
+ * every addition here is optional so the existing 9 registered modules'
+ * descriptors (which only set the original fields) remain valid without
+ * any change.
+ *
+ * Everything in a `ModuleDescriptor` is **trusted code-only metadata** —
+ * written by the module's own `module.ts`, checked in to the repo, never
+ * user/tenant-controlled. It must never carry a runtime secret, token,
+ * password, or provider credential (those live in `process.env` only,
+ * doc 18) — this is descriptive/declarative metadata, not configuration
+ * *values*.
+ */
+
+/** Broad category a module falls into — descriptive only, not itself an authorization or enable/disable mechanism. */
+export type ModuleType =
+  "base" | "system" | "domain" | "integration" | "derived";
+
+/**
+ * `disabled` here means globally disabled by code/deployment (the module
+ * is registered but inert everywhere) — **not** a per-tenant toggle.
+ * Tenant-level enable/disable is database state
+ * (`awcms_mini_tenant_modules`, Issue #512/#515), tracked independently of
+ * this descriptor-level status.
+ */
+export type ModuleLifecycleStatus =
+  "active" | "experimental" | "deprecated" | "maintenance" | "disabled";
 
 export type ModuleApiContract = {
   openApiPath: string;
@@ -11,15 +38,67 @@ export type ModuleEventContract = {
   subscribes?: string[];
 };
 
+/** One permission this module declares to the catalog — `module_key` is the descriptor's own `key`, never repeated here. Consumed by Issue #517's sync/status comparison against `awcms_mini_permissions`. */
+export type ModulePermissionDescriptor = {
+  activityCode: string;
+  action: string;
+  description: string;
+};
+
+/** One admin navigation entry this module wants rendered — consumed by Issue #518's navigation registry/sidebar. `requiredPermission` is checked in addition to (not instead of) the target page/API's own server-side guard. */
+export type ModuleNavigationEntry = {
+  labelKey: string;
+  path: string;
+  icon?: string;
+  order?: number;
+  group?: string;
+  requiredPermission?: string;
+};
+
+/** Non-secret settings shape/defaults only — consumed by Issue #516. Never put a secret-shaped default here; real secrets stay in env/secret manager. */
+export type ModuleSettingsContract = {
+  schemaVersion?: number;
+  defaults?: Record<string, unknown>;
+};
+
+/** One operational command this module ships — consumed by Issue #519's job registry (documentation only, never an execute-from-UI action). */
+export type ModuleJobDescriptor = {
+  command: string;
+  purpose: string;
+  recommendedSchedule?: string;
+  environmentNotes?: string;
+  safeInOfflineLan?: boolean;
+};
+
+/** Capability flags only — the real check logic (DB reachable, provider configured, etc.) is implemented in Issue #520, this just declares that the module has one. */
+export type ModuleHealthContract = {
+  hasHealthCheck?: boolean;
+  hasReadinessCheck?: boolean;
+};
+
+/** Compatibility metadata used by Issue #515's dependency-graph validation to report version incompatibility when present — absence means "no constraint declared", not "incompatible". */
+export type ModuleCompatibilityContract = {
+  minAppVersion?: string;
+};
+
 export type ModuleDescriptor = {
   key: string;
   name: string;
   version: string;
-  status: ModuleStatus;
+  status: ModuleLifecycleStatus;
   description: string;
   dependencies: string[];
   api?: ModuleApiContract;
   events?: ModuleEventContract;
+  type?: ModuleType;
+  isCore?: boolean;
+  permissions?: ModulePermissionDescriptor[];
+  navigation?: ModuleNavigationEntry[];
+  settings?: ModuleSettingsContract;
+  jobs?: ModuleJobDescriptor[];
+  health?: ModuleHealthContract;
+  compatibility?: ModuleCompatibilityContract;
+  maintainers?: string[];
 };
 
 export function defineModule(descriptor: ModuleDescriptor): ModuleDescriptor {

--- a/tests/module-contract.test.ts
+++ b/tests/module-contract.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+
+import { defineModule } from "../src/modules/_shared/module-contract";
+
+describe("defineModule — backward compatibility (Issue #511)", () => {
+  test("a descriptor with only the original fields remains valid", () => {
+    const descriptor = defineModule({
+      key: "example",
+      name: "Example",
+      version: "1.0.0",
+      status: "active",
+      description: "Minimal descriptor using only pre-Issue-#511 fields.",
+      dependencies: []
+    });
+
+    expect(descriptor.key).toBe("example");
+    expect(descriptor.type).toBeUndefined();
+    expect(descriptor.permissions).toBeUndefined();
+  });
+
+  test("the existing three lifecycle statuses still type-check", () => {
+    for (const status of ["active", "experimental", "deprecated"] as const) {
+      const descriptor = defineModule({
+        key: "example",
+        name: "Example",
+        version: "1.0.0",
+        status,
+        description: "Status compatibility check.",
+        dependencies: []
+      });
+
+      expect(descriptor.status).toBe(status);
+    }
+  });
+});
+
+describe("defineModule — new optional metadata (Issue #511)", () => {
+  test("the two new lifecycle statuses (maintenance, disabled) are accepted", () => {
+    for (const status of ["maintenance", "disabled"] as const) {
+      const descriptor = defineModule({
+        key: "example",
+        name: "Example",
+        version: "1.0.0",
+        status,
+        description: "New lifecycle status.",
+        dependencies: []
+      });
+
+      expect(descriptor.status).toBe(status);
+    }
+  });
+
+  test("a fully-populated module_management-shaped descriptor is constructible", () => {
+    const descriptor = defineModule({
+      key: "module_management",
+      name: "Module Management",
+      version: "0.1.0",
+      status: "active",
+      description:
+        "Database-backed, tenant-aware module registry, lifecycle, settings, navigation, jobs, and health (epic #510).",
+      dependencies: ["tenant_admin", "identity_access"],
+      type: "system",
+      isCore: true,
+      permissions: [
+        {
+          activityCode: "modules",
+          action: "read",
+          description: "Read the module registry"
+        },
+        {
+          activityCode: "modules",
+          action: "sync",
+          description: "Sync trusted descriptors into the database registry"
+        }
+      ],
+      navigation: [
+        {
+          labelKey: "admin.layout.nav_modules",
+          path: "/admin/modules",
+          order: 100,
+          requiredPermission: "module_management.modules.read"
+        }
+      ],
+      settings: {
+        schemaVersion: 1,
+        defaults: { autoSyncOnBoot: false }
+      },
+      jobs: [
+        {
+          command: "bun run modules:sync",
+          purpose: "Sync trusted code descriptors into the database registry.",
+          recommendedSchedule: "on deploy",
+          safeInOfflineLan: true
+        }
+      ],
+      health: { hasHealthCheck: true, hasReadinessCheck: true },
+      compatibility: { minAppVersion: "0.23.0" },
+      maintainers: ["platform-team"]
+    });
+
+    expect(descriptor.type).toBe("system");
+    expect(descriptor.isCore).toBe(true);
+    expect(descriptor.permissions).toHaveLength(2);
+    expect(descriptor.navigation?.[0]?.path).toBe("/admin/modules");
+    expect(descriptor.settings?.defaults).toEqual({ autoSyncOnBoot: false });
+    expect(descriptor.jobs?.[0]?.command).toBe("bun run modules:sync");
+    expect(descriptor.health).toEqual({
+      hasHealthCheck: true,
+      hasReadinessCheck: true
+    });
+    expect(descriptor.compatibility?.minAppVersion).toBe("0.23.0");
+    expect(descriptor.maintainers).toEqual(["platform-team"]);
+  });
+
+  test("descriptor metadata never needs a secret-shaped field to be useful", () => {
+    // Documents the security note as an executable check: none of the new
+    // optional fields require (or even accept a natural place for) a
+    // runtime secret — settings.defaults is the only free-form bag, and it
+    // is documented as non-secret-only (Issue #511/#516).
+    const descriptor = defineModule({
+      key: "module_management",
+      name: "Module Management",
+      version: "0.1.0",
+      status: "active",
+      description: "Secret-free descriptor check.",
+      dependencies: [],
+      settings: { defaults: { autoSyncOnBoot: false } }
+    });
+
+    const serialized = JSON.stringify(descriptor);
+    expect(serialized).not.toContain("password");
+    expect(serialized).not.toContain("token");
+    expect(serialized).not.toContain("secret");
+  });
+});


### PR DESCRIPTION
## Summary
- Closes issue #511 (epic #510) — extends `ModuleDescriptor` with optional, backward-compatible metadata for Module Management: `type`, widened `status` (now `ModuleLifecycleStatus`, adds `maintenance`/`disabled`), `isCore`, `permissions`, `navigation`, `settings`, `jobs`, `health`, `compatibility`, `maintainers`.
- All additions are optional — none of the 9 currently-registered modules needed any change.
- `disabled` status is explicitly documented as global (code/deployment), never a per-tenant toggle — that's separate database state coming in #512/#515.
- No secret-shaped field anywhere in the new metadata, per the issue's security note.

## Test plan
- [x] `bun run check` green (lint, check:docs, api:spec:check, typecheck, test, build)
- [x] Live-verified against real PostgreSQL (557 tests pass, up from 552)
- [x] New `tests/module-contract.test.ts`: backward-compat check, both new lifecycle statuses, a fully-populated `module_management`-shaped descriptor exercising every new field, and a secret-free serialization check

🤖 Generated with [Claude Code](https://claude.com/claude-code)