### PR TITLE
feat(module-management): add module permission sync and status inspection

### DIFF
--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -2911,6 +2911,51 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/modules/{moduleKey}/permissions:
+    get:
+      tags:
+        - Module Management
+      summary: Module permission sync/status
+      description: >-
+        Compares the module's descriptor-declared `permissions` against the
+        `awcms_mini_permissions` catalog and classifies each one `synced`,
+        `missing`, `orphaned`, or `mismatched_description`. Read-only —
+        never writes to the catalog, never changes a role's assigned
+        permissions.
+      operationId: modulesGetPermissionSync
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: moduleKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Permission sync report for the module.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/ModulePermissionSyncReport"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/tenant/modules:
     get:
       tags:
@@ -5134,6 +5179,55 @@ components:
           type: string
           format: date-time
           nullable: true
+    PermissionSyncEntry:
+      type: object
+      required:
+        - moduleKey
+        - activityCode
+        - action
+        - status
+        - descriptorDescription
+        - catalogDescription
+      additionalProperties: false
+      properties:
+        moduleKey:
+          type: string
+        activityCode:
+          type: string
+        action:
+          type: string
+        status:
+          type: string
+          enum:
+            - synced
+            - missing
+            - orphaned
+            - mismatched_description
+        descriptorDescription:
+          type: string
+          nullable: true
+          description: >-
+            Description declared in the module's own code descriptor;
+            `null` when `status` is `orphaned`.
+        catalogDescription:
+          type: string
+          nullable: true
+          description: >-
+            Description stored in `awcms_mini_permissions`; `null` when
+            `status` is `missing`.
+    ModulePermissionSyncReport:
+      type: object
+      required:
+        - moduleKey
+        - entries
+      additionalProperties: false
+      properties:
+        moduleKey:
+          type: string
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/PermissionSyncEntry"
     ModuleUsageEntry:
       type: object
       required:

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -99,6 +99,45 @@ variables or a secret manager.
   migration-between-versions logic exists yet — out of scope until a real
   module actually bumps its settings shape.
 
+## Module permission sync/status — `application/permission-sync.ts` (Issue #517)
+
+`GET /api/v1/modules/{moduleKey}/permissions`. Read-only comparison
+between a module's descriptor-declared `permissions` (trusted code
+metadata, `ModuleDescriptor.permissions`) and the actual
+`awcms_mini_permissions` catalog rows for that module —
+`domain/permission-sync.ts`'s `comparePermissions`, pure, no I/O.
+
+- **`synced`** — declared and present, same description.
+- **`missing`** — declared in the descriptor, no catalog row (a migration
+  seeding it hasn't run yet, or was simply never added).
+- **`orphaned`** — a catalog row exists, no descriptor declares it anymore.
+  **Never auto-deleted or auto-corrected** — this is a report an operator
+  reads and acts on manually (issue's own security note), not a mutation.
+- **`mismatched_description`** — present in both, but the description text
+  differs.
+- **The "optional safe sync action" the issue mentions is deliberately not
+  implemented.** `descriptor-sync.ts` (Issue #513) already upserts
+  `awcms_mini_modules`/`_dependencies`/`_navigation`/`_jobs` from
+  `listModules()`, but never touches `awcms_mini_permissions` — extending
+  it to write permissions too is a real, separate capability the
+  acceptance criteria for this issue doesn't actually require (only the
+  read-side report does), so it's left out rather than half-built.
+- **Only `module_management`'s own descriptor currently declares
+  `permissions`** (the other 9 registered modules' permissions were seeded
+  directly by their own migrations, e.g. migration 005/010/014, without
+  ever being added to their `module.ts`). This means every one of those
+  modules' catalog permissions legitimately shows as `orphaned` today —
+  an honest reflection of incomplete descriptor metadata, not a real
+  drift/incident. Backfilling every other module's `permissions` array is
+  out of scope here (the issue itself says this metadata is "optional...
+  if not completed in Issue 1" — #511 didn't do it for the pre-existing
+  modules, and this issue's job is the comparison service, not that
+  backfill).
+- A `moduleKey` that is neither a registered descriptor nor present in the
+  permission catalog at all is `404` — distinct from a registered module
+  with zero declared permissions (still `200`, an empty or
+  all-`orphaned` report).
+
 ## Out of scope for this issue
 
 Admin UI, and runtime plugin installation are explicitly out of scope —

--- a/src/modules/module-management/application/permission-sync.ts
+++ b/src/modules/module-management/application/permission-sync.ts
@@ -1,0 +1,93 @@
+/**
+ * Module permission sync/status service (Issue #517, epic #510). Read-only:
+ * reports whether each module-declared permission is `synced`, `missing`,
+ * `orphaned`, or has a `mismatched_description` against
+ * `awcms_mini_permissions` — never writes to that table (see
+ * `domain/permission-sync.ts`'s doc comment for why the issue's optional
+ * sync-write action isn't implemented).
+ */
+import { listModules } from "../..";
+import {
+  comparePermissions,
+  type CatalogPermission,
+  type DescriptorPermission,
+  type PermissionSyncEntry
+} from "../domain/permission-sync";
+
+type CatalogPermissionRow = {
+  module_key: string;
+  activity_code: string;
+  action: string;
+  description: string | null;
+};
+
+async function fetchCatalogPermissions(
+  tx: Bun.SQL,
+  moduleKey?: string
+): Promise<CatalogPermission[]> {
+  const rows = (
+    moduleKey
+      ? await tx`
+          SELECT module_key, activity_code, action, description
+          FROM awcms_mini_permissions
+          WHERE module_key = ${moduleKey}
+        `
+      : await tx`
+          SELECT module_key, activity_code, action, description
+          FROM awcms_mini_permissions
+        `
+  ) as CatalogPermissionRow[];
+
+  return rows.map((row) => ({
+    moduleKey: row.module_key,
+    activityCode: row.activity_code,
+    action: row.action,
+    description: row.description
+  }));
+}
+
+function descriptorPermissionsForModule(
+  moduleKey: string
+): DescriptorPermission[] {
+  const descriptor = listModules().find((d) => d.key === moduleKey);
+
+  return (descriptor?.permissions ?? []).map((permission) => ({
+    moduleKey,
+    activityCode: permission.activityCode,
+    action: permission.action,
+    description: permission.description
+  }));
+}
+
+export type ModulePermissionSyncReport = {
+  moduleKey: string;
+  entries: PermissionSyncEntry[];
+};
+
+/**
+ * `null` means `moduleKey` is neither a registered descriptor nor present
+ * anywhere in the permission catalog — a genuinely unknown key, `404`.
+ * A registered module that simply hasn't declared any `permissions` yet
+ * (most existing modules — see `module-management/README.md`) still
+ * returns a report; every one of its catalog rows shows as `orphaned`,
+ * which honestly reflects that its descriptor hasn't been backfilled,
+ * not that those permissions are actually abandoned.
+ */
+export async function fetchModulePermissionSyncReport(
+  tx: Bun.SQL,
+  moduleKey: string
+): Promise<ModulePermissionSyncReport | null> {
+  const catalogPermissions = await fetchCatalogPermissions(tx, moduleKey);
+  const descriptorExists = listModules().some((d) => d.key === moduleKey);
+
+  if (!descriptorExists && catalogPermissions.length === 0) {
+    return null;
+  }
+
+  const entries = comparePermissions(
+    descriptorPermissionsForModule(moduleKey),
+    catalogPermissions
+  );
+
+  return { moduleKey, entries };
+}

--- a/src/modules/module-management/domain/permission-sync.ts
+++ b/src/modules/module-management/domain/permission-sync.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure comparison logic for module permission sync/status (Issue #517, epic
+ * #510). No I/O here — the application layer
+ * (`application/permission-sync.ts`) reads each descriptor's own
+ * `permissions` array (trusted code metadata) and the current
+ * `awcms_mini_permissions` catalog rows, then hands both to
+ * `comparePermissions` to classify each one, keeping the decision testable
+ * without a database.
+ *
+ * Deliberately read-only: this never writes to `awcms_mini_permissions` —
+ * the issue's "optional safe sync action" is not implemented (see
+ * `module-management/README.md`), so an `orphaned`/`missing` result here
+ * never auto-corrects itself.
+ */
+export type PermissionSyncStatus =
+  "synced" | "missing" | "orphaned" | "mismatched_description";
+
+export type PermissionIdentity = {
+  moduleKey: string;
+  activityCode: string;
+  action: string;
+};
+
+export type DescriptorPermission = PermissionIdentity & {
+  description: string;
+};
+
+export type CatalogPermission = PermissionIdentity & {
+  description: string | null;
+};
+
+export type PermissionSyncEntry = PermissionIdentity & {
+  status: PermissionSyncStatus;
+  descriptorDescription: string | null;
+  catalogDescription: string | null;
+};
+
+function keyOf(permission: PermissionIdentity): string {
+  return `${permission.moduleKey}.${permission.activityCode}.${permission.action}`;
+}
+
+/**
+ * `synced` — declared in the descriptor, present in the catalog, same
+ * description.
+ * `missing` — declared in the descriptor, absent from the catalog (a
+ * migration seeding it hasn't run, or was never added).
+ * `orphaned` — present in the catalog, no descriptor declares it anymore
+ * (never auto-deleted — an operator decides, per the issue's security
+ * note).
+ * `mismatched_description` — present in both, but the descriptor's
+ * description text and the catalog's stored description differ.
+ */
+export function comparePermissions(
+  descriptorPermissions: readonly DescriptorPermission[],
+  catalogPermissions: readonly CatalogPermission[]
+): PermissionSyncEntry[] {
+  const byKey = new Map<
+    string,
+    {
+      identity: PermissionIdentity;
+      descriptor?: DescriptorPermission;
+      catalog?: CatalogPermission;
+    }
+  >();
+
+  for (const descriptor of descriptorPermissions) {
+    byKey.set(keyOf(descriptor), { identity: descriptor, descriptor });
+  }
+
+  for (const catalog of catalogPermissions) {
+    const key = keyOf(catalog);
+    const existing = byKey.get(key);
+
+    if (existing) {
+      existing.catalog = catalog;
+    } else {
+      byKey.set(key, { identity: catalog, catalog });
+    }
+  }
+
+  return [...byKey.values()]
+    .map(({ identity, descriptor, catalog }) => {
+      let status: PermissionSyncStatus;
+
+      if (descriptor && !catalog) {
+        status = "missing";
+      } else if (!descriptor && catalog) {
+        status = "orphaned";
+      } else if (descriptor!.description === catalog!.description) {
+        status = "synced";
+      } else {
+        status = "mismatched_description";
+      }
+
+      return {
+        moduleKey: identity.moduleKey,
+        activityCode: identity.activityCode,
+        action: identity.action,
+        status,
+        descriptorDescription: descriptor?.description ?? null,
+        catalogDescription: catalog?.description ?? null
+      };
+    })
+    .sort((a, b) => keyOf(a).localeCompare(keyOf(b)));
+}

--- a/src/pages/api/v1/modules/[moduleKey]/permissions.ts
+++ b/src/pages/api/v1/modules/[moduleKey]/permissions.ts
@@ -1,0 +1,69 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { fetchModulePermissionSyncReport } from "../../../../../modules/module-management/application/permission-sync";
+
+const READ_GUARD = {
+  moduleKey: "module_management",
+  activityCode: "permissions",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/modules/{moduleKey}/permissions` (Issue #517) — compares the
+ * module's descriptor-declared `permissions` against the
+ * `awcms_mini_permissions` catalog and classifies each one `synced`,
+ * `missing`, `orphaned`, or `mismatched_description`. Read-only: never
+ * writes to the catalog, never changes a role's assigned permissions. A
+ * genuinely unknown `moduleKey` (no descriptor, no catalog rows either) is
+ * `404`.
+ */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const moduleKey = params.moduleKey;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!moduleKey) {
+    return fail(400, "VALIDATION_ERROR", "Module key is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const report = await fetchModulePermissionSyncReport(tx, moduleKey);
+
+    if (!report) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Module not found.");
+    }
+
+    return ok(report);
+  });
+};

--- a/tests/integration/module-permission-sync.integration.test.ts
+++ b/tests/integration/module-permission-sync.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Integration tests for module permission sync/status (Issue #517, epic
+ * #510) against a real PostgreSQL: `module_management` itself declares
+ * permissions in code (`module.ts`) matching migration 025's seed exactly,
+ * so it is the natural "all synced" fixture; `tenant_admin` declares none,
+ * so its real seeded permissions (migration 005) are the natural
+ * "all orphaned" fixture — no synthetic data needed for either case.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { GET as getModulePermissions } from "../../src/pages/api/v1/modules/[moduleKey]/permissions";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string };
+
+async function bootstrap(): Promise<Bootstrap> {
+  const loginIdentifier = `acme-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: "Acme",
+      tenantCode: "acme",
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId, token: login.body.data.token };
+}
+
+function authHeaders(owner: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": owner.tenantId,
+    authorization: `Bearer ${owner.token}`
+  };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("module permission sync/status API", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("module_management's own permissions are all synced", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{
+      data: {
+        moduleKey: string;
+        entries: { status: string }[];
+      };
+    }>(getModulePermissions, {
+      method: "GET",
+      path: "/api/v1/modules/module_management/permissions",
+      headers: authHeaders(owner),
+      params: { moduleKey: "module_management" }
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.moduleKey).toBe("module_management");
+    expect(result.body.data.entries.length).toBeGreaterThan(0);
+    expect(
+      result.body.data.entries.every((entry) => entry.status === "synced")
+    ).toBe(true);
+  });
+
+  test("a module with no declared descriptor permissions reports its real catalog rows as orphaned", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{
+      data: { entries: { status: string; activityCode: string }[] };
+    }>(getModulePermissions, {
+      method: "GET",
+      path: "/api/v1/modules/tenant_admin/permissions",
+      headers: authHeaders(owner),
+      params: { moduleKey: "tenant_admin" }
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.entries.length).toBeGreaterThan(0);
+    expect(
+      result.body.data.entries.every((entry) => entry.status === "orphaned")
+    ).toBe(true);
+  });
+
+  test("an entirely unknown module key is a 404", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke(getModulePermissions, {
+      method: "GET",
+      path: "/api/v1/modules/does_not_exist/permissions",
+      headers: authHeaders(owner),
+      params: { moduleKey: "does_not_exist" }
+    });
+
+    expect(result.status).toBe(404);
+  });
+
+  test("does not mutate awcms_mini_permissions (read-only)", async () => {
+    const owner = await bootstrap();
+    const admin = getAdminSql();
+
+    const before = (await admin`
+      SELECT count(*)::int AS count FROM awcms_mini_permissions
+    `) as { count: number }[];
+
+    await invoke(getModulePermissions, {
+      method: "GET",
+      path: "/api/v1/modules/tenant_admin/permissions",
+      headers: authHeaders(owner),
+      params: { moduleKey: "tenant_admin" }
+    });
+
+    const after = (await admin`
+      SELECT count(*)::int AS count FROM awcms_mini_permissions
+    `) as { count: number }[];
+
+    expect(after[0]?.count).toBe(before[0]?.count);
+  });
+});

--- a/tests/module-management-permission-sync.test.ts
+++ b/tests/module-management-permission-sync.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+
+import { comparePermissions } from "../src/modules/module-management/domain/permission-sync";
+
+describe("comparePermissions", () => {
+  test("synced when descriptor and catalog agree on description", () => {
+    const result = comparePermissions(
+      [
+        {
+          moduleKey: "email",
+          activityCode: "template",
+          action: "read",
+          description: "Read email templates"
+        }
+      ],
+      [
+        {
+          moduleKey: "email",
+          activityCode: "template",
+          action: "read",
+          description: "Read email templates"
+        }
+      ]
+    );
+
+    expect(result).toEqual([
+      {
+        moduleKey: "email",
+        activityCode: "template",
+        action: "read",
+        status: "synced",
+        descriptorDescription: "Read email templates",
+        catalogDescription: "Read email templates"
+      }
+    ]);
+  });
+
+  test("missing when declared in the descriptor but absent from the catalog", () => {
+    const result = comparePermissions(
+      [
+        {
+          moduleKey: "email",
+          activityCode: "template",
+          action: "delete",
+          description: "Delete email templates"
+        }
+      ],
+      []
+    );
+
+    expect(result).toEqual([
+      {
+        moduleKey: "email",
+        activityCode: "template",
+        action: "delete",
+        status: "missing",
+        descriptorDescription: "Delete email templates",
+        catalogDescription: null
+      }
+    ]);
+  });
+
+  test("orphaned when present in the catalog but no descriptor declares it", () => {
+    const result = comparePermissions(
+      [],
+      [
+        {
+          moduleKey: "tenant_admin",
+          activityCode: "office_management",
+          action: "read",
+          description: "Read office records"
+        }
+      ]
+    );
+
+    expect(result).toEqual([
+      {
+        moduleKey: "tenant_admin",
+        activityCode: "office_management",
+        action: "read",
+        status: "orphaned",
+        descriptorDescription: null,
+        catalogDescription: "Read office records"
+      }
+    ]);
+  });
+
+  test("mismatched_description when present in both but descriptions differ", () => {
+    const result = comparePermissions(
+      [
+        {
+          moduleKey: "email",
+          activityCode: "template",
+          action: "read",
+          description: "Read templates (new wording)"
+        }
+      ],
+      [
+        {
+          moduleKey: "email",
+          activityCode: "template",
+          action: "read",
+          description: "Read templates (old wording)"
+        }
+      ]
+    );
+
+    expect(result).toEqual([
+      {
+        moduleKey: "email",
+        activityCode: "template",
+        action: "read",
+        status: "mismatched_description",
+        descriptorDescription: "Read templates (new wording)",
+        catalogDescription: "Read templates (old wording)"
+      }
+    ]);
+  });
+
+  test("a null catalog description never equals a descriptor description (mismatched, not synced)", () => {
+    const result = comparePermissions(
+      [
+        {
+          moduleKey: "email",
+          activityCode: "template",
+          action: "read",
+          description: "Read templates"
+        }
+      ],
+      [
+        {
+          moduleKey: "email",
+          activityCode: "template",
+          action: "read",
+          description: null
+        }
+      ]
+    );
+
+    expect(result).toEqual([
+      {
+        moduleKey: "email",
+        activityCode: "template",
+        action: "read",
+        status: "mismatched_description",
+        descriptorDescription: "Read templates",
+        catalogDescription: null
+      }
+    ]);
+  });
+
+  test("sorts entries by module/activity/action for stable output", () => {
+    const result = comparePermissions(
+      [
+        {
+          moduleKey: "email",
+          activityCode: "template",
+          action: "update",
+          description: "Update"
+        },
+        {
+          moduleKey: "email",
+          activityCode: "template",
+          action: "create",
+          description: "Create"
+        }
+      ],
+      []
+    );
+
+    expect(result.map((entry) => entry.action)).toEqual(["create", "update"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/modules/{moduleKey}/permissions` — compares a module's descriptor-declared `permissions` against the `awcms_mini_permissions` catalog.
- Classifies each permission as `synced`, `missing` (declared, no catalog row), `orphaned` (catalog row, no longer declared), or `mismatched_description`.
- Read-only: never writes to the catalog, never changes a role's assigned permissions. Orphaned permissions are reported, never auto-deleted.
- The issue's "optional safe sync action" (writing descriptor permissions into the catalog) is intentionally **not** implemented — `descriptor-sync.ts` (#513) never touched `awcms_mini_permissions`, and the acceptance criteria only require the read-side report. Documented in `module-management/README.md`.
- Only `module_management`'s own descriptor currently declares `permissions` in code, so every other registered module's real catalog permissions legitimately show as `orphaned` today — an honest reflection of incomplete descriptor metadata (out of scope to backfill here), not a real drift.
- A genuinely unknown `moduleKey` (no descriptor, no catalog rows) is `404`.

Stacked on #528 (issue #516), which is itself stacked on #527 (issue #515) — this PR's base is `feat/module-settings-management-516`, so the diff here only shows the incremental #517 work. Closes #517 (part of epic #510).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run api:spec:check` / `bun run check:docs`
- [x] `bun test` — 652 pass (unit + integration against real PostgreSQL), including new `comparePermissions` domain unit tests and API integration tests (module_management all-synced, tenant_admin all-orphaned, unknown module 404, read-only/no-mutation check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)