### PR TITLE
feat(module-management): scaffold module and descriptor sync service (#513)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "email:dispatch": "bun scripts/email-dispatch.ts",
     "email:provider:health": "bun scripts/email-provider-health.ts",
     "email:templates:seed-defaults": "bun scripts/email-templates-seed-defaults.ts",
+    "modules:sync": "bun scripts/modules-sync.ts",
     "security:readiness": "bun scripts/security-readiness.ts",
     "config:validate": "bun scripts/validate-env.ts",
     "production:preflight": "bun scripts/production-preflight.ts",

--- a/scripts/modules-sync.ts
+++ b/scripts/modules-sync.ts
@@ -1,0 +1,47 @@
+/**
+ * modules-sync.ts — `bun run modules:sync`.
+ *
+ * Issue #513 (epic #510, Module Management). CLI wrapper for
+ * `syncModuleDescriptors` (`src/modules/module-management/application/
+ * descriptor-sync.ts`) — reads the trusted code registry (`listModules()`)
+ * and upserts it into the database-backed registry. Safe to run on every
+ * deploy (idempotent, no network calls, no user input).
+ */
+import { getDatabaseClient } from "../src/lib/database/client";
+import { syncModuleDescriptors } from "../src/modules/module-management/application/descriptor-sync";
+
+async function main() {
+  const sql = getDatabaseClient();
+
+  try {
+    const result = await syncModuleDescriptors(sql);
+
+    console.log(
+      `modules:sync complete — created=${result.created.length} ` +
+        `updated=${result.updated.length} unchanged=${result.unchanged.length} ` +
+        `orphaned=${result.orphaned.length}`
+    );
+
+    if (result.created.length > 0) {
+      console.log(`  created: ${result.created.join(", ")}`);
+    }
+    if (result.updated.length > 0) {
+      console.log(`  updated: ${result.updated.join(", ")}`);
+    }
+    if (result.orphaned.length > 0) {
+      console.log(
+        `  orphaned (marked disabled, not deleted): ${result.orphaned.join(", ")}`
+      );
+    }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(`modules:sync FAILED — ${detail}`);
+    process.exitCode = 1;
+  } finally {
+    await sql.close({ timeout: 1 });
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -3,6 +3,7 @@ import { emailModule } from "./email/module";
 import { formDraftsModule } from "./form-drafts/module";
 import { identityAccessModule } from "./identity-access/module";
 import { loggingModule } from "./logging/module";
+import { moduleManagementModule } from "./module-management/module";
 import { profileIdentityModule } from "./profile-identity/module";
 import { reportingModule } from "./reporting/module";
 import { syncStorageModule } from "./sync-storage/module";
@@ -18,7 +19,8 @@ export const modules: ModuleDescriptor[] = [
   loggingModule,
   workflowApprovalModule,
   formDraftsModule,
-  emailModule
+  emailModule,
+  moduleManagementModule
 ];
 
 export function getModuleByKey(

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -1,0 +1,55 @@
+# Module Management
+
+Implementasi Issue #513 (epic #510) — turns the static code registry
+(`src/modules/index.ts`) into a database-backed, tenant-aware module
+management capability. `awcms_mini_modules` (migration 001) had existed
+since the very first migration but was never written to by any
+application code until this issue — `src/modules/index.ts`'s
+`listModules()` was the only source of truth until now.
+
+## Descriptor sync — `application/descriptor-sync.ts`
+
+`syncModuleDescriptors(sql, descriptors = listModules())`:
+
+1. Reads the current `awcms_mini_modules` rows.
+2. Computes a plan (`domain/descriptor-diff.ts`'s `planModuleSync` — pure,
+   no I/O, unit-testable): each code descriptor is classified `create`
+   (no matching DB row yet), `update` (a tracked field differs), or
+   `unchanged`.
+3. Upserts `awcms_mini_modules` for every `create`/`update` entry.
+4. Fully replaces (`DELETE` then `INSERT`) each module's
+   `awcms_mini_module_dependencies`/`_navigation`/`_jobs` rows from its
+   current descriptor — cheap at this scale (a handful of rows per
+   module) and guarantees the stored set can never silently drift from
+   what the descriptor currently declares.
+5. Any `awcms_mini_modules` row whose `module_key` is no longer in
+   `listModules()` is **marked** `lifecycle_status = 'disabled'` — never
+   deleted, and its dependencies/navigation/jobs rows are left untouched
+   as a historical record. A module absent from code is, by `#511`'s own
+   descriptor contract, globally disabled by definition.
+
+No network calls, no user-controlled path — the only input is the
+trusted, statically-imported module list already running in this
+process (`src/modules/index.ts`). Safe to call repeatedly: syncing the
+same descriptors twice produces `unchanged` the second time, never a
+duplicate row.
+
+These tables are global/RLS-free (migration 025's own justification —
+code-derived registry metadata, not tenant data), so the sync service
+runs on the plain app connection with no tenant context needed.
+
+## `module_management`'s own descriptor
+
+Declares `type: "system"`, `isCore: true` (module management cannot be
+tenant-disabled — you cannot disable the thing that manages modules), and
+its 12 seeded permissions (`migration 025`). Deliberately does **not**
+declare `navigation`/`jobs`/`health`/`api` yet — those fields exist on
+`ModuleDescriptor` (Issue #511) but the actual admin page (`/admin/modules`,
+Issue #521), job registry (#519), health checks (#520), and API routes
+(#514) don't exist yet. A descriptor should only claim a capability once
+the corresponding feature is real, not in advance.
+
+## Out of scope for this issue
+
+Admin UI, tenant enable/disable API, and runtime plugin installation are
+explicitly out of scope — see Issues #514/#515/#521 respectively.

--- a/src/modules/module-management/application/descriptor-sync.ts
+++ b/src/modules/module-management/application/descriptor-sync.ts
@@ -1,0 +1,209 @@
+/**
+ * Descriptor sync service (Issue #513, epic #510). Reads the trusted,
+ * in-process code registry (`listModules()`, `src/modules/index.ts`) and
+ * upserts it into the database-backed registry (`awcms_mini_modules` +
+ * `awcms_mini_module_dependencies`/`_navigation`/`_jobs`, migration 025).
+ *
+ * No network calls, no user-controlled path — the only input is the
+ * trusted, statically-imported module descriptor list already running in
+ * this process. Safe to call repeatedly: running with the same descriptors
+ * twice in a row produces the same DB state both times (`unchanged` on the
+ * second run), never a duplicate row or a second write of the same value.
+ *
+ * These tables are global/RLS-free (migration 025's own justification —
+ * code-derived registry metadata, not tenant data), so this runs on the
+ * plain app connection with no tenant context needed.
+ */
+import { listModules } from "../..";
+import type { ModuleDescriptor } from "../../_shared/module-contract";
+import {
+  planModuleSync,
+  type ExistingModuleRow
+} from "../domain/descriptor-diff";
+
+export type DescriptorSyncResult = {
+  created: string[];
+  updated: string[];
+  unchanged: string[];
+  orphaned: string[];
+};
+
+async function fetchExistingModules(
+  sql: Bun.SQL
+): Promise<ExistingModuleRow[]> {
+  const rows = (await sql`
+    SELECT module_key, module_name, version, description, lifecycle_status, module_type, is_core
+    FROM awcms_mini_modules
+  `) as {
+    module_key: string;
+    module_name: string;
+    version: string;
+    description: string | null;
+    lifecycle_status: string;
+    module_type: string | null;
+    is_core: boolean;
+  }[];
+
+  return rows.map((row) => ({
+    moduleKey: row.module_key,
+    moduleName: row.module_name,
+    version: row.version,
+    description: row.description,
+    lifecycleStatus: row.lifecycle_status,
+    moduleType: row.module_type,
+    isCore: row.is_core
+  }));
+}
+
+async function upsertModule(
+  sql: Bun.SQL,
+  descriptor: ModuleDescriptor
+): Promise<void> {
+  await sql`
+    INSERT INTO awcms_mini_modules
+      (module_key, module_name, status, version, description, module_type,
+       lifecycle_status, is_core, updated_at)
+    VALUES (
+      ${descriptor.key}, ${descriptor.name}, ${descriptor.status},
+      ${descriptor.version}, ${descriptor.description ?? null},
+      ${descriptor.type ?? null}, ${descriptor.status},
+      ${descriptor.isCore ?? false}, now()
+    )
+    ON CONFLICT (module_key) DO UPDATE SET
+      module_name = EXCLUDED.module_name,
+      status = EXCLUDED.status,
+      version = EXCLUDED.version,
+      description = EXCLUDED.description,
+      module_type = EXCLUDED.module_type,
+      lifecycle_status = EXCLUDED.lifecycle_status,
+      is_core = EXCLUDED.is_core,
+      updated_at = now()
+  `;
+}
+
+/** Full replace, not a diff — cheap at this scale (a handful of rows per module) and guarantees the stored set can never silently drift from the descriptor's declared set. */
+async function replaceDependencies(
+  sql: Bun.SQL,
+  descriptor: ModuleDescriptor
+): Promise<void> {
+  await sql`
+    DELETE FROM awcms_mini_module_dependencies WHERE module_key = ${descriptor.key}
+  `;
+
+  for (const dependsOn of descriptor.dependencies) {
+    await sql`
+      INSERT INTO awcms_mini_module_dependencies (module_key, depends_on_module_key)
+      VALUES (${descriptor.key}, ${dependsOn})
+      ON CONFLICT (module_key, depends_on_module_key) DO NOTHING
+    `;
+  }
+}
+
+async function replaceNavigation(
+  sql: Bun.SQL,
+  descriptor: ModuleDescriptor
+): Promise<void> {
+  await sql`
+    DELETE FROM awcms_mini_module_navigation WHERE module_key = ${descriptor.key}
+  `;
+
+  for (const entry of descriptor.navigation ?? []) {
+    await sql`
+      INSERT INTO awcms_mini_module_navigation
+        (module_key, label_key, path, icon, sort_order, nav_group, required_permission)
+      VALUES (
+        ${descriptor.key}, ${entry.labelKey}, ${entry.path}, ${entry.icon ?? null},
+        ${entry.order ?? 0}, ${entry.group ?? null}, ${entry.requiredPermission ?? null}
+      )
+    `;
+  }
+}
+
+async function replaceJobs(
+  sql: Bun.SQL,
+  descriptor: ModuleDescriptor
+): Promise<void> {
+  await sql`
+    DELETE FROM awcms_mini_module_jobs WHERE module_key = ${descriptor.key}
+  `;
+
+  for (const job of descriptor.jobs ?? []) {
+    await sql`
+      INSERT INTO awcms_mini_module_jobs
+        (module_key, command, purpose, recommended_schedule, environment_notes, safe_in_offline_lan)
+      VALUES (
+        ${descriptor.key}, ${job.command}, ${job.purpose},
+        ${job.recommendedSchedule ?? null}, ${job.environmentNotes ?? null},
+        ${job.safeInOfflineLan ?? false}
+      )
+    `;
+  }
+}
+
+/**
+ * Orphaned modules (registered in the DB previously, no longer in
+ * `listModules()`) are marked `lifecycle_status = 'disabled'` — never
+ * deleted, and never touching their dependencies/navigation/jobs rows,
+ * which stay as a historical record. `#511`'s own contract note applies
+ * here: a module absent from code is, by definition, globally disabled.
+ */
+async function markOrphaned(sql: Bun.SQL, moduleKey: string): Promise<void> {
+  await sql`
+    UPDATE awcms_mini_modules
+    SET lifecycle_status = 'disabled', updated_at = now()
+    WHERE module_key = ${moduleKey} AND lifecycle_status <> 'disabled'
+  `;
+}
+
+export async function syncModuleDescriptors(
+  sql: Bun.SQL,
+  descriptors: readonly ModuleDescriptor[] = listModules()
+): Promise<DescriptorSyncResult> {
+  const existingRows = await fetchExistingModules(sql);
+  const plan = planModuleSync(descriptors, existingRows);
+
+  const result: DescriptorSyncResult = {
+    created: [],
+    updated: [],
+    unchanged: [],
+    orphaned: plan.orphanedModuleKeys
+  };
+
+  const descriptorsByKey = new Map(
+    descriptors.map((descriptor) => [descriptor.key, descriptor] as const)
+  );
+
+  // Pass 1: upsert every module row first. A module can declare a
+  // dependency on one that appears *later* in `descriptors` (e.g.
+  // `reporting` depends on `email`, which is registered after it) — the
+  // dependency FK requires the target row to already exist, so all module
+  // rows must land before any dependency row is written (pass 2 below).
+  for (const entry of plan.entries) {
+    const descriptor = descriptorsByKey.get(entry.moduleKey)!;
+
+    if (entry.action === "unchanged") {
+      result.unchanged.push(entry.moduleKey);
+    } else {
+      await upsertModule(sql, descriptor);
+      (entry.action === "create" ? result.created : result.updated).push(
+        entry.moduleKey
+      );
+    }
+  }
+
+  // Pass 2: now that every module row exists, dependency/navigation/job
+  // rows can be safely (re)written for each module.
+  for (const entry of plan.entries) {
+    const descriptor = descriptorsByKey.get(entry.moduleKey)!;
+
+    await replaceDependencies(sql, descriptor);
+    await replaceNavigation(sql, descriptor);
+    await replaceJobs(sql, descriptor);
+  }
+
+  for (const moduleKey of plan.orphanedModuleKeys) {
+    await markOrphaned(sql, moduleKey);
+  }
+
+  return result;
+}

--- a/src/modules/module-management/domain/descriptor-diff.ts
+++ b/src/modules/module-management/domain/descriptor-diff.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure diff/orphan-detection logic for the descriptor sync service (Issue
+ * #513, epic #510). No I/O here — the application layer
+ * (`application/descriptor-sync.ts`) reads `listModules()` and the current
+ * `awcms_mini_modules` rows, then hands both to `planModuleSync` to decide
+ * what to write, keeping the actual decision testable without a database.
+ */
+import type { ModuleDescriptor } from "../../_shared/module-contract";
+
+export type ExistingModuleRow = {
+  moduleKey: string;
+  moduleName: string;
+  version: string;
+  description: string | null;
+  lifecycleStatus: string;
+  moduleType: string | null;
+  isCore: boolean;
+};
+
+export type ModuleSyncAction = "create" | "update" | "unchanged";
+
+export type ModuleSyncPlanEntry = {
+  moduleKey: string;
+  action: ModuleSyncAction;
+  changedFields: string[];
+};
+
+export type ModuleSyncPlan = {
+  entries: ModuleSyncPlanEntry[];
+  /** Present in `awcms_mini_modules` but no longer in `listModules()` — reported so the sync service can mark them (never delete), and so operators/tests can see drift explicitly. */
+  orphanedModuleKeys: string[];
+};
+
+function diffFields(
+  descriptor: ModuleDescriptor,
+  existing: ExistingModuleRow
+): string[] {
+  const changed: string[] = [];
+
+  if (descriptor.name !== existing.moduleName) {
+    changed.push("name");
+  }
+  if (descriptor.version !== existing.version) {
+    changed.push("version");
+  }
+  if ((descriptor.description ?? null) !== (existing.description ?? null)) {
+    changed.push("description");
+  }
+  if (descriptor.status !== existing.lifecycleStatus) {
+    changed.push("status");
+  }
+  if ((descriptor.type ?? null) !== (existing.moduleType ?? null)) {
+    changed.push("type");
+  }
+  if ((descriptor.isCore ?? false) !== existing.isCore) {
+    changed.push("isCore");
+  }
+
+  return changed;
+}
+
+export function planModuleSync(
+  descriptors: readonly ModuleDescriptor[],
+  existingRows: readonly ExistingModuleRow[]
+): ModuleSyncPlan {
+  const existingByKey = new Map(
+    existingRows.map((row) => [row.moduleKey, row] as const)
+  );
+  const descriptorKeys = new Set(descriptors.map((d) => d.key));
+
+  const entries: ModuleSyncPlanEntry[] = descriptors.map((descriptor) => {
+    const existing = existingByKey.get(descriptor.key);
+
+    if (!existing) {
+      return { moduleKey: descriptor.key, action: "create", changedFields: [] };
+    }
+
+    const changedFields = diffFields(descriptor, existing);
+
+    return {
+      moduleKey: descriptor.key,
+      action: changedFields.length > 0 ? "update" : "unchanged",
+      changedFields
+    };
+  });
+
+  const orphanedModuleKeys = existingRows
+    .map((row) => row.moduleKey)
+    .filter((moduleKey) => !descriptorKeys.has(moduleKey));
+
+  return { entries, orphanedModuleKeys };
+}

--- a/src/modules/module-management/module.ts
+++ b/src/modules/module-management/module.ts
@@ -1,0 +1,75 @@
+import { defineModule } from "../_shared/module-contract";
+
+export const moduleManagementModule = defineModule({
+  key: "module_management",
+  name: "Module Management",
+  version: "0.1.0",
+  status: "active",
+  description:
+    "Database-backed, tenant-aware module registry (epic #510): syncs trusted code descriptors (`listModules()`) into the database, tracks per-tenant module enablement, dependency validation, non-secret settings, permission sync/status, admin navigation, job/command registry, and health/readiness. Generic infrastructure for managing every other registered module — not a domain-specific feature.",
+  dependencies: ["tenant_admin", "identity_access"],
+  type: "system",
+  isCore: true,
+  permissions: [
+    {
+      activityCode: "modules",
+      action: "read",
+      description: "Read the module registry"
+    },
+    {
+      activityCode: "modules",
+      action: "sync",
+      description: "Sync trusted code descriptors into the database registry"
+    },
+    {
+      activityCode: "tenant_modules",
+      action: "read",
+      description: "Read tenant module enablement state"
+    },
+    {
+      activityCode: "tenant_modules",
+      action: "enable",
+      description: "Enable a module for a tenant"
+    },
+    {
+      activityCode: "tenant_modules",
+      action: "disable",
+      description: "Disable a module for a tenant"
+    },
+    {
+      activityCode: "settings",
+      action: "read",
+      description: "Read effective tenant module settings"
+    },
+    {
+      activityCode: "settings",
+      action: "update",
+      description: "Update tenant module settings"
+    },
+    {
+      activityCode: "permissions",
+      action: "read",
+      description: "Read module permission sync/status"
+    },
+    {
+      activityCode: "navigation",
+      action: "read",
+      description: "Read the module admin navigation registry"
+    },
+    {
+      activityCode: "jobs",
+      action: "read",
+      description: "Read the module job/command registry"
+    },
+    {
+      activityCode: "health",
+      action: "read",
+      description: "Read module health/readiness status"
+    },
+    {
+      activityCode: "health",
+      action: "check",
+      description: "Trigger a module health check"
+    }
+  ]
+});

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -58,8 +58,8 @@ describe("soft delete helper", () => {
 });
 
 describe("module registry", () => {
-  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, and email are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498", () => {
-    expect(listModules()).toHaveLength(9);
+  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, email, and module_management are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498, #511-#513", () => {
+    expect(listModules()).toHaveLength(10);
     expect(getModuleByKey("tenant_admin")).toMatchObject({
       key: "tenant_admin",
       status: "active"
@@ -103,6 +103,13 @@ describe("module registry", () => {
       key: "email",
       status: "active",
       dependencies: ["tenant_admin", "profile_identity", "identity_access"]
+    });
+    expect(getModuleByKey("module_management")).toMatchObject({
+      key: "module_management",
+      status: "active",
+      type: "system",
+      isCore: true,
+      dependencies: ["tenant_admin", "identity_access"]
     });
     expect(getModuleByKey("unknown_module")).toBeUndefined();
   });

--- a/tests/integration/module-management-sync.integration.test.ts
+++ b/tests/integration/module-management-sync.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Integration tests for the descriptor sync service (Issue #513, epic
+ * #510) against a real PostgreSQL: real `listModules()` synced into
+ * `awcms_mini_modules`/`_dependencies`/`_navigation`/`_jobs`, idempotency
+ * across repeated runs, and orphan detection/marking.
+ *
+ * Runs on the plain app-role connection (`getDatabaseClient()`), not the
+ * admin/migration connection — proving the least-privilege
+ * `awcms_mini_app` role (migration 013's default-privileges grant) can
+ * actually write to these new global tables without any special
+ * connection.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { syncModuleDescriptors } from "../../src/modules/module-management/application/descriptor-sync";
+import { listModules } from "../../src/modules";
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("module descriptor sync service", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("first run creates every registered module", async () => {
+    const sql = getDatabaseClient();
+    const result = await syncModuleDescriptors(sql);
+
+    expect(result.created.sort()).toEqual(
+      [...listModules()].map((m) => m.key).sort()
+    );
+    expect(result.updated).toEqual([]);
+    expect(result.unchanged).toEqual([]);
+    expect(result.orphaned).toEqual([]);
+
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT count(*)::int AS count FROM awcms_mini_modules
+    `) as { count: number }[];
+    expect(rows[0]?.count).toBe(listModules().length);
+  });
+
+  test("second run with identical descriptors reports everything unchanged", async () => {
+    const sql = getDatabaseClient();
+    await syncModuleDescriptors(sql);
+    const second = await syncModuleDescriptors(sql);
+
+    expect(second.created).toEqual([]);
+    expect(second.updated).toEqual([]);
+    expect(second.unchanged.sort()).toEqual(
+      [...listModules()].map((m) => m.key).sort()
+    );
+  });
+
+  test("syncs dependency rows for a module with dependencies", async () => {
+    const sql = getDatabaseClient();
+    await syncModuleDescriptors(sql);
+
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT depends_on_module_key FROM awcms_mini_module_dependencies
+      WHERE module_key = 'email'
+      ORDER BY depends_on_module_key
+    `) as { depends_on_module_key: string }[];
+
+    expect(rows.map((r) => r.depends_on_module_key)).toEqual(
+      ["identity_access", "profile_identity", "tenant_admin"].sort()
+    );
+  });
+
+  test("re-syncing after a descriptor field changes reports an update", async () => {
+    const sql = getDatabaseClient();
+    await syncModuleDescriptors(sql);
+
+    const bumped = listModules().map((descriptor) =>
+      descriptor.key === "email"
+        ? { ...descriptor, version: "9.9.9" }
+        : descriptor
+    );
+    const result = await syncModuleDescriptors(sql, bumped);
+
+    expect(result.updated).toEqual(["email"]);
+    expect(result.created).toEqual([]);
+
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT version FROM awcms_mini_modules WHERE module_key = 'email'
+    `) as { version: string }[];
+    expect(rows[0]?.version).toBe("9.9.9");
+  });
+
+  test("a module removed from the descriptor list is marked disabled, not deleted", async () => {
+    const sql = getDatabaseClient();
+    await syncModuleDescriptors(sql);
+
+    const withoutEmail = listModules().filter((d) => d.key !== "email");
+    const result = await syncModuleDescriptors(sql, withoutEmail);
+
+    expect(result.orphaned).toEqual(["email"]);
+
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT lifecycle_status FROM awcms_mini_modules WHERE module_key = 'email'
+    `) as { lifecycle_status: string }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.lifecycle_status).toBe("disabled");
+  });
+
+  test("running sync a third time does not re-mark an already-orphaned module", async () => {
+    const sql = getDatabaseClient();
+    await syncModuleDescriptors(sql);
+
+    const withoutEmail = listModules().filter((d) => d.key !== "email");
+    await syncModuleDescriptors(sql, withoutEmail);
+    const third = await syncModuleDescriptors(sql, withoutEmail);
+
+    expect(third.orphaned).toEqual(["email"]);
+
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT lifecycle_status FROM awcms_mini_modules WHERE module_key = 'email'
+    `) as { lifecycle_status: string }[];
+    expect(rows[0]?.lifecycle_status).toBe("disabled");
+  });
+});

--- a/tests/module-management-descriptor-diff.test.ts
+++ b/tests/module-management-descriptor-diff.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+
+import { planModuleSync } from "../src/modules/module-management/domain/descriptor-diff";
+import type { ModuleDescriptor } from "../src/modules/_shared/module-contract";
+
+function descriptor(
+  overrides: Partial<ModuleDescriptor> = {}
+): ModuleDescriptor {
+  return {
+    key: "example",
+    name: "Example",
+    version: "1.0.0",
+    status: "active",
+    description: "An example module.",
+    dependencies: [],
+    ...overrides
+  };
+}
+
+describe("planModuleSync", () => {
+  test("a descriptor with no existing row is a create", () => {
+    const plan = planModuleSync([descriptor()], []);
+
+    expect(plan.entries).toEqual([
+      { moduleKey: "example", action: "create", changedFields: [] }
+    ]);
+    expect(plan.orphanedModuleKeys).toEqual([]);
+  });
+
+  test("a descriptor identical to its existing row is unchanged", () => {
+    const plan = planModuleSync(
+      [descriptor()],
+      [
+        {
+          moduleKey: "example",
+          moduleName: "Example",
+          version: "1.0.0",
+          description: "An example module.",
+          lifecycleStatus: "active",
+          moduleType: null,
+          isCore: false
+        }
+      ]
+    );
+
+    expect(plan.entries).toEqual([
+      { moduleKey: "example", action: "unchanged", changedFields: [] }
+    ]);
+  });
+
+  test("a version bump is reported as an update with the changed field named", () => {
+    const plan = planModuleSync(
+      [descriptor({ version: "2.0.0" })],
+      [
+        {
+          moduleKey: "example",
+          moduleName: "Example",
+          version: "1.0.0",
+          description: "An example module.",
+          lifecycleStatus: "active",
+          moduleType: null,
+          isCore: false
+        }
+      ]
+    );
+
+    expect(plan.entries).toEqual([
+      { moduleKey: "example", action: "update", changedFields: ["version"] }
+    ]);
+  });
+
+  test("multiple changed fields are all reported", () => {
+    const plan = planModuleSync(
+      [descriptor({ name: "Renamed", status: "maintenance", type: "system" })],
+      [
+        {
+          moduleKey: "example",
+          moduleName: "Example",
+          version: "1.0.0",
+          description: "An example module.",
+          lifecycleStatus: "active",
+          moduleType: null,
+          isCore: false
+        }
+      ]
+    );
+
+    expect(plan.entries[0]!.action).toBe("update");
+    expect(plan.entries[0]!.changedFields.sort()).toEqual(
+      ["name", "status", "type"].sort()
+    );
+  });
+
+  test("a DB row with no matching descriptor is reported as orphaned", () => {
+    const plan = planModuleSync(
+      [],
+      [
+        {
+          moduleKey: "gone",
+          moduleName: "Gone",
+          version: "1.0.0",
+          description: null,
+          lifecycleStatus: "active",
+          moduleType: null,
+          isCore: false
+        }
+      ]
+    );
+
+    expect(plan.entries).toEqual([]);
+    expect(plan.orphanedModuleKeys).toEqual(["gone"]);
+  });
+
+  test("running the plan twice with the same inputs is stable (idempotent)", () => {
+    const descriptors = [descriptor()];
+    const existing = [
+      {
+        moduleKey: "example",
+        moduleName: "Example",
+        version: "1.0.0",
+        description: "An example module.",
+        lifecycleStatus: "active",
+        moduleType: null,
+        isCore: false
+      }
+    ];
+
+    const first = planModuleSync(descriptors, existing);
+    const second = planModuleSync(descriptors, existing);
+
+    expect(first).toEqual(second);
+    expect(first.entries[0]!.action).toBe("unchanged");
+  });
+});


### PR DESCRIPTION
## Summary
- Implements issue #513 (epic #510) — registers `module_management` as the 10th real module and adds the idempotent descriptor sync service (`syncModuleDescriptors`) that populates the database registry migration 025 (#512) added.
- `domain/descriptor-diff.ts`: pure create/update/unchanged/orphan classification, fully unit-tested.
- `application/descriptor-sync.ts`: two-pass upsert (all modules first, then dependencies/navigation/jobs) — **caught and fixed a real forward-dependency bug live**: `reporting` depends on `email`, which is registered after it in `src/modules/index.ts`; a naive single-pass loop violated the dependency FK.
- Orphaned modules (in DB, no longer in code) are marked `disabled`, never deleted.
- New `bun run modules:sync` CLI wrapper.
- `module_management`'s own descriptor only declares `permissions` (already real/seeded) — deliberately omits `navigation`/`jobs`/`health`/`api` until the issues that implement those features actually land.

## Test plan
- [x] `bun run check` green (lint, check:docs, api:spec:check, typecheck, test, build)
- [x] Live-verified against real PostgreSQL, including running the sync service on the plain least-privilege app-role connection (582 tests, up from 570)
- [x] New `tests/module-management-descriptor-diff.test.ts` (unit) + `tests/integration/module-management-sync.integration.test.ts` (idempotency across repeated runs, dependency population, update detection, orphan marking, orphan-marking is itself idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)