### PR TITLE
feat(module-management): add admin UI for Module Management

### DIFF
--- a/i18n/en.po
+++ b/i18n/en.po
@@ -546,6 +546,172 @@ msgstr "Core"
 msgid "admin.modules.no_modules"
 msgstr "No modules registered."
 
+#. admin.modules — Issue #521 (full list + detail admin UI)
+msgid "admin.modules.filters_aria_label"
+msgstr "Module filters"
+
+msgid "admin.modules.filter_type_label"
+msgstr "Type"
+
+msgid "admin.modules.filter_status_label"
+msgstr "Status"
+
+msgid "admin.modules.filter_health_label"
+msgstr "Health"
+
+msgid "admin.modules.filter_all"
+msgstr "All"
+
+msgid "admin.modules.health_column"
+msgstr "Health"
+
+msgid "admin.modules.actions_column"
+msgstr "Actions"
+
+msgid "admin.modules.view_detail_link"
+msgstr "View"
+
+msgid "admin.modules.detail_not_found_title"
+msgstr "Module not found."
+
+msgid "admin.modules.detail_not_found_body"
+msgstr "This module key is not registered."
+
+msgid "admin.modules.back_to_list"
+msgstr "Back to module list"
+
+msgid "admin.modules.dependencies_legend"
+msgstr "Dependencies"
+
+msgid "admin.modules.no_dependencies"
+msgstr "No dependencies."
+
+msgid "admin.modules.tenant_enablement_legend"
+msgstr "Tenant Availability"
+
+msgid "admin.modules.enabled_label"
+msgstr "Enabled"
+
+msgid "admin.modules.disabled_label"
+msgstr "Disabled"
+
+msgid "admin.modules.enable_button"
+msgstr "Enable for this tenant"
+
+msgid "admin.modules.disable_button"
+msgstr "Disable for this tenant"
+
+msgid "admin.modules.disable_reason_prompt"
+msgstr "Reason for disabling this module"
+
+msgid "admin.modules.enable_success"
+msgstr "Module enabled for this tenant."
+
+msgid "admin.modules.disable_success"
+msgstr "Module disabled for this tenant."
+
+msgid "admin.modules.settings_legend"
+msgstr "Settings"
+
+msgid "admin.modules.settings_json_label"
+msgstr "Tenant override (JSON object)"
+
+msgid "admin.modules.settings_hint"
+msgstr "Only the keys you set here override the module's own defaults. Never enter a provider secret/token here — those belong in environment variables."
+
+msgid "admin.modules.invalid_settings"
+msgstr "Settings must be valid JSON."
+
+msgid "admin.modules.settings_save_button"
+msgstr "Save settings"
+
+msgid "admin.modules.settings_save_success"
+msgstr "Settings saved."
+
+msgid "admin.modules.permissions_legend"
+msgstr "Permission Sync Status"
+
+msgid "admin.modules.permission_activity_column"
+msgstr "Activity"
+
+msgid "admin.modules.permission_action_column"
+msgstr "Action"
+
+msgid "admin.modules.no_permissions"
+msgstr "No permissions declared or seeded."
+
+msgid "admin.modules.navigation_legend"
+msgstr "Admin Navigation"
+
+msgid "admin.modules.no_navigation"
+msgstr "This module declares no admin navigation entries."
+
+msgid "admin.modules.nav_label_column"
+msgstr "Label"
+
+msgid "admin.modules.nav_path_column"
+msgstr "Path"
+
+msgid "admin.modules.nav_order_column"
+msgstr "Order"
+
+msgid "admin.modules.nav_permission_column"
+msgstr "Required Permission"
+
+msgid "admin.modules.jobs_legend"
+msgstr "Operational Jobs"
+
+msgid "admin.modules.no_jobs"
+msgstr "This module declares no operational jobs."
+
+msgid "admin.modules.job_command_column"
+msgstr "Command"
+
+msgid "admin.modules.job_purpose_column"
+msgstr "Purpose"
+
+msgid "admin.modules.job_schedule_column"
+msgstr "Recommended Schedule"
+
+msgid "admin.modules.job_offline_lan_column"
+msgstr "Safe Offline/LAN"
+
+msgid "admin.modules.health_legend"
+msgstr "Health / Readiness"
+
+msgid "admin.modules.health_check_button"
+msgstr "Run health check"
+
+msgid "admin.modules.health_check_success"
+msgstr "Health check completed."
+
+msgid "admin.modules.signal_column"
+msgstr "Signal"
+
+msgid "admin.modules.signal_status_column"
+msgstr "Status"
+
+msgid "admin.modules.signal_detail_column"
+msgstr "Detail"
+
+msgid "admin.modules.audit_legend"
+msgstr "Recent Activity"
+
+msgid "admin.modules.audit_action_column"
+msgstr "Action"
+
+msgid "admin.modules.audit_severity_column"
+msgstr "Severity"
+
+msgid "admin.modules.audit_message_column"
+msgstr "Message"
+
+msgid "admin.modules.audit_time_column"
+msgstr "Time"
+
+msgid "admin.modules.no_audit_events"
+msgstr "No recent activity for this module."
+
 #. admin.examples.wizard — Issue #483, non-domain fixture page
 msgid "admin.examples.wizard.nav_title"
 msgstr "Wizard Example"

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -546,6 +546,172 @@ msgstr "Inti"
 msgid "admin.modules.no_modules"
 msgstr "Belum ada modul yang terdaftar."
 
+#. admin.modules — Issue #521 (UI admin daftar + detail lengkap)
+msgid "admin.modules.filters_aria_label"
+msgstr "Filter modul"
+
+msgid "admin.modules.filter_type_label"
+msgstr "Tipe"
+
+msgid "admin.modules.filter_status_label"
+msgstr "Status"
+
+msgid "admin.modules.filter_health_label"
+msgstr "Kesehatan"
+
+msgid "admin.modules.filter_all"
+msgstr "Semua"
+
+msgid "admin.modules.health_column"
+msgstr "Kesehatan"
+
+msgid "admin.modules.actions_column"
+msgstr "Aksi"
+
+msgid "admin.modules.view_detail_link"
+msgstr "Lihat"
+
+msgid "admin.modules.detail_not_found_title"
+msgstr "Modul tidak ditemukan."
+
+msgid "admin.modules.detail_not_found_body"
+msgstr "Kunci modul ini tidak terdaftar."
+
+msgid "admin.modules.back_to_list"
+msgstr "Kembali ke daftar modul"
+
+msgid "admin.modules.dependencies_legend"
+msgstr "Dependensi"
+
+msgid "admin.modules.no_dependencies"
+msgstr "Tidak ada dependensi."
+
+msgid "admin.modules.tenant_enablement_legend"
+msgstr "Ketersediaan untuk Tenant"
+
+msgid "admin.modules.enabled_label"
+msgstr "Aktif"
+
+msgid "admin.modules.disabled_label"
+msgstr "Nonaktif"
+
+msgid "admin.modules.enable_button"
+msgstr "Aktifkan untuk tenant ini"
+
+msgid "admin.modules.disable_button"
+msgstr "Nonaktifkan untuk tenant ini"
+
+msgid "admin.modules.disable_reason_prompt"
+msgstr "Alasan menonaktifkan modul ini"
+
+msgid "admin.modules.enable_success"
+msgstr "Modul diaktifkan untuk tenant ini."
+
+msgid "admin.modules.disable_success"
+msgstr "Modul dinonaktifkan untuk tenant ini."
+
+msgid "admin.modules.settings_legend"
+msgstr "Pengaturan"
+
+msgid "admin.modules.settings_json_label"
+msgstr "Override tenant (JSON object)"
+
+msgid "admin.modules.settings_hint"
+msgstr "Hanya key yang Anda isi di sini yang menimpa default modul. Jangan pernah memasukkan secret/token provider di sini — itu harus di environment variable."
+
+msgid "admin.modules.invalid_settings"
+msgstr "Settings harus berupa JSON yang valid."
+
+msgid "admin.modules.settings_save_button"
+msgstr "Simpan pengaturan"
+
+msgid "admin.modules.settings_save_success"
+msgstr "Pengaturan tersimpan."
+
+msgid "admin.modules.permissions_legend"
+msgstr "Status Sinkronisasi Permission"
+
+msgid "admin.modules.permission_activity_column"
+msgstr "Aktivitas"
+
+msgid "admin.modules.permission_action_column"
+msgstr "Aksi"
+
+msgid "admin.modules.no_permissions"
+msgstr "Tidak ada permission yang dideklarasikan atau di-seed."
+
+msgid "admin.modules.navigation_legend"
+msgstr "Navigasi Admin"
+
+msgid "admin.modules.no_navigation"
+msgstr "Modul ini tidak mendeklarasikan entri navigasi admin."
+
+msgid "admin.modules.nav_label_column"
+msgstr "Label"
+
+msgid "admin.modules.nav_path_column"
+msgstr "Path"
+
+msgid "admin.modules.nav_order_column"
+msgstr "Urutan"
+
+msgid "admin.modules.nav_permission_column"
+msgstr "Permission Wajib"
+
+msgid "admin.modules.jobs_legend"
+msgstr "Job Operasional"
+
+msgid "admin.modules.no_jobs"
+msgstr "Modul ini tidak mendeklarasikan job operasional."
+
+msgid "admin.modules.job_command_column"
+msgstr "Command"
+
+msgid "admin.modules.job_purpose_column"
+msgstr "Tujuan"
+
+msgid "admin.modules.job_schedule_column"
+msgstr "Jadwal Disarankan"
+
+msgid "admin.modules.job_offline_lan_column"
+msgstr "Aman Offline/LAN"
+
+msgid "admin.modules.health_legend"
+msgstr "Kesehatan / Kesiapan"
+
+msgid "admin.modules.health_check_button"
+msgstr "Jalankan health check"
+
+msgid "admin.modules.health_check_success"
+msgstr "Health check selesai."
+
+msgid "admin.modules.signal_column"
+msgstr "Sinyal"
+
+msgid "admin.modules.signal_status_column"
+msgstr "Status"
+
+msgid "admin.modules.signal_detail_column"
+msgstr "Detail"
+
+msgid "admin.modules.audit_legend"
+msgstr "Aktivitas Terbaru"
+
+msgid "admin.modules.audit_action_column"
+msgstr "Aksi"
+
+msgid "admin.modules.audit_severity_column"
+msgstr "Tingkat"
+
+msgid "admin.modules.audit_message_column"
+msgstr "Pesan"
+
+msgid "admin.modules.audit_time_column"
+msgstr "Waktu"
+
+msgid "admin.modules.no_audit_events"
+msgstr "Belum ada aktivitas terbaru untuk modul ini."
+
 #. admin.examples.wizard — Issue #483, fixture non-domain
 msgid "admin.examples.wizard.nav_title"
 msgstr "Contoh Wizard"

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -270,7 +270,48 @@ stack trace, or `DATABASE_URL`. Every `catch` logs the real error
 server-side via `log()` (which redacts defensively anyway) before
 returning the safe, generic `detail`.
 
-## Out of scope for this issue
+## Admin UI (Issue #521)
 
-Admin UI, and runtime plugin installation are explicitly out of scope —
-see Issue #521.
+`/admin/modules` (list — replaces #518's minimal stub) and
+`/admin/modules/{moduleKey}` (full detail) — the last issue in epic #510.
+
+- **List**: catalog table + client-side type/status/health filters (pure
+  `data-*` attribute show/hide — only 10 modules exist in this base, a
+  server round-trip per filter change would be pure overhead) + a health
+  status column (every module's `fetchModuleHealthReport`, #520, computed
+  in parallel — each check is individually cheap/bounded by design, and
+  this only runs on an explicit admin page load).
+- **Detail**: dependency panel, tenant enable/disable action, settings
+  panel, permission sync/status panel, navigation panel, jobs panel,
+  health/readiness panel (+ explicit `POST .../health/check` trigger
+  button), and a lifecycle/audit summary
+  (`application/module-audit-summary.ts` — a new, small, read-only query
+  over `awcms_mini_audit_events` scoped to the module-management actions
+  that target this specific module: `tenant_module_enabled`/`_disabled`
+  #515, `settings_updated` #516, `health_checked` #520).
+- **Every panel is permission-gated to its own endpoint's guard exactly**
+  (defense-in-depth — hiding a control here is a UX nicety, the real
+  enforcement is server-side): `module_management.navigation.read` gets
+  its first real consumer here (seeded since #512/#518's own doc note
+  flagged it as otherwise unused).
+- **All mutations go through the real API endpoints via client-side
+  `fetch`** (`POST .../enable`, `POST .../disable`, `PATCH .../settings`,
+  `POST .../health/check`) — this page has no privileged shortcut, same
+  as every other admin screen in this app (`admin/access-users.astro`,
+  `admin/sync.astro`). Anti double-submit via the shared
+  `lib/ui/admin-form-client.ts` helpers (`lockElement`); disable prompts
+  for a reason via `window.prompt` (same established pattern as
+  `admin/access-users.astro`'s role delete).
+- **Settings panel edits only the tenant override**, never `defaults`
+  (read-only, code-declared) — the same secret-shaped-key rejection
+  #516's `PATCH` endpoint already enforces applies here too, since this
+  form calls that exact endpoint.
+
+## Out of scope (epic #510)
+
+Marketplace, runtime plugin upload, running arbitrary jobs from the UI,
+editing raw secrets, and a complex graph visualization library are
+explicitly out of scope for the admin UI (Issue #521's own out-of-scope
+list) — and for the epic as a whole, per #510's own out-of-scope list:
+runtime upload/install of arbitrary third-party code, a marketplace, a
+remote module repository, and dynamic import from untrusted paths.

--- a/src/modules/module-management/application/module-audit-summary.ts
+++ b/src/modules/module-management/application/module-audit-summary.ts
@@ -1,0 +1,51 @@
+/**
+ * Lifecycle/audit summary for one module's admin detail page (Issue #521,
+ * epic #510) — recent audit events across the module-management actions
+ * that target this specific module: tenant enable/disable (#515), settings
+ * update (#516), and health check (#520). Read-only, bounded (`LIMIT 20`),
+ * tenant-scoped via RLS like every other audit query in this app.
+ */
+export type ModuleAuditSummaryEntry = {
+  action: string;
+  resourceType: string;
+  severity: string;
+  message: string;
+  createdAt: string;
+};
+
+const RELEVANT_RESOURCE_TYPES = [
+  "tenant_module",
+  "module_settings",
+  "module_health"
+] as const;
+
+export async function fetchModuleAuditSummary(
+  tx: Bun.SQL,
+  tenantId: string,
+  moduleKey: string,
+  limit = 20
+): Promise<ModuleAuditSummaryEntry[]> {
+  const rows = (await tx`
+    SELECT action, resource_type, severity, message, created_at
+    FROM awcms_mini_audit_events
+    WHERE tenant_id = ${tenantId}
+      AND resource_id = ${moduleKey}
+      AND resource_type = ANY(${tx.array([...RELEVANT_RESOURCE_TYPES], "text")})
+    ORDER BY created_at DESC
+    LIMIT ${limit}
+  `) as {
+    action: string;
+    resource_type: string;
+    severity: string;
+    message: string;
+    created_at: Date;
+  }[];
+
+  return rows.map((row) => ({
+    action: row.action,
+    resourceType: row.resource_type,
+    severity: row.severity,
+    message: row.message,
+    createdAt: row.created_at.toISOString()
+  }));
+}

--- a/src/pages/admin/modules.astro
+++ b/src/pages/admin/modules.astro
@@ -1,18 +1,18 @@
 ---
 /**
- * Module Management admin screen (Issue #518) — deliberately minimal: a
- * read-only module catalog list, reusing the exact same application-layer
- * function the JSON endpoint uses (`fetchModuleCatalog`, Issue #514), same
- * pattern as `admin/sync.astro` reusing `fetchSyncHealthReport`.
+ * Module Management admin screen (Issue #521 — full list; Issue #518 built
+ * the minimal first version this replaces). Reuses the same
+ * application-layer functions the JSON endpoints use — `fetchModuleCatalog`
+ * (#514), `fetchModuleHealthReport` (#520) — same pattern as
+ * `admin/sync.astro` reusing `fetchSyncHealthReport`.
  *
- * The full experience (filters, module detail, dependency/settings/
- * permission-sync/navigation/jobs/health panels, tenant enable/disable
- * action) is Issue #521's scope — this page exists now only so the nav
- * entry this issue adds (`module_management`'s own descriptor, Issue #518)
- * doesn't point at a 404. No mutation affordance here at all: this issue's
- * job is the navigation registry, not module lifecycle actions (already
- * covered by `POST /api/v1/tenant/modules/{moduleKey}/{enable,disable}`,
- * Issue #515 — this page just doesn't expose them yet).
+ * Filters (type/status/health) are pure client-side `data-*` attribute
+ * filtering over the already-rendered rows — only 10 modules exist in this
+ * base, so a server round-trip per filter change would be pure overhead.
+ *
+ * Health is computed for every module in parallel (`Promise.all`) — each
+ * check is individually cheap/bounded (#520's own design goal), and this
+ * list only renders on an explicit admin page load, never a hot path.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import StateNotice from "../../components/ui/StateNotice.astro";
@@ -20,6 +20,7 @@ import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { fetchModuleCatalog } from "../../modules/module-management/application/module-catalog";
+import { fetchModuleHealthReport } from "../../modules/module-management/application/health-registry";
 import { createTranslator } from "../../lib/i18n/translate";
 
 const context = Astro.locals.ssrContext;
@@ -35,20 +36,55 @@ const t = await createTranslator(Astro.locals.locale);
 const CAN_READ_MODULES = context.permissions.has(
   permissionKey("module_management", "modules", "read")
 );
+const CAN_READ_HEALTH = context.permissions.has(
+  permissionKey("module_management", "health", "read")
+);
 
-let modules: Awaited<ReturnType<typeof fetchModuleCatalog>> = [];
+type Row = Awaited<ReturnType<typeof fetchModuleCatalog>>[number] & {
+  healthStatus: string | null;
+};
+
+let modules: Row[] = [];
 let loadError = false;
 
 if (CAN_READ_MODULES) {
   try {
-    modules = await withTenant(getDatabaseClient(), context.tenantId, (tx) =>
-      fetchModuleCatalog(tx)
+    modules = await withTenant(
+      getDatabaseClient(),
+      context.tenantId,
+      async (tx) => {
+        const catalog = await fetchModuleCatalog(tx);
+
+        if (!CAN_READ_HEALTH) {
+          return catalog.map((entry) => ({ ...entry, healthStatus: null }));
+        }
+
+        const withHealth = await Promise.all(
+          catalog.map(async (entry) => {
+            const report = await fetchModuleHealthReport(
+              tx,
+              context.tenantId,
+              entry.moduleKey,
+              Astro.locals.correlationId
+            );
+            return { ...entry, healthStatus: report?.status ?? null };
+          })
+        );
+
+        return withHealth;
+      }
     );
   } catch (error) {
     console.error("admin/modules.astro: failed to load module catalog", error);
     loadError = true;
   }
 }
+
+const types = [...new Set(modules.map((m) => m.type).filter(Boolean))];
+const statuses = [...new Set(modules.map((m) => m.status))];
+const healthStatuses = [
+  ...new Set(modules.map((m) => m.healthStatus).filter(Boolean))
+];
 ---
 
 <AdminLayout title={t("admin.layout.nav_modules")}>
@@ -74,48 +110,136 @@ if (CAN_READ_MODULES) {
   }
   {
     CAN_READ_MODULES && !loadError && (
-      <div class="table-scroll">
-        <table class="modules-table">
-          <thead>
-            <tr>
-              <th>{t("admin.modules.module_column")}</th>
-              <th>{t("admin.modules.version_column")}</th>
-              <th>{t("admin.modules.status_column")}</th>
-              <th>{t("admin.modules.type_column")}</th>
-              <th>{t("admin.modules.core_column")}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {modules.length === 0 && (
+      <div class="modules-list">
+        <form
+          class="modules-filters"
+          aria-label={t("admin.modules.filters_aria_label")}
+        >
+          <label>
+            {t("admin.modules.filter_type_label")}
+            <select id="filter-type">
+              <option value="">{t("admin.modules.filter_all")}</option>
+              {types.map((type) => (
+                <option value={type ?? ""}>{type}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            {t("admin.modules.filter_status_label")}
+            <select id="filter-status">
+              <option value="">{t("admin.modules.filter_all")}</option>
+              {statuses.map((status) => (
+                <option value={status}>{status}</option>
+              ))}
+            </select>
+          </label>
+          {CAN_READ_HEALTH && (
+            <label>
+              {t("admin.modules.filter_health_label")}
+              <select id="filter-health">
+                <option value="">{t("admin.modules.filter_all")}</option>
+                {healthStatuses.map((status) => (
+                  <option value={status ?? ""}>{status}</option>
+                ))}
+              </select>
+            </label>
+          )}
+        </form>
+
+        <div class="table-scroll">
+          <table class="modules-table">
+            <thead>
               <tr>
-                <td colspan={5}>{t("admin.modules.no_modules")}</td>
-              </tr>
-            )}
-            {modules.map((module) => (
-              <tr>
-                <td>
-                  <strong>{module.name}</strong>
-                  <br />
-                  <code>{module.moduleKey}</code>
-                </td>
-                <td>{module.version}</td>
-                <td>
-                  <span class="status-pill" data-status={module.status}>
-                    {module.status}
+                <th>{t("admin.modules.module_column")}</th>
+                <th>{t("admin.modules.version_column")}</th>
+                <th>{t("admin.modules.status_column")}</th>
+                <th>{t("admin.modules.type_column")}</th>
+                <th>{t("admin.modules.core_column")}</th>
+                {CAN_READ_HEALTH && <th>{t("admin.modules.health_column")}</th>}
+                <th>
+                  <span class="sr-only">
+                    {t("admin.modules.actions_column")}
                   </span>
-                </td>
-                <td>{module.type ?? "-"}</td>
-                <td>{module.isCore ? t("common.yes") : t("common.no")}</td>
+                </th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody id="modules-tbody">
+              {modules.length === 0 && (
+                <tr>
+                  <td colspan={CAN_READ_HEALTH ? 7 : 6}>
+                    {t("admin.modules.no_modules")}
+                  </td>
+                </tr>
+              )}
+              {modules.map((module) => (
+                <tr
+                  data-type={module.type ?? ""}
+                  data-status={module.status}
+                  data-health={module.healthStatus ?? ""}
+                >
+                  <td>
+                    <strong>{module.name}</strong>
+                    <br />
+                    <code>{module.moduleKey}</code>
+                  </td>
+                  <td>{module.version}</td>
+                  <td>
+                    <span class="status-pill" data-status={module.status}>
+                      {module.status}
+                    </span>
+                  </td>
+                  <td>{module.type ?? "-"}</td>
+                  <td>{module.isCore ? t("common.yes") : t("common.no")}</td>
+                  {CAN_READ_HEALTH && (
+                    <td>
+                      {module.healthStatus ? (
+                        <span
+                          class="health-pill"
+                          data-health={module.healthStatus}
+                        >
+                          {module.healthStatus}
+                        </span>
+                      ) : (
+                        "-"
+                      )}
+                    </td>
+                  )}
+                  <td>
+                    <a href={`/admin/modules/${module.moduleKey}`}>
+                      {t("admin.modules.view_detail_link")}
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     )
   }
 </AdminLayout>
 
 <style>
+  .modules-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .modules-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-4);
+    align-items: end;
+  }
+
+  .modules-filters label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
   .table-scroll {
     overflow-x: auto;
   }
@@ -134,7 +258,8 @@ if (CAN_READ_MODULES) {
     vertical-align: top;
   }
 
-  .status-pill {
+  .status-pill,
+  .health-pill {
     display: inline-block;
     padding: 0 var(--sp-2);
     border-radius: var(--radius-full);
@@ -142,4 +267,69 @@ if (CAN_READ_MODULES) {
     background: var(--color-surface-2);
     border: 1px solid var(--color-border);
   }
+
+  .health-pill[data-health="healthy"] {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .health-pill[data-health="degraded"] {
+    background: var(--color-warning);
+    border-color: var(--color-warning);
+  }
+
+  .health-pill[data-health="failed"] {
+    background: var(--color-danger-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-danger-strong);
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 </style>
+
+<script>
+  function applyFilters(): void {
+    const typeValue =
+      (document.getElementById("filter-type") as HTMLSelectElement | null)
+        ?.value ?? "";
+    const statusValue =
+      (document.getElementById("filter-status") as HTMLSelectElement | null)
+        ?.value ?? "";
+    const healthValue =
+      (document.getElementById("filter-health") as HTMLSelectElement | null)
+        ?.value ?? "";
+
+    document
+      .querySelectorAll<HTMLTableRowElement>("#modules-tbody tr[data-type]")
+      .forEach((row) => {
+        const matchesType = !typeValue || row.dataset.type === typeValue;
+        const matchesStatus =
+          !statusValue || row.dataset.status === statusValue;
+        const matchesHealth =
+          !healthValue || row.dataset.health === healthValue;
+
+        row.hidden = !(matchesType && matchesStatus && matchesHealth);
+      });
+  }
+
+  document
+    .getElementById("filter-type")
+    ?.addEventListener("change", applyFilters);
+  document
+    .getElementById("filter-status")
+    ?.addEventListener("change", applyFilters);
+  document
+    .getElementById("filter-health")
+    ?.addEventListener("change", applyFilters);
+</script>

--- a/src/pages/admin/modules/[moduleKey].astro
+++ b/src/pages/admin/modules/[moduleKey].astro
@@ -1,0 +1,804 @@
+---
+/**
+ * Module Management detail screen (Issue #521, epic #510) — the full
+ * per-module experience: dependency panel, tenant enable/disable action,
+ * settings panel, permission sync/status panel, navigation panel, jobs
+ * panel, health/readiness panel (+ explicit check trigger), and a
+ * lifecycle/audit summary.
+ *
+ * SSR reads reuse the exact same application-layer functions the JSON
+ * endpoints call (#514/#515/#516/#517/#519/#520) — same pattern as every
+ * other admin page in this app (`admin/sync.astro`, `admin/access-users.astro`).
+ * All mutations (enable/disable, settings PATCH, health check) go through
+ * the real, already-guarded/audited API endpoints via client-side `fetch` —
+ * this page has no privileged shortcut (issue's own security note: "every
+ * mutation must be enforced by API guards").
+ *
+ * Permission-gated per-section, matching each endpoint's own guard exactly
+ * (defense-in-depth — hiding a control here is a UX nicety, the real
+ * enforcement is server-side):
+ *   - module_management.modules.read          -> base page access, detail, dependencies, audit summary
+ *   - module_management.tenant_modules.{read,enable,disable} -> tenant enablement panel
+ *   - module_management.settings.{read,update} -> settings panel
+ *   - module_management.permissions.read       -> permission sync panel
+ *   - module_management.navigation.read        -> navigation panel (Issue #518's seeded-but-unused permission, first real consumer)
+ *   - module_management.jobs.read               -> jobs panel
+ *   - module_management.health.{read,check}    -> health/readiness panel
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { listModules } from "../../../modules";
+import { fetchModuleCatalogEntry } from "../../../modules/module-management/application/module-catalog";
+import { fetchTenantModuleEntries } from "../../../modules/module-management/application/tenant-module-lifecycle";
+import { fetchModuleSettingsView } from "../../../modules/module-management/application/module-settings";
+import { fetchModulePermissionSyncReport } from "../../../modules/module-management/application/permission-sync";
+import { fetchModuleJobs } from "../../../modules/module-management/application/job-registry";
+import { fetchModuleHealthReport } from "../../../modules/module-management/application/health-registry";
+import { fetchModuleAuditSummary } from "../../../modules/module-management/application/module-audit-summary";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+import { formatDateTime } from "../../../lib/i18n/format";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/modules/[moduleKey].astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const moduleKey = Astro.params.moduleKey!;
+const locale = Astro.locals.locale;
+const t = await createTranslator(locale);
+
+const clientStrings = {
+  enableSuccess: t("admin.modules.enable_success"),
+  disableSuccess: t("admin.modules.disable_success"),
+  disableReasonPrompt: t("admin.modules.disable_reason_prompt"),
+  settingsSaveSuccess: t("admin.modules.settings_save_success"),
+  invalidSettings: t("admin.modules.invalid_settings"),
+  healthCheckSuccess: t("admin.modules.health_check_success"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+const CAN_READ_MODULES = context.permissions.has(
+  permissionKey("module_management", "modules", "read")
+);
+const CAN_READ_TENANT_MODULES = context.permissions.has(
+  permissionKey("module_management", "tenant_modules", "read")
+);
+const CAN_ENABLE = context.permissions.has(
+  permissionKey("module_management", "tenant_modules", "enable")
+);
+const CAN_DISABLE = context.permissions.has(
+  permissionKey("module_management", "tenant_modules", "disable")
+);
+const CAN_READ_SETTINGS = context.permissions.has(
+  permissionKey("module_management", "settings", "read")
+);
+const CAN_UPDATE_SETTINGS = context.permissions.has(
+  permissionKey("module_management", "settings", "update")
+);
+const CAN_READ_PERMISSIONS = context.permissions.has(
+  permissionKey("module_management", "permissions", "read")
+);
+const CAN_READ_NAVIGATION = context.permissions.has(
+  permissionKey("module_management", "navigation", "read")
+);
+const CAN_READ_JOBS = context.permissions.has(
+  permissionKey("module_management", "jobs", "read")
+);
+const CAN_READ_HEALTH = context.permissions.has(
+  permissionKey("module_management", "health", "read")
+);
+const CAN_CHECK_HEALTH = context.permissions.has(
+  permissionKey("module_management", "health", "check")
+);
+
+type Data = {
+  catalogEntry: NonNullable<
+    Awaited<ReturnType<typeof fetchModuleCatalogEntry>>
+  >;
+  tenantModule:
+    Awaited<ReturnType<typeof fetchTenantModuleEntries>>[number] | null;
+  settings: Awaited<ReturnType<typeof fetchModuleSettingsView>> | null;
+  permissionReport: Awaited<
+    ReturnType<typeof fetchModulePermissionSyncReport>
+  > | null;
+  navigationEntries: NonNullable<
+    ReturnType<typeof listModules>[number]["navigation"]
+  >;
+  jobs: NonNullable<ReturnType<typeof fetchModuleJobs>>;
+  health: Awaited<ReturnType<typeof fetchModuleHealthReport>> | null;
+  auditSummary: Awaited<ReturnType<typeof fetchModuleAuditSummary>>;
+};
+
+let data: Data | null = null;
+let loadError = false;
+let notFound = false;
+
+if (CAN_READ_MODULES) {
+  try {
+    data = await withTenant(
+      getDatabaseClient(),
+      context.tenantId,
+      async (tx) => {
+        const catalogEntry = await fetchModuleCatalogEntry(tx, moduleKey);
+
+        if (!catalogEntry) {
+          return null;
+        }
+
+        const [
+          tenantModuleEntries,
+          settings,
+          permissionReport,
+          health,
+          auditSummary
+        ] = await Promise.all([
+          CAN_READ_TENANT_MODULES
+            ? fetchTenantModuleEntries(tx, context.tenantId)
+            : Promise.resolve([]),
+          CAN_READ_SETTINGS
+            ? fetchModuleSettingsView(tx, context.tenantId, moduleKey)
+            : Promise.resolve(null),
+          CAN_READ_PERMISSIONS
+            ? fetchModulePermissionSyncReport(tx, moduleKey)
+            : Promise.resolve(null),
+          CAN_READ_HEALTH
+            ? fetchModuleHealthReport(
+                tx,
+                context.tenantId,
+                moduleKey,
+                Astro.locals.correlationId
+              )
+            : Promise.resolve(null),
+          fetchModuleAuditSummary(tx, context.tenantId, moduleKey)
+        ]);
+
+        const descriptor = listModules().find((d) => d.key === moduleKey);
+
+        return {
+          catalogEntry,
+          tenantModule:
+            tenantModuleEntries.find((e) => e.moduleKey === moduleKey) ?? null,
+          settings,
+          permissionReport,
+          navigationEntries: CAN_READ_NAVIGATION
+            ? (descriptor?.navigation ?? [])
+            : [],
+          jobs: CAN_READ_JOBS ? (fetchModuleJobs(moduleKey) ?? []) : [],
+          health,
+          auditSummary
+        };
+      }
+    );
+
+    if (!data) {
+      notFound = true;
+    }
+  } catch (error) {
+    console.error(
+      "admin/modules/[moduleKey].astro: failed to load module detail",
+      error
+    );
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title={data?.catalogEntry.name ?? t("admin.layout.nav_modules")}>
+  {
+    !CAN_READ_MODULES && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.modules.access_denied_title")}
+        body={t("admin.modules.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_MODULES && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ_MODULES && !loadError && notFound && (
+      <StateNotice
+        kind="error"
+        title={t("admin.modules.detail_not_found_title")}
+        body={t("admin.modules.detail_not_found_body")}
+        retryLabel={t("admin.modules.back_to_list")}
+        retryHref="/admin/modules"
+      />
+    )
+  }
+  {
+    data && (
+      <div class="module-detail" data-module-key={moduleKey}>
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        <section class="detail-section">
+          <p>{data.catalogEntry.description}</p>
+          <dl class="detail-meta">
+            <div>
+              <dt>{t("admin.modules.version_column")}</dt>
+              <dd>{data.catalogEntry.version}</dd>
+            </div>
+            <div>
+              <dt>{t("admin.modules.status_column")}</dt>
+              <dd>{data.catalogEntry.status}</dd>
+            </div>
+            <div>
+              <dt>{t("admin.modules.type_column")}</dt>
+              <dd>{data.catalogEntry.type ?? "-"}</dd>
+            </div>
+            <div>
+              <dt>{t("admin.modules.core_column")}</dt>
+              <dd>
+                {data.catalogEntry.isCore ? t("common.yes") : t("common.no")}
+              </dd>
+            </div>
+          </dl>
+
+          <h2>{t("admin.modules.dependencies_legend")}</h2>
+          {data.catalogEntry.dependencies.length === 0 ? (
+            <p>{t("admin.modules.no_dependencies")}</p>
+          ) : (
+            <ul>
+              {data.catalogEntry.dependencies.map((dep) => (
+                <li>
+                  <code>{dep}</code>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {CAN_READ_TENANT_MODULES && data.tenantModule && (
+          <section class="detail-section">
+            <h2>{t("admin.modules.tenant_enablement_legend")}</h2>
+            <p>
+              <span
+                class="status-pill"
+                data-status={
+                  data.tenantModule.tenantEnabled ? "active" : "inactive"
+                }
+              >
+                {data.tenantModule.tenantEnabled
+                  ? t("admin.modules.enabled_label")
+                  : t("admin.modules.disabled_label")}
+              </span>
+            </p>
+            {data.tenantModule.disableReason && (
+              <p class="field-hint">
+                {t("admin.modules.disable_reason_prompt")}:{" "}
+                {data.tenantModule.disableReason}
+              </p>
+            )}
+            {!data.tenantModule.tenantEnabled && CAN_ENABLE && (
+              <button type="button" id="enable-module-button">
+                {t("admin.modules.enable_button")}
+              </button>
+            )}
+            {data.tenantModule.tenantEnabled &&
+              CAN_DISABLE &&
+              !data.catalogEntry.isCore && (
+                <button type="button" id="disable-module-button">
+                  {t("admin.modules.disable_button")}
+                </button>
+              )}
+          </section>
+        )}
+
+        {CAN_READ_SETTINGS && data.settings && (
+          <section class="detail-section">
+            <h2>{t("admin.modules.settings_legend")}</h2>
+            <form id="settings-form">
+              <fieldset disabled={!CAN_UPDATE_SETTINGS}>
+                <label>
+                  {t("admin.modules.settings_json_label")}
+                  <textarea name="settings" rows="8" spellcheck="false">
+                    {JSON.stringify(data.settings.tenantOverride, null, 2)}
+                  </textarea>
+                </label>
+                <p class="field-hint">{t("admin.modules.settings_hint")}</p>
+              </fieldset>
+              {CAN_UPDATE_SETTINGS && (
+                <button type="submit">
+                  {t("admin.modules.settings_save_button")}
+                </button>
+              )}
+            </form>
+          </section>
+        )}
+
+        {CAN_READ_PERMISSIONS && data.permissionReport && (
+          <section class="detail-section">
+            <h2>{t("admin.modules.permissions_legend")}</h2>
+            <div class="table-scroll">
+              <table class="detail-table">
+                <thead>
+                  <tr>
+                    <th>{t("admin.modules.permission_activity_column")}</th>
+                    <th>{t("admin.modules.permission_action_column")}</th>
+                    <th>{t("admin.modules.status_column")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.permissionReport.entries.length === 0 && (
+                    <tr>
+                      <td colspan={3}>{t("admin.modules.no_permissions")}</td>
+                    </tr>
+                  )}
+                  {data.permissionReport.entries.map((entry) => (
+                    <tr>
+                      <td>{entry.activityCode}</td>
+                      <td>{entry.action}</td>
+                      <td>
+                        <span
+                          class="status-pill"
+                          data-permission-status={entry.status}
+                        >
+                          {entry.status}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {CAN_READ_NAVIGATION && (
+          <section class="detail-section">
+            <h2>{t("admin.modules.navigation_legend")}</h2>
+            {data.navigationEntries.length === 0 ? (
+              <p>{t("admin.modules.no_navigation")}</p>
+            ) : (
+              <div class="table-scroll">
+                <table class="detail-table">
+                  <thead>
+                    <tr>
+                      <th>{t("admin.modules.nav_label_column")}</th>
+                      <th>{t("admin.modules.nav_path_column")}</th>
+                      <th>{t("admin.modules.nav_order_column")}</th>
+                      <th>{t("admin.modules.nav_permission_column")}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.navigationEntries.map((entry) => (
+                      <tr>
+                        <td>{t(entry.labelKey)}</td>
+                        <td>
+                          <code>{entry.path}</code>
+                        </td>
+                        <td>{entry.order ?? 0}</td>
+                        <td>{entry.requiredPermission ?? "-"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        )}
+
+        {CAN_READ_JOBS && (
+          <section class="detail-section">
+            <h2>{t("admin.modules.jobs_legend")}</h2>
+            {data.jobs.length === 0 ? (
+              <p>{t("admin.modules.no_jobs")}</p>
+            ) : (
+              <div class="table-scroll">
+                <table class="detail-table">
+                  <thead>
+                    <tr>
+                      <th>{t("admin.modules.job_command_column")}</th>
+                      <th>{t("admin.modules.job_purpose_column")}</th>
+                      <th>{t("admin.modules.job_schedule_column")}</th>
+                      <th>{t("admin.modules.job_offline_lan_column")}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.jobs.map((job) => (
+                      <tr>
+                        <td>
+                          <code>{job.command}</code>
+                        </td>
+                        <td>{job.purpose}</td>
+                        <td>{job.recommendedSchedule ?? "-"}</td>
+                        <td>
+                          {job.safeInOfflineLan
+                            ? t("common.yes")
+                            : t("common.no")}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        )}
+
+        {CAN_READ_HEALTH && data.health && (
+          <section class="detail-section">
+            <h2>{t("admin.modules.health_legend")}</h2>
+            <p>
+              <span class="health-pill" data-health={data.health.status}>
+                {data.health.status}
+              </span>
+            </p>
+            <div class="table-scroll">
+              <table class="detail-table">
+                <thead>
+                  <tr>
+                    <th>{t("admin.modules.signal_column")}</th>
+                    <th>{t("admin.modules.signal_status_column")}</th>
+                    <th>{t("admin.modules.signal_detail_column")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.health.signals.map((signal) => (
+                    <tr>
+                      <td>{signal.name}</td>
+                      <td>
+                        <span
+                          class="status-pill"
+                          data-signal-status={signal.status}
+                        >
+                          {signal.status}
+                        </span>
+                      </td>
+                      <td>{signal.detail ?? "-"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {CAN_CHECK_HEALTH && (
+              <button type="button" id="health-check-button">
+                {t("admin.modules.health_check_button")}
+              </button>
+            )}
+          </section>
+        )}
+
+        <section class="detail-section">
+          <h2>{t("admin.modules.audit_legend")}</h2>
+          {data.auditSummary.length === 0 ? (
+            <p>{t("admin.modules.no_audit_events")}</p>
+          ) : (
+            <div class="table-scroll">
+              <table class="detail-table">
+                <thead>
+                  <tr>
+                    <th>{t("admin.modules.audit_action_column")}</th>
+                    <th>{t("admin.modules.audit_severity_column")}</th>
+                    <th>{t("admin.modules.audit_message_column")}</th>
+                    <th>{t("admin.modules.audit_time_column")}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.auditSummary.map((entry) => (
+                    <tr>
+                      <td>{entry.action}</td>
+                      <td>{entry.severity}</td>
+                      <td>{entry.message}</td>
+                      <td>
+                        {formatDateTime(new Date(entry.createdAt), locale)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .module-detail {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-6);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .detail-section h2 {
+    margin: 0 0 var(--sp-3);
+    font-size: var(--fs-md);
+  }
+
+  .detail-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: var(--sp-3);
+    margin: var(--sp-3) 0;
+  }
+
+  .detail-meta dt {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+    margin: 0 0 var(--sp-1);
+  }
+
+  .detail-meta dd {
+    margin: 0;
+    font-weight: 600;
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .detail-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .detail-table th,
+  .detail-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .status-pill,
+  .health-pill {
+    display: inline-block;
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-full);
+    font-size: var(--fs-xs);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+  }
+
+  .status-pill[data-status="active"],
+  .status-pill[data-permission-status="synced"],
+  .status-pill[data-signal-status="pass"],
+  .health-pill[data-health="healthy"] {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .status-pill[data-status="inactive"],
+  .status-pill[data-permission-status="missing"],
+  .status-pill[data-permission-status="mismatched_description"],
+  .status-pill[data-signal-status="fail"],
+  .health-pill[data-health="failed"] {
+    background: var(--color-danger-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-danger-strong);
+  }
+
+  .status-pill[data-permission-status="orphaned"],
+  .health-pill[data-health="degraded"] {
+    background: var(--color-warning);
+    border-color: var(--color-warning);
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+  }
+
+  #settings-form textarea {
+    width: 100%;
+    font-family: monospace;
+  }
+
+  #enable-module-button,
+  #disable-module-button,
+  #health-check-button,
+  #settings-form button {
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    cursor: pointer;
+    margin-top: var(--sp-2);
+  }
+
+  /* Touch target >= 44px on tablet/mobile (doc 14 §Aksesibilitas). */
+  @media (max-width: 768px) {
+    #enable-module-button,
+    #disable-module-button,
+    #health-check-button,
+    #settings-form button {
+      min-height: 44px;
+    }
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface ModuleDetailStrings {
+    enableSuccess: string;
+    disableSuccess: string;
+    disableReasonPrompt: string;
+    settingsSaveSuccess: string;
+    invalidSettings: string;
+    healthCheckSuccess: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<ModuleDetailStrings>();
+  const moduleKey =
+    document.querySelector<HTMLElement>(".module-detail")?.dataset.moduleKey;
+
+  document
+    .getElementById("enable-module-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !moduleKey) return;
+      const unlock = lockElement(el, strings.pleaseWait);
+
+      try {
+        const result = await submitJson(
+          `/api/v1/tenant/modules/${moduleKey}/enable`,
+          "POST",
+          {},
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.enableSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+
+  document
+    .getElementById("disable-module-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !moduleKey) return;
+
+      const reason = window.prompt(strings.disableReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const result = await submitJson(
+          `/api/v1/tenant/modules/${moduleKey}/disable`,
+          "POST",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.disableSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+
+  document
+    .getElementById("settings-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!moduleKey) return;
+
+      const form = event.target as HTMLFormElement;
+      const button = form.querySelector<HTMLButtonElement>(
+        'button[type="submit"]'
+      );
+      if (button?.disabled) return;
+
+      const formData = new FormData(form);
+      const raw = String(formData.get("settings") ?? "{}");
+      let settings: unknown;
+      try {
+        settings = JSON.parse(raw);
+      } catch {
+        showBanner("action-banner", strings.invalidSettings, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const result = await submitJson(
+          `/api/v1/tenant/modules/${moduleKey}/settings`,
+          "PATCH",
+          settings,
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.settingsSaveSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document
+    .getElementById("health-check-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !moduleKey) return;
+      const unlock = lockElement(el, strings.pleaseWait);
+
+      try {
+        const result = await submitJson(
+          `/api/v1/modules/${moduleKey}/health/check`,
+          "POST",
+          {},
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.healthCheckSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+</script>

--- a/tests/integration/module-audit-summary.integration.test.ts
+++ b/tests/integration/module-audit-summary.integration.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Integration tests for the module admin detail page's lifecycle/audit
+ * summary (Issue #521, epic #510) against a real PostgreSQL —
+ * `fetchModuleAuditSummary` reads the same `awcms_mini_audit_events` rows
+ * the tenant-module-lifecycle (#515), settings (#516), and health-check
+ * (#520) endpoints already write, scoped to one target module and one
+ * tenant.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { POST as disableModule } from "../../src/pages/api/v1/tenant/modules/[moduleKey]/disable";
+import { PATCH as patchModuleSettings } from "../../src/pages/api/v1/tenant/modules/[moduleKey]/settings";
+import { fetchModuleAuditSummary } from "../../src/modules/module-management/application/module-audit-summary";
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string };
+
+async function bootstrap(): Promise<Bootstrap> {
+  const loginIdentifier = `acme-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: "Acme",
+      tenantCode: "acme",
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId, token: login.body.data.token };
+}
+
+function authHeaders(owner: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": owner.tenantId,
+    authorization: `Bearer ${owner.token}`
+  };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("module audit summary", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("returns disable and settings-update events for the target module, newest first", async () => {
+    const owner = await bootstrap();
+
+    await invoke(disableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/form_drafts/disable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "form_drafts" },
+      body: { reason: "Not used." }
+    });
+
+    await invoke(patchModuleSettings, {
+      method: "PATCH",
+      path: "/api/v1/tenant/modules/form_drafts/settings",
+      headers: authHeaders(owner),
+      params: { moduleKey: "form_drafts" },
+      body: { retentionDays: 30 }
+    });
+
+    const summary = await withTenant(
+      getDatabaseClient(),
+      owner.tenantId,
+      (tx) => fetchModuleAuditSummary(tx, owner.tenantId, "form_drafts")
+    );
+
+    expect(summary.map((entry) => entry.action)).toEqual([
+      "settings_updated",
+      "tenant_module_disabled"
+    ]);
+  });
+
+  test("never returns events for a different module", async () => {
+    const owner = await bootstrap();
+
+    await invoke(disableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/form_drafts/disable",
+      headers: authHeaders(owner),
+      params: { moduleKey: "form_drafts" },
+      body: { reason: "Not used." }
+    });
+
+    const summary = await withTenant(
+      getDatabaseClient(),
+      owner.tenantId,
+      (tx) => fetchModuleAuditSummary(tx, owner.tenantId, "email")
+    );
+
+    expect(summary).toEqual([]);
+  });
+
+  test("RLS: never returns another tenant's audit events", async () => {
+    const ownerA = await bootstrap();
+    const admin = getAdminSql();
+    const tenantBId = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    await admin`
+      INSERT INTO awcms_mini_tenants
+        (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+      VALUES (${tenantBId}, 'tenant-b-audit', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+    `;
+
+    await invoke(disableModule, {
+      method: "POST",
+      path: "/api/v1/tenant/modules/form_drafts/disable",
+      headers: authHeaders(ownerA),
+      params: { moduleKey: "form_drafts" },
+      body: { reason: "Tenant A only." }
+    });
+
+    const summary = await withTenant(getDatabaseClient(), tenantBId, (tx) =>
+      fetchModuleAuditSummary(tx, tenantBId, "form_drafts")
+    );
+
+    expect(summary).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Completes epic #510 (Module Management, issues #511-#521).

- Enhances `/admin/modules` (list, replacing #518's minimal stub): type/status/health filters (pure client-side `data-*` filtering — only 10 modules exist in this base), plus a health column (`fetchModuleHealthReport` computed in parallel for every module, #520).
- Adds `/admin/modules/{moduleKey}` (full detail), with every panel gated to its own endpoint's exact permission (defense-in-depth — server-side guards are the real enforcement):
  - **Dependency panel** — reuses `fetchModuleCatalogEntry` (#514)
  - **Tenant enable/disable action** — reason-prompted (`window.prompt`, same established pattern as `admin/access-users.astro`'s role delete), core modules correctly never show a disable button
  - **Settings panel** — tenant-override JSON editor (`PATCH .../settings`, #516) — only edits the override, never the code-declared defaults
  - **Permission sync/status panel** — reuses `fetchModulePermissionSyncReport` (#517)
  - **Navigation panel** — first real consumer of `module_management.navigation.read` (seeded since #512, flagged as otherwise-unused by #518's own doc note)
  - **Jobs panel** — reuses `fetchModuleJobs` (#519)
  - **Health/readiness panel** — reuses `fetchModuleHealthReport` (#520) + an explicit `POST .../health/check` trigger button
  - **Lifecycle/audit summary** — new `fetchModuleAuditSummary`, a small read-only query scoped to the `tenant_module`/`module_settings`/`module_health` audit events already written by #515/#516/#520
- Every mutation goes through the real, already-guarded/audited API endpoints via client-side `fetch` (shared `lib/ui/admin-form-client.ts` helpers — anti-double-submit via `lockElement`) — no privileged shortcut, same pattern as every other admin screen in this app.
- EN + ID i18n keys added for both pages.

## Verification

Beyond the automated suite, drove the full flow end-to-end against a real Postgres + `bun run dev`: fresh tenant setup → login → list page (filters + health column populated correctly for all 10 modules) → detail page for `module_management` (core module correctly shows no disable button, all panels render — dependencies, settings, 12 synced permissions, its own nav entry, its 3 jobs, health signals) → disabled `form_drafts` with a reason via the real API and confirmed the panel/audit-summary updated on reload → PATCHed settings and confirmed persistence → triggered `POST .../health/check` for `email` and confirmed the provider-check signal fails safely (no leaked misconfiguration detail) → spot-checked the Indonesian locale on both pages.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run api:spec:check` / `bun run check:docs`
- [x] `bun run build`
- [x] `bun test` — 692 pass (unit + integration against real PostgreSQL), including new `fetchModuleAuditSummary` tests (scoping, cross-module isolation, RLS tenant isolation)
- [x] Manual end-to-end browser-equivalent verification (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)