### PR TITLE
feat(module-management): add module job registry for operational commands

### DIFF
--- a/docs/awcms-mini/deploy-coolify.md
+++ b/docs/awcms-mini/deploy-coolify.md
@@ -284,6 +284,13 @@ bersama lintas aplikasi. Bila `EMAIL_ENABLED` aplikasi tersebut `false`,
 perintah ini no-op (exit 0) sehingga aman dijadwalkan meski belum
 diaktifkan.
 
+`sync:objects:dispatch` (setiap 1-2 menit) dan `logs:audit:purge`/
+`form-drafts:purge` (harian) dijadwalkan dengan pola **Scheduled
+Task**/cron `docker exec` yang sama persis, hanya beda nama command —
+lihat [`deployment-profiles.md`](deployment-profiles.md) §Job registry
+lainnya (Issue #519) untuk daftar lengkap job dan mana yang on-demand
+(bukan cron berulang).
+
 ## Rollback
 
 - **Image registry (Pola 2)**: rollback = deploy ulang tag image

--- a/docs/awcms-mini/deployment-profiles.md
+++ b/docs/awcms-mini/deployment-profiles.md
@@ -256,6 +256,41 @@ Catatan operasional:
   deployment (claim-lease aman terhadap tumpang tindih, tapi menjadwalkan
   dari banyak host sekaligus tetap pemborosan resource tanpa manfaat).
 
+## Job registry lainnya (Issue #519)
+
+Selain `email:dispatch` di atas, Module Management (epic #510) sekarang
+mendaftarkan seluruh command operasional lain sebagai metadata trusted
+per modul (`ModuleDescriptor.jobs`, dibaca lewat
+`GET /api/v1/modules/{moduleKey}/jobs`) — lihat
+`src/modules/module-management/README.md` §Module job registry untuk
+daftar lengkap dan alasan tiap job dimiliki modul mana. Dua kategori:
+
+**Dispatcher/purge terjadwal berulang** — pola cron identik dengan
+`email:dispatch` di atas (ganti nama command pada contoh crontab),
+idempoten/aman dijalankan berulang, no-op aman bila fiturnya nonaktif:
+
+| Command                 | Modul        | Jadwal disarankan |
+| ----------------------- | ------------ | ----------------- |
+| `sync:objects:dispatch` | sync_storage | Setiap 1-2 menit  |
+| `logs:audit:purge`      | logging      | Harian            |
+| `form-drafts:purge`     | form_drafts  | Harian            |
+
+Semua tiga bersifat operasi database murni (kecuali `sync:objects:dispatch`
+yang menyentuh R2 bila `STORAGE_DRIVER` bukan `local`) — aman dijadwalkan
+di profil offline/LAN sekalipun.
+
+**On-demand/manual (bukan cron berulang)** — dijalankan operator sesuai
+kebutuhan, bukan dijadwalkan terus-menerus:
+
+- `email:provider:health` — smoke-test manual/deployment, butuh akses
+  jaringan nyata ke provider.
+- `email:templates:seed-defaults` — sekali per tenant, biasanya tepat
+  setelah Setup Wizard.
+- `security:readiness` — sebelum go-live, dan periodik (mis. mingguan) di
+  staging/production untuk mendeteksi drift.
+- `config:validate`/`production:preflight` — sebelum setiap deploy (lihat
+  §Validasi konfigurasi sebelum boot di atas).
+
 ## Backup lokal (semua profil)
 
 `deploy/backup/backup-postgres.sh` dan `deploy/backup/restore-postgres.sh`

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -2956,6 +2956,51 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/modules/{moduleKey}/jobs:
+    get:
+      tags:
+        - Module Management
+      summary: Module job/command registry
+      description: >-
+        The module's declared operational commands (`command`, `purpose`,
+        `recommendedSchedule`, `environmentNotes`, `safeInOfflineLan`).
+        Documentation only — there is no corresponding endpoint to execute
+        a job; running arbitrary commands from a web UI is explicitly out
+        of scope.
+      operationId: modulesGetJobs
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: moduleKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Job registry entries for the module.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/ModuleJobsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/tenant/modules:
     get:
       tags:
@@ -5228,6 +5273,40 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/PermissionSyncEntry"
+    JobRegistryEntry:
+      type: object
+      required:
+        - moduleKey
+        - command
+        - purpose
+      additionalProperties: false
+      properties:
+        moduleKey:
+          type: string
+        command:
+          type: string
+          description: 'Always "bun run <script>" — this repo is Bun-only.'
+        purpose:
+          type: string
+        recommendedSchedule:
+          type: string
+        environmentNotes:
+          type: string
+        safeInOfflineLan:
+          type: boolean
+    ModuleJobsResponse:
+      type: object
+      required:
+        - moduleKey
+        - jobs
+      additionalProperties: false
+      properties:
+        moduleKey:
+          type: string
+        jobs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JobRegistryEntry"
     ModuleUsageEntry:
       type: object
       required:

--- a/src/modules/email/module.ts
+++ b/src/modules/email/module.ts
@@ -21,5 +21,36 @@ export const emailModule = defineModule({
       "awcms-mini.email.message.suppressed",
       "awcms-mini.email.message.cancelled"
     ]
-  }
+  },
+  jobs: [
+    {
+      command: "bun run email:dispatch",
+      purpose:
+        "Drain the due email delivery queue (claim-lease, retry/backoff, circuit breaker) for every active tenant.",
+      recommendedSchedule: "Every 1-2 minutes via cron/systemd timer.",
+      environmentNotes:
+        'No-op when EMAIL_ENABLED is not "true" — safe to schedule regardless of deployment profile (e.g. offline/LAN).',
+      safeInOfflineLan: true
+    },
+    {
+      command: "bun run email:provider:health",
+      purpose:
+        "Live network check against the configured email provider's health endpoint.",
+      recommendedSchedule:
+        "On-demand — operators run manually or from a deployment smoke-test step, not on a recurring schedule.",
+      environmentNotes:
+        'Exits 0 (no-op) when EMAIL_ENABLED is not "true". Requires real network egress to the provider — not run in CI.',
+      safeInOfflineLan: false
+    },
+    {
+      command: "bun run email:templates:seed-defaults",
+      purpose:
+        "Seed the default system email templates for one tenant (idempotent — skips any template_key that already has an active row).",
+      recommendedSchedule:
+        "On-demand — once per tenant, typically right after tenant setup.",
+      environmentNotes:
+        "Requires --tenant=<tenantId> --actor=<tenantUserId> arguments.",
+      safeInOfflineLan: true
+    }
+  ]
 });

