### PR TITLE
feat(module-management): add tenant module lifecycle with dependency validation

### DIFF
--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -2911,6 +2911,167 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/tenant/modules:
+    get:
+      tags:
+        - Module Management
+      summary: List every registered module's enablement state for the caller's tenant
+      description: >-
+        A module with no explicit state (`tenantEnabled: true`, no
+        `enabledAt`/`disabledAt`) has never been toggled — available by
+        default (backward-compatible with pre-epic behavior).
+      operationId: tenantModulesList
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Tenant module enablement state.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/TenantModuleListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/tenant/modules/{moduleKey}/enable:
+    post:
+      tags:
+        - Module Management
+      summary: Enable a module for the caller's tenant
+      description: >-
+        Tenant-level availability only, never a runtime code load.
+        Server-side dependency validation rejects the request with `409`
+        if a direct dependency is missing/disabled, the module is part of
+        a dependency cycle, or the module declares an incompatible
+        `minAppVersion`. `404` only for an unknown/globally-disabled
+        module key.
+      operationId: tenantModulesEnable
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: moduleKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Module enabled for the tenant.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/TenantModuleMutationResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: >-
+            Dependency validation failed (see `error.code`:
+            `MODULE_ALREADY_ENABLED`, `MODULE_DEPENDENCY_MISSING`,
+            `MODULE_DEPENDENCY_DISABLED`, `MODULE_DEPENDENCY_CYCLE`,
+            `MODULE_VERSION_INCOMPATIBLE`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/tenant/modules/{moduleKey}/disable:
+    post:
+      tags:
+        - Module Management
+      summary: Disable a module for the caller's tenant
+      description: >-
+        `reason` required. Never deletes tenant data — only writes
+        `awcms_mini_tenant_modules`. Rejected with `409` if the module is
+        core/system, already disabled, or another still-enabled module
+        depends on it.
+      operationId: tenantModulesDisable
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: moduleKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              additionalProperties: false
+              properties:
+                reason:
+                  type: string
+      responses:
+        "200":
+          description: Module disabled for the tenant.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/TenantModuleMutationResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: >-
+            Dependency validation failed (see `error.code`:
+            `MODULE_ALREADY_DISABLED`, `CORE_MODULE_CANNOT_BE_DISABLED`,
+            `MODULE_REVERSE_DEPENDENCY_ACTIVE`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/health:
     get:
       tags:
@@ -4778,6 +4939,61 @@ components:
           description: >-
             Module keys present in the database registry but no longer in
             `listModules()` — marked `disabled`, never deleted.
+    TenantModuleEntry:
+      type: object
+      required:
+        - moduleKey
+        - name
+        - version
+        - isCore
+        - tenantEnabled
+        - enabledAt
+        - disabledAt
+        - disableReason
+      additionalProperties: false
+      properties:
+        moduleKey:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        isCore:
+          type: boolean
+        tenantEnabled:
+          type: boolean
+        enabledAt:
+          type: string
+          format: date-time
+          nullable: true
+        disabledAt:
+          type: string
+          format: date-time
+          nullable: true
+        disableReason:
+          type: string
+          nullable: true
+    TenantModuleListResponse:
+      type: object
+      required:
+        - modules
+      additionalProperties: false
+      properties:
+        modules:
+          type: array
+          items:
+            $ref: "#/components/schemas/TenantModuleEntry"
+    TenantModuleMutationResponse:
+      type: object
+      required:
+        - moduleKey
+        - tenantEnabled
+      additionalProperties: false
+      properties:
+        moduleKey:
+          type: string
+        tenantEnabled:
+          type: boolean
     ModuleUsageEntry:
       type: object
       required:

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -39,6 +39,8 @@ Pola yang sama diulang untuk `retry` (PR: Sync admin ops dashboard) — migrasi 
 
 Pola yang sama sekali lagi untuk `sync` (Issue #514, epic #510) — migrasi 025 sudah menyeed `module_management.modules.sync` sejak Issue #512, konsumen pertamanya baru `POST /api/v1/modules/sync` di issue ini. `sync` juga **tidak** ditambahkan ke `HIGH_RISK_ACTIONS` — descriptor sync bersifat idempoten/non-destruktif (upsert + tandai orphan, tidak pernah delete), bukan kelas risiko yang sama dengan `delete`/`approve`/`export`. Tetap diaudit eksplisit (`action: "modules_synced"`) terlepas dari klasifikasi itu.
 
+Dan sekali lagi untuk `enable`/`disable` (Issue #515, epic #510) — migrasi 025 sudah menyeed `module_management.tenant_modules.{enable,disable}`, konsumen pertamanya `POST /api/v1/tenant/modules/{moduleKey}/{enable,disable}` di issue ini. Keduanya **tidak** ditambahkan ke `HIGH_RISK_ACTIONS` — toggle ketersediaan modul per-tenant bersifat reversibel dan tidak menghapus data tenant (`disable` hanya menulis baris `awcms_mini_tenant_modules`, tidak pernah menyentuh data modul lain), berbeda dari `delete`/`purge` yang ireversibel. Tetap diaudit eksplisit (`action: "tenant_module_enabled"`/`"tenant_module_disabled"`) terlepas dari klasifikasi itu.
+
 ## Infrastruktur baru
 
 Issue ini adalah endpoint live pertama yang menyentuh database, sehingga menambahkan infrastruktur dasar akses data yang akan dipakai modul lain:

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -41,6 +41,10 @@ Pola yang sama sekali lagi untuk `sync` (Issue #514, epic #510) — migrasi 025 
 
 Dan sekali lagi untuk `enable`/`disable` (Issue #515, epic #510) — migrasi 025 sudah menyeed `module_management.tenant_modules.{enable,disable}`, konsumen pertamanya `POST /api/v1/tenant/modules/{moduleKey}/{enable,disable}` di issue ini. Keduanya **tidak** ditambahkan ke `HIGH_RISK_ACTIONS` — toggle ketersediaan modul per-tenant bersifat reversibel dan tidak menghapus data tenant (`disable` hanya menulis baris `awcms_mini_tenant_modules`, tidak pernah menyentuh data modul lain), berbeda dari `delete`/`purge` yang ireversibel. Tetap diaudit eksplisit (`action: "tenant_module_enabled"`/`"tenant_module_disabled"`) terlepas dari klasifikasi itu.
 
+### Enforcement modul disabled di `authorizeInTransaction` (Issue #515)
+
+Epic #510's security notes menegaskan "disabled module endpoints must still enforce server-side access/status checks" — status disabled bukan cuma sinyal UI. `authorizeInTransaction` (`access-guard.ts`) karena itu mengecek `resolveModuleEnabled(tx, tenantId, guard.moduleKey)` (`auth-context.ts`) **sebelum** evaluasi ABAC/RBAC: kalau modul nonaktif untuk tenant tsb, request ditolak `403 MODULE_DISABLED` — apa pun permission yang dimiliki actor — dan tetap dicatat ke decision log (`matchedPolicy: "module_disabled"`). Karena guard ini dipakai oleh setiap endpoint terproteksi (bukan cuma endpoint lifecycle-nya sendiri), satu perubahan ini otomatis menutup semua endpoint milik modul yang dinonaktifkan tanpa perlu menyentuh tiap route satu-satu — lihat pengujian di `tests/integration/module-tenant-lifecycle.integration.test.ts` ("disabling a module actually blocks its own endpoints"). `module_management` sendiri `isCore` (tidak bisa dinonaktifkan), jadi tidak ada risiko endpoint lifecycle-nya sendiri terkunci oleh cek ini.
+
 ## Infrastruktur baru
 
 Issue ini adalah endpoint live pertama yang menyentuh database, sehingga menambahkan infrastruktur dasar akses data yang akan dipakai modul lain:

--- a/src/modules/identity-access/application/access-guard.ts
+++ b/src/modules/identity-access/application/access-guard.ts
@@ -9,6 +9,7 @@ import type { AccessRequest, TenantContext } from "../domain/access-control";
 import { evaluateAccess } from "../domain/access-control";
 import {
   fetchGrantedPermissionKeys,
+  resolveModuleEnabled,
   resolveTenantContext
 } from "./auth-context";
 import { recordDecisionLog } from "./decision-log";
@@ -50,12 +51,15 @@ export type AuthorizeResult =
 
 /**
  * Runs the full guard chain inside an existing tenant transaction: resolve the
- * session context → fetch granted permission keys → evaluate ABAC (default
- * deny, deny overrides allow) → record the decision log. Returns the
- * authorized context on allow, or a ready-to-return `fail()` Response (401/403)
- * on deny. This is the same chain the existing access endpoints inline; it is
- * centralized here so the several Access & Users endpoints stay consistent and
- * always record a decision log.
+ * session context → check the guard's module is enabled for this tenant
+ * (Issue #515 — a disabled module must actually block every endpoint it
+ * owns, not just look disabled in the UI) → fetch granted permission keys →
+ * evaluate ABAC (default deny, deny overrides allow) → record the decision
+ * log. Returns the authorized context on allow, or a ready-to-return `fail()`
+ * Response (401/403) on deny. This is the same chain the existing access
+ * endpoints inline; it is centralized here so every guarded endpoint stays
+ * consistent, always enforces tenant module state, and always records a
+ * decision log.
  */
 export async function authorizeInTransaction(
   tx: Bun.SQL,
@@ -70,6 +74,33 @@ export async function authorizeInTransaction(
     return {
       allowed: false,
       denied: fail(401, "AUTH_REQUIRED", "Session is invalid or expired.")
+    };
+  }
+
+  const moduleEnabled = await resolveModuleEnabled(
+    tx,
+    tenantId,
+    guard.moduleKey
+  );
+
+  if (!moduleEnabled) {
+    const decision = {
+      allowed: false,
+      reason: "Module is disabled for this tenant.",
+      matchedPolicy: "module_disabled"
+    };
+
+    await recordDecisionLog(
+      tx,
+      tenantId,
+      context.tenantUserId,
+      guard,
+      decision
+    );
+
+    return {
+      allowed: false,
+      denied: fail(403, "MODULE_DISABLED", decision.reason)
     };
   }
 

--- a/src/modules/identity-access/application/auth-context.ts
+++ b/src/modules/identity-access/application/auth-context.ts
@@ -41,6 +41,24 @@ export async function resolveTenantContext(
   };
 }
 
+/**
+ * Whether `moduleKey` is available for `tenantId` (Issue #515's
+ * `awcms_mini_tenant_modules` — no row means "never toggled", available by
+ * default, same convention as the tenant module lifecycle service itself).
+ */
+export async function resolveModuleEnabled(
+  tx: Bun.SQL,
+  tenantId: string,
+  moduleKey: string
+): Promise<boolean> {
+  const rows = (await tx`
+    SELECT enabled FROM awcms_mini_tenant_modules
+    WHERE tenant_id = ${tenantId} AND module_key = ${moduleKey}
+  `) as { enabled: boolean }[];
+
+  return rows[0]?.enabled ?? true;
+}
+
 export async function fetchGrantedPermissionKeys(
   tx: Bun.SQL,
   tenantId: string,

--- a/src/modules/identity-access/domain/access-control.ts
+++ b/src/modules/identity-access/domain/access-control.ts
@@ -25,7 +25,9 @@ export type AccessAction =
   | "restore"
   | "purge"
   | "retry"
-  | "sync";
+  | "sync"
+  | "enable"
+  | "disable";
 
 export type AccessRequest = {
   moduleKey: string;

--- a/src/modules/module-management/application/tenant-module-lifecycle.ts
+++ b/src/modules/module-management/application/tenant-module-lifecycle.ts
@@ -1,0 +1,194 @@
+/**
+ * Tenant module lifecycle service (Issue #515, epic #510). Tenant-level
+ * availability/configuration only — never unloads code from the runtime
+ * (`awcms_mini_tenant_modules` is the only thing written here).
+ */
+import packageJson from "../../../../package.json";
+import { listModules } from "../..";
+import type { ModuleDescriptor } from "../../_shared/module-contract";
+import { syncModuleDescriptors } from "./descriptor-sync";
+import {
+  evaluateModuleDisable,
+  evaluateModuleEnable,
+  type LifecycleValidationResult,
+  type ModuleTenantState
+} from "../domain/tenant-module-lifecycle";
+
+const CURRENT_APP_VERSION = packageJson.version;
+
+export type TenantModuleListEntry = {
+  moduleKey: string;
+  name: string;
+  version: string;
+  isCore: boolean;
+  tenantEnabled: boolean;
+  enabledAt: string | null;
+  disabledAt: string | null;
+  disableReason: string | null;
+};
+
+type TenantModuleRow = {
+  module_key: string;
+  enabled: boolean;
+  enabled_at: Date | null;
+  disabled_at: Date | null;
+  disable_reason: string | null;
+};
+
+async function fetchTenantModuleRows(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<Map<string, TenantModuleRow>> {
+  const rows = (await tx`
+    SELECT module_key, enabled, enabled_at, disabled_at, disable_reason
+    FROM awcms_mini_tenant_modules
+    WHERE tenant_id = ${tenantId}
+  `) as TenantModuleRow[];
+
+  return new Map(rows.map((row) => [row.module_key, row]));
+}
+
+function resolveTenantState(
+  moduleKey: string,
+  rows: Map<string, TenantModuleRow>
+): ModuleTenantState {
+  const row = rows.get(moduleKey);
+
+  return { moduleKey, tenantEnabled: row?.enabled ?? true };
+}
+
+export async function fetchTenantModuleEntries(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<TenantModuleListEntry[]> {
+  const rows = await fetchTenantModuleRows(tx, tenantId);
+
+  return listModules().map((descriptor) => {
+    const row = rows.get(descriptor.key);
+
+    return {
+      moduleKey: descriptor.key,
+      name: descriptor.name,
+      version: descriptor.version,
+      isCore: descriptor.isCore ?? false,
+      tenantEnabled: row?.enabled ?? true,
+      enabledAt: row?.enabled_at?.toISOString() ?? null,
+      disabledAt: row?.disabled_at?.toISOString() ?? null,
+      disableReason: row?.disable_reason ?? null
+    };
+  });
+}
+
+function findDescriptor(moduleKey: string): ModuleDescriptor | null {
+  return listModules().find((d) => d.key === moduleKey) ?? null;
+}
+
+export type TenantModuleMutationResult =
+  | { outcome: "applied" }
+  | {
+      outcome: "rejected";
+      validation: Extract<LifecycleValidationResult, { valid: false }>;
+    };
+
+export async function enableTenantModule(
+  tx: Bun.SQL,
+  tenantId: string,
+  moduleKey: string,
+  actorTenantUserId: string
+): Promise<TenantModuleMutationResult> {
+  // `awcms_mini_tenant_modules.module_key` has an FK to `awcms_mini_modules`
+  // — ensure the registry is current before writing tenant state that
+  // references it, rather than requiring an operator to have already run
+  // `bun run modules:sync`/`POST /api/v1/modules/sync` at least once.
+  // Idempotent and cheap (a handful of upserts, no network calls).
+  await syncModuleDescriptors(tx);
+
+  const rows = await fetchTenantModuleRows(tx, tenantId);
+  const target = findDescriptor(moduleKey);
+  const allDescriptors = listModules();
+
+  const dependencyStates = (target?.dependencies ?? []).map((depKey) => {
+    const depDescriptor = findDescriptor(depKey);
+
+    return depDescriptor
+      ? {
+          descriptor: depDescriptor,
+          tenantState: resolveTenantState(depKey, rows)
+        }
+      : { descriptor: null, moduleKey: depKey };
+  });
+
+  const validation = evaluateModuleEnable({
+    target,
+    targetTenantState: resolveTenantState(moduleKey, rows),
+    dependencyStates,
+    allDescriptors,
+    currentAppVersion: CURRENT_APP_VERSION
+  });
+
+  if (!validation.valid) {
+    return { outcome: "rejected", validation };
+  }
+
+  await tx`
+    INSERT INTO awcms_mini_tenant_modules
+      (tenant_id, module_key, enabled, enabled_at, enabled_by, disabled_at, disabled_by, disable_reason)
+    VALUES (${tenantId}, ${moduleKey}, true, now(), ${actorTenantUserId}, null, null, null)
+    ON CONFLICT (tenant_id, module_key) DO UPDATE SET
+      enabled = true,
+      enabled_at = now(),
+      enabled_by = ${actorTenantUserId},
+      disabled_at = null,
+      disabled_by = null,
+      disable_reason = null,
+      updated_at = now()
+  `;
+
+  return { outcome: "applied" };
+}
+
+export async function disableTenantModule(
+  tx: Bun.SQL,
+  tenantId: string,
+  moduleKey: string,
+  actorTenantUserId: string,
+  reason: string
+): Promise<TenantModuleMutationResult> {
+  // Same reasoning as `enableTenantModule` — the FK to `awcms_mini_modules`
+  // requires the registry to be current.
+  await syncModuleDescriptors(tx);
+
+  const rows = await fetchTenantModuleRows(tx, tenantId);
+  const target = findDescriptor(moduleKey);
+
+  const reverseDependencies = listModules()
+    .filter((d) => d.key !== moduleKey && d.dependencies.includes(moduleKey))
+    .map((descriptor) => ({
+      descriptor,
+      tenantState: resolveTenantState(descriptor.key, rows)
+    }));
+
+  const validation = evaluateModuleDisable({
+    target,
+    targetTenantState: resolveTenantState(moduleKey, rows),
+    reverseDependencies
+  });
+
+  if (!validation.valid) {
+    return { outcome: "rejected", validation };
+  }
+
+  await tx`
+    INSERT INTO awcms_mini_tenant_modules
+      (tenant_id, module_key, enabled, enabled_at, disabled_at, disabled_by, disable_reason)
+    VALUES (${tenantId}, ${moduleKey}, false, null, now(), ${actorTenantUserId}, ${reason})
+    ON CONFLICT (tenant_id, module_key) DO UPDATE SET
+      enabled = false,
+      disabled_at = now(),
+      disabled_by = ${actorTenantUserId},
+      disable_reason = ${reason},
+      updated_at = now()
+  `;
+
+  return { outcome: "applied" };
+}

--- a/src/modules/module-management/domain/tenant-module-lifecycle.ts
+++ b/src/modules/module-management/domain/tenant-module-lifecycle.ts
@@ -1,0 +1,213 @@
+/**
+ * Pure dependency-graph validation for tenant module enable/disable (Issue
+ * #515, epic #510). No I/O here — the application layer
+ * (`application/tenant-module-lifecycle.ts`) resolves the current state
+ * from `listModules()` + `awcms_mini_tenant_modules` and hands it to these
+ * functions, keeping the actual decision testable without a database.
+ *
+ * The dependency graph itself always comes from the live code registry
+ * (`listModules()`'s own `dependencies` arrays), never the DB's
+ * `awcms_mini_module_dependencies` table — that table only reflects
+ * whatever `bun run modules:sync` last wrote, and enable/disable must
+ * never depend on someone having remembered to run a sync first.
+ */
+import type { ModuleDescriptor } from "../../_shared/module-contract";
+
+export type ModuleLifecycleErrorCode =
+  | "MODULE_NOT_FOUND"
+  | "MODULE_ALREADY_ENABLED"
+  | "MODULE_ALREADY_DISABLED"
+  | "MODULE_DEPENDENCY_MISSING"
+  | "MODULE_DEPENDENCY_DISABLED"
+  | "MODULE_REVERSE_DEPENDENCY_ACTIVE"
+  | "MODULE_DEPENDENCY_CYCLE"
+  | "MODULE_VERSION_INCOMPATIBLE"
+  | "CORE_MODULE_CANNOT_BE_DISABLED";
+
+export type LifecycleValidationResult =
+  | { valid: true }
+  | { valid: false; code: ModuleLifecycleErrorCode; message: string };
+
+/** `tenantEnabled` defaults to `true` when no `awcms_mini_tenant_modules` row exists — a module with no explicit tenant state is available by default (backward-compatible with pre-epic behavior). */
+export type ModuleTenantState = {
+  moduleKey: string;
+  tenantEnabled: boolean;
+};
+
+function buildDependencyGraph(
+  descriptors: readonly ModuleDescriptor[]
+): Map<string, readonly string[]> {
+  return new Map(descriptors.map((d) => [d.key, d.dependencies] as const));
+}
+
+/** DFS from `startKey` through the dependency graph — `true` if the walk revisits `startKey`, i.e. `startKey` is part of a dependency cycle. */
+export function hasDependencyCycle(
+  startKey: string,
+  descriptors: readonly ModuleDescriptor[]
+): boolean {
+  const graph = buildDependencyGraph(descriptors);
+  const visited = new Set<string>();
+
+  function walk(key: string, depth: number): boolean {
+    if (depth > 0 && key === startKey) {
+      return true;
+    }
+    if (visited.has(key)) {
+      return false;
+    }
+    visited.add(key);
+
+    for (const dep of graph.get(key) ?? []) {
+      if (walk(dep, depth + 1)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  return walk(startKey, 0);
+}
+
+function compareSemver(a: string, b: string): number {
+  const partsA = a.split(".").map((n) => Number(n) || 0);
+  const partsB = b.split(".").map((n) => Number(n) || 0);
+
+  for (let i = 0; i < Math.max(partsA.length, partsB.length); i += 1) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+export type EnableValidationInput = {
+  target: ModuleDescriptor | null;
+  targetTenantState: ModuleTenantState;
+  /** One entry per direct dependency declared by `target.dependencies`. `null` for a dependency key not found in `listModules()` at all. */
+  dependencyStates: (
+    | { descriptor: ModuleDescriptor; tenantState: ModuleTenantState }
+    | { descriptor: null; moduleKey: string }
+  )[];
+  allDescriptors: readonly ModuleDescriptor[];
+  currentAppVersion: string;
+};
+
+export function evaluateModuleEnable(
+  input: EnableValidationInput
+): LifecycleValidationResult {
+  const { target } = input;
+
+  if (!target || target.status === "disabled") {
+    return {
+      valid: false,
+      code: "MODULE_NOT_FOUND",
+      message: "Module is not registered or is globally disabled."
+    };
+  }
+
+  if (input.targetTenantState.tenantEnabled) {
+    return {
+      valid: false,
+      code: "MODULE_ALREADY_ENABLED",
+      message: "Module is already enabled for this tenant."
+    };
+  }
+
+  for (const dependency of input.dependencyStates) {
+    if (!dependency.descriptor) {
+      return {
+        valid: false,
+        code: "MODULE_DEPENDENCY_MISSING",
+        message: `Dependency "${dependency.moduleKey}" is not a registered module.`
+      };
+    }
+
+    if (
+      dependency.descriptor.status === "disabled" ||
+      !dependency.tenantState.tenantEnabled
+    ) {
+      return {
+        valid: false,
+        code: "MODULE_DEPENDENCY_DISABLED",
+        message: `Dependency "${dependency.descriptor.key}" is disabled.`
+      };
+    }
+  }
+
+  if (hasDependencyCycle(target.key, input.allDescriptors)) {
+    return {
+      valid: false,
+      code: "MODULE_DEPENDENCY_CYCLE",
+      message: `Module "${target.key}" is part of a circular dependency.`
+    };
+  }
+
+  const minAppVersion = target.compatibility?.minAppVersion;
+  if (
+    minAppVersion &&
+    compareSemver(input.currentAppVersion, minAppVersion) < 0
+  ) {
+    return {
+      valid: false,
+      code: "MODULE_VERSION_INCOMPATIBLE",
+      message: `Module "${target.key}" requires app version >= ${minAppVersion}, current is ${input.currentAppVersion}.`
+    };
+  }
+
+  return { valid: true };
+}
+
+export type DisableValidationInput = {
+  target: ModuleDescriptor | null;
+  targetTenantState: ModuleTenantState;
+  /** Every OTHER registered module that declares a dependency on the target, with its own current tenant state. */
+  reverseDependencies: {
+    descriptor: ModuleDescriptor;
+    tenantState: ModuleTenantState;
+  }[];
+};
+
+export function evaluateModuleDisable(
+  input: DisableValidationInput
+): LifecycleValidationResult {
+  const { target } = input;
+
+  if (!target) {
+    return {
+      valid: false,
+      code: "MODULE_NOT_FOUND",
+      message: "Module is not registered."
+    };
+  }
+
+  if (target.isCore) {
+    return {
+      valid: false,
+      code: "CORE_MODULE_CANNOT_BE_DISABLED",
+      message: `Module "${target.key}" is core and cannot be disabled.`
+    };
+  }
+
+  if (!input.targetTenantState.tenantEnabled) {
+    return {
+      valid: false,
+      code: "MODULE_ALREADY_DISABLED",
+      message: "Module is already disabled for this tenant."
+    };
+  }
+
+  const activeDependent = input.reverseDependencies.find(
+    (dependent) => dependent.tenantState.tenantEnabled
+  );
+
+  if (activeDependent) {
+    return {
+      valid: false,
+      code: "MODULE_REVERSE_DEPENDENCY_ACTIVE",
+      message: `Module "${activeDependent.descriptor.key}" depends on "${target.key}" and is still enabled.`
+    };
+  }
+
+  return { valid: true };
+}

--- a/src/pages/api/v1/tenant/modules/[moduleKey]/disable.ts
+++ b/src/pages/api/v1/tenant/modules/[moduleKey]/disable.ts
@@ -1,0 +1,98 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import { disableTenantModule } from "../../../../../../modules/module-management/application/tenant-module-lifecycle";
+
+const DISABLE_GUARD = {
+  moduleKey: "module_management",
+  activityCode: "tenant_modules",
+  action: "disable" as const
+};
+
+/**
+ * `POST /api/v1/tenant/modules/{moduleKey}/disable` (Issue #515) —
+ * `reason` required (same precedent as `DELETE /api/v1/email/templates/{id}`
+ * — a meaningful operational action, not scratch state). Never deletes
+ * tenant data: only writes `awcms_mini_tenant_modules`. Rejected if the
+ * module is core/system, already disabled, or another still-enabled
+ * module depends on it.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const moduleKey = params.moduleKey;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!moduleKey) {
+    return fail(400, "VALIDATION_ERROR", "Module key is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const body = await request.json().catch(() => null);
+  const reasonRaw = (body as { reason?: unknown } | null)?.reason;
+
+  if (typeof reasonRaw !== "string" || reasonRaw.trim().length === 0) {
+    return fail(400, "VALIDATION_ERROR", "reason is required.");
+  }
+
+  const reason = reasonRaw.trim();
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DISABLE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const result = await disableTenantModule(
+      tx,
+      tenantId,
+      moduleKey,
+      auth.context.tenantUserId,
+      reason
+    );
+
+    if (result.outcome === "rejected") {
+      const status = result.validation.code === "MODULE_NOT_FOUND" ? 404 : 409;
+      return fail(status, result.validation.code, result.validation.message);
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "module_management",
+      action: "tenant_module_disabled",
+      resourceType: "tenant_module",
+      resourceId: moduleKey,
+      severity: "warning",
+      message: `Module disabled for tenant: ${moduleKey}.`,
+      attributes: { reason },
+      correlationId
+    });
+
+    return ok({ moduleKey, tenantEnabled: false });
+  });
+};

--- a/src/pages/api/v1/tenant/modules/[moduleKey]/enable.ts
+++ b/src/pages/api/v1/tenant/modules/[moduleKey]/enable.ts
@@ -1,0 +1,89 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import { enableTenantModule } from "../../../../../../modules/module-management/application/tenant-module-lifecycle";
+
+const ENABLE_GUARD = {
+  moduleKey: "module_management",
+  activityCode: "tenant_modules",
+  action: "enable" as const
+};
+
+/**
+ * `POST /api/v1/tenant/modules/{moduleKey}/enable` (Issue #515) —
+ * tenant-level availability only, never a runtime code load. Server-side
+ * dependency validation: a module can't be enabled if any direct
+ * dependency is missing, globally disabled, or disabled for this tenant.
+ * `MODULE_NOT_FOUND` (unknown/globally-disabled module) is `404`; every
+ * other rejection reason is a `409` conflict, not a validation error —
+ * the request is well-formed, the current state just doesn't allow it.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const moduleKey = params.moduleKey;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!moduleKey) {
+    return fail(400, "VALIDATION_ERROR", "Module key is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      ENABLE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const result = await enableTenantModule(
+      tx,
+      tenantId,
+      moduleKey,
+      auth.context.tenantUserId
+    );
+
+    if (result.outcome === "rejected") {
+      const status = result.validation.code === "MODULE_NOT_FOUND" ? 404 : 409;
+      return fail(status, result.validation.code, result.validation.message);
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "module_management",
+      action: "tenant_module_enabled",
+      resourceType: "tenant_module",
+      resourceId: moduleKey,
+      severity: "info",
+      message: `Module enabled for tenant: ${moduleKey}.`,
+      correlationId
+    });
+
+    return ok({ moduleKey, tenantEnabled: true });
+  });
+};

--- a/src/pages/api/v1/tenant/modules/index.ts
+++ b/src/pages/api/v1/tenant/modules/index.ts
@@ -1,0 +1,58 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { fetchTenantModuleEntries } from "../../../../../modules/module-management/application/tenant-module-lifecycle";
+
+const READ_GUARD = {
+  moduleKey: "module_management",
+  activityCode: "tenant_modules",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/tenant/modules` (Issue #515) — every registered module's
+ * enablement state for the caller's tenant. A module with no explicit
+ * state (`tenantEnabled: true`, no `enabledAt`/`disabledAt`) has never
+ * been toggled — available by default (backward-compatible with pre-epic
+ * behavior).
+ */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const modules = await fetchTenantModuleEntries(tx, tenantId);
+
+    return ok({ modules });
+  });
+};

--- a/tests/access-control.test.ts
+++ b/tests/access-control.test.ts
@@ -45,6 +45,11 @@ describe("isHighRiskAction", () => {
   test("does not classify sync as high risk (Issue #514 — idempotent, non-destructive)", () => {
     expect(isHighRiskAction("sync")).toBe(false);
   });
+
+  test("does not classify enable/disable as high risk (Issue #515 — reversible, never deletes tenant data)", () => {
+    expect(isHighRiskAction("enable")).toBe(false);
+    expect(isHighRiskAction("disable")).toBe(false);
+  });
 });
 
 describe("evaluateAccess", () => {

--- a/tests/integration/module-tenant-lifecycle.integration.test.ts
+++ b/tests/integration/module-tenant-lifecycle.integration.test.ts
@@ -24,6 +24,7 @@ import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
 import { GET as listTenantModules } from "../../src/pages/api/v1/tenant/modules/index";
 import { POST as enableModule } from "../../src/pages/api/v1/tenant/modules/[moduleKey]/enable";
 import { POST as disableModule } from "../../src/pages/api/v1/tenant/modules/[moduleKey]/disable";
+import { GET as listFormDrafts } from "../../src/pages/api/v1/form-drafts/index";
 import { syncModuleDescriptors } from "../../src/modules/module-management/application/descriptor-sync";
 
 const OWNER_LOGIN = "owner@example.com";
@@ -286,6 +287,35 @@ suite("tenant module lifecycle API", () => {
     });
 
     expect(result.status).toBe(400);
+  });
+
+  test("disabling a module actually blocks its own endpoints (not just the tenant_modules flag)", async () => {
+    const owner = await bootstrap();
+
+    const before = await invoke(listFormDrafts, {
+      method: "GET",
+      path: "/api/v1/form-drafts",
+      headers: authHeaders(owner)
+    });
+    expect(before.status).toBe(200);
+
+    await invoke(disableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/form_drafts/disable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "form_drafts" },
+      body: { reason: "Not used by this tenant." }
+    });
+
+    const after = await invoke(listFormDrafts, {
+      method: "GET",
+      path: "/api/v1/form-drafts",
+      headers: authHeaders(owner)
+    });
+    expect(after.status).toBe(403);
+    expect((after.body as { error: { code: string } }).error.code).toBe(
+      "MODULE_DISABLED"
+    );
   });
 
   test("RLS: disabling a module for tenant A never affects tenant B's state", async () => {

--- a/tests/integration/module-tenant-lifecycle.integration.test.ts
+++ b/tests/integration/module-tenant-lifecycle.integration.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Integration tests for the tenant module lifecycle API (Issue #515, epic
+ * #510) against a real PostgreSQL: enable/disable using the *real*
+ * registered module dependency graph (`identity_access` has several
+ * active reverse dependents; `form_drafts` is a leaf with none), RLS
+ * isolation, and audit.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { GET as listTenantModules } from "../../src/pages/api/v1/tenant/modules/index";
+import { POST as enableModule } from "../../src/pages/api/v1/tenant/modules/[moduleKey]/enable";
+import { POST as disableModule } from "../../src/pages/api/v1/tenant/modules/[moduleKey]/disable";
+import { syncModuleDescriptors } from "../../src/modules/module-management/application/descriptor-sync";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string; tenantUserId: string };
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const loginIdentifier = `${tenantCode}-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  const admin = getAdminSql();
+  const tenantUserRows = (await admin`
+    SELECT tu.id FROM awcms_mini_tenant_users tu
+    JOIN awcms_mini_identities i ON i.id = tu.identity_id
+    WHERE tu.tenant_id = ${setup.body.data.tenantId} AND i.login_identifier = ${loginIdentifier}
+  `) as { id: string }[];
+
+  return {
+    tenantId: setup.body.data.tenantId,
+    token: login.body.data.token,
+    tenantUserId: tenantUserRows[0]!.id
+  };
+}
+
+function authHeaders(owner: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": owner.tenantId,
+    authorization: `Bearer ${owner.token}`
+  };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("tenant module lifecycle API", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("GET /api/v1/tenant/modules lists every module as enabled by default", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{
+      data: { modules: { moduleKey: string; tenantEnabled: boolean }[] };
+    }>(listTenantModules, {
+      method: "GET",
+      path: "/api/v1/tenant/modules",
+      headers: authHeaders(owner)
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.modules.every((m) => m.tenantEnabled)).toBe(true);
+  });
+
+  test("disabling a leaf module (no reverse dependents) succeeds and is audited", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{ data: { tenantEnabled: boolean } }>(
+      disableModule,
+      {
+        method: "POST",
+        path: "/api/v1/tenant/modules/form_drafts/disable",
+        headers: authHeaders(owner),
+        params: { moduleKey: "form_drafts" },
+        body: { reason: "Not used by this tenant." }
+      }
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.tenantEnabled).toBe(false);
+
+    const admin = getAdminSql();
+    const auditRows = (await admin`
+      SELECT action, resource_type, resource_id, attributes
+      FROM awcms_mini_audit_events
+      WHERE tenant_id = ${owner.tenantId} AND action = 'tenant_module_disabled'
+    `) as {
+      action: string;
+      resource_type: string;
+      resource_id: string;
+      attributes: { reason: string };
+    }[];
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]!.resource_id).toBe("form_drafts");
+    expect(auditRows[0]!.attributes.reason).toBe("Not used by this tenant.");
+  });
+
+  test("re-enabling a previously disabled module succeeds and is audited", async () => {
+    const owner = await bootstrap();
+    await invoke(disableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/form_drafts/disable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "form_drafts" },
+      body: { reason: "Temporary." }
+    });
+
+    const result = await invoke<{ data: { tenantEnabled: boolean } }>(
+      enableModule,
+      {
+        method: "POST",
+        path: "/api/v1/tenant/modules/form_drafts/enable",
+        headers: authHeaders(owner),
+        params: { moduleKey: "form_drafts" }
+      }
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.tenantEnabled).toBe(true);
+
+    const admin = getAdminSql();
+    const auditRows = (await admin`
+      SELECT action FROM awcms_mini_audit_events
+      WHERE tenant_id = ${owner.tenantId} AND action = 'tenant_module_enabled'
+    `) as { action: string }[];
+    expect(auditRows).toHaveLength(1);
+  });
+
+  test("enabling an already-enabled module is rejected (409 MODULE_ALREADY_ENABLED)", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke(enableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/email/enable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "email" }
+    });
+
+    expect(result.status).toBe(409);
+  });
+
+  test("disabling a module that another enabled module depends on is rejected (409 MODULE_REVERSE_DEPENDENCY_ACTIVE)", async () => {
+    const owner = await bootstrap();
+
+    // `reporting` depends on `email` and is enabled by default.
+    const result = await invoke(disableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/email/disable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "email" },
+      body: { reason: "Trying to disable a relied-upon module." }
+    });
+
+    expect(result.status).toBe(409);
+  });
+
+  test("disabling a core module is rejected (409 CORE_MODULE_CANNOT_BE_DISABLED)", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke(disableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/module_management/disable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "module_management" },
+      body: { reason: "Trying to disable module management itself." }
+    });
+
+    expect(result.status).toBe(409);
+  });
+
+  test("enabling a module whose dependency is disabled for this tenant is rejected (409 MODULE_DEPENDENCY_DISABLED)", async () => {
+    const owner = await bootstrap();
+    const admin = getAdminSql();
+
+    // The registry FK requires awcms_mini_modules to be populated first —
+    // enable/disable auto-syncs, but this test writes tenant_modules rows
+    // directly (bypassing the endpoints), so it must sync explicitly.
+    await syncModuleDescriptors(admin);
+
+    // Directly force identity_access into a disabled tenant state — this
+    // bypasses the endpoint's own reverse-dependency guard on purpose,
+    // as pure test setup (arranging a state the real disable flow would
+    // never reach on its own, since identity_access has active reverse
+    // dependents).
+    await admin`
+      INSERT INTO awcms_mini_tenant_modules (tenant_id, module_key, enabled, disabled_at)
+      VALUES (${owner.tenantId}, 'identity_access', false, now())
+    `;
+    await admin`
+      INSERT INTO awcms_mini_tenant_modules (tenant_id, module_key, enabled, disabled_at)
+      VALUES (${owner.tenantId}, 'form_drafts', false, now())
+    `;
+
+    // form_drafts depends only on identity_access, which is now disabled.
+    const result = await invoke(enableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/form_drafts/enable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "form_drafts" }
+    });
+
+    expect(result.status).toBe(409);
+  });
+
+  test("enabling/disabling an unknown module key is a 404", async () => {
+    const owner = await bootstrap();
+
+    const enableResult = await invoke(enableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/does_not_exist/enable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "does_not_exist" }
+    });
+    expect(enableResult.status).toBe(404);
+
+    const disableResult = await invoke(disableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/does_not_exist/disable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "does_not_exist" },
+      body: { reason: "n/a" }
+    });
+    expect(disableResult.status).toBe(404);
+  });
+
+  test("disable requires a reason", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke(disableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/form_drafts/disable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "form_drafts" },
+      body: {}
+    });
+
+    expect(result.status).toBe(400);
+  });
+
+  test("RLS: disabling a module for tenant A never affects tenant B's state", async () => {
+    const ownerA = await bootstrap("tenant-a", "Tenant A");
+    const admin = getAdminSql();
+    const tenantBId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    await admin`
+      INSERT INTO awcms_mini_tenants
+        (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+      VALUES (${tenantBId}, 'tenant-b', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+    `;
+
+    await invoke(disableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/form_drafts/disable",
+      headers: authHeaders(ownerA),
+      params: { moduleKey: "form_drafts" },
+      body: { reason: "Tenant A only." }
+    });
+
+    const rows = (await admin`
+      SELECT count(*)::int AS count FROM awcms_mini_tenant_modules
+      WHERE tenant_id = ${tenantBId}
+    `) as { count: number }[];
+    expect(rows[0]?.count).toBe(0);
+  });
+});

--- a/tests/module-management-tenant-lifecycle.test.ts
+++ b/tests/module-management-tenant-lifecycle.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluateModuleDisable,
+  evaluateModuleEnable,
+  hasDependencyCycle
+} from "../src/modules/module-management/domain/tenant-module-lifecycle";
+import type { ModuleDescriptor } from "../src/modules/_shared/module-contract";
+
+function descriptor(
+  overrides: Partial<ModuleDescriptor> = {}
+): ModuleDescriptor {
+  return {
+    key: "a",
+    name: "A",
+    version: "1.0.0",
+    status: "active",
+    description: "Module A.",
+    dependencies: [],
+    ...overrides
+  };
+}
+
+describe("hasDependencyCycle", () => {
+  test("no cycle for a simple linear chain", () => {
+    const a = descriptor({ key: "a", dependencies: ["b"] });
+    const b = descriptor({ key: "b", dependencies: [] });
+
+    expect(hasDependencyCycle("a", [a, b])).toBe(false);
+  });
+
+  test("detects a direct cycle (a depends on b, b depends on a)", () => {
+    const a = descriptor({ key: "a", dependencies: ["b"] });
+    const b = descriptor({ key: "b", dependencies: ["a"] });
+
+    expect(hasDependencyCycle("a", [a, b])).toBe(true);
+    expect(hasDependencyCycle("b", [a, b])).toBe(true);
+  });
+
+  test("detects an indirect cycle (a -> b -> c -> a)", () => {
+    const a = descriptor({ key: "a", dependencies: ["b"] });
+    const b = descriptor({ key: "b", dependencies: ["c"] });
+    const c = descriptor({ key: "c", dependencies: ["a"] });
+
+    expect(hasDependencyCycle("a", [a, b, c])).toBe(true);
+  });
+
+  test("no false positive when two modules share a common dependency (diamond)", () => {
+    const a = descriptor({ key: "a", dependencies: ["b", "c"] });
+    const b = descriptor({ key: "b", dependencies: ["d"] });
+    const c = descriptor({ key: "c", dependencies: ["d"] });
+    const d = descriptor({ key: "d", dependencies: [] });
+
+    expect(hasDependencyCycle("a", [a, b, c, d])).toBe(false);
+  });
+});
+
+describe("evaluateModuleEnable", () => {
+  const baseInput = {
+    target: descriptor({ key: "a", dependencies: [] }),
+    targetTenantState: { moduleKey: "a", tenantEnabled: false },
+    dependencyStates: [],
+    allDescriptors: [descriptor({ key: "a", dependencies: [] })],
+    currentAppVersion: "1.0.0"
+  };
+
+  test("rejects an unregistered module", () => {
+    const result = evaluateModuleEnable({ ...baseInput, target: null });
+
+    expect(result).toMatchObject({ valid: false, code: "MODULE_NOT_FOUND" });
+  });
+
+  test("rejects a globally-disabled module the same as not found", () => {
+    const result = evaluateModuleEnable({
+      ...baseInput,
+      target: descriptor({ key: "a", status: "disabled" })
+    });
+
+    expect(result).toMatchObject({ valid: false, code: "MODULE_NOT_FOUND" });
+  });
+
+  test("rejects a module already enabled for the tenant", () => {
+    const result = evaluateModuleEnable({
+      ...baseInput,
+      targetTenantState: { moduleKey: "a", tenantEnabled: true }
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      code: "MODULE_ALREADY_ENABLED"
+    });
+  });
+
+  test("rejects when a dependency descriptor cannot be found at all", () => {
+    const result = evaluateModuleEnable({
+      ...baseInput,
+      dependencyStates: [{ descriptor: null, moduleKey: "missing" }]
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      code: "MODULE_DEPENDENCY_MISSING"
+    });
+  });
+
+  test("rejects when a dependency is globally disabled", () => {
+    const result = evaluateModuleEnable({
+      ...baseInput,
+      dependencyStates: [
+        {
+          descriptor: descriptor({ key: "b", status: "disabled" }),
+          tenantState: { moduleKey: "b", tenantEnabled: true }
+        }
+      ]
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      code: "MODULE_DEPENDENCY_DISABLED"
+    });
+  });
+
+  test("rejects when a dependency is disabled for this tenant", () => {
+    const result = evaluateModuleEnable({
+      ...baseInput,
+      dependencyStates: [
+        {
+          descriptor: descriptor({ key: "b" }),
+          tenantState: { moduleKey: "b", tenantEnabled: false }
+        }
+      ]
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      code: "MODULE_DEPENDENCY_DISABLED"
+    });
+  });
+
+  test("rejects a module that is part of a dependency cycle", () => {
+    const a = descriptor({ key: "a", dependencies: ["b"] });
+    const b = descriptor({ key: "b", dependencies: ["a"] });
+
+    const result = evaluateModuleEnable({
+      ...baseInput,
+      target: a,
+      dependencyStates: [
+        {
+          descriptor: b,
+          tenantState: { moduleKey: "b", tenantEnabled: true }
+        }
+      ],
+      allDescriptors: [a, b]
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      code: "MODULE_DEPENDENCY_CYCLE"
+    });
+  });
+
+  test("rejects when the module requires a newer app version", () => {
+    const result = evaluateModuleEnable({
+      ...baseInput,
+      target: descriptor({
+        key: "a",
+        compatibility: { minAppVersion: "9.9.9" }
+      }),
+      currentAppVersion: "1.0.0"
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      code: "MODULE_VERSION_INCOMPATIBLE"
+    });
+  });
+
+  test("passes when all dependencies are enabled and no cycle/version issue exists", () => {
+    const result = evaluateModuleEnable({
+      ...baseInput,
+      dependencyStates: [
+        {
+          descriptor: descriptor({ key: "b" }),
+          tenantState: { moduleKey: "b", tenantEnabled: true }
+        }
+      ]
+    });
+
+    expect(result).toEqual({ valid: true });
+  });
+});
+
+describe("evaluateModuleDisable", () => {
+  const baseInput = {
+    target: descriptor({ key: "a", isCore: false }),
+    targetTenantState: { moduleKey: "a", tenantEnabled: true },
+    reverseDependencies: []
+  };
+
+  test("rejects an unregistered module", () => {
+    const result = evaluateModuleDisable({ ...baseInput, target: null });
+
+    expect(result).toMatchObject({ valid: false, code: "MODULE_NOT_FOUND" });
+  });
+
+  test("rejects disabling a core module", () => {
+    const result = evaluateModuleDisable({
+      ...baseInput,
+      target: descriptor({ key: "a", isCore: true })
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      code: "CORE_MODULE_CANNOT_BE_DISABLED"
+    });
+  });
+
+  test("rejects a module already disabled for the tenant", () => {
+    const result = evaluateModuleDisable({
+      ...baseInput,
+      targetTenantState: { moduleKey: "a", tenantEnabled: false }
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      code: "MODULE_ALREADY_DISABLED"
+    });
+  });
+
+  test("rejects when an enabled module still depends on it", () => {
+    const result = evaluateModuleDisable({
+      ...baseInput,
+      reverseDependencies: [
+        {
+          descriptor: descriptor({ key: "b", dependencies: ["a"] }),
+          tenantState: { moduleKey: "b", tenantEnabled: true }
+        }
+      ]
+    });
+
+    expect(result).toMatchObject({
+      valid: false,
+      code: "MODULE_REVERSE_DEPENDENCY_ACTIVE"
+    });
+  });
+
+  test("passes when the only reverse dependency is itself tenant-disabled", () => {
+    const result = evaluateModuleDisable({
+      ...baseInput,
+      reverseDependencies: [
+        {
+          descriptor: descriptor({ key: "b", dependencies: ["a"] }),
+          tenantState: { moduleKey: "b", tenantEnabled: false }
+        }
+      ]
+    });
+
+    expect(result).toEqual({ valid: true });
+  });
+
+  test("passes when there are no reverse dependencies", () => {
+    const result = evaluateModuleDisable(baseInput);
+
+    expect(result).toEqual({ valid: true });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/tenant/modules`, `POST /api/v1/tenant/modules/{moduleKey}/enable`, `POST /api/v1/tenant/modules/{moduleKey}/disable` — tenant-level module availability, never a runtime code unload.
- Server-side dependency graph validation: missing/disabled direct dependency, disabled-for-tenant dependency, active reverse dependency on disable, dependency cycle detection, `minAppVersion` version incompatibility, and core/system modules cannot be disabled.
- `disable` never deletes tenant data — only writes `awcms_mini_tenant_modules`; requires a `reason`.
- Both mutations are audited (`tenant_module_enabled` / `tenant_module_disabled`) and RLS-isolated per tenant.
- Naturally idempotent via state checks + `ON CONFLICT` upsert (same precedent as `POST /api/v1/modules/sync`, #514) — not added to `HIGH_RISK_ACTIONS` since toggling availability is reversible and non-destructive, unlike `delete`/`purge`.

Closes #515 (part of epic #510).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run api:spec:check` / `bun run check:docs`
- [x] `bun test` — 620 pass (unit + integration against real PostgreSQL, including new dependency-graph unit tests and API/RLS/audit integration tests for this issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)