### PR TITLE
feat(module-management): add schema and permission seed (#512)

### DIFF
--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -361,13 +361,23 @@ export function checkLoginLockoutImplemented(): SecurityCheckResult {
  *   permission catalog, shared by all tenants.
  * - `awcms_mini_setup_state` (sql/006) — global singleton setup lock that
  *   exists before any tenant does.
+ * - `awcms_mini_module_dependencies`, `awcms_mini_module_navigation`,
+ *   `awcms_mini_module_jobs`, `awcms_mini_module_health_checks` (sql/025) —
+ *   code-derived module registry metadata (dependency graph, admin nav,
+ *   job/command catalog, instance-level health check history), synced from
+ *   trusted descriptors, never tenant-writable. Same reasoning as
+ *   `awcms_mini_modules` above.
  */
 const RLS_FREE_TABLES = new Set([
   "awcms_mini_schema_migrations",
   "awcms_mini_modules",
   "awcms_mini_tenants",
   "awcms_mini_permissions",
-  "awcms_mini_setup_state"
+  "awcms_mini_setup_state",
+  "awcms_mini_module_dependencies",
+  "awcms_mini_module_navigation",
+  "awcms_mini_module_jobs",
+  "awcms_mini_module_health_checks"
 ]);
 
 export async function checkRlsEnabled(): Promise<SecurityCheckResult> {

--- a/sql/025_awcms_mini_module_management_schema.sql
+++ b/sql/025_awcms_mini_module_management_schema.sql
@@ -1,0 +1,173 @@
+-- Issue #512 (epic #510, module management) — database-backed module
+-- registry, tenant module lifecycle, dependency graph, settings,
+-- navigation, jobs, and health-check history.
+--
+-- `awcms_mini_modules` already exists (migration 001) as a dormant table —
+-- no application code has ever written to it (the code-level registry,
+-- `src/modules/index.ts`, has been the only source of truth so far). This
+-- migration extends it in place (never recreated) and adds the supporting
+-- tables Issue #513's descriptor-sync service populates.
+--
+-- Deliberately does NOT add a `module_management.audit.read` permission or
+-- a dedicated `awcms_mini_module_lifecycle_events` table (both were in the
+-- original issue draft) — module lifecycle/config actions are recorded
+-- through the existing generic `awcms_mini_audit_events` table
+-- (`module_key = 'module_management'`, `resource_type` = 'tenant_module' /
+-- 'module_settings' / etc.), the same audit trail every other module
+-- already reuses (see `GET /api/v1/logs/audit?resourceType=...`). A second,
+-- module-specific event table would just be a second, divergent source of
+-- truth for the same fact ("who changed what, when") — exactly the
+-- redundancy this epic's own Issue #517 (permission sync/status reporting)
+-- exists to catch elsewhere, so it should not be introduced here either.
+ALTER TABLE awcms_mini_modules
+  ADD COLUMN IF NOT EXISTS module_type text,
+  ADD COLUMN IF NOT EXISTS lifecycle_status text NOT NULL DEFAULT 'active',
+  ADD COLUMN IF NOT EXISTS descriptor_version integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS is_core boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS is_tenant_configurable boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+ALTER TABLE awcms_mini_modules
+  ADD CONSTRAINT awcms_mini_modules_lifecycle_status_check
+    CHECK (lifecycle_status IN ('active', 'experimental', 'deprecated', 'maintenance', 'disabled'));
+
+ALTER TABLE awcms_mini_modules
+  ADD CONSTRAINT awcms_mini_modules_module_type_check
+    CHECK (module_type IS NULL OR module_type IN ('base', 'system', 'domain', 'integration', 'derived'));
+
+-- Tenant-level module enablement (Issue #515). A missing row for a given
+-- (tenant, module) pair means "using the default" — enabled, matching
+-- pre-epic behavior where every registered module was simply always on
+-- for every tenant (epic #510 acceptance criterion: "Existing module
+-- behavior remains backward-compatible").
+CREATE TABLE IF NOT EXISTS awcms_mini_tenant_modules (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  module_key text NOT NULL REFERENCES awcms_mini_modules (module_key),
+  enabled boolean NOT NULL DEFAULT true,
+  enabled_at timestamptz,
+  enabled_by uuid,
+  disabled_at timestamptz,
+  disabled_by uuid,
+  disable_reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_mini_tenant_modules_tenant_module_key UNIQUE (tenant_id, module_key)
+);
+
+ALTER TABLE awcms_mini_tenant_modules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_tenant_modules FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_tenant_modules_tenant_isolation
+  ON awcms_mini_tenant_modules
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_tenant_modules_tenant_idx
+  ON awcms_mini_tenant_modules (tenant_id, module_key);
+
+-- Dependency graph (Issue #515's validation reads this). Code-derived —
+-- populated by Issue #513's descriptor sync from each module's own
+-- `dependencies` array, never tenant-writable. RLS-free: this is global
+-- registry metadata describing which module needs which, identical in
+-- meaning for every tenant (same justification as `awcms_mini_modules`
+-- itself being RLS-free since migration 001).
+CREATE TABLE IF NOT EXISTS awcms_mini_module_dependencies (
+  module_key text NOT NULL REFERENCES awcms_mini_modules (module_key),
+  depends_on_module_key text NOT NULL REFERENCES awcms_mini_modules (module_key),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (module_key, depends_on_module_key),
+  CONSTRAINT awcms_mini_module_dependencies_no_self_dependency
+    CHECK (module_key <> depends_on_module_key)
+);
+
+-- Tenant-aware, non-secret module settings (Issue #516). `settings` must
+-- never hold a raw provider secret/token — enforced at the application
+-- layer (redact/reject secret-shaped keys, reusing
+-- `_shared/redaction.ts`'s `REDACTION_KEYS`), not by this schema.
+CREATE TABLE IF NOT EXISTS awcms_mini_module_settings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  module_key text NOT NULL REFERENCES awcms_mini_modules (module_key),
+  schema_version integer NOT NULL DEFAULT 1,
+  settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by uuid,
+  CONSTRAINT awcms_mini_module_settings_tenant_module_key UNIQUE (tenant_id, module_key)
+);
+
+ALTER TABLE awcms_mini_module_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_module_settings FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_module_settings_tenant_isolation
+  ON awcms_mini_module_settings
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Admin navigation registry (Issue #518). Code-derived (synced from each
+-- module descriptor's `navigation` entries), not tenant-writable — RLS-free
+-- for the same reason as dependencies/jobs above. `path` is globally
+-- unique: two modules declaring the same admin route would be a
+-- descriptor-authoring bug, not a valid state.
+CREATE TABLE IF NOT EXISTS awcms_mini_module_navigation (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  module_key text NOT NULL REFERENCES awcms_mini_modules (module_key),
+  label_key text NOT NULL,
+  path text NOT NULL,
+  icon text,
+  sort_order integer NOT NULL DEFAULT 0,
+  nav_group text,
+  required_permission text,
+  synced_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_mini_module_navigation_path_key UNIQUE (path)
+);
+
+-- Operational job/command registry (Issue #519). Documentation-only —
+-- never an "execute this command" surface. Code-derived, RLS-free.
+CREATE TABLE IF NOT EXISTS awcms_mini_module_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  module_key text NOT NULL REFERENCES awcms_mini_modules (module_key),
+  command text NOT NULL,
+  purpose text NOT NULL,
+  recommended_schedule text,
+  environment_notes text,
+  safe_in_offline_lan boolean NOT NULL DEFAULT false,
+  synced_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_mini_module_jobs_module_command_key UNIQUE (module_key, command)
+);
+
+-- Health check result history (Issue #520). Instance-level (schema
+-- validity, migrations applied, permission catalog synced, provider config
+-- present, etc. are facts about the deployed instance, not about any one
+-- tenant) — RLS-free, same reasoning as the other registry tables above.
+-- `message` must be redaction-ready (never a raw secret/stack trace) —
+-- enforced at the application layer, same rule `email_delivery_attempts`
+-- follows for provider response snippets.
+CREATE TABLE IF NOT EXISTS awcms_mini_module_health_checks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  module_key text NOT NULL REFERENCES awcms_mini_modules (module_key),
+  status text NOT NULL,
+  message text,
+  checked_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_mini_module_health_checks_status_check
+    CHECK (status IN ('healthy', 'degraded', 'failed', 'unknown'))
+);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_module_health_checks_module_idx
+  ON awcms_mini_module_health_checks (module_key, checked_at DESC);
+
+-- Permission catalog for Module Management (Issues #514-#520). No
+-- `module_management.audit.read` — see header comment.
+INSERT INTO awcms_mini_permissions (module_key, activity_code, action, description)
+VALUES
+  ('module_management', 'modules', 'read', 'Read the module registry'),
+  ('module_management', 'modules', 'sync', 'Sync trusted code descriptors into the database registry'),
+  ('module_management', 'tenant_modules', 'read', 'Read tenant module enablement state'),
+  ('module_management', 'tenant_modules', 'enable', 'Enable a module for a tenant'),
+  ('module_management', 'tenant_modules', 'disable', 'Disable a module for a tenant'),
+  ('module_management', 'settings', 'read', 'Read effective tenant module settings'),
+  ('module_management', 'settings', 'update', 'Update tenant module settings'),
+  ('module_management', 'permissions', 'read', 'Read module permission sync/status'),
+  ('module_management', 'navigation', 'read', 'Read the module admin navigation registry'),
+  ('module_management', 'jobs', 'read', 'Read the module job/command registry'),
+  ('module_management', 'health', 'read', 'Read module health/readiness status'),
+  ('module_management', 'health', 'check', 'Trigger a module health check')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -207,7 +207,8 @@ describe("database migration runner helpers", () => {
       "021_awcms_mini_email_template_i18n_schema.sql",
       "022_awcms_mini_password_reset_schema.sql",
       "023_awcms_mini_email_announcement_permission_schema.sql",
-      "024_awcms_mini_email_message_cancel_permission_schema.sql"
+      "024_awcms_mini_email_message_cancel_permission_schema.sql",
+      "025_awcms_mini_module_management_schema.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/module-management-schema.integration.test.ts
+++ b/tests/integration/module-management-schema.integration.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Integration tests for the module management schema/RLS (Issue #512,
+ * epic #510) against a real PostgreSQL. No endpoints/services exist yet
+ * (Issue #513 scaffolds the descriptor sync service that will populate
+ * these tables for real) — this exercises the migration's constraints and
+ * RLS enforcement directly via `withTenant`/raw admin SQL, the same
+ * pattern `email-schema.integration.test.ts` (#494) used.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+
+const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const MODULE_KEY = "example_module";
+const OTHER_MODULE_KEY = "other_module";
+
+async function seedTenants(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES
+      (${TENANT_A}, 'tenant-a', 'Tenant A', 'Tenant A Legal', 'active', 'en', 'light'),
+      (${TENANT_B}, 'tenant-b', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+  `;
+}
+
+async function seedModules(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_modules (module_key, module_name, status, version)
+    VALUES
+      (${MODULE_KEY}, 'Example Module', 'active', '1.0.0'),
+      (${OTHER_MODULE_KEY}, 'Other Module', 'active', '1.0.0')
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("module management schema — RLS isolation and constraints", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+    await seedModules();
+  });
+
+  test("awcms_mini_modules gained the new columns with sane defaults", async () => {
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT module_type, lifecycle_status, descriptor_version, is_core,
+             is_tenant_configurable, updated_at
+      FROM awcms_mini_modules WHERE module_key = ${MODULE_KEY}
+    `) as {
+      module_type: string | null;
+      lifecycle_status: string;
+      descriptor_version: number;
+      is_core: boolean;
+      is_tenant_configurable: boolean;
+      updated_at: Date;
+    }[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.module_type).toBeNull();
+    expect(rows[0]!.lifecycle_status).toBe("active");
+    expect(rows[0]!.descriptor_version).toBe(1);
+    expect(rows[0]!.is_core).toBe(false);
+    expect(rows[0]!.is_tenant_configurable).toBe(true);
+    expect(rows[0]!.updated_at).toBeInstanceOf(Date);
+  });
+
+  test("lifecycle_status rejects an unknown value", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+
+    try {
+      await admin`
+        UPDATE awcms_mini_modules SET lifecycle_status = 'bogus'
+        WHERE module_key = ${MODULE_KEY}
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("module_type rejects an unknown value but allows null", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+
+    try {
+      await admin`
+        UPDATE awcms_mini_modules SET module_type = 'bogus'
+        WHERE module_key = ${MODULE_KEY}
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+
+    await admin`
+      UPDATE awcms_mini_modules SET module_type = 'system'
+      WHERE module_key = ${MODULE_KEY}
+    `;
+    const rows = (await admin`
+      SELECT module_type FROM awcms_mini_modules WHERE module_key = ${MODULE_KEY}
+    `) as { module_type: string }[];
+    expect(rows[0]!.module_type).toBe("system");
+  });
+
+  test("tenant A cannot see tenant B's tenant_modules row", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_tenant_modules (tenant_id, module_key, enabled)
+      VALUES (${TENANT_A}, ${MODULE_KEY}, true), (${TENANT_B}, ${MODULE_KEY}, false)
+    `;
+
+    const sql = getDatabaseClient();
+    const tenantARows = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT enabled FROM awcms_mini_tenant_modules`
+    );
+    expect(tenantARows).toHaveLength(1);
+    expect((tenantARows as { enabled: boolean }[])[0]?.enabled).toBe(true);
+
+    const tenantBRows = await withTenant(
+      sql,
+      TENANT_B,
+      (tx) => tx`SELECT enabled FROM awcms_mini_tenant_modules`
+    );
+    expect(tenantBRows).toHaveLength(1);
+    expect((tenantBRows as { enabled: boolean }[])[0]?.enabled).toBe(false);
+  });
+
+  test("querying tenant_modules without a tenant GUC set returns no rows (fail-closed)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_tenant_modules (tenant_id, module_key)
+      VALUES (${TENANT_A}, ${MODULE_KEY})
+    `;
+
+    const sql = getDatabaseClient();
+    const rows = await sql`SELECT enabled FROM awcms_mini_tenant_modules`;
+    expect(rows).toHaveLength(0);
+  });
+
+  test("tenant_modules enforces one row per (tenant, module)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_tenant_modules (tenant_id, module_key)
+      VALUES (${TENANT_A}, ${MODULE_KEY})
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_tenant_modules (tenant_id, module_key)
+        VALUES (${TENANT_A}, ${MODULE_KEY})
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("tenant A cannot see tenant B's module_settings row", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_module_settings (tenant_id, module_key, settings)
+      VALUES
+        (${TENANT_A}, ${MODULE_KEY}, ${{ autoSyncOnBoot: true }}),
+        (${TENANT_B}, ${MODULE_KEY}, ${{ autoSyncOnBoot: false }})
+    `;
+
+    const sql = getDatabaseClient();
+    const tenantARows = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT settings FROM awcms_mini_module_settings`
+    );
+    expect(tenantARows).toHaveLength(1);
+    expect(
+      (tenantARows as { settings: { autoSyncOnBoot: boolean } }[])[0]?.settings
+    ).toEqual({ autoSyncOnBoot: true });
+  });
+
+  test("module_dependencies rejects a self-dependency", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+
+    try {
+      await admin`
+        INSERT INTO awcms_mini_module_dependencies (module_key, depends_on_module_key)
+        VALUES (${MODULE_KEY}, ${MODULE_KEY})
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("module_dependencies requires both module keys to already exist", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+
+    try {
+      await admin`
+        INSERT INTO awcms_mini_module_dependencies (module_key, depends_on_module_key)
+        VALUES (${MODULE_KEY}, 'does_not_exist')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+
+    const rows = await admin`
+      INSERT INTO awcms_mini_module_dependencies (module_key, depends_on_module_key)
+      VALUES (${MODULE_KEY}, ${OTHER_MODULE_KEY})
+      RETURNING module_key
+    `;
+    expect(rows).toHaveLength(1);
+  });
+
+  test("module_navigation enforces a globally unique path", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_module_navigation (module_key, label_key, path)
+      VALUES (${MODULE_KEY}, 'nav.example', '/admin/example')
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_module_navigation (module_key, label_key, path)
+        VALUES (${OTHER_MODULE_KEY}, 'nav.other', '/admin/example')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("module_jobs enforces one row per (module, command)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_module_jobs (module_key, command, purpose)
+      VALUES (${MODULE_KEY}, 'bun run example:job', 'Example job.')
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_module_jobs (module_key, command, purpose)
+        VALUES (${MODULE_KEY}, 'bun run example:job', 'Duplicate.')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("module_health_checks rejects an unknown status and supports a latest-per-module query", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+
+    try {
+      await admin`
+        INSERT INTO awcms_mini_module_health_checks (module_key, status)
+        VALUES (${MODULE_KEY}, 'bogus')
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+
+    await admin`
+      INSERT INTO awcms_mini_module_health_checks (module_key, status, checked_at)
+      VALUES
+        (${MODULE_KEY}, 'degraded', now() - interval '1 hour'),
+        (${MODULE_KEY}, 'healthy', now())
+    `;
+
+    const rows = (await admin`
+      SELECT status FROM awcms_mini_module_health_checks
+      WHERE module_key = ${MODULE_KEY}
+      ORDER BY checked_at DESC
+      LIMIT 1
+    `) as { status: string }[];
+
+    expect(rows[0]!.status).toBe("healthy");
+  });
+
+  test("module_management permission catalog is seeded (no audit.read entry)", async () => {
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT activity_code, action FROM awcms_mini_permissions
+      WHERE module_key = 'module_management'
+      ORDER BY activity_code, action
+    `) as { activity_code: string; action: string }[];
+
+    expect(rows.map((row) => `${row.activity_code}.${row.action}`)).toEqual([
+      "health.check",
+      "health.read",
+      "jobs.read",
+      "modules.read",
+      "modules.sync",
+      "navigation.read",
+      "permissions.read",
+      "settings.read",
+      "settings.update",
+      "tenant_modules.disable",
+      "tenant_modules.enable",
+      "tenant_modules.read"
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements issue #512 (epic #510) — the module management schema and permission seed.
- Extends the dormant `awcms_mini_modules` (migration 001) in place; adds 6 new tables (`tenant_modules`, `module_dependencies`, `module_settings`, `module_navigation`, `module_jobs`, `module_health_checks`); seeds the 12 `module_management.*` permissions.
- Deliberately omits `module_management.audit.read` and a dedicated lifecycle-events table (both were in the issue's original draft, edited earlier this session) — reuses the existing generic `awcms_mini_audit_events` table instead, avoiding a second, divergent source of truth.
- `scripts/security-readiness.ts`'s RLS-free table exclusion list updated for the 4 new global (code-derived, non-tenant-scoped) tables.

**This is a schema change (migration 025) — holding here for review before merge, per your request.**

## Test plan
- [x] `bun run check` green (lint, check:docs, api:spec:check, typecheck, test, build)
- [x] Live-verified against real PostgreSQL: migration applies cleanly (25 migrations), RLS isolation confirmed on both new tenant-scoped tables, all CHECK/FK/uniqueness constraints behave as designed, permission catalog seeded correctly (no orphaned `audit.read`)
- [x] New `tests/integration/module-management-schema.integration.test.ts` (13 tests) + `tests/foundation.test.ts` migration-list update

🤖 Generated with [Claude Code](https://claude.com/claude-code)