--- a/src/modules/form-drafts/module.ts
+++ b/src/modules/form-drafts/module.ts
@@ -11,5 +11,16 @@ export const formDraftsModule = defineModule({
   api: {
     openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
     basePath: "/api/v1/form-drafts"
-  }
+  },
+  jobs: [
+    {
+      command: "bun run form-drafts:purge",
+      purpose:
+        "Expire overdue draft rows, then physically delete expired/abandoned drafts past the retention cutoff, for every active tenant.",
+      recommendedSchedule: "Daily via cron/systemd timer.",
+      environmentNotes:
+        "Pure database operation — no external network dependency.",
+      safeInOfflineLan: true
+    }
+  ]
 });

--- a/src/modules/logging/module.ts
+++ b/src/modules/logging/module.ts
@@ -11,5 +11,16 @@ export const loggingModule = defineModule({
   api: {
     openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
     basePath: "/api/v1/logs"
-  }
+  },
+  jobs: [
+    {
+      command: "bun run logs:audit:purge",
+      purpose:
+        "Delete awcms_mini_audit_events rows past their retention cutoff for every active tenant, in bounded batches.",
+      recommendedSchedule: "Daily via cron/systemd timer.",
+      environmentNotes:
+        "Pure database operation — no external network dependency.",
+      safeInOfflineLan: true
+    }
+  ]
 });

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -44,11 +44,13 @@ Declares `type: "system"`, `isCore: true` (module management cannot be
 tenant-disabled — you cannot disable the thing that manages modules), and
 its 12 seeded permissions (`migration 025`). Also declares one `navigation`
 entry (Issue #518 — `/admin/modules`, gated by `module_management.modules.read`)
-now that a real, if minimal, page exists there. Deliberately still does
-**not** declare `jobs`/`health` — those fields exist on `ModuleDescriptor`
-(Issue #511) but the job registry (#519) and health checks (#520) don't
-exist yet. A descriptor should only claim a capability once the
-corresponding feature is real, not in advance.
+now that a real, if minimal, page exists there, and three `jobs` entries
+(Issue #519 — `security:readiness`/`config:validate`/`production:preflight`,
+platform-wide checks not owned by any single domain module). Deliberately
+still does **not** declare `health` — that field exists on
+`ModuleDescriptor` (Issue #511) but health checks (#520) don't exist yet.
+A descriptor should only claim a capability once the corresponding
+feature is real, not in advance.
 
 ## Tenant module lifecycle — `application/tenant-module-lifecycle.ts` (Issue #515)
 
@@ -180,6 +182,44 @@ mutation affordance at all. It exists only so this issue's new nav entry
 doesn't point at a 404; the real experience (filters, module detail,
 dependency/settings/permission-sync/navigation/jobs/health panels, tenant
 enable/disable actions) is Issue #521's job.
+
+## Module job registry — `application/job-registry.ts` (Issue #519)
+
+`GET /api/v1/modules/{moduleKey}/jobs`. Documentation only — never
+executes anything, and there is deliberately no corresponding "run this
+job" endpoint (issue's own security note: running arbitrary commands from
+a web UI is out of scope; if job execution is ever added, it must be a
+separate, heavily-restricted feature). Reads directly from `listModules()`
+— same reasoning as the navigation registry (#518): `awcms_mini_module_jobs`
+only reflects whatever `bun run modules:sync` last wrote, and this is
+operator-facing documentation that shouldn't silently go stale.
+
+Job ownership (`ModuleDescriptor.jobs`) by module:
+
+- `sync_storage` — `sync:objects:dispatch`.
+- `logging` — `logs:audit:purge`.
+- `form_drafts` — `form-drafts:purge`.
+- `email` — `email:dispatch`, `email:provider:health`,
+  `email:templates:seed-defaults`.
+- `module_management` — `security:readiness`, `config:validate`,
+  `production:preflight` (platform-wide/deployment-level checks that
+  aren't owned by any single domain module — `module_management` is
+  already the "generic infrastructure for managing every other registered
+  module", the natural home for these).
+
+Scheduling guidance (LAN/systemd/container/Coolify) lives in
+`docs/awcms-mini/deployment-profiles.md` §Job registry lainnya and
+`docs/awcms-mini/deploy-coolify.md` §Dispatcher terjadwal (email) — not
+duplicated here.
+
+`domain/job-registry.ts`'s `validateJobDescriptor` checks structural shape
+only (`command` must look like `bun run <script>`, `purpose` non-empty).
+"No secrets in job metadata" (acceptance criteria) is enforced the same
+way as every other `ModuleDescriptor` field — review discipline on
+trusted, checked-in code, per the contract's own doc comment — not an
+automated content scanner: a free-text `environmentNotes`/`purpose`
+string has no reliable secret-shaped _key_ the way a JSON-object settings
+value does (`findSensitiveKeys`, Issue #516).
 
 ## Out of scope for this issue
 

--- a/src/modules/module-management/application/job-registry.ts
+++ b/src/modules/module-management/application/job-registry.ts
@@ -1,0 +1,28 @@
+/**
+ * Module job/command registry service (Issue #519, epic #510). Reads
+ * directly from `listModules()` — never `awcms_mini_module_jobs` — same
+ * reasoning as the navigation registry (Issue #518) and tenant module
+ * lifecycle (Issue #515): that table only reflects whatever
+ * `bun run modules:sync` last wrote, and this is documentation the operator
+ * reads, not something that should silently go stale until someone
+ * remembers to sync. No I/O at all: every job descriptor is trusted,
+ * statically-imported code metadata already in this process.
+ */
+import { listModules } from "../..";
+import type { JobRegistryEntry } from "../domain/job-registry";
+
+/** Every job declared by every registered module, or just one module's when `moduleKey` is given. `null` distinguishes "module not registered at all" from "registered but declares zero jobs" (still `[]`, a valid empty list). */
+export function fetchModuleJobs(moduleKey?: string): JobRegistryEntry[] | null {
+  if (moduleKey && !listModules().some((d) => d.key === moduleKey)) {
+    return null;
+  }
+
+  return listModules()
+    .filter((descriptor) => !moduleKey || descriptor.key === moduleKey)
+    .flatMap((descriptor) =>
+      (descriptor.jobs ?? []).map((job) => ({
+        ...job,
+        moduleKey: descriptor.key
+      }))
+    );
+}

--- a/src/modules/module-management/domain/job-registry.ts
+++ b/src/modules/module-management/domain/job-registry.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure shape validation for module-declared job/command metadata (Issue
+ * #519, epic #510). No I/O here — the application layer
+ * (`application/job-registry.ts`) collects each descriptor's own `jobs`
+ * array (`listModules()`) and hands the entries to `validateJobDescriptor`.
+ *
+ * This is documentation-only, trusted code metadata (Issue #511's
+ * `ModuleJobDescriptor` contract) — it never executes anything (doc's own
+ * security note: no endpoint runs arbitrary shell commands from this).
+ * "No secrets" is enforced by the same review discipline as every other
+ * `ModuleDescriptor` field (doc comment on the contract itself), not by an
+ * automated content scanner here — a free-text `environmentNotes`/`purpose`
+ * string has no reliable secret-shaped *key* to check (unlike JSON-object
+ * settings, Issue #516, where `findSensitiveKeys` scans object keys).
+ */
+import type { ModuleJobDescriptor } from "../../_shared/module-contract";
+
+export type JobRegistryEntry = ModuleJobDescriptor & { moduleKey: string };
+
+export type JobDescriptorValidationResult =
+  { valid: true } | { valid: false; errors: string[] };
+
+const COMMAND_PATTERN = /^bun run [a-z0-9][a-z0-9:_-]*$/;
+
+/**
+ * `command` must look like `bun run <script>` (this repo is Bun-only, doc
+ * 18 §Runtime & tooling — never `npm run`/a raw shell command) and
+ * `purpose` must be a non-empty, human-readable explanation. Both
+ * `recommendedSchedule` and `environmentNotes` are optional free text;
+ * `safeInOfflineLan` is a plain boolean flag — none of these have a shape
+ * to validate beyond "declared or not".
+ */
+export function validateJobDescriptor(
+  job: ModuleJobDescriptor
+): JobDescriptorValidationResult {
+  const errors: string[] = [];
+
+  if (!COMMAND_PATTERN.test(job.command)) {
+    errors.push(`command "${job.command}" must look like "bun run <script>".`);
+  }
+
+  if (job.purpose.trim().length === 0) {
+    errors.push("purpose must not be empty.");
+  }
+
+  return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}

--- a/src/modules/module-management/module.ts
+++ b/src/modules/module-management/module.ts
@@ -83,5 +83,35 @@ export const moduleManagementModule = defineModule({
       action: "check",
       description: "Trigger a module health check"
     }
+  ],
+  jobs: [
+    {
+      command: "bun run security:readiness",
+      purpose:
+        "Run the go-live security readiness checklist (RLS, RBAC/ABAC, secrets, env) against the real codebase/database/environment. Any critical failure blocks go-live.",
+      recommendedSchedule:
+        "On-demand — before go-live, and periodically (e.g. weekly) in staging/production to catch drift.",
+      environmentNotes: "Requires DATABASE_URL to be reachable.",
+      safeInOfflineLan: true
+    },
+    {
+      command: "bun run config:validate",
+      purpose:
+        "Validate required/conditional environment variables at boot time before anything attempts to connect to a database or run migrations.",
+      recommendedSchedule:
+        "On-demand — run before every deploy, first stage of `production:preflight`.",
+      environmentNotes: "No database connection required.",
+      safeInOfflineLan: true
+    },
+    {
+      command: "bun run production:preflight",
+      purpose:
+        "Orchestrate the full go-live checklist in order (config:validate, db:migrate, api:spec:check, bun test, build, db:pool:health, security:readiness) and print an aggregated go/no-go verdict.",
+      recommendedSchedule:
+        "On-demand — before every production deploy/go-live.",
+      environmentNotes:
+        "db:pool:health is skipped (not failed) when no server is reachable, e.g. in a CI preflight run.",
+      safeInOfflineLan: true
+    }
   ]
 });

--- a/src/modules/sync-storage/module.ts
+++ b/src/modules/sync-storage/module.ts
@@ -11,5 +11,16 @@ export const syncStorageModule = defineModule({
   api: {
     openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
     basePath: "/api/v1/sync"
-  }
+  },
+  jobs: [
+    {
+      command: "bun run sync:objects:dispatch",
+      purpose:
+        "Drain the due object sync upload queue (claim-lease, retry/backoff, circuit breaker) for every active tenant.",
+      recommendedSchedule: "Every 1-2 minutes via cron/systemd timer.",
+      environmentNotes:
+        "No-op when R2 is disabled (STORAGE_DRIVER=local) — safe to schedule regardless of deployment profile.",
+      safeInOfflineLan: true
+    }
+  ]
 });

--- a/src/pages/api/v1/modules/[moduleKey]/jobs.ts
+++ b/src/pages/api/v1/modules/[moduleKey]/jobs.ts
@@ -1,0 +1,71 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { fetchModuleJobs } from "../../../../../modules/module-management/application/job-registry";
+
+const READ_GUARD = {
+  moduleKey: "module_management",
+  activityCode: "jobs",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/modules/{moduleKey}/jobs` (Issue #519) — the module's
+ * declared operational commands (`command`, `purpose`,
+ * `recommendedSchedule`, `environmentNotes`, `safeInOfflineLan`).
+ * Documentation only: this never executes anything and there is no
+ * corresponding "run this job" endpoint, deliberately (issue's own
+ * security note — running arbitrary commands from a web UI is explicitly
+ * out of scope). A genuinely unknown `moduleKey` is `404`; a registered
+ * module that simply declares no jobs still returns `200` with an empty
+ * list.
+ */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const moduleKey = params.moduleKey;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!moduleKey) {
+    return fail(400, "VALIDATION_ERROR", "Module key is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const jobs = fetchModuleJobs(moduleKey);
+
+    if (!jobs) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Module not found.");
+    }
+
+    return ok({ moduleKey, jobs });
+  });
+};

--- a/tests/integration/module-job-registry.integration.test.ts
+++ b/tests/integration/module-job-registry.integration.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Integration tests for the module job registry endpoint (Issue #519, epic
+ * #510) against a real PostgreSQL — the endpoint itself has zero I/O
+ * beyond the auth guard (`fetchModuleJobs` reads `listModules()` directly),
+ * so this mostly exercises the guard/404 wiring; the actual job data is
+ * already exhaustively covered by `tests/module-management-job-registry.test.ts`.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { GET as getModuleJobs } from "../../src/pages/api/v1/modules/[moduleKey]/jobs";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string };
+
+async function bootstrap(): Promise<Bootstrap> {
+  const loginIdentifier = `acme-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: "Acme",
+      tenantCode: "acme",
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId, token: login.body.data.token };
+}
+
+function authHeaders(owner: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": owner.tenantId,
+    authorization: `Bearer ${owner.token}`
+  };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("module job registry API", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("returns the declared jobs for a module that has some", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{
+      data: { moduleKey: string; jobs: { command: string }[] };
+    }>(getModuleJobs, {
+      method: "GET",
+      path: "/api/v1/modules/logging/jobs",
+      headers: authHeaders(owner),
+      params: { moduleKey: "logging" }
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.moduleKey).toBe("logging");
+    expect(result.body.data.jobs).toEqual([
+      expect.objectContaining({ command: "bun run logs:audit:purge" })
+    ]);
+  });
+
+  test("returns an empty list for a registered module with no jobs", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke<{ data: { jobs: unknown[] } }>(getModuleJobs, {
+      method: "GET",
+      path: "/api/v1/modules/identity_access/jobs",
+      headers: authHeaders(owner),
+      params: { moduleKey: "identity_access" }
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.jobs).toEqual([]);
+  });
+
+  test("an unknown module key is a 404", async () => {
+    const owner = await bootstrap();
+
+    const result = await invoke(getModuleJobs, {
+      method: "GET",
+      path: "/api/v1/modules/does_not_exist/jobs",
+      headers: authHeaders(owner),
+      params: { moduleKey: "does_not_exist" }
+    });
+
+    expect(result.status).toBe(404);
+  });
+});

--- a/tests/module-management-job-registry.test.ts
+++ b/tests/module-management-job-registry.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateJobDescriptor } from "../src/modules/module-management/domain/job-registry";
+import { fetchModuleJobs } from "../src/modules/module-management/application/job-registry";
+import { listModules } from "../src/modules";
+
+describe("validateJobDescriptor", () => {
+  test("accepts a well-formed job descriptor", () => {
+    const result = validateJobDescriptor({
+      command: "bun run logs:audit:purge",
+      purpose: "Purge expired audit events."
+    });
+
+    expect(result).toEqual({ valid: true });
+  });
+
+  test("rejects a command that isn't a bun run script", () => {
+    const result = validateJobDescriptor({
+      command: "npm run logs:audit:purge",
+      purpose: "Purge expired audit events."
+    });
+
+    expect(result).toMatchObject({ valid: false });
+    expect((result as { errors: string[] }).errors[0]).toContain(
+      "bun run <script>"
+    );
+  });
+
+  test("rejects a raw shell command", () => {
+    const result = validateJobDescriptor({
+      command: "rm -rf /tmp/whatever",
+      purpose: "Something"
+    });
+
+    expect(result).toMatchObject({ valid: false });
+  });
+
+  test("rejects an empty purpose", () => {
+    const result = validateJobDescriptor({
+      command: "bun run logs:audit:purge",
+      purpose: "   "
+    });
+
+    expect(result).toMatchObject({ valid: false });
+  });
+
+  test("collects multiple errors at once", () => {
+    const result = validateJobDescriptor({
+      command: "not-bun-at-all",
+      purpose: ""
+    });
+
+    expect(result).toMatchObject({ valid: false });
+    expect((result as { errors: string[] }).errors).toHaveLength(2);
+  });
+});
+
+describe("fetchModuleJobs", () => {
+  test("returns null for an unregistered module key", () => {
+    expect(fetchModuleJobs("does_not_exist")).toBeNull();
+  });
+
+  test("returns an empty list for a registered module with no declared jobs", () => {
+    expect(fetchModuleJobs("identity_access")).toEqual([]);
+  });
+
+  test("returns jobs scoped to one module, each tagged with its moduleKey", () => {
+    const jobs = fetchModuleJobs("logging");
+
+    expect(jobs).toEqual([
+      expect.objectContaining({
+        moduleKey: "logging",
+        command: "bun run logs:audit:purge"
+      })
+    ]);
+  });
+
+  test("returns every declared job across all modules when no moduleKey is given", () => {
+    const jobs = fetchModuleJobs();
+    const commands = jobs!.map((job) => job.command).sort();
+
+    expect(commands).toEqual(
+      [
+        "bun run config:validate",
+        "bun run email:dispatch",
+        "bun run email:provider:health",
+        "bun run email:templates:seed-defaults",
+        "bun run form-drafts:purge",
+        "bun run logs:audit:purge",
+        "bun run production:preflight",
+        "bun run security:readiness",
+        "bun run sync:objects:dispatch"
+      ].sort()
+    );
+  });
+
+  test("every real registered job descriptor passes shape validation", () => {
+    const jobs = fetchModuleJobs()!;
+    expect(jobs.length).toBeGreaterThan(0);
+
+    for (const job of jobs) {
+      const result = validateJobDescriptor(job);
+      expect(result).toEqual({ valid: true });
+    }
+  });
+
+  test("every real registered job descriptor's declared moduleKey is an actual registered module", () => {
+    const registeredKeys = new Set(listModules().map((d) => d.key));
+
+    for (const job of fetchModuleJobs()!) {
+      expect(registeredKeys.has(job.moduleKey)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/modules/{moduleKey}/jobs` — documentation-only registry of each module's declared operational commands (`command`, `purpose`, `recommendedSchedule`, `environmentNotes`, `safeInOfflineLan`). No execution endpoint exists or is planned — running arbitrary commands from a web UI is explicitly out of scope per the issue's security note.
- Registers the 9 commands named in the issue, attached to their owning module:
  - `sync_storage` — `sync:objects:dispatch`
  - `logging` — `logs:audit:purge`
  - `form_drafts` — `form-drafts:purge`
  - `email` — `email:dispatch`, `email:provider:health`, `email:templates:seed-defaults`
  - `module_management` — `security:readiness`, `config:validate`, `production:preflight` (platform-wide checks not owned by any single domain module — `module_management` is already the "generic infrastructure for managing every other registered module")
- `domain/job-registry.ts`'s `validateJobDescriptor` checks structural shape (`command` must look like `bun run <script>`, non-empty `purpose`) — "no secrets" is enforced by the same review discipline as every other trusted `ModuleDescriptor` field, not a content scanner (documented why in `module-management/README.md`).
- Adds scheduling documentation for the newly-registered recurring dispatcher/purge jobs (`deployment-profiles.md`, `deploy-coolify.md`), mirroring the existing `email:dispatch` cron guidance exactly.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run api:spec:check` / `bun run check:docs`
- [x] `bun test` — 674 pass (unit + integration against real PostgreSQL), including a test that every real registered job descriptor passes shape validation and every declared `moduleKey` is an actual registered module

🤖 Generated with [Claude Code](https://claude.com/claude-code)