### PR TITLE
feat(module-management): add module catalog API (#514)

### DIFF
--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -67,6 +67,12 @@ tags:
     description: >-
       Manual suppression list read/create/delete — recipients excluded from
       future sends (bounce/complaint/manual/unsubscribed), Issue #499.
+  - name: Module Management
+    description: >-
+      Database-backed module catalog and descriptor sync (epic #510). Read
+      the module registry, inspect a single module's detail, and trigger a
+      sync of trusted code descriptors into the database — distinct from
+      `GET /api/v1/access/modules`'s permission catalog.
 paths:
   /api/v1/sync/push:
     post:
@@ -2790,6 +2796,121 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/modules:
+    get:
+      tags:
+        - Module Management
+      summary: >-
+        List the module catalog — every module currently registered in
+        code, merged with its database-tracked lifecycle state
+      description: >-
+        Distinct from `GET /api/v1/access/modules` (Issue 12.1's permission
+        catalog grouped by module) — that endpoint's behavior is unchanged
+        by this one.
+      operationId: modulesList
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Module catalog.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/ModuleCatalogListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/modules/sync:
+    post:
+      tags:
+        - Module Management
+      summary: Sync trusted code descriptors into the database registry
+      description: >-
+        Naturally idempotent — no `Idempotency-Key` required. Running it
+        repeatedly is always safe and reports the same result each time
+        when nothing has changed.
+      operationId: modulesSync
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Sync result.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/ModuleSyncResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/modules/{moduleKey}:
+    get:
+      tags:
+        - Module Management
+      summary: Module catalog detail
+      operationId: modulesGetDetail
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: moduleKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Module catalog entry.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/ModuleCatalogEntry"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/health:
     get:
       tags:
@@ -4539,6 +4660,124 @@ components:
           properties:
             alreadySuppressed:
               type: boolean
+    ModuleApiContractInfo:
+      type: object
+      required:
+        - openApiPath
+        - basePath
+      additionalProperties: false
+      properties:
+        openApiPath:
+          type: string
+        basePath:
+          type: string
+    ModuleEventContractInfo:
+      type: object
+      additionalProperties: false
+      properties:
+        asyncApiPath:
+          type: string
+        publishes:
+          type: array
+          items:
+            type: string
+        subscribes:
+          type: array
+          items:
+            type: string
+    ModuleCatalogEntry:
+      type: object
+      required:
+        - moduleKey
+        - name
+        - version
+        - description
+        - status
+        - isCore
+        - dependencies
+        - lastSyncedAt
+      additionalProperties: false
+      properties:
+        moduleKey:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum:
+            - active
+            - experimental
+            - deprecated
+            - maintenance
+            - disabled
+        type:
+          type: string
+          nullable: true
+          enum:
+            - base
+            - system
+            - domain
+            - integration
+            - derived
+        isCore:
+          type: boolean
+        dependencies:
+          type: array
+          items:
+            type: string
+        api:
+          $ref: "#/components/schemas/ModuleApiContractInfo"
+        events:
+          $ref: "#/components/schemas/ModuleEventContractInfo"
+        lastSyncedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Null if `bun run modules:sync`/`POST /api/v1/modules/sync` has
+            never been run since this module was registered in code.
+    ModuleCatalogListResponse:
+      type: object
+      required:
+        - modules
+      additionalProperties: false
+      properties:
+        modules:
+          type: array
+          items:
+            $ref: "#/components/schemas/ModuleCatalogEntry"
+    ModuleSyncResponse:
+      type: object
+      required:
+        - created
+        - updated
+        - unchanged
+        - orphaned
+      additionalProperties: false
+      properties:
+        created:
+          type: array
+          items:
+            type: string
+        updated:
+          type: array
+          items:
+            type: string
+        unchanged:
+          type: array
+          items:
+            type: string
+        orphaned:
+          type: array
+          items:
+            type: string
+          description: >-
+            Module keys present in the database registry but no longer in
+            `listModules()` — marked `disabled`, never deleted.
     ModuleUsageEntry:
       type: object
       required:

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -37,6 +37,8 @@ Doc 10 §ABAC guard: "Tambahkan action `restore` dan `purge` pada kontrak modul 
 
 Pola yang sama diulang untuk `retry` (PR: Sync admin ops dashboard) — migrasi 009 sudah menyeed permission `sync_storage.object_queue.retry` sejak Issue 6.3, tapi tidak ada konsumen sampai action itu ditambahkan ke union `AccessAction`. Berbeda dari `restore`/`purge`, `retry` **tidak** ditambahkan ke `HIGH_RISK_ACTIONS` — ia hanya nudge terhadap jadwal backoff otomatis (`isHighRiskAction("retry") === false`), bukan aksi destruktif/irreversibel. Endpoint yang memakainya tetap memanggil `recordAuditEvent` secara eksplisit terlepas dari klasifikasi risiko (`isHighRiskAction` bersifat metadata dokumentatif, bukan gerbang yang menentukan apakah suatu endpoint boleh skip audit — lihat `src/pages/api/v1/sync/object-queue/[id]/retry.ts`).
 
+Pola yang sama sekali lagi untuk `sync` (Issue #514, epic #510) — migrasi 025 sudah menyeed `module_management.modules.sync` sejak Issue #512, konsumen pertamanya baru `POST /api/v1/modules/sync` di issue ini. `sync` juga **tidak** ditambahkan ke `HIGH_RISK_ACTIONS` — descriptor sync bersifat idempoten/non-destruktif (upsert + tandai orphan, tidak pernah delete), bukan kelas risiko yang sama dengan `delete`/`approve`/`export`. Tetap diaudit eksplisit (`action: "modules_synced"`) terlepas dari klasifikasi itu.
+
 ## Infrastruktur baru
 
 Issue ini adalah endpoint live pertama yang menyentuh database, sehingga menambahkan infrastruktur dasar akses data yang akan dipakai modul lain:

--- a/src/modules/identity-access/domain/access-control.ts
+++ b/src/modules/identity-access/domain/access-control.ts
@@ -24,7 +24,8 @@ export type AccessAction =
   | "assign"
   | "restore"
   | "purge"
-  | "retry";
+  | "retry"
+  | "sync";
 
 export type AccessRequest = {
   moduleKey: string;

--- a/src/modules/module-management/application/module-catalog.ts
+++ b/src/modules/module-management/application/module-catalog.ts
@@ -1,0 +1,86 @@
+/**
+ * Module catalog read service (Issue #514, epic #510). The trusted code
+ * registry (`listModules()`) is the source of truth for a module's static
+ * metadata (name/version/description/dependencies/api/events/type) — it is
+ * always current, never stale, unlike the DB registry which only reflects
+ * whatever `bun run modules:sync` last wrote. This merges the two: static
+ * fields come from the descriptor, `lifecycleStatus`/`isCore`/
+ * `lastSyncedAt` come from `awcms_mini_modules` when a row exists (falling
+ * back to the descriptor's own `status`/`isCore` if sync hasn't run yet).
+ *
+ * A module absent from `listModules()` is never returned here, even if a
+ * stale DB row exists for it (Issue #513's descriptor sync already marks
+ * that case `lifecycle_status = 'disabled'` — surfacing orphaned rows to
+ * an operator is Issue #517/#520's concern, not this basic catalog).
+ */
+import { listModules } from "../..";
+import type {
+  ModuleApiContract,
+  ModuleEventContract,
+  ModuleType
+} from "../../_shared/module-contract";
+
+export type ModuleCatalogEntry = {
+  moduleKey: string;
+  name: string;
+  version: string;
+  description: string;
+  status: string;
+  type: ModuleType | null;
+  isCore: boolean;
+  dependencies: string[];
+  api?: ModuleApiContract;
+  events?: ModuleEventContract;
+  lastSyncedAt: string | null;
+};
+
+type ModuleRegistryRow = {
+  module_key: string;
+  lifecycle_status: string;
+  is_core: boolean;
+  updated_at: Date;
+};
+
+async function fetchRegistryRows(
+  tx: Bun.SQL
+): Promise<Map<string, ModuleRegistryRow>> {
+  const rows = (await tx`
+    SELECT module_key, lifecycle_status, is_core, updated_at
+    FROM awcms_mini_modules
+  `) as ModuleRegistryRow[];
+
+  return new Map(rows.map((row) => [row.module_key, row]));
+}
+
+export async function fetchModuleCatalog(
+  tx: Bun.SQL
+): Promise<ModuleCatalogEntry[]> {
+  const registryByKey = await fetchRegistryRows(tx);
+
+  return listModules().map((descriptor) => {
+    const registryRow = registryByKey.get(descriptor.key);
+
+    return {
+      moduleKey: descriptor.key,
+      name: descriptor.name,
+      version: descriptor.version,
+      description: descriptor.description,
+      status: registryRow?.lifecycle_status ?? descriptor.status,
+      type: descriptor.type ?? null,
+      isCore: registryRow?.is_core ?? descriptor.isCore ?? false,
+      dependencies: descriptor.dependencies,
+      api: descriptor.api,
+      events: descriptor.events,
+      lastSyncedAt: registryRow?.updated_at.toISOString() ?? null
+    };
+  });
+}
+
+export async function fetchModuleCatalogEntry(
+  tx: Bun.SQL,
+  moduleKey: string
+): Promise<ModuleCatalogEntry | null> {
+  const catalog = await fetchModuleCatalog(tx);
+
+  return catalog.find((entry) => entry.moduleKey === moduleKey) ?? null;
+}

--- a/src/modules/module-management/module.ts
+++ b/src/modules/module-management/module.ts
@@ -6,10 +6,14 @@ export const moduleManagementModule = defineModule({
   version: "0.1.0",
   status: "active",
   description:
-    "Database-backed, tenant-aware module registry (epic #510): syncs trusted code descriptors (`listModules()`) into the database, tracks per-tenant module enablement, dependency validation, non-secret settings, permission sync/status, admin navigation, job/command registry, and health/readiness. Generic infrastructure for managing every other registered module — not a domain-specific feature.",
+    "Database-backed, tenant-aware module registry (epic #510): syncs trusted code descriptors (`listModules()`) into the database, tracks per-tenant module enablement, dependency validation, non-secret settings, permission sync/status, admin navigation, job/command registry, and health/readiness. Generic infrastructure for managing every other registered module — not a domain-specific feature. Module catalog API (`GET /api/v1/modules[/{moduleKey}]`, `POST /api/v1/modules/sync`) added Issue #514.",
   dependencies: ["tenant_admin", "identity_access"],
   type: "system",
   isCore: true,
+  api: {
+    openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
+    basePath: "/api/v1/modules"
+  },
   permissions: [
     {
       activityCode: "modules",

--- a/src/pages/api/v1/modules/[moduleKey].ts
+++ b/src/pages/api/v1/modules/[moduleKey].ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchModuleCatalogEntry } from "../../../../modules/module-management/application/module-catalog";
+
+const READ_GUARD = {
+  moduleKey: "module_management",
+  activityCode: "modules",
+  action: "read" as const
+};
+
+/** `GET /api/v1/modules/{moduleKey}` (Issue #514) — module detail, or a safe 404 for an unknown key (never a raw DB error/stack trace). */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const moduleKey = params.moduleKey;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!moduleKey) {
+    return fail(400, "VALIDATION_ERROR", "Module key is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const entry = await fetchModuleCatalogEntry(tx, moduleKey);
+
+    if (!entry) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Module not found.");
+    }
+
+    return ok(entry);
+  });
+};

--- a/src/pages/api/v1/modules/index.ts
+++ b/src/pages/api/v1/modules/index.ts
@@ -1,0 +1,59 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchModuleCatalog } from "../../../../modules/module-management/application/module-catalog";
+
+const READ_GUARD = {
+  moduleKey: "module_management",
+  activityCode: "modules",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/modules` (Issue #514) — the module catalog: every module
+ * currently registered in code (`listModules()`), merged with its
+ * database-tracked lifecycle state where `bun run modules:sync` has run.
+ * Distinct from `GET /api/v1/access/modules` (Issue 12.1's permission
+ * catalog grouped by module) — that endpoint's shape/behavior is
+ * unchanged by this issue.
+ */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const modules = await fetchModuleCatalog(tx);
+
+    return ok({ modules });
+  });
+};

--- a/src/pages/api/v1/modules/sync.ts
+++ b/src/pages/api/v1/modules/sync.ts
@@ -1,0 +1,76 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import { syncModuleDescriptors } from "../../../../modules/module-management/application/descriptor-sync";
+
+const SYNC_GUARD = {
+  moduleKey: "module_management",
+  activityCode: "modules",
+  action: "sync" as const
+};
+
+/**
+ * `POST /api/v1/modules/sync` (Issue #514) — trigger the descriptor sync
+ * service (Issue #513) on demand. No `Idempotency-Key` required: the sync
+ * itself is already naturally idempotent (verified live, #513) — running
+ * it twice in a row is always safe and produces the same result, not a
+ * duplicate side effect.
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      SYNC_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const result = await syncModuleDescriptors(tx);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "module_management",
+      action: "modules_synced",
+      resourceType: "module_registry",
+      severity: "info",
+      message: `Module registry synced: ${result.created.length} created, ${result.updated.length} updated, ${result.orphaned.length} orphaned.`,
+      attributes: {
+        created: result.created,
+        updated: result.updated,
+        orphaned: result.orphaned
+      },
+      correlationId
+    });
+
+    return ok(result);
+  });
+};

--- a/tests/access-control.test.ts
+++ b/tests/access-control.test.ts
@@ -41,6 +41,10 @@ describe("isHighRiskAction", () => {
     expect(isHighRiskAction("create")).toBe(false);
     expect(isHighRiskAction("update")).toBe(false);
   });
+
+  test("does not classify sync as high risk (Issue #514 — idempotent, non-destructive)", () => {
+    expect(isHighRiskAction("sync")).toBe(false);
+  });
 });
 
 describe("evaluateAccess", () => {

--- a/tests/integration/module-catalog.integration.test.ts
+++ b/tests/integration/module-catalog.integration.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Integration tests for the module catalog API (Issue #514, epic #510)
+ * against a real PostgreSQL: list/detail/sync, ABAC, safe 404, and audit
+ * on sync.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { GET as listModulesRoute } from "../../src/pages/api/v1/modules/index";
+import { GET as getModuleDetail } from "../../src/pages/api/v1/modules/[moduleKey]";
+import { POST as syncModulesRoute } from "../../src/pages/api/v1/modules/sync";
+import { GET as listAccessModules } from "../../src/pages/api/v1/access/modules";
+import { listModules } from "../../src/modules";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string; tenantUserId: string };
+
+async function bootstrap(): Promise<Bootstrap> {
+  const loginIdentifier = `acme-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: "Acme",
+      tenantCode: "acme",
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  const admin = getAdminSql();
+  const tenantUserRows = (await admin`
+    SELECT tu.id FROM awcms_mini_tenant_users tu
+    JOIN awcms_mini_identities i ON i.id = tu.identity_id
+    WHERE tu.tenant_id = ${setup.body.data.tenantId} AND i.login_identifier = ${loginIdentifier}
+  `) as { id: string }[];
+
+  return {
+    tenantId: setup.body.data.tenantId,
+    token: login.body.data.token,
+    tenantUserId: tenantUserRows[0]!.id
+  };
+}
+
+function authHeaders(owner: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": owner.tenantId,
+    authorization: `Bearer ${owner.token}`
+  };
+}
+
+async function provisionNoPermissionUser(
+  tenantId: string
+): Promise<{ token: string }> {
+  const password = "integration-test-no-permission-password";
+  const admin = getAdminSql();
+  const passwordHash = await Bun.password.hash(password);
+
+  await admin.begin(async (tx) => {
+    await tx.unsafe(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+    const profile = (await tx`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', 'No Permission') RETURNING id
+    `) as { id: string }[];
+    const identity = (await tx`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profile[0]!.id}, 'no-permission@example.com', ${passwordHash})
+      RETURNING id
+    `) as { id: string }[];
+    await tx`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${tenantId}, ${identity[0]!.id})
+    `;
+  });
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier: "no-permission@example.com", password },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { token: login.body.data.token };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("module catalog API", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("GET /api/v1/modules lists every registered module, unsynced modules have a null lastSyncedAt", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{
+      data: { modules: { moduleKey: string; lastSyncedAt: string | null }[] };
+    }>(listModulesRoute, {
+      method: "GET",
+      path: "/api/v1/modules",
+      headers: authHeaders(owner)
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.modules).toHaveLength(listModules().length);
+    expect(
+      result.body.data.modules.find((m) => m.moduleKey === "module_management")
+        ?.lastSyncedAt
+    ).toBeNull();
+  });
+
+  test("GET /api/v1/modules/{moduleKey} returns detail for a known module", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{
+      data: { moduleKey: string; type: string; isCore: boolean };
+    }>(getModuleDetail, {
+      method: "GET",
+      path: "/api/v1/modules/module_management",
+      headers: authHeaders(owner),
+      params: { moduleKey: "module_management" }
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.moduleKey).toBe("module_management");
+    expect(result.body.data.type).toBe("system");
+    expect(result.body.data.isCore).toBe(true);
+  });
+
+  test("GET /api/v1/modules/{moduleKey} returns a safe 404 for an unknown module", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke(getModuleDetail, {
+      method: "GET",
+      path: "/api/v1/modules/does_not_exist",
+      headers: authHeaders(owner),
+      params: { moduleKey: "does_not_exist" }
+    });
+
+    expect(result.status).toBe(404);
+  });
+
+  test("POST /api/v1/modules/sync populates the registry, reports created modules, and audits the action", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{
+      data: { created: string[]; updated: string[]; orphaned: string[] };
+    }>(syncModulesRoute, {
+      method: "POST",
+      path: "/api/v1/modules/sync",
+      headers: authHeaders(owner)
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.created.sort()).toEqual(
+      [...listModules()].map((m) => m.key).sort()
+    );
+
+    const detail = await invoke<{ data: { lastSyncedAt: string | null } }>(
+      getModuleDetail,
+      {
+        method: "GET",
+        path: "/api/v1/modules/module_management",
+        headers: authHeaders(owner),
+        params: { moduleKey: "module_management" }
+      }
+    );
+    expect(detail.body.data.lastSyncedAt).not.toBeNull();
+
+    const admin = getAdminSql();
+    const auditRows = (await admin`
+      SELECT action, resource_type, attributes
+      FROM awcms_mini_audit_events
+      WHERE tenant_id = ${owner.tenantId} AND action = 'modules_synced'
+    `) as {
+      action: string;
+      resource_type: string;
+      attributes: { created: string[] };
+    }[];
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]!.resource_type).toBe("module_registry");
+    expect(auditRows[0]!.attributes.created.length).toBe(listModules().length);
+  });
+
+  test("running sync twice reports the second run as fully unchanged", async () => {
+    const owner = await bootstrap();
+
+    await invoke(syncModulesRoute, {
+      method: "POST",
+      path: "/api/v1/modules/sync",
+      headers: authHeaders(owner)
+    });
+    const second = await invoke<{ data: { unchanged: string[] } }>(
+      syncModulesRoute,
+      {
+        method: "POST",
+        path: "/api/v1/modules/sync",
+        headers: authHeaders(owner)
+      }
+    );
+
+    expect(second.body.data.unchanged.sort()).toEqual(
+      [...listModules()].map((m) => m.key).sort()
+    );
+  });
+
+  test("ABAC: a user with no module_management.* permissions is denied on list/detail/sync", async () => {
+    const owner = await bootstrap();
+    const noPermission = await provisionNoPermissionUser(owner.tenantId);
+    const headers = {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": owner.tenantId,
+      authorization: `Bearer ${noPermission.token}`
+    };
+
+    const list = await invoke(listModulesRoute, {
+      method: "GET",
+      path: "/api/v1/modules",
+      headers
+    });
+    expect(list.status).toBe(403);
+
+    const detail = await invoke(getModuleDetail, {
+      method: "GET",
+      path: "/api/v1/modules/module_management",
+      headers,
+      params: { moduleKey: "module_management" }
+    });
+    expect(detail.status).toBe(403);
+
+    const sync = await invoke(syncModulesRoute, {
+      method: "POST",
+      path: "/api/v1/modules/sync",
+      headers
+    });
+    expect(sync.status).toBe(403);
+  });
+
+  test("GET /api/v1/access/modules (permission catalog) is unaffected by this issue", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{
+      data: { modules: { moduleKey: string; activityCode: string }[] };
+    }>(listAccessModules, {
+      method: "GET",
+      path: "/api/v1/access/modules",
+      headers: authHeaders(owner)
+    });
+
+    expect(result.status).toBe(200);
+    expect(
+      result.body.data.modules.some((m) => m.moduleKey === "module_management")
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements issue #514 (epic #510) — `GET /api/v1/modules`, `GET /api/v1/modules/{moduleKey}`, `POST /api/v1/modules/sync`.
- Merges the trusted code registry (`listModules()`) with database-tracked lifecycle state; a module absent from code is never returned even if a stale DB row exists.
- `POST /modules/sync` invokes #513's `syncModuleDescriptors` and records one audit event; no `Idempotency-Key` needed since sync is already naturally idempotent.
- Extended `AccessAction` with `"sync"` (same precedent as `"retry"`) so the already-seeded `module_management.modules.sync` permission type-checks — not classified high-risk (idempotent/non-destructive).
- `GET /api/v1/access/modules` (permission catalog) is verified unchanged.
- OpenAPI updated (new tag + 3 paths + 5 schemas).

## Test plan
- [x] `bun run check` green (lint, check:docs, api:spec:check, typecheck, test, build)
- [x] Live-verified against real PostgreSQL (590 tests, up from 582)
- [x] New `tests/integration/module-catalog.integration.test.ts` (7 tests): list, detail, safe 404, sync populates registry + audits, repeat sync reports unchanged, ABAC denial on all 3 routes, `access/modules` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)