### PR TITLE
feat(module-management): add module navigation registry and admin layout integration

### DIFF
--- a/i18n/en.po
+++ b/i18n/en.po
@@ -49,6 +49,12 @@ msgstr "Next"
 msgid "common.submit"
 msgstr "Submit"
 
+msgid "common.yes"
+msgstr "Yes"
+
+msgid "common.no"
+msgstr "No"
+
 #. error codes (doc 05 §Error code standard)
 msgid "error.validation_error"
 msgstr "The submitted data is invalid."
@@ -128,6 +134,9 @@ msgstr "Sync"
 
 msgid "admin.layout.nav_settings"
 msgstr "Settings"
+
+msgid "admin.layout.nav_modules"
+msgstr "Modules"
 
 msgid "admin.layout.breadcrumb_aria_label"
 msgstr "Breadcrumb"
@@ -511,6 +520,31 @@ msgstr "Feature flags must be a valid JSON object."
 
 msgid "admin.settings.save_success"
 msgstr "Settings saved successfully."
+
+#. admin.modules — Issue #518 (minimal read-only list; full UI is #521)
+msgid "admin.modules.access_denied_title"
+msgstr "Access denied."
+
+msgid "admin.modules.access_denied_body"
+msgstr "Your account does not have permission to view the module registry. Contact your tenant admin/owner to request access."
+
+msgid "admin.modules.module_column"
+msgstr "Module"
+
+msgid "admin.modules.version_column"
+msgstr "Version"
+
+msgid "admin.modules.status_column"
+msgstr "Status"
+
+msgid "admin.modules.type_column"
+msgstr "Type"
+
+msgid "admin.modules.core_column"
+msgstr "Core"
+
+msgid "admin.modules.no_modules"
+msgstr "No modules registered."
 
 #. admin.examples.wizard — Issue #483, non-domain fixture page
 msgid "admin.examples.wizard.nav_title"

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -49,6 +49,12 @@ msgstr "Lanjut"
 msgid "common.submit"
 msgstr "Kirim"
 
+msgid "common.yes"
+msgstr "Ya"
+
+msgid "common.no"
+msgstr "Tidak"
+
 #. error codes (doc 05 §Error code standard)
 msgid "error.validation_error"
 msgstr "Data yang dikirim tidak valid."
@@ -128,6 +134,9 @@ msgstr "Sync"
 
 msgid "admin.layout.nav_settings"
 msgstr "Pengaturan"
+
+msgid "admin.layout.nav_modules"
+msgstr "Modul"
 
 msgid "admin.layout.breadcrumb_aria_label"
 msgstr "Breadcrumb"
@@ -511,6 +520,31 @@ msgstr "Feature flags harus berupa JSON object yang valid."
 
 msgid "admin.settings.save_success"
 msgstr "Pengaturan berhasil disimpan."
+
+#. admin.modules — Issue #518 (daftar baca-saja minimal; UI lengkap di #521)
+msgid "admin.modules.access_denied_title"
+msgstr "Akses ditolak."
+
+msgid "admin.modules.access_denied_body"
+msgstr "Akun Anda tidak memiliki izin untuk melihat registry modul. Hubungi admin/owner tenant Anda untuk meminta akses."
+
+msgid "admin.modules.module_column"
+msgstr "Modul"
+
+msgid "admin.modules.version_column"
+msgstr "Versi"
+
+msgid "admin.modules.status_column"
+msgstr "Status"
+
+msgid "admin.modules.type_column"
+msgstr "Tipe"
+
+msgid "admin.modules.core_column"
+msgstr "Inti"
+
+msgid "admin.modules.no_modules"
+msgstr "Belum ada modul yang terdaftar."
 
 #. admin.examples.wizard — Issue #483, fixture non-domain
 msgid "admin.examples.wizard.nav_title"

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -28,6 +28,7 @@ import LanguageSwitcher from "../components/LanguageSwitcher.astro";
 import { getDatabaseClient } from "../lib/database/client";
 import { withTenant } from "../lib/database/tenant-context";
 import { fetchSyncIndicatorActive } from "../modules/reporting/application/sync-indicator";
+import { fetchVisibleModuleNavigationEntries } from "../modules/module-management/application/navigation-registry";
 import { createTranslator } from "../lib/i18n/translate";
 import { THEME_INIT_SCRIPT_BODY } from "../lib/security/theme-init-script";
 
@@ -77,6 +78,27 @@ try {
   );
 } catch (error) {
   console.error("AdminLayout: failed to load sync indicator state", error);
+}
+
+// Issue #518 — module-declared nav entries (currently just
+// `module_management`'s own `/admin/modules`), appended after the 4
+// existing hardcoded items below. Same defensive pattern as
+// tenantName/syncActive above: a failure here must never hide the
+// hardcoded items or otherwise lock an admin out, so it falls back to an
+// empty list rather than failing the whole page.
+let moduleNavEntries: Awaited<
+  ReturnType<typeof fetchVisibleModuleNavigationEntries>
+> = [];
+try {
+  moduleNavEntries = await withTenant(sql, context.tenantId, (tx) =>
+    fetchVisibleModuleNavigationEntries(
+      tx,
+      context.tenantId,
+      context.permissions
+    )
+  );
+} catch (error) {
+  console.error("AdminLayout: failed to load module navigation entries", error);
 }
 
 // i18n (Issue #433): already fully resolved (cookie -> tenant default -> en)
@@ -239,6 +261,18 @@ const isSettingsActive = pathname === "/admin/settings";
                 {t("admin.layout.nav_settings")}
               </a>
             </li>
+            {
+              moduleNavEntries.map((entry) => (
+                <li>
+                  <a
+                    href={entry.path}
+                    aria-current={pathname === entry.path ? "page" : undefined}
+                  >
+                    {t(entry.labelKey)}
+                  </a>
+                </li>
+              ))
+            }
           </ul>
         </nav>
         <main class="admin-main">

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -42,12 +42,13 @@ runs on the plain app connection with no tenant context needed.
 
 Declares `type: "system"`, `isCore: true` (module management cannot be
 tenant-disabled — you cannot disable the thing that manages modules), and
-its 12 seeded permissions (`migration 025`). Deliberately does **not**
-declare `navigation`/`jobs`/`health`/`api` yet — those fields exist on
-`ModuleDescriptor` (Issue #511) but the actual admin page (`/admin/modules`,
-Issue #521), job registry (#519), health checks (#520), and API routes
-(#514) don't exist yet. A descriptor should only claim a capability once
-the corresponding feature is real, not in advance.
+its 12 seeded permissions (`migration 025`). Also declares one `navigation`
+entry (Issue #518 — `/admin/modules`, gated by `module_management.modules.read`)
+now that a real, if minimal, page exists there. Deliberately still does
+**not** declare `jobs`/`health` — those fields exist on `ModuleDescriptor`
+(Issue #511) but the job registry (#519) and health checks (#520) don't
+exist yet. A descriptor should only claim a capability once the
+corresponding feature is real, not in advance.
 
 ## Tenant module lifecycle — `application/tenant-module-lifecycle.ts` (Issue #515)
 
@@ -137,6 +138,48 @@ metadata, `ModuleDescriptor.permissions`) and the actual
   permission catalog at all is `404` — distinct from a registered module
   with zero declared permissions (still `200`, an empty or
   all-`orphaned` report).
+
+## Module navigation registry — `application/navigation-registry.ts` (Issue #518)
+
+`AdminLayout.astro`'s sidebar. Reads navigation candidates directly from
+`listModules()` (never `awcms_mini_module_navigation` — same reasoning as
+`tenant-module-lifecycle.ts`: that table only reflects whatever
+`bun run modules:sync` last wrote, and a sidebar rendered on every single
+`/admin/*` request must never depend on someone having remembered to run a
+sync first). `domain/navigation-registry.ts`'s `filterVisibleNavigationEntries`
+(pure) decides visibility:
+
+- Hidden if the module is globally `disabled` (code/deployment-level) —
+  `experimental`/`deprecated`/`maintenance` still show.
+- Hidden if the tenant has disabled that module
+  (`awcms_mini_tenant_modules.enabled = false`).
+- Hidden if the entry declares a `requiredPermission` the caller doesn't
+  hold. No `requiredPermission` declared at all means always visible (to
+  anyone who can already reach `/admin/*`).
+- Survivors sort by `order` ascending.
+
+**The 4 pre-existing hardcoded sidebar items (Dashboard/Access &
+Users/Sync/Settings) are deliberately left exactly as they were** —
+still hardcoded in `AdminLayout.astro`, still using their own
+prefix-based permission checks (`hasAccessMenu`/`hasSyncMenu`). Converting
+them to descriptor-declared entries with a single `requiredPermission`
+each would risk _changing_ who sees them (their current checks are
+"holds any `identity_access.*`/`sync_storage.*` permission", not one
+specific permission key) — out of scope for this issue, which only needs
+to add the registry _alongside_ the existing items, not migrate them onto
+it. The registry-driven list is appended after those 4, currently
+surfacing exactly one entry: `module_management`'s own `/admin/modules`.
+A failure loading the registry (e.g. a transient DB hiccup) falls back to
+an empty list — same defensive pattern as `tenantName`/`syncActive` above
+it — so it never hides the 4 hardcoded items or otherwise locks an admin
+out.
+
+`src/pages/admin/modules.astro` is deliberately minimal — a read-only
+module catalog table (reusing `fetchModuleCatalog`, Issue #514), no
+mutation affordance at all. It exists only so this issue's new nav entry
+doesn't point at a 404; the real experience (filters, module detail,
+dependency/settings/permission-sync/navigation/jobs/health panels, tenant
+enable/disable actions) is Issue #521's job.
 
 ## Out of scope for this issue
 

--- a/src/modules/module-management/application/navigation-registry.ts
+++ b/src/modules/module-management/application/navigation-registry.ts
@@ -1,0 +1,69 @@
+/**
+ * Module admin navigation registry service (Issue #518, epic #510). Reads
+ * navigation entries directly from the live code registry (`listModules()`)
+ * — never `awcms_mini_module_navigation` — same reasoning as
+ * `tenant-module-lifecycle.ts`'s dependency graph: that table only reflects
+ * whatever `bun run modules:sync` last wrote, and a sidebar rendered on
+ * every single `/admin/*` request must never depend on someone having
+ * remembered to run a sync first. This also keeps the per-request cost to
+ * exactly one lightweight query (the tenant's disabled-module keys) —
+ * `AdminLayout.astro` already renders on every admin request, so this
+ * service is deliberately as cheap as `fetchSyncIndicatorActive`.
+ */
+import { listModules } from "../..";
+import {
+  filterVisibleNavigationEntries,
+  type NavigationCandidate
+} from "../domain/navigation-registry";
+
+function collectNavigationCandidates(): NavigationCandidate[] {
+  return listModules().flatMap((descriptor) =>
+    (descriptor.navigation ?? []).map((entry) => ({
+      moduleKey: descriptor.key,
+      moduleStatus: descriptor.status,
+      labelKey: entry.labelKey,
+      path: entry.path,
+      icon: entry.icon,
+      order: entry.order ?? 0,
+      group: entry.group,
+      requiredPermission: entry.requiredPermission
+    }))
+  );
+}
+
+async function fetchTenantDisabledModuleKeys(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<Set<string>> {
+  const rows = (await tx`
+    SELECT module_key FROM awcms_mini_tenant_modules
+    WHERE tenant_id = ${tenantId} AND enabled = false
+  `) as { module_key: string }[];
+
+  return new Set(rows.map((row) => row.module_key));
+}
+
+/**
+ * Every module-declared nav entry currently visible to this caller —
+ * filtered by module status, tenant module enablement, and the entry's own
+ * `requiredPermission` (see `domain/navigation-registry.ts` for the exact
+ * rules). Callers append this to whatever fallback nav items they already
+ * render unconditionally (`AdminLayout.astro` keeps Dashboard/Access &
+ * Users/Sync/Settings exactly as before) — a failure here must never hide
+ * those.
+ */
+export async function fetchVisibleModuleNavigationEntries(
+  tx: Bun.SQL,
+  tenantId: string,
+  grantedPermissionKeys: ReadonlySet<string>
+): Promise<NavigationCandidate[]> {
+  const tenantDisabledModuleKeys = await fetchTenantDisabledModuleKeys(
+    tx,
+    tenantId
+  );
+
+  return filterVisibleNavigationEntries(collectNavigationCandidates(), {
+    grantedPermissionKeys,
+    tenantDisabledModuleKeys
+  });
+}

--- a/src/modules/module-management/domain/navigation-registry.ts
+++ b/src/modules/module-management/domain/navigation-registry.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure filtering/sorting logic for the module admin navigation registry
+ * (Issue #518, epic #510). No I/O here — the application layer
+ * (`application/navigation-registry.ts`) collects candidates from each
+ * descriptor's `navigation` array (`listModules()`) plus the tenant's
+ * disabled-module set, then hands both to `filterVisibleNavigationEntries`.
+ *
+ * Navigation filtering is **not** authorization (doc 10/issue's own
+ * security note) — every target page/API this produces a link to must
+ * still enforce its own server-side guard regardless of whether a link to
+ * it happens to be visible.
+ */
+import type { ModuleLifecycleStatus } from "../../_shared/module-contract";
+
+export type NavigationCandidate = {
+  moduleKey: string;
+  moduleStatus: ModuleLifecycleStatus;
+  labelKey: string;
+  path: string;
+  icon?: string;
+  order: number;
+  group?: string;
+  requiredPermission?: string;
+};
+
+export type NavigationFilterOptions = {
+  grantedPermissionKeys: ReadonlySet<string>;
+  /** Module keys the tenant has explicitly disabled (`awcms_mini_tenant_modules.enabled = false`). A module absent from this set is available by default — same convention as the tenant module lifecycle service. */
+  tenantDisabledModuleKeys: ReadonlySet<string>;
+};
+
+/**
+ * A candidate survives when all three hold:
+ * 1. Its module isn't globally `disabled` (code/deployment-level — distinct
+ *    from the tenant toggle below). `experimental`/`deprecated`/
+ *    `maintenance` modules still show their nav — only `disabled` hides it.
+ * 2. The tenant hasn't disabled that module.
+ * 3. Either it declares no `requiredPermission` at all, or the caller holds
+ *    that exact permission key.
+ *
+ * Survivors are sorted by `order` ascending (stable) for predictable
+ * rendering — `group` is carried through but not used to group-render here
+ * (the sidebar is still a flat list; grouped rendering is a UI concern for
+ * whichever issue actually introduces grouped sections).
+ */
+export function filterVisibleNavigationEntries(
+  candidates: readonly NavigationCandidate[],
+  options: NavigationFilterOptions
+): NavigationCandidate[] {
+  return candidates
+    .filter((candidate) => candidate.moduleStatus !== "disabled")
+    .filter(
+      (candidate) => !options.tenantDisabledModuleKeys.has(candidate.moduleKey)
+    )
+    .filter(
+      (candidate) =>
+        !candidate.requiredPermission ||
+        options.grantedPermissionKeys.has(candidate.requiredPermission)
+    )
+    .sort((a, b) => a.order - b.order);
+}

--- a/src/modules/module-management/module.ts
+++ b/src/modules/module-management/module.ts
@@ -14,6 +14,14 @@ export const moduleManagementModule = defineModule({
     openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
     basePath: "/api/v1/modules"
   },
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_modules",
+      path: "/admin/modules",
+      order: 50,
+      requiredPermission: "module_management.modules.read"
+    }
+  ],
   permissions: [
     {
       activityCode: "modules",

--- a/src/pages/admin/modules.astro
+++ b/src/pages/admin/modules.astro
@@ -1,0 +1,145 @@
+---
+/**
+ * Module Management admin screen (Issue #518) — deliberately minimal: a
+ * read-only module catalog list, reusing the exact same application-layer
+ * function the JSON endpoint uses (`fetchModuleCatalog`, Issue #514), same
+ * pattern as `admin/sync.astro` reusing `fetchSyncHealthReport`.
+ *
+ * The full experience (filters, module detail, dependency/settings/
+ * permission-sync/navigation/jobs/health panels, tenant enable/disable
+ * action) is Issue #521's scope — this page exists now only so the nav
+ * entry this issue adds (`module_management`'s own descriptor, Issue #518)
+ * doesn't point at a 404. No mutation affordance here at all: this issue's
+ * job is the navigation registry, not module lifecycle actions (already
+ * covered by `POST /api/v1/tenant/modules/{moduleKey}/{enable,disable}`,
+ * Issue #515 — this page just doesn't expose them yet).
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import StateNotice from "../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { fetchModuleCatalog } from "../../modules/module-management/application/module-catalog";
+import { createTranslator } from "../../lib/i18n/translate";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/modules.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_READ_MODULES = context.permissions.has(
+  permissionKey("module_management", "modules", "read")
+);
+
+let modules: Awaited<ReturnType<typeof fetchModuleCatalog>> = [];
+let loadError = false;
+
+if (CAN_READ_MODULES) {
+  try {
+    modules = await withTenant(getDatabaseClient(), context.tenantId, (tx) =>
+      fetchModuleCatalog(tx)
+    );
+  } catch (error) {
+    console.error("admin/modules.astro: failed to load module catalog", error);
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title={t("admin.layout.nav_modules")}>
+  {
+    !CAN_READ_MODULES && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.modules.access_denied_title")}
+        body={t("admin.modules.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_MODULES && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ_MODULES && !loadError && (
+      <div class="table-scroll">
+        <table class="modules-table">
+          <thead>
+            <tr>
+              <th>{t("admin.modules.module_column")}</th>
+              <th>{t("admin.modules.version_column")}</th>
+              <th>{t("admin.modules.status_column")}</th>
+              <th>{t("admin.modules.type_column")}</th>
+              <th>{t("admin.modules.core_column")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {modules.length === 0 && (
+              <tr>
+                <td colspan={5}>{t("admin.modules.no_modules")}</td>
+              </tr>
+            )}
+            {modules.map((module) => (
+              <tr>
+                <td>
+                  <strong>{module.name}</strong>
+                  <br />
+                  <code>{module.moduleKey}</code>
+                </td>
+                <td>{module.version}</td>
+                <td>
+                  <span class="status-pill" data-status={module.status}>
+                    {module.status}
+                  </span>
+                </td>
+                <td>{module.type ?? "-"}</td>
+                <td>{module.isCore ? t("common.yes") : t("common.no")}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .modules-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .modules-table th,
+  .modules-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .status-pill {
+    display: inline-block;
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-full);
+    font-size: var(--fs-xs);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+  }
+</style>

--- a/tests/module-management-navigation-registry.test.ts
+++ b/tests/module-management-navigation-registry.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  filterVisibleNavigationEntries,
+  type NavigationCandidate
+} from "../src/modules/module-management/domain/navigation-registry";
+
+function candidate(
+  overrides: Partial<NavigationCandidate> = {}
+): NavigationCandidate {
+  return {
+    moduleKey: "module_management",
+    moduleStatus: "active",
+    labelKey: "admin.layout.nav_modules",
+    path: "/admin/modules",
+    order: 0,
+    ...overrides
+  };
+}
+
+describe("filterVisibleNavigationEntries", () => {
+  test("visible when no requiredPermission is declared", () => {
+    const result = filterVisibleNavigationEntries([candidate()], {
+      grantedPermissionKeys: new Set(),
+      tenantDisabledModuleKeys: new Set()
+    });
+
+    expect(result).toHaveLength(1);
+  });
+
+  test("visible when the caller holds the declared requiredPermission", () => {
+    const result = filterVisibleNavigationEntries(
+      [candidate({ requiredPermission: "module_management.modules.read" })],
+      {
+        grantedPermissionKeys: new Set(["module_management.modules.read"]),
+        tenantDisabledModuleKeys: new Set()
+      }
+    );
+
+    expect(result).toHaveLength(1);
+  });
+
+  test("hidden when the caller lacks the declared requiredPermission", () => {
+    const result = filterVisibleNavigationEntries(
+      [candidate({ requiredPermission: "module_management.modules.read" })],
+      {
+        grantedPermissionKeys: new Set(),
+        tenantDisabledModuleKeys: new Set()
+      }
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("hidden when the module is globally disabled", () => {
+    const result = filterVisibleNavigationEntries(
+      [candidate({ moduleStatus: "disabled" })],
+      {
+        grantedPermissionKeys: new Set(),
+        tenantDisabledModuleKeys: new Set()
+      }
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("still visible for experimental/deprecated/maintenance status", () => {
+    for (const moduleStatus of [
+      "experimental",
+      "deprecated",
+      "maintenance"
+    ] as const) {
+      const result = filterVisibleNavigationEntries(
+        [candidate({ moduleStatus })],
+        {
+          grantedPermissionKeys: new Set(),
+          tenantDisabledModuleKeys: new Set()
+        }
+      );
+
+      expect(result).toHaveLength(1);
+    }
+  });
+
+  test("hidden when the tenant has disabled that module", () => {
+    const result = filterVisibleNavigationEntries(
+      [candidate({ moduleKey: "form_drafts" })],
+      {
+        grantedPermissionKeys: new Set(),
+        tenantDisabledModuleKeys: new Set(["form_drafts"])
+      }
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("a tenant-disabled module doesn't hide a different module's entry", () => {
+    const result = filterVisibleNavigationEntries(
+      [
+        candidate({ moduleKey: "form_drafts", path: "/admin/form-drafts" }),
+        candidate({ moduleKey: "module_management", path: "/admin/modules" })
+      ],
+      {
+        grantedPermissionKeys: new Set(),
+        tenantDisabledModuleKeys: new Set(["form_drafts"])
+      }
+    );
+
+    expect(result).toEqual([
+      candidate({ moduleKey: "module_management", path: "/admin/modules" })
+    ]);
+  });
+
+  test("sorts survivors by order ascending", () => {
+    const result = filterVisibleNavigationEntries(
+      [
+        candidate({ path: "/admin/b", order: 20 }),
+        candidate({ path: "/admin/a", order: 10 })
+      ],
+      {
+        grantedPermissionKeys: new Set(),
+        tenantDisabledModuleKeys: new Set()
+      }
+    );
+
+    expect(result.map((entry) => entry.path)).toEqual(["/admin/a", "/admin/b"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a module-declared admin navigation registry: `AdminLayout.astro`'s sidebar now appends entries collected from each descriptor's own `navigation` array (`ModuleDescriptor.navigation`, Issue #511's contract).
- `domain/navigation-registry.ts`'s `filterVisibleNavigationEntries` (pure) decides visibility: hidden if the module is globally `disabled`, hidden if the tenant has disabled that module, hidden if the entry declares a `requiredPermission` the caller doesn't hold. Survivors sort by `order`.
- **The 4 existing hardcoded sidebar items (Dashboard/Access & Users/Sync/Settings) are left exactly as-is** — still hardcoded, still using their own prefix-based permission checks. Converting them to the registry risked *changing* who sees them (their checks are "holds any `identity_access.*`/`sync_storage.*` permission", not one specific key) — out of scope here. A registry-load failure falls back to an empty list, so it never hides those 4 items (same defensive pattern as the existing `tenantName`/`syncActive` try/catch).
- `module_management`'s own descriptor now declares one navigation entry: `/admin/modules`, gated by `module_management.modules.read`.
- New `src/pages/admin/modules.astro` — deliberately minimal, a read-only module catalog table (reuses `fetchModuleCatalog`, #514), no mutation affordance. Exists only so this issue's new nav entry doesn't point at a 404; the full admin UI (filters, detail page, dependency/settings/permission-sync/navigation/jobs/health panels, tenant enable/disable actions) is Issue #521's job.
- i18n keys added to both `en.po`/`id.po`: `admin.layout.nav_modules`, `admin.modules.*`, plus generic `common.yes`/`common.no`.

## Verification
Beyond the automated suite, this touches actual UI, so I drove it end-to-end against a real Postgres + `bun run dev`: ran the setup wizard, logged in as the tenant Owner, confirmed the sidebar renders all 5 items (4 existing + new "Modules" link) with correct `aria-current`, and that `/admin/modules` renders a 200 page listing all 10 registered modules (including `module_management` itself, correctly showing `Core: Yes`/`Type: system`) — checked in both `en` and `id` locales.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run api:spec:check` / `bun run check:docs`
- [x] `bun run build` (explicit acceptance criterion for this issue)
- [x] `bun test` — 660 pass (unit + integration against real PostgreSQL), including new `filterVisibleNavigationEntries` domain unit tests
- [x] Manual browser-equivalent verification (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)