### PR TITLE
docs(module-management): update contracts, SOP, threat model for epic #510

### DIFF
--- a/.changeset/module-management.md
+++ b/.changeset/module-management.md
@@ -1,0 +1,25 @@
+---
+"awcms-mini": minor
+---
+
+Add a database-backed, tenant-aware Module Management system (epic #510,
+Issues #511-#521): extends the code-only module registry
+(`src/modules/index.ts`) with a synced database registry
+(`awcms_mini_modules`/`_dependencies`/`_navigation`/`_jobs`/`_health_checks`,
+`sql/025`), tenant module lifecycle with server-side dependency
+validation (`POST /api/v1/tenant/modules/{moduleKey}/{enable,disable}`),
+non-secret tenant module settings
+(`GET/PATCH /api/v1/tenant/modules/{moduleKey}/settings`), module
+permission sync/status reporting
+(`GET /api/v1/modules/{moduleKey}/permissions`), an admin navigation
+registry (`module_management.navigation.read`, first real consumer of a
+permission seeded since Issue #512), a documentation-only operational job
+registry (`GET /api/v1/modules/{moduleKey}/jobs`), module health/readiness
+checks (`GET /api/v1/modules/{moduleKey}/health`,
+`POST .../health/check`, an explicit and bounded live provider check for
+`email`), and a full admin UI (`/admin/modules`,
+`/admin/modules/{moduleKey}`) covering every one of the above as a
+permission-gated panel. Also adds `enable`/`disable`/`check` to the ABAC
+action vocabulary, and enforces `403 MODULE_DISABLED` for any request to
+a tenant-disabled module directly in the shared access guard (not just
+the lifecycle endpoint itself). See `src/modules/module-management/README.md`.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -6,33 +6,34 @@ Skill Claude Code tingkat-proyek untuk AWCMS-Mini. Setiap skill meng-encode stan
 
 ## Katalog
 
-| Skill                                                  | Kapan dipakai                                                                   | Sumber docs            |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------- | ---------------------- |
-| `awcms-mini-implement-issue`                           | Orkestrator: kerjakan satu issue/sprint atomic end-to-end                       | 06, 11, 12             |
-| `awcms-mini-new-module`                                | Scaffold modul baru di `src/modules/`                                           | 10, 11                 |
-| `awcms-mini-new-migration`                             | Buat/ubah migration SQL (tabel, index, RLS)                                     | 04, 10                 |
-| `awcms-mini-new-endpoint`                              | Tambah/ubah endpoint REST + OpenAPI                                             | 05, 10                 |
-| `awcms-mini-new-event`                                 | Tambah/ubah domain event + AsyncAPI                                             | 05                     |
-| `awcms-mini-idempotency`                               | Mutation high-risk anti double-submit                                           | 10                     |
-| `awcms-mini-abac-guard`                                | Kontrol akses default-deny + RLS                                                | 03, 10                 |
-| `awcms-mini-audit-log`                                 | Audit aksi high-risk + redaction                                                | 03, 10                 |
-| `awcms-mini-observability`                             | Correlation ID otomatis, retensi/purge audit log, extension point log/audit     | 10, 16, 20             |
-| `awcms-mini-new-migration` + `awcms-mini-new-endpoint` | Soft delete/restore/purge resource deletable                                    | 04, 05, 10, 16         |
-| `awcms-mini-sensitive-data`                            | Normalize/hash/mask identifier sensitif                                         | 04                     |
-| `awcms-mini-sync-hmac`                                 | Sync push/pull bertanda HMAC + anti-replay                                      | 08, 10                 |
-| `awcms-mini-security-review`                           | Review keamanan modul                                                           | 12, 13                 |
-| `awcms-mini-codeql-triage`                             | Triase & perbaiki temuan CodeQL code scanning (termasuk katalog false-positive) | 20                     |
-| `awcms-mini-pr-review`                                 | Review pull request terhadap DoD                                                | 09, 10, 12             |
-| `awcms-mini-testing`                                   | Tulis test berlapis (unit→security)                                             | 07                     |
-| `awcms-mini-production-preflight`                      | Preflight & go-live readiness                                                   | 07, 12                 |
-| `awcms-mini-deploy`                                    | Pilih & jalankan profil deployment (LAN-first vs registry/Coolify)              | 18, deploy-coolify.md  |
-| `awcms-mini-ui-screen`                                 | Implementasi layar/komponen UI sesuai design system                             | 14, 15                 |
-| `awcms-mini-wizard-form`                               | Form multi-step (reusable wizard pattern)                                       | wizard-form-pattern.md |
-| `awcms-mini-form-drafts`                               | Server-side draft persistence (resume lintas sesi/perangkat)                    | form-drafts/README.md  |
-| `awcms-mini-email`                                     | Kirim email transaksional (provider-neutral, template management, outbox)       | email/README.md        |
-| `awcms-mini-i18n`                                      | String UI `.po` gettext & konten multi-bahasa                                   | 14, 04, 19             |
-| `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)                               | 09                     |
-| `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                    | 07, 06                 |
+| Skill                                                  | Kapan dipakai                                                                    | Sumber docs                 |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------- | --------------------------- |
+| `awcms-mini-implement-issue`                           | Orkestrator: kerjakan satu issue/sprint atomic end-to-end                        | 06, 11, 12                  |
+| `awcms-mini-new-module`                                | Scaffold modul baru di `src/modules/`                                            | 10, 11                      |
+| `awcms-mini-module-management`                         | Kelola/konsumsi sistem Module Management (registry, lifecycle, settings, health) | module-management/README.md |
+| `awcms-mini-new-migration`                             | Buat/ubah migration SQL (tabel, index, RLS)                                      | 04, 10                      |
+| `awcms-mini-new-endpoint`                              | Tambah/ubah endpoint REST + OpenAPI                                              | 05, 10                      |
+| `awcms-mini-new-event`                                 | Tambah/ubah domain event + AsyncAPI                                              | 05                          |
+| `awcms-mini-idempotency`                               | Mutation high-risk anti double-submit                                            | 10                          |
+| `awcms-mini-abac-guard`                                | Kontrol akses default-deny + RLS                                                 | 03, 10                      |
+| `awcms-mini-audit-log`                                 | Audit aksi high-risk + redaction                                                 | 03, 10                      |
+| `awcms-mini-observability`                             | Correlation ID otomatis, retensi/purge audit log, extension point log/audit      | 10, 16, 20                  |
+| `awcms-mini-new-migration` + `awcms-mini-new-endpoint` | Soft delete/restore/purge resource deletable                                     | 04, 05, 10, 16              |
+| `awcms-mini-sensitive-data`                            | Normalize/hash/mask identifier sensitif                                          | 04                          |
+| `awcms-mini-sync-hmac`                                 | Sync push/pull bertanda HMAC + anti-replay                                       | 08, 10                      |
+| `awcms-mini-security-review`                           | Review keamanan modul                                                            | 12, 13                      |
+| `awcms-mini-codeql-triage`                             | Triase & perbaiki temuan CodeQL code scanning (termasuk katalog false-positive)  | 20                          |
+| `awcms-mini-pr-review`                                 | Review pull request terhadap DoD                                                 | 09, 10, 12                  |
+| `awcms-mini-testing`                                   | Tulis test berlapis (unit→security)                                              | 07                          |
+| `awcms-mini-production-preflight`                      | Preflight & go-live readiness                                                    | 07, 12                      |
+| `awcms-mini-deploy`                                    | Pilih & jalankan profil deployment (LAN-first vs registry/Coolify)               | 18, deploy-coolify.md       |
+| `awcms-mini-ui-screen`                                 | Implementasi layar/komponen UI sesuai design system                              | 14, 15                      |
+| `awcms-mini-wizard-form`                               | Form multi-step (reusable wizard pattern)                                        | wizard-form-pattern.md      |
+| `awcms-mini-form-drafts`                               | Server-side draft persistence (resume lintas sesi/perangkat)                     | form-drafts/README.md       |
+| `awcms-mini-email`                                     | Kirim email transaksional (provider-neutral, template management, outbox)        | email/README.md             |
+| `awcms-mini-i18n`                                      | String UI `.po` gettext & konten multi-bahasa                                    | 14, 04, 19                  |
+| `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)                                | 09                          |
+| `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                     | 07, 06                      |
 
 ## Katalog peningkatan (improvement/hardening)
 
@@ -59,6 +60,8 @@ mekanis (docs snapshot, dsb.) tetap sinkron dengan state eksternal.
 ```mermaid
 flowchart TD
   II[awcms-mini-implement-issue] --> NM[awcms-mini-new-module]
+  NM --> MM[awcms-mini-module-management]
+  MM --> ABAC
   II --> MIG[awcms-mini-new-migration]
   II --> EP[awcms-mini-new-endpoint]
   II --> EV[awcms-mini-new-event]

--- a/.claude/skills/awcms-mini-module-management/SKILL.md
+++ b/.claude/skills/awcms-mini-module-management/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: awcms-mini-module-management
+description: Kelola/konsumsi sistem Module Management AWCMS-Mini (registry, tenant lifecycle enable/disable, settings, permission sync/status, navigation, job registry, health/readiness). Gunakan saat menambah field descriptor baru (permissions/navigation/settings/jobs/health) di modul lain, saat menyelidiki kenapa suatu modul terlihat degraded/orphaned, atau saat mengubah perilaku enable/disable/settings/health module_management sendiri. Sesuai src/modules/module-management/README.md, epic #510.
+---
+
+# AWCMS-Mini — Module Management System
+
+Ikuti `src/modules/module-management/README.md` (sumber kebenaran penuh
+per issue #511-#521) dan `docs/awcms-mini/10_template_kode_coding_standard.md`
+§Module contract. Skill ini merangkum pola yang **tidak jelas dari
+sekadar membaca satu file** — dependency graph, urutan sync, semantik
+merge settings, dan makna tiap sinyal health.
+
+## Kapan pakai skill ini vs `awcms-mini-new-module`
+
+`awcms-mini-new-module` = cara **scaffold** modul baru (struktur folder,
+descriptor minimal). Skill ini = cara kerja **sistem** yang mengelola
+modul yang sudah terdaftar — enable/disable per tenant, settings,
+permission sync, navigation, jobs, health. Pakai skill ini saat modulmu
+sudah ada dan kamu perlu mendeklarasikan `permissions`/`navigation`/
+`settings`/`jobs` di descriptornya, atau saat menyelidiki masalah di
+sistem module management itu sendiri.
+
+## "Sync first" — aturan FK yang wajib dipahami
+
+`awcms_mini_tenant_modules`, `_module_settings`, `_module_health_checks`
+semua punya FK ke `awcms_mini_modules.module_key`. Mendaftarkan modul di
+`src/modules/index.ts` **tidak otomatis** membuat baris registrynya.
+Setiap mutasi tenant-scoped yang butuh baris registry ada
+(`enableTenantModule`/`disableTenantModule`/`updateModuleSettings`/
+`runModuleHealthCheck`) memanggil `syncModuleDescriptors(tx)` sendiri di
+awal — **jangan** asumsikan operator sudah menjalankan
+`POST /api/v1/modules/sync` manual lebih dulu. Bila menambah mutasi baru
+dengan FK serupa, ikuti pola yang sama.
+
+Konsekuensi: `GET /api/v1/modules/{moduleKey}/health`'s sinyal
+`db_registry_synced` bisa `fail` di instance yang baru dimigrasikan
+(belum pernah ada mutasi tenant-scoped apa pun) — ini **bukan bug**,
+laporan yang jujur. `POST .../health/check` men-sync duluan sebagai efek
+samping menulis riwayat, jadi bisa menunjukkan hasil `pass` untuk sinyal
+yang sama di momen yang sama — asimetri yang disengaja, didokumentasikan
+di README modul.
+
+## Dependency graph (enable/disable)
+
+Graph **selalu** dibaca dari `listModules()` (code), **tidak pernah**
+dari `awcms_mini_module_dependencies` (cache hasil sync terakhir — bisa
+basi). Kode error dari `domain/tenant-module-lifecycle.ts`:
+
+| Kode                                 | Kapan                                                |
+| ------------------------------------ | ---------------------------------------------------- |
+| `MODULE_NOT_FOUND`                   | Key tidak terdaftar / dinonaktifkan global (code)    |
+| `MODULE_ALREADY_ENABLED`/`_DISABLED` | Tidak ada perubahan state                            |
+| `MODULE_DEPENDENCY_MISSING`          | Dependency tidak terdaftar sama sekali               |
+| `MODULE_DEPENDENCY_DISABLED`         | Dependency nonaktif (global atau tenant ini)         |
+| `MODULE_REVERSE_DEPENDENCY_ACTIVE`   | Modul lain yang aktif masih bergantung padanya       |
+| `MODULE_DEPENDENCY_CYCLE`            | Circular dependency di graph                         |
+| `MODULE_VERSION_INCOMPATIBLE`        | `minAppVersion` modul > versi app saat ini           |
+| `CORE_MODULE_CANNOT_BE_DISABLED`     | `isCore: true` — tidak bisa dinonaktifkan, bukan bug |
+
+Modul `isCore: true` (saat ini hanya `module_management` sendiri) tidak
+bisa dinonaktifkan — ini pencegah _admin lockout_ utama: kemampuan
+mengelola modul lain tidak pernah hilang.
+
+## Settings — merge dangkal, bukan replace
+
+`PATCH .../settings` men-**merge dangkal** body ke `tenantOverride` yang
+ada (`{ ...before, ...patch }`) — key yang tidak disebut tetap tidak
+berubah. Berbeda dari `PATCH /api/v1/settings`'s `featureFlags` (replace
+utuh field itu) karena di sini seluruh body request **adalah** resource
+settings-nya, bukan satu field bernama di resource lain. Key yang
+menyerupai secret (daftar sama `_shared/redaction.ts`'s `REDACTION_KEYS`,
+termasuk `credential`) **ditolak saat request** (`400
+SETTINGS_SENSITIVE_KEY_REJECTED`), tidak pernah disimpan lalu di-redact
+saat dibaca.
+
+## Permission sync status — jangan auto-fix `orphaned`
+
+`GET /api/v1/modules/{moduleKey}/permissions` (Issue #517) melaporkan
+`synced`/`missing`/`orphaned`/`mismatched_description` — **read-only**,
+tidak pernah menulis ke `awcms_mini_permissions`. Hanya `module_management`
+sendiri yang sudah mendeklarasikan `permissions` di descriptornya; 9
+modul lain punya permission seed nyata (dari migration masing-masing)
+tapi belum ditambahkan ke descriptor — jadi permission mereka
+**legitimately** muncul `orphaned` hari ini, bukan insiden. Jangan hapus
+baris `awcms_mini_permissions` berdasarkan laporan ini tanpa keputusan
+admin eksplisit.
+
+## Health check — GET pasif, POST eksplisit
+
+`GET .../health` = sinyal generik murah saja (registry synced, migrasi
+diterapkan, permission/jobs/OpenAPI/AsyncAPI terdokumentasi, settings
+valid) — **tidak pernah** memanggil provider eksternal, aman dipanggil
+berulang. `POST .../health/check` = sinyal sama **plus** live check ke
+provider bila modul punya satu (`email` saat ini, lewat
+`resolveEmailProvider().healthCheck()` yang sudah timeout-bounded sejak
+Issue #495) — dan menulis riwayat ke `awcms_mini_module_health_checks`.
+Menambah provider check baru untuk modul lain: ikuti pola yang sama
+(hanya di `POST`, bounded/non-throwing, `detail` selalu string generik
+tetap — tidak pernah pesan error mentah).
+
+## Job registry — dokumentasi murni
+
+`ModuleDescriptor.jobs` **tidak pernah** jadi permukaan eksekusi command
+dari web — hanya metadata (`command`, `purpose`, `recommendedSchedule`,
+`environmentNotes`, `safeInOfflineLan`). Jangan tambah endpoint yang
+menjalankan command dari sini; bila eksekusi job dari UI benar-benar
+dibutuhkan suatu saat, itu harus fitur terpisah yang dibatasi ketat
+(security note eksplisit epic #510).
+
+## Verifikasi
+
+`tests/module-management-*.test.ts` (domain, unit, per Issue) dan
+`tests/integration/module-*.integration.test.ts` (API+RLS+audit
+end-to-end, real Postgres) — jalankan `bun test` dengan `DATABASE_URL`
+sebelum PR yang menyentuh sistem ini dianggap selesai (`bun run check`
+tanpa `DATABASE_URL` **melewatkan** semua test integration secara diam-diam).
+
+## Skill terkait
+
+`awcms-mini-new-module` (scaffold modul baru, termasuk field descriptor
+ini), `awcms-mini-abac-guard` (guard bersama yang juga menegakkan
+`403 MODULE_DISABLED`), `awcms-mini-sensitive-data`/redaction
+(`REDACTION_KEYS` yang dipakai validasi settings), `awcms-mini-audit-log`
+(pola audit `tenant_module_enabled`/`_disabled`/`settings_updated`/`health_checked`).

--- a/.claude/skills/awcms-mini-new-module/SKILL.md
+++ b/.claude/skills/awcms-mini-new-module/SKILL.md
@@ -28,7 +28,7 @@ export const <camelCase>Module: ModuleDescriptor = {
   key: "<snake_case>",
   name: "<Nama Modul>",
   version: "0.1.0",
-  status: "active", // active | experimental | deprecated
+  status: "active", // active | experimental | deprecated | maintenance | disabled
   description: "...",
   dependencies: ["tenant_admin", "identity_access", "observability_logging"],
   api: { openApiPath: "openapi/modules/<module>.openapi.yaml", basePath: "/api/v1" },
@@ -37,6 +37,13 @@ export const <camelCase>Module: ModuleDescriptor = {
     publishes: [],
     subscribes: []
   }
+  // Field opsional lain (Issue #511, epic #510 — Module Management):
+  // type, isCore, permissions, navigation, settings, jobs, health,
+  // compatibility, maintainers. Deklarasikan hanya setelah fitur
+  // sungguhan yang bersangkutan ADA di modul ini — jangan klaim
+  // kapabilitas yang belum diimplementasi (lihat contoh nyata:
+  // `src/modules/module-management/module.ts` menambah `navigation`
+  // baru setelah Issue #518 selesai, `jobs` setelah #519, satu-satu).
 };
 ```
 
@@ -47,10 +54,14 @@ export const <camelCase>Module: ModuleDescriptor = {
 3. Route tipis → guard → validasi → service → repository (lihat `awcms-mini-abac-guard`).
 4. Sertakan TODO jelas; jangan klaim production-ready.
 5. Jika modul punya tabel → `awcms-mini-new-migration`. Jika ada API → `awcms-mini-new-endpoint`. Jika ada event → `awcms-mini-new-event`.
+6. **Sync descriptor ke database registry wajib** (Issue #513, epic #510) — mendaftarkan modul di `src/modules/index.ts` saja **tidak otomatis** membuat baris `awcms_mini_modules`/`_dependencies`/`_navigation`/`_jobs`. Jalankan `POST /api/v1/modules/sync` (atau `bun run modules:sync` bila skrip CLI tersedia) minimal sekali setelah modul terdaftar — atau andalkan sinkronisasi otomatis yang sudah terpasang di beberapa mutasi tenant-scoped modul lain yang punya FK ke `awcms_mini_modules` (`enableTenantModule`/`disableTenantModule`/`updateModuleSettings`/`runModuleHealthCheck` semua memanggil `syncModuleDescriptors(tx)` sendiri) — **jangan asumsikan** operator sudah sync manual sebelum modul barumu dipakai lewat jalur itu.
+7. Jika modul mendeklarasikan `permissions` di descriptor, verifikasi juga migration seed permission-nya konsisten (`GET /api/v1/modules/{moduleKey}/permissions`, Issue #517, akan melaporkan `missing`/`mismatched_description` kalau tidak sinkron).
 
 ## Nama modul valid
 
-`tenant-admin`, `identity-access`, `profile-identity`, `catalog-inventory`, `sales-pos`, `shared-stock-routing`, `warehouse-management`, `accounting-tax`, `crm-communication`, `sync-storage`, `ai-analyst`, `localization-ui`, `observability-logging`, `database-connectivity`, `workflow-approval`, `management-reporting`, `ui-experience`, `production-security-readiness`.
+Domain retail/POS contoh (aspirational, belum tentu ada di base generik ini): `tenant-admin`, `identity-access`, `profile-identity`, `catalog-inventory`, `sales-pos`, `shared-stock-routing`, `warehouse-management`, `accounting-tax`, `crm-communication`, `sync-storage`, `ai-analyst`, `localization-ui`, `observability-logging`, `database-connectivity`, `workflow-approval`, `management-reporting`, `ui-experience`, `production-security-readiness`.
+
+Modul base generik yang **sudah nyata terdaftar** di repo ini (`src/modules/index.ts`): `tenant-admin`, `profile-identity`, `identity-access`, `sync-storage`, `reporting`, `logging`, `workflow-approval`, `form-drafts`, `email`, `module-management`.
 
 ## Verifikasi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,32 +91,33 @@ flowchart LR
 
 AWCMS-Mini menyediakan **skill Claude Code tingkat-proyek** yang meng-encode standar dokumen agar diterapkan konsisten. Model memanggilnya otomatis saat relevan, atau kamu panggil manual via `/<nama-skill>`. Katalog lengkap: [`.claude/skills/README.md`](.claude/skills/README.md).
 
-| Butuh…                                                             | Skill                             |
-| ------------------------------------------------------------------ | --------------------------------- |
-| Kerjakan issue/sprint atomic (orkestrator)                         | `awcms-mini-implement-issue`      |
-| Scaffold modul baru                                                | `awcms-mini-new-module`           |
-| Migration SQL (tabel/index/RLS)                                    | `awcms-mini-new-migration`        |
-| Endpoint REST + OpenAPI                                            | `awcms-mini-new-endpoint`         |
-| Domain event + AsyncAPI                                            | `awcms-mini-new-event`            |
-| Idempotency mutation high-risk                                     | `awcms-mini-idempotency`          |
-| ABAC default-deny + RLS                                            | `awcms-mini-abac-guard`           |
-| Audit high-risk + redaction                                        | `awcms-mini-audit-log`            |
-| Correlation ID otomatis, retensi/purge log                         | `awcms-mini-observability`        |
-| Masking data sensitif                                              | `awcms-mini-sensitive-data`       |
-| Sync HMAC + anti-replay                                            | `awcms-mini-sync-hmac`            |
-| Review keamanan modul                                              | `awcms-mini-security-review`      |
-| Triase & perbaiki temuan CodeQL code scanning                      | `awcms-mini-codeql-triage`        |
-| Review pull request                                                | `awcms-mini-pr-review`            |
-| Tulis test berlapis                                                | `awcms-mini-testing`              |
-| Preflight & go-live                                                | `awcms-mini-production-preflight` |
-| Pilih & jalankan profil deployment (LAN-first vs registry/Coolify) | `awcms-mini-deploy`               |
-| Layar/komponen UI sesuai design system                             | `awcms-mini-ui-screen`            |
-| Form multi-step (reusable wizard pattern)                          | `awcms-mini-wizard-form`          |
-| Server-side draft persistence (resume lintas sesi/perangkat)       | `awcms-mini-form-drafts`          |
-| Kirim email transaksional (provider-neutral, template, outbox)     | `awcms-mini-email`                |
-| String UI `.po` gettext & konten multi-bahasa                      | `awcms-mini-i18n`                 |
-| Rilis versi (Changesets, tag, CHANGELOG)                           | `awcms-mini-release`              |
-| Migrasi data legacy (dry-run, backfill)                            | `awcms-mini-legacy-migration`     |
+| Butuh…                                                                 | Skill                             |
+| ---------------------------------------------------------------------- | --------------------------------- |
+| Kerjakan issue/sprint atomic (orkestrator)                             | `awcms-mini-implement-issue`      |
+| Scaffold modul baru                                                    | `awcms-mini-new-module`           |
+| Kelola/konsumsi sistem Module Management (registry, lifecycle, health) | `awcms-mini-module-management`    |
+| Migration SQL (tabel/index/RLS)                                        | `awcms-mini-new-migration`        |
+| Endpoint REST + OpenAPI                                                | `awcms-mini-new-endpoint`         |
+| Domain event + AsyncAPI                                                | `awcms-mini-new-event`            |
+| Idempotency mutation high-risk                                         | `awcms-mini-idempotency`          |
+| ABAC default-deny + RLS                                                | `awcms-mini-abac-guard`           |
+| Audit high-risk + redaction                                            | `awcms-mini-audit-log`            |
+| Correlation ID otomatis, retensi/purge log                             | `awcms-mini-observability`        |
+| Masking data sensitif                                                  | `awcms-mini-sensitive-data`       |
+| Sync HMAC + anti-replay                                                | `awcms-mini-sync-hmac`            |
+| Review keamanan modul                                                  | `awcms-mini-security-review`      |
+| Triase & perbaiki temuan CodeQL code scanning                          | `awcms-mini-codeql-triage`        |
+| Review pull request                                                    | `awcms-mini-pr-review`            |
+| Tulis test berlapis                                                    | `awcms-mini-testing`              |
+| Preflight & go-live                                                    | `awcms-mini-production-preflight` |
+| Pilih & jalankan profil deployment (LAN-first vs registry/Coolify)     | `awcms-mini-deploy`               |
+| Layar/komponen UI sesuai design system                                 | `awcms-mini-ui-screen`            |
+| Form multi-step (reusable wizard pattern)                              | `awcms-mini-wizard-form`          |
+| Server-side draft persistence (resume lintas sesi/perangkat)           | `awcms-mini-form-drafts`          |
+| Kirim email transaksional (provider-neutral, template, outbox)         | `awcms-mini-email`                |
+| String UI `.po` gettext & konten multi-bahasa                          | `awcms-mini-i18n`                 |
+| Rilis versi (Changesets, tag, CHANGELOG)                               | `awcms-mini-release`              |
+| Migrasi data legacy (dry-run, backfill)                                | `awcms-mini-legacy-migration`     |
 
 **Peningkatan (audit & hardening artefak yang sudah ada):**
 

--- a/docs/awcms-mini/04_erd_data_dictionary.md
+++ b/docs/awcms-mini/04_erd_data_dictionary.md
@@ -91,6 +91,7 @@ erDiagram
 | Workflow             | `awcms_mini_workflow_definitions`, `awcms_mini_workflow_instances`, `awcms_mini_workflow_tasks`, `awcms_mini_workflow_decisions`                                                                                                                             |
 | Reporting            | report views/materialized views                                                                                                                                                                                                                              |
 | Production Security  | `awcms_mini_security_controls`, `awcms_mini_security_readiness_assessments`, `awcms_mini_security_findings`, `awcms_mini_go_live_gates`                                                                                                                      |
+| Module Management    | `awcms_mini_modules` (extended), `awcms_mini_tenant_modules`, `awcms_mini_module_dependencies`, `awcms_mini_module_settings`, `awcms_mini_module_navigation`, `awcms_mini_module_jobs`, `awcms_mini_module_health_checks`                                    |
 
 ## Data dictionary ringkas per modul
 
@@ -218,6 +219,19 @@ Berbeda dari `awcms_mini_message_outbox` di atas (contoh domain retail/POS) — 
 Event lokal yang perlu disinkronkan.
 
 Kolom penting: `node_id`, `event_type`, `aggregate_type`, `aggregate_id`, `payload_json`, `status`.
+
+### Module Management (Issue #511–#521, epic #510, `sql/025`)
+
+Mengubah registry modul dari code-only (`src/modules/index.ts`) jadi database-backed sekaligus tenant-aware. `awcms_mini_modules` sudah ada sejak migration 001 (dormant, belum pernah ditulis aplikasi) — migration 025 memperluasnya di tempat (`module_type`, `lifecycle_status`, `descriptor_version`, `is_core`, `is_tenant_configurable`, `updated_at`) dan menambah tabel pendukung berikut. Semua tabel "registry" (dependencies/navigation/jobs/health-checks) **RLS-free** — metadata code-derived, sama untuk semua tenant, sinkron dari `listModules()` lewat `syncModuleDescriptors` (Issue #513); dua tabel tenant-writable (`tenant_modules`/`module_settings`) **RLS FORCE**.
+
+- **`awcms_mini_tenant_modules`** (Issue #515) — status aktif/nonaktif modul **per tenant**. Baris tidak ada = default enabled (backward-compatible dengan perilaku pre-epic "semua modul selalu aktif"). Kolom: `enabled`, `enabled_at`/`enabled_by`, `disabled_at`/`disabled_by`/`disable_reason`. Unik `(tenant_id, module_key)`. RLS FORCE.
+- **`awcms_mini_module_dependencies`** — graph dependency antar modul, dibaca validasi enable/disable Issue #515. Composite PK `(module_key, depends_on_module_key)`, `CHECK` menolak self-dependency.
+- **`awcms_mini_module_settings`** (Issue #516) — override pengaturan non-secret **per tenant** (`settings` jsonb, `schema_version`). Tidak boleh berisi secret/token mentah — ditegakkan di application layer (`findSensitiveKeys`, `_shared/redaction.ts`), bukan skema. Unik `(tenant_id, module_key)`. RLS FORCE.
+- **`awcms_mini_module_navigation`** (Issue #518) — entri navigasi admin per modul (`label_key`, `path`, `sort_order`, `nav_group`, `required_permission`). `path` unik global — dua modul mendeklarasikan route sama adalah bug authoring descriptor.
+- **`awcms_mini_module_jobs`** (Issue #519) — registry command operasional (`command`, `purpose`, `recommended_schedule`, `environment_notes`, `safe_in_offline_lan`). Dokumentasi murni — tidak pernah jadi permukaan "eksekusi command". Unik `(module_key, command)`.
+- **`awcms_mini_module_health_checks`** (Issue #520) — riwayat hasil health check, **instance-level** (bukan per-tenant — status kesehatan adalah fakta tentang instance yang di-deploy). `status` (`healthy`/`degraded`/`failed`/`unknown`), `message` (harus redaction-ready, sama seperti `email_delivery_attempts.provider_response_snippet` — tidak pernah raw secret/stack trace). Hanya ditulis oleh `POST /api/v1/modules/{moduleKey}/health/check` (aksi eksplisit) — `GET .../health` murni baca, tidak pernah menulis baris.
+
+Tidak ada tabel `awcms_mini_module_lifecycle_events` terpisah (sempat diusulkan draft issue awal) — aksi lifecycle/config modul tetap tercatat lewat `awcms_mini_audit_events` generik yang sudah ada (`module_key = 'module_management'`, `resource_type` = `tenant_module`/`module_settings`/`module_health`), menghindari sumber kebenaran kedua yang divergen untuk fakta yang sama.
 
 ## Konten multi-bahasa (translatable content)
 

--- a/docs/awcms-mini/05_openapi_asyncapi_detail.md
+++ b/docs/awcms-mini/05_openapi_asyncapi_detail.md
@@ -240,6 +240,27 @@ Default response list/detail tidak menampilkan soft-deleted record. Detail soft-
 | POST   | `/sync/conflicts/{id}/resolve` | Resolve conflict      |
 | POST   | `/sync/objects/presign`        | Object upload/presign |
 
+### Module Management (Issue #511–#521, epic #510)
+
+Database-backed, tenant-aware module registry — generic infrastructure for managing every other registered module, not a domain-specific feature. Full detail: `src/modules/module-management/README.md`.
+
+| Method | Endpoint                               | Fungsi                                                     |
+| ------ | -------------------------------------- | ---------------------------------------------------------- |
+| GET    | `/modules`                             | Katalog modul (code + DB registry)                         |
+| GET    | `/modules/{moduleKey}`                 | Detail satu modul                                          |
+| POST   | `/modules/sync`                        | Sync descriptor code → DB registry                         |
+| GET    | `/modules/{moduleKey}/permissions`     | Status sinkron permission (synced/missing/orphaned)        |
+| GET    | `/modules/{moduleKey}/jobs`            | Registry command operasional (dokumentasi, tidak eksekusi) |
+| GET    | `/modules/{moduleKey}/health`          | Health/readiness cepat, read-only                          |
+| POST   | `/modules/{moduleKey}/health/check`    | Trigger health check eksplisit (+ provider check bila ada) |
+| GET    | `/tenant/modules`                      | Status enable/disable modul untuk tenant pemanggil         |
+| POST   | `/tenant/modules/{moduleKey}/enable`   | Aktifkan modul untuk tenant                                |
+| POST   | `/tenant/modules/{moduleKey}/disable`  | Nonaktifkan modul untuk tenant (butuh `reason`)            |
+| GET    | `/tenant/modules/{moduleKey}/settings` | Effective settings (default + override tenant)             |
+| PATCH  | `/tenant/modules/{moduleKey}/settings` | Update override settings tenant                            |
+
+Tidak ada event AsyncAPI baru — perubahan lifecycle/config modul tercatat lewat `awcms_mini_audit_events` generik yang sudah ada, bukan domain event terpisah.
+
 ### AI, Reports, Logs, Workflow, Security
 
 | Modul    | Endpoint utama                                                 |

--- a/docs/awcms-mini/08_sop_operasional_user_guide.md
+++ b/docs/awcms-mini/08_sop_operasional_user_guide.md
@@ -509,6 +509,68 @@ pakai, dan sesi identity **dicabut penuh** setelah reset berhasil.
    runbook lengkap (provider outage, rotasi kredensial, accidental bulk
    send).
 
+## SOP Modul Manajemen Modul (epic #510, Issue #511-#521)
+
+Registry modul database-backed, tenant-aware (`src/modules/module-management/README.md`) — infrastruktur generik untuk mengelola modul lain, bukan fitur domain. Belum ada tabel "aksi eksekusi command" — job registry murni dokumentasi (lihat §Inspeksi job registry di bawah), sesuai batasan out-of-scope epic (tidak ada marketplace/instalasi plugin runtime).
+
+### Sinkronisasi descriptor modul
+
+1. `POST /api/v1/modules/sync` (butuh `module_management.modules.sync`) — menyamakan `awcms_mini_modules`/`_dependencies`/`_navigation`/`_jobs` dengan `listModules()` code saat ini. Idempoten — jalankan berulang aman, hasil kedua kali `unchanged`.
+2. Modul yang hilang dari code (di-uninstall/dihapus) **ditandai** `lifecycle_status = 'disabled'`, tidak pernah dihapus — riwayat dependency/navigation/jobs tetap ada sebagai catatan historis.
+3. Beberapa aksi lain (enable/disable modul, update settings, trigger health check) otomatis menjalankan sync ini lebih dulu di dalam transaction yang sama (FK ke `awcms_mini_modules`) — operator **tidak wajib** menjalankan sync manual sebelum aksi tersebut.
+
+### Enable/disable modul untuk tenant
+
+1. Cek status: `GET /api/v1/tenant/modules` (butuh `module_management.tenant_modules.read`) — daftar semua modul + status aktif/nonaktif untuk tenant pemanggil. Baris tanpa state eksplisit berarti aktif (default backward-compatible).
+2. Aktifkan: `POST /api/v1/tenant/modules/{moduleKey}/enable` (butuh `.enable`).
+3. Nonaktifkan: `POST /api/v1/tenant/modules/{moduleKey}/disable` (butuh `.disable`) dengan body `{ "reason": "..." }` — **wajib** diisi, tercatat di `disable_reason`.
+4. Modul core (`isCore: true`, mis. `module_management` sendiri) **tidak bisa** dinonaktifkan — selalu `409 CORE_MODULE_CANNOT_BE_DISABLED`.
+5. Menonaktifkan modul **tidak pernah menghapus data tenant** — hanya menulis baris `awcms_mini_tenant_modules`. Data modul yang dinonaktifkan tetap utuh, siap dipakai lagi begitu diaktifkan kembali.
+6. Setiap enable/disable tercatat di audit trail (`tenant_module_enabled`/`tenant_module_disabled`, `resource_type: tenant_module`, `resource_id: moduleKey`).
+7. **Efeknya nyata di seluruh endpoint modul tersebut**, bukan cuma status di halaman ini — guard bersama (`authorizeInTransaction`) menolak `403 MODULE_DISABLED` untuk request apa pun ke modul yang dinonaktifkan tenant tsb (lihat `src/modules/identity-access/README.md` §"Enforcement modul disabled").
+
+### Update pengaturan modul (tenant)
+
+1. `GET /api/v1/tenant/modules/{moduleKey}/settings` (butuh `.settings.read`) — mengembalikan `defaults` (bawaan code), `tenantOverride` (yang sudah diset tenant ini), dan `effective` (gabungan, override menang).
+2. `PATCH /api/v1/tenant/modules/{moduleKey}/settings` (butuh `.settings.update`) — body JSON di-**merge dangkal** ke override yang ada (key yang tidak disebut tetap tidak berubah); **tidak** mengganti seluruh objek.
+3. Key berbentuk secret (mengandung `password`/`token`/`secret`/`credential`/dll., daftar sama dengan redaksi log/audit) **ditolak** `400 SETTINGS_SENSITIVE_KEY_REJECTED` — secret provider selalu lewat environment variable/secret manager, tidak pernah lewat settings tenant.
+4. Setiap update tercatat di audit trail (`settings_updated`) dengan **diff key yang berubah saja** (`addedKeys`/`changedKeys`/`removedKeys`) — tidak pernah nilai settings itu sendiri.
+
+### Inspeksi kesehatan modul
+
+1. `GET /api/v1/modules/{moduleKey}/health` (butuh `.health.read`) — cepat, read-only, **tidak pernah** memanggil provider eksternal. Status `healthy`/`degraded`/`failed`/`unknown` dari sekumpulan sinyal (registry ter-sync, migrasi diterapkan, permission katalog sinkron, settings valid, jobs terdokumentasi, OpenAPI/AsyncAPI terdokumentasi).
+2. `POST /api/v1/modules/{moduleKey}/health/check` (butuh `.health.check`) — sinyal sama seperti di atas **plus** live check ke provider eksternal bila modul punya satu (hanya `email` saat ini, timeout-bounded, tidak pernah memblokir transaksi bisnis normal). Hasilnya dicatat di `awcms_mini_module_health_checks` (riwayat instance-level) dan diaudit (`health_checked`).
+3. Setiap `detail` sinyal adalah teks generik tetap — **tidak pernah** pesan error mentah, stack trace, atau nilai `DATABASE_URL`/secret.
+
+### Interpretasi error validasi dependency
+
+Kode error dari `POST .../enable` atau `.../disable` (semua `409` kecuali disebutkan lain):
+
+| Kode                               | Arti                                                          | Tindakan                                                        |
+| ---------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------- |
+| `MODULE_NOT_FOUND` (`404`)         | Module key tidak terdaftar atau dinonaktifkan global (code)   | Cek ejaan/`GET /modules` untuk daftar valid                     |
+| `MODULE_ALREADY_ENABLED`           | Sudah aktif untuk tenant ini                                  | Tidak perlu aksi                                                |
+| `MODULE_ALREADY_DISABLED`          | Sudah nonaktif untuk tenant ini                               | Tidak perlu aksi                                                |
+| `MODULE_DEPENDENCY_MISSING`        | Modul yang dibutuhkan tidak terdaftar sama sekali             | Periksa `dependencies` descriptor; kemungkinan bug authoring    |
+| `MODULE_DEPENDENCY_DISABLED`       | Modul yang dibutuhkan nonaktif (global atau untuk tenant ini) | Aktifkan dependency-nya dulu, baru modul ini                    |
+| `MODULE_REVERSE_DEPENDENCY_ACTIVE` | Modul lain yang masih aktif bergantung pada modul ini         | Nonaktifkan modul dependent dulu, atau batalkan rencana disable |
+| `MODULE_DEPENDENCY_CYCLE`          | Terdeteksi circular dependency pada graph                     | Bug authoring descriptor — laporkan ke tim modul terkait        |
+| `MODULE_VERSION_INCOMPATIBLE`      | `minAppVersion` modul lebih tinggi dari versi app saat ini    | Upgrade aplikasi dulu sebelum mengaktifkan modul ini            |
+| `CORE_MODULE_CANNOT_BE_DISABLED`   | Modul core (`isCore: true`)                                   | Tidak bisa dinonaktifkan — ini bukan bug                        |
+
+### Inspeksi job registry
+
+1. `GET /api/v1/modules/{moduleKey}/jobs` (butuh `.jobs.read`) — daftar command operasional modul (`command`, `purpose`, `recommendedSchedule`, `environmentNotes`, `safeInOfflineLan`). **Dokumentasi murni** — tidak ada endpoint untuk menjalankan command dari sini, dan tidak akan pernah ada (lihat §Batasan keamanan epic ini di doc 20).
+2. Untuk menjadwalkan command yang muncul di sini (mis. `bun run sync:objects:dispatch`, `bun run logs:audit:purge`), lihat `docs/awcms-mini/deployment-profiles.md` §Job registry lainnya.
+
+### Insiden misconfiguration modul
+
+1. **Modul tampak "degraded"/"failed" di health check**: baca `signals[].detail` untuk tahu sinyal mana yang gagal (mis. `db_registry_synced` gagal → jalankan `POST /modules/sync`; `permission_catalog_synced` gagal → migrasi permission belum diterapkan, cek migration terbaru).
+2. **Tenant tidak sengaja menonaktifkan modul yang dibutuhkan modul lain**: dependency graph mencegah ini di sisi enable (`MODULE_DEPENDENCY_DISABLED`) — tapi jika sudah terlanjur (mis. dinonaktifkan sebelum dependent-nya ada), aktifkan kembali lewat `POST .../enable`, tidak ada data yang hilang.
+3. **Tenant tidak sengaja mengisi settings dengan nilai salah**: `PATCH .../settings` dengan value yang benar untuk key yang sama — merge dangkal berarti hanya key tsb yang berubah.
+4. **Curiga ada secret ter-input ke settings**: request akan **ditolak** di request time (`SETTINGS_SENSITIVE_KEY_REJECTED`) untuk key bernama secret — bila ada kebocoran nilai lewat jalur lain, audit `settings_updated` hanya berisi nama key (bukan nilai), jadi cek langsung baris `awcms_mini_module_settings` (admin DB) sebagai langkah forensik, lalu rotasi kredensial yang bersangkutan di environment variable/secret manager.
+5. **Modul core ter-disable secara tidak sengaja**: tidak mungkin — enforced server-side (`CORE_MODULE_CANNOT_BE_DISABLED`), bukan cuma UI hint.
+
 ## SOP Backup/Restore
 
 Backup:

--- a/docs/awcms-mini/10_template_kode_coding_standard.md
+++ b/docs/awcms-mini/10_template_kode_coding_standard.md
@@ -150,14 +150,60 @@ export const warehouseManagementModule: ModuleDescriptor = {
 
 ## Module contract
 
+Diperluas oleh Issue #511 (epic #510, Module Management) — semua field baru **opsional**, descriptor 9 modul yang sudah ada sebelum epic ini tetap valid tanpa perubahan. Lihat `src/modules/_shared/module-contract.ts` untuk sumber kebenaran + doc comment lengkap tiap field (canonical; kode adalah sumber utama, blok ini harus tetap sinkron dengannya).
+
 ```ts
-export type ModuleStatus = "active" | "experimental" | "deprecated";
+export type ModuleType =
+  "base" | "system" | "domain" | "integration" | "derived";
+
+// `disabled` = dimatikan global oleh code/deployment — BUKAN toggle per-tenant
+// (itu `awcms_mini_tenant_modules`, Issue #515, state database independen).
+export type ModuleLifecycleStatus =
+  "active" | "experimental" | "deprecated" | "maintenance" | "disabled";
+
+export type ModulePermissionDescriptor = {
+  activityCode: string;
+  action: string;
+  description: string;
+};
+
+export type ModuleNavigationEntry = {
+  labelKey: string;
+  path: string;
+  icon?: string;
+  order?: number;
+  group?: string;
+  requiredPermission?: string;
+};
+
+// Non-secret defaults saja — jangan pernah taruh default berbentuk secret di sini.
+export type ModuleSettingsContract = {
+  schemaVersion?: number;
+  defaults?: Record<string, unknown>;
+};
+
+export type ModuleJobDescriptor = {
+  command: string;
+  purpose: string;
+  recommendedSchedule?: string;
+  environmentNotes?: string;
+  safeInOfflineLan?: boolean;
+};
+
+export type ModuleHealthContract = {
+  hasHealthCheck?: boolean;
+  hasReadinessCheck?: boolean;
+};
+
+export type ModuleCompatibilityContract = {
+  minAppVersion?: string;
+};
 
 export type ModuleDescriptor = {
   key: string;
   name: string;
   version: string;
-  status: ModuleStatus;
+  status: ModuleLifecycleStatus;
   description: string;
   dependencies: string[];
   api?: {
@@ -169,8 +215,19 @@ export type ModuleDescriptor = {
     publishes?: string[];
     subscribes?: string[];
   };
+  type?: ModuleType;
+  isCore?: boolean;
+  permissions?: ModulePermissionDescriptor[];
+  navigation?: ModuleNavigationEntry[];
+  settings?: ModuleSettingsContract;
+  jobs?: ModuleJobDescriptor[];
+  health?: ModuleHealthContract;
+  compatibility?: ModuleCompatibilityContract;
+  maintainers?: string[];
 };
 ```
+
+Aturan authoring: deklarasikan sebuah field (`navigation`/`jobs`/`health`/`api`/`events`) hanya setelah fitur sungguhan yang bersangkutan ada — descriptor tidak boleh mengklaim kapabilitas yang belum diimplementasi (lihat `src/modules/module-management/README.md` §"module_management's own descriptor" untuk contoh nyata: field `jobs`/`navigation` ditambahkan satu-satu seiring Issue #518/#519 masing-masing selesai, bukan sekaligus di depan).
 
 ## API response helper
 
@@ -291,7 +348,14 @@ export type AccessRequest = {
     | "send"
     | "configure"
     | "analyze"
-    | "assign";
+    | "assign"
+    | "restore"
+    | "purge"
+    | "retry"
+    | "sync"
+    | "enable"
+    | "disable"
+    | "check";
   resourceType?: string;
   resourceId?: string;
   resourceAttributes?: Record<string, unknown>;
@@ -314,6 +378,10 @@ Aturan:
 - RLS tetap wajib.
 - Access denied high-risk masuk decision log.
 - Untuk resource soft-deletable, action `delete` berarti soft delete. Tambahkan action `restore` dan `purge` pada kontrak modul yang membutuhkan pemulihan atau purge retention; keduanya default deny sampai permission/ABAC eksplisit tersedia.
+- `retry` (Issue 6.3/10.2) — retry manual entri antrian (sync/object queue), bukan aksi destruktif; tidak masuk `HIGH_RISK_ACTIONS`.
+- `sync` (Issue #514) — sinkronisasi descriptor code → registry database, idempoten/non-destruktif; tidak masuk `HIGH_RISK_ACTIONS`.
+- `enable`/`disable` (Issue #515) — toggle ketersediaan modul per-tenant, reversibel dan tidak menghapus data; tidak masuk `HIGH_RISK_ACTIONS`. Guard bersama (`authorizeInTransaction`) juga menolak `403 MODULE_DISABLED` untuk permintaan apa pun ke modul yang dinonaktifkan tenant tsb, terlepas dari action-nya — lihat `src/modules/identity-access/README.md` §"Enforcement modul disabled".
+- `check` (Issue #520) — memicu health check eksplisit (read-mostly, bounded); tidak masuk `HIGH_RISK_ACTIONS`.
 
 ## Audit helper
 

--- a/docs/awcms-mini/13_final_master_index_traceability.md
+++ b/docs/awcms-mini/13_final_master_index_traceability.md
@@ -133,34 +133,35 @@ flowchart LR
 
 ## Matrix Modul vs Migration
 
-| Modul                 | Migration                                                        |
-| --------------------- | ---------------------------------------------------------------- |
-| Foundation            | `001_awcms_mini_foundation_schema.sql`                           |
-| Tenant Admin          | `002_awcms_mini_tenant_identity_schema.sql`                      |
-| Catalog Inventory     | `003_awcms_mini_catalog_inventory_schema.sql`                    |
-| Sales POS             | `004_awcms_mini_sales_pos_schema.sql`                            |
-| Sync Storage          | `005_awcms_mini_sync_storage_r2_schema.sql`                      |
-| CRM                   | `006_awcms_mini_crm_receipt_communication_schema.sql`            |
-| Accounting Tax        | `007_awcms_mini_accounting_tax_coretax_schema.sql`               |
-| AI                    | `008_awcms_mini_ai_hermes_business_analyst_schema.sql`           |
-| i18n                  | `009_awcms_mini_i18n_po_schema.sql`                              |
-| Theme                 | `010_awcms_mini_theme_mode_schema.sql`                           |
-| ABAC                  | `011_awcms_mini_abac_access_control_schema.sql`                  |
-| Contracts             | `012_awcms_mini_modular_monolith_contracts_schema.sql`           |
-| Logging               | `013_awcms_mini_logging_observability_schema.sql`                |
-| Profile               | `014_awcms_mini_central_profile_management_schema.sql`           |
-| Profile Stabilization | `015_awcms_mini_profile_stabilization_schema.sql`                |
-| Workflow              | `016_awcms_mini_workflow_approval_audit_schema.sql`              |
-| Reporting             | `017_awcms_mini_management_dashboard_reporting_schema.sql`       |
-| Legacy Migration      | `018_awcms_mini_legacy_migration_backfill_toolkit_schema.sql`    |
-| Performance Sync      | `019_awcms_mini_performance_sync_validation_schema.sql`          |
-| Production Security   | `020_awcms_mini_production_security_readiness_schema.sql`        |
-| DB Pooling            | `021_awcms_mini_database_connection_pooling_schema.sql`          |
-| UI Experience         | `022_awcms_mini_ui_ux_persona_experience_schema.sql`             |
-| Warehouse             | `023_awcms_mini_warehouse_management_schema.sql`                 |
-| Idempotency           | `024_awcms_mini_transaction_integrity_idempotency_hardening.sql` |
-| Setup Wizard          | `025_awcms_mini_setup_wizard_extension.sql`                      |
-| Dashboard Views       | `026_awcms_mini_dashboard_materialized_views.sql`                |
+| Modul                 | Migration                                                                      |
+| --------------------- | ------------------------------------------------------------------------------ |
+| Foundation            | `001_awcms_mini_foundation_schema.sql`                                         |
+| Tenant Admin          | `002_awcms_mini_tenant_identity_schema.sql`                                    |
+| Catalog Inventory     | `003_awcms_mini_catalog_inventory_schema.sql`                                  |
+| Sales POS             | `004_awcms_mini_sales_pos_schema.sql`                                          |
+| Sync Storage          | `005_awcms_mini_sync_storage_r2_schema.sql`                                    |
+| CRM                   | `006_awcms_mini_crm_receipt_communication_schema.sql`                          |
+| Accounting Tax        | `007_awcms_mini_accounting_tax_coretax_schema.sql`                             |
+| AI                    | `008_awcms_mini_ai_hermes_business_analyst_schema.sql`                         |
+| i18n                  | `009_awcms_mini_i18n_po_schema.sql`                                            |
+| Theme                 | `010_awcms_mini_theme_mode_schema.sql`                                         |
+| ABAC                  | `011_awcms_mini_abac_access_control_schema.sql`                                |
+| Contracts             | `012_awcms_mini_modular_monolith_contracts_schema.sql`                         |
+| Logging               | `013_awcms_mini_logging_observability_schema.sql`                              |
+| Profile               | `014_awcms_mini_central_profile_management_schema.sql`                         |
+| Profile Stabilization | `015_awcms_mini_profile_stabilization_schema.sql`                              |
+| Workflow              | `016_awcms_mini_workflow_approval_audit_schema.sql`                            |
+| Reporting             | `017_awcms_mini_management_dashboard_reporting_schema.sql`                     |
+| Legacy Migration      | `018_awcms_mini_legacy_migration_backfill_toolkit_schema.sql`                  |
+| Performance Sync      | `019_awcms_mini_performance_sync_validation_schema.sql`                        |
+| Production Security   | `020_awcms_mini_production_security_readiness_schema.sql`                      |
+| DB Pooling            | `021_awcms_mini_database_connection_pooling_schema.sql`                        |
+| UI Experience         | `022_awcms_mini_ui_ux_persona_experience_schema.sql`                           |
+| Warehouse             | `023_awcms_mini_warehouse_management_schema.sql`                               |
+| Idempotency           | `024_awcms_mini_transaction_integrity_idempotency_hardening.sql`               |
+| Setup Wizard          | `025_awcms_mini_setup_wizard_extension.sql`                                    |
+| Dashboard Views       | `026_awcms_mini_dashboard_materialized_views.sql`                              |
+| Module Management     | `sql/025_awcms_mini_module_management_schema.sql` (epic #510, Issue #511-#521) |
 
 ## Matrix Modul vs Security Control
 
@@ -208,6 +209,7 @@ flowchart LR
 | Form multi-step (wizard)              | `awcms-mini-wizard-form`                                                                               |
 | Server-side draft persistence         | `awcms-mini-form-drafts`                                                                               |
 | Kirim email transaksional             | `awcms-mini-email`                                                                                     |
+| Kelola sistem Module Management       | `awcms-mini-module-management` (+ `awcms-mini-new-module` untuk scaffold field descriptor)             |
 | Rilis/CHANGELOG                       | `awcms-mini-release`                                                                                   |
 | Legacy migration                      | `awcms-mini-legacy-migration`                                                                          |
 | Implementasi issue                    | skill `awcms-mini-implement-issue` + agent `awcms-mini-coder`                                          |
@@ -235,6 +237,7 @@ flowchart LR
 | AI Analyst            | AI                             |
 | Backup/restore        | Deployment/Database            |
 | Troubleshooting       | Observability/DB               |
+| Manajemen modul       | Module Management (epic #510)  |
 | Handover              | Semua                          |
 
 ## Matrix kesiapan implementasi

--- a/docs/awcms-mini/14_ui_ux_design_system.md
+++ b/docs/awcms-mini/14_ui_ux_design_system.md
@@ -179,23 +179,25 @@ Item menu difilter oleh permission efektif user (lihat doc 17). Menu tanpa akses
 
 ## Screen inventory
 
-| Route                        | Persona         | Tujuan                      | Komponen utama               | API utama                                                     |
-| ---------------------------- | --------------- | --------------------------- | ---------------------------- | ------------------------------------------------------------- |
-| `/login`                     | Semua           | Autentikasi                 | FormField, Button            | `POST /auth/login`                                            |
-| `/setup`                     | Owner awal      | Setup wizard                | Stepper, FormField           | `GET/POST /setup/*`                                           |
-| `/admin`                     | Admin/Owner     | Dashboard                   | Card, Chart, Table           | `GET /reports/*`                                              |
-| `/admin/products`            | Admin/Inventory | List/CRUD produk            | DataGrid, SearchBar, Dialog  | `/inventory/products`                                         |
-| `/admin/stock`               | Admin/Inventory | Stok & opening balance      | DataGrid, NumberInput        | `/inventory/stock-balances`                                   |
-| `/admin/warehouse`           | Gudang          | Transfer, bin, cycle count  | Tabs, StatusPill             | `/warehouses`, `/warehouse-transfers`                         |
-| `/admin/tax`                 | Tax Officer     | VAT invoice, Coretax        | DataGrid, MaskedText         | `/tax/*`                                                      |
-| `/admin/crm`                 | CRM Staff       | Kontak, receipt, outbox     | Table, Switch                | `/crm/*`                                                      |
-| `/admin/reports`             | Analyst/Owner   | Laporan                     | Chart, Table                 | `/reports/*`                                                  |
-| `/admin/ai`                  | Analyst/Owner   | AI analyst chat             | Chat, Card                   | `/ai/business-analyst/chat`                                   |
-| `/admin/access-users`        | Admin/Owner     | User & akses                | Table, FormField             | `/users/*`, `/roles/*`, `/permissions`, `/access/assignments` |
-| `/admin/sync`                | Admin/Owner     | Node, konflik, antrean sync | Table, StatusPill, FormField | `/sync/nodes`, `/sync/conflicts/*`, `/sync/object-queue/*`    |
-| `/admin/logs`                | Auditor/Admin   | Logs & security             | DataGrid, Badge              | `/logs/*`, `/security/*`                                      |
-| `/pos`                       | Kasir           | Transaksi POS               | POS shell, Combobox          | `/sales/*`                                                    |
-| `/customer/receipts/{token}` | Customer        | Receipt & consent           | Card, Switch                 | `/crm/receipts/*`                                             |
+| Route                        | Persona         | Tujuan                                                                         | Komponen utama                      | API utama                                                                                                  |
+| ---------------------------- | --------------- | ------------------------------------------------------------------------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `/login`                     | Semua           | Autentikasi                                                                    | FormField, Button                   | `POST /auth/login`                                                                                         |
+| `/setup`                     | Owner awal      | Setup wizard                                                                   | Stepper, FormField                  | `GET/POST /setup/*`                                                                                        |
+| `/admin`                     | Admin/Owner     | Dashboard                                                                      | Card, Chart, Table                  | `GET /reports/*`                                                                                           |
+| `/admin/products`            | Admin/Inventory | List/CRUD produk                                                               | DataGrid, SearchBar, Dialog         | `/inventory/products`                                                                                      |
+| `/admin/stock`               | Admin/Inventory | Stok & opening balance                                                         | DataGrid, NumberInput               | `/inventory/stock-balances`                                                                                |
+| `/admin/warehouse`           | Gudang          | Transfer, bin, cycle count                                                     | Tabs, StatusPill                    | `/warehouses`, `/warehouse-transfers`                                                                      |
+| `/admin/tax`                 | Tax Officer     | VAT invoice, Coretax                                                           | DataGrid, MaskedText                | `/tax/*`                                                                                                   |
+| `/admin/crm`                 | CRM Staff       | Kontak, receipt, outbox                                                        | Table, Switch                       | `/crm/*`                                                                                                   |
+| `/admin/reports`             | Analyst/Owner   | Laporan                                                                        | Chart, Table                        | `/reports/*`                                                                                               |
+| `/admin/ai`                  | Analyst/Owner   | AI analyst chat                                                                | Chat, Card                          | `/ai/business-analyst/chat`                                                                                |
+| `/admin/access-users`        | Admin/Owner     | User & akses                                                                   | Table, FormField                    | `/users/*`, `/roles/*`, `/permissions`, `/access/assignments`                                              |
+| `/admin/sync`                | Admin/Owner     | Node, konflik, antrean sync                                                    | Table, StatusPill, FormField        | `/sync/nodes`, `/sync/conflicts/*`, `/sync/object-queue/*`                                                 |
+| `/admin/logs`                | Auditor/Admin   | Logs & security                                                                | DataGrid, Badge                     | `/logs/*`, `/security/*`                                                                                   |
+| `/admin/modules`             | Admin/Owner     | List, filter modul + health                                                    | DataGrid, StatusPill                | `/modules`, `/modules/{moduleKey}/health`                                                                  |
+| `/admin/modules/{moduleKey}` | Admin/Owner     | Detail, dependency, settings, permission sync, navigation, jobs, health, audit | Tabs/Section, FormField, StatusPill | `/modules/{moduleKey}`, `/tenant/modules/{moduleKey}/*`, `/modules/{moduleKey}/{permissions,jobs,health*}` |
+| `/pos`                       | Kasir           | Transaksi POS                                                                  | POS shell, Combobox                 | `/sales/*`                                                                                                 |
+| `/customer/receipts/{token}` | Customer        | Receipt & consent                                                              | Card, Switch                        | `/crm/receipts/*`                                                                                          |
 
 ## State pattern wajib
 

--- a/docs/awcms-mini/16_backend_data_access_integration.md
+++ b/docs/awcms-mini/16_backend_data_access_integration.md
@@ -226,6 +226,14 @@ flowchart TD
 5. Hindari N+1: gunakan join/batch.
 6. Untuk tabel soft-deletable, repository list/detail default menambahkan `deleted_at IS NULL`; `includeDeleted`/`onlyDeleted` hanya setelah ABAC.
 
+## Contoh multi-tabel: module registry (Issue #511–#521, epic #510)
+
+Registry modul (`src/modules/module-management/`) memakai dua kelas akses data yang kontras, ilustrasi konkret dari aturan RLS di atas (baris 60-89):
+
+- **Registry global, RLS-free** — `awcms_mini_modules`/`_dependencies`/`_navigation`/`_jobs`/`_health_checks`. Metadata code-derived, sama untuk semua tenant (sinkron dari `listModules()` lewat `syncModuleDescriptors`, sama alasan `awcms_mini_permissions` RLS-free) — jalan di koneksi app biasa, **tidak** butuh `withTenant`/`SET LOCAL app.current_tenant_id`.
+- **State tenant-writable, RLS FORCE** — `awcms_mini_tenant_modules` (enable/disable per tenant) dan `awcms_mini_module_settings` (pengaturan non-secret per tenant). Setiap akses **wajib** lewat `withTenant`, sama seperti tabel tenant-scoped lainnya.
+- **"Sync first" sebelum tulis tenant-scoped**: `enableTenantModule`/`disableTenantModule`/`updateModuleSettings`/`runModuleHealthCheck` semua memanggil `syncModuleDescriptors(tx)` di awal — dua tabel di atas punya FK ke `awcms_mini_modules.module_key`, jadi baris registry harus ada dulu sebelum insert baris tenant-scoped. Pola ini generik: kapan pun tabel tenant-scoped punya FK ke tabel registry code-derived, pastikan registry di-sync dalam transaction yang sama sebelum menulis, jangan mengasumsikan operator sudah menjalankan sync manual lebih dulu.
+
 ## Soft delete data access
 
 Soft delete adalah update status data, bukan `DELETE` SQL pada jalur operasional.

--- a/docs/awcms-mini/17_default_seed_rbac_abac.md
+++ b/docs/awcms-mini/17_default_seed_rbac_abac.md
@@ -58,6 +58,13 @@ flowchart LR
 | `workflow_approval`             | `approval`            | read, approve                         |
 | `observability_logging`         | `logs`                | read                                  |
 | `production_security_readiness` | `go_live`             | read, approve                         |
+| `module_management`             | `modules`             | read, sync                            |
+| `module_management`             | `tenant_modules`      | read, enable, disable                 |
+| `module_management`             | `settings`            | read, update                          |
+| `module_management`             | `permissions`         | read                                  |
+| `module_management`             | `navigation`          | read                                  |
+| `module_management`             | `jobs`                | read                                  |
+| `module_management`             | `health`              | read, check                           |
 
 ## Role default
 
@@ -76,7 +83,7 @@ flowchart LR
 
 ## Matriks role → permission (ringkas)
 
-Legenda action: R=read, C=create, U=update, P=post, X=cancel, A=approve, E=export, S=send, G=assign, N=analyze, F=configure.
+Legenda action: R=read, C=create, U=update, P=post, X=cancel, A=approve, E=export, S=send, G=assign, N=analyze, F=configure, Y=sync, I=enable, D=disable, K=health check.
 
 Permission `delete`, `restore`, dan `purge` untuk soft delete tidak tersirat dari `U`; seed harus memberikannya eksplisit per resource dan ABAC tetap default deny untuk archive/restore/purge.
 
@@ -108,6 +115,13 @@ Permission `delete`, `restore`, dan `purge` untuk soft delete tidak tersirat dar
 | workflow.approval              | RA    | R     | –     | RA      | –      | –          | –   | –   | –       | R       |
 | logs.logs                      | R     | R     | –     | –       | –      | –          | –   | –   | –       | R       |
 | security.go_live               | RA    | R     | –     | –       | –      | –          | –   | –   | –       | R       |
+| module_management.modules      | RY    | RY    | –     | –       | –      | –          | –   | –   | –       | R       |
+| module_management.tenant       | RID   | RID   | –     | –       | –      | –          | –   | –   | –       | R       |
+| module_management.settings     | RU    | RU    | –     | –       | –      | –          | –   | –   | –       | R       |
+| module_management.permissions  | R     | R     | –     | –       | –      | –          | –   | –   | –       | R       |
+| module_management.navigation   | R     | R     | –     | –       | –      | –          | –   | –   | –       | R       |
+| module_management.jobs         | R     | R     | –     | –       | –      | –          | –   | –   | –       | R       |
+| module_management.health       | RK    | RK    | –     | –       | –      | –          | –   | –   | –       | R       |
 
 `*` Diskon operator dibatasi ABAC (batas nominal/persentase sesuai kebijakan).
 

--- a/docs/awcms-mini/20_threat_model_security_architecture.md
+++ b/docs/awcms-mini/20_threat_model_security_architecture.md
@@ -227,3 +227,100 @@ PSTE spesifik-email tambahan di luar itu yang teridentifikasi untuk base
 generik ini. Kewajiban sertifikasi/pendaftaran PSE (bila berlaku untuk
 skala operator tertentu) adalah tanggung jawab lapisan operasional
 aplikasi turunan, bukan sesuatu yang bisa dibuktikan dari kode.
+
+## Standar tambahan dipicu modul Manajemen Modul (Issue #511-#521, epic #510)
+
+Modul Management memperkenalkan trust boundary yang belum pernah dibahas
+eksplisit oleh matrix di atas: **admin dapat mengubah ketersediaan/
+konfigurasi modul lain untuk tenant-nya sendiri** (bukan cuma CRUD data
+domain), dan **registry code-derived (dependency/jobs/navigation) yang
+dulunya statis kini sebagian tersinkron ke database**. Bagian ini
+memetakan tujuh risiko yang diminta eksplisit oleh Issue #522, tidak
+mengulang kontrol generik (RLS, ABAC default-deny, redaction) yang sudah
+dicakup di atas dan berlaku sama di sini.
+
+### Privilege escalation lewat enable/disable modul
+
+Setiap mutasi lifecycle (`enable`/`disable`) dan config (`settings.update`,
+`health.check`) tetap lewat ABAC default-deny standar — tidak ada jalur
+pintas. Yang membedakan modul ini: efek sebuah keputusan **menyebar ke
+endpoint modul lain**, bukan cuma resource-nya sendiri. `authorizeInTransaction`
+(guard bersama semua endpoint terproteksi) mengecek
+`awcms_mini_tenant_modules` **sebelum** evaluasi ABAC/RBAC — menonaktifkan
+modul memblokir `403 MODULE_DISABLED` untuk _permintaan apa pun_ ke modul
+itu, terlepas permission yang dimiliki actor (`src/modules/identity-access/README.md`
+§"Enforcement modul disabled"). Ini mencegah skenario "modul terlihat
+nonaktif di UI tapi endpoint-nya tetap bisa diakses" — visibilitas
+navigasi bukan otorisasi (issue's own security note).
+
+### Module misconfiguration dan dependency abuse
+
+Validasi dependency (Issue #515, `domain/tenant-module-lifecycle.ts`)
+berjalan **server-side**, tidak bisa dilewati dari client: modul tidak
+bisa diaktifkan bila dependency-nya hilang/nonaktif
+(`MODULE_DEPENDENCY_MISSING`/`_DISABLED`), tidak bisa dinonaktifkan bila
+modul lain yang masih aktif bergantung padanya
+(`MODULE_REVERSE_DEPENDENCY_ACTIVE`), circular dependency terdeteksi
+eksplisit (`MODULE_DEPENDENCY_CYCLE`), dan modul core (`isCore: true`)
+tidak bisa dinonaktifkan sama sekali (`CORE_MODULE_CANNOT_BE_DISABLED`).
+Graph dependency sendiri **selalu dibaca dari registry code
+(`listModules()`)**, tidak pernah dari tabel database
+(`awcms_mini_module_dependencies` hanya cache hasil sync terakhir) — actor
+dengan akses database langsung tidak bisa memanipulasi graph yang
+dipakai untuk keputusan enable/disable dengan mengubah tabel itu saja.
+
+### Kebocoran konfigurasi sensitif (module settings)
+
+`awcms_mini_module_settings` tenant-scoped (RLS FORCE) tapi **tetap
+divalidasi di application layer**, bukan cuma diandalkan pada isolasi
+tenant: key berbentuk secret (mengandung `password`/`token`/`apikey`/
+`secret`/`credential`, daftar sama `_shared/redaction.ts`'s
+`REDACTION_KEYS`) **ditolak saat request** (`400 SETTINGS_SENSITIVE_KEY_REJECTED`),
+bukan disimpan lalu di-redact saat dibaca — nilai yang tidak pernah
+disimpan tidak bisa bocor kemudian. Audit trail (`settings_updated`)
+hanya mencatat _nama key_ yang berubah (`addedKeys`/`changedKeys`/`removedKeys`),
+tidak pernah nilainya — konsisten dengan prinsip data minimization yang
+sama dipakai modul Email untuk data recipient (§ di atas).
+
+### Provider outage (module health check)
+
+Satu-satunya live network call di seluruh epic ini
+(`resolveEmailProvider().healthCheck()`, dipanggil dari
+`POST /modules/email/health/check`) sudah timeout-bounded dan
+error-truncating sejak Issue #495 (dipakai ulang, bukan diimplementasi
+baru) — kegagalan/outage provider tidak pernah melempar exception tak
+tertangani (`{ok: false, error}` selalu, tidak pernah throw) dan tidak
+pernah memblokir transaksi bisnis lain, karena endpoint ini bukan bagian
+dari alur bisnis manapun (aksi admin eksplisit dan terpisah). `GET
+/modules/{moduleKey}/health` (passive) tidak pernah memanggil provider
+sama sekali — sesuai acceptance criteria issue ini "provider checks are
+explicit and do not block normal business transactions".
+
+### Stale/orphaned permission
+
+Issue #517's `comparePermissions` melaporkan permission yang ada di
+katalog (`awcms_mini_permissions`) tapi tidak lagi dideklarasikan
+descriptor (`orphaned`) — **dilaporkan, tidak pernah dihapus otomatis**
+(security note eksplisit issue #517: keputusan hapus/pertahankan tetap
+di tangan operator manusia). Ini secara sengaja mencegah dua kelas
+risiko sekaligus: penghapusan otomatis yang bisa memutus assignment role
+yang masih valid (jika laporan salah/ada race), dan permission
+"tersesat" tak bertuan yang tidak pernah terlihat oleh siapa pun karena
+tidak ada mekanisme audit read-only untuk menemukannya.
+
+### Admin lockout risk
+
+Dua lapis mitigasi independen mencegah tenant mengunci diri sendiri dari
+kemampuan administratif: (1) modul `module_management` sendiri
+dideklarasikan `isCore: true` — tidak bisa dinonaktifkan sama sekali,
+jadi kemampuan mengelola modul lain (termasuk mengaktifkan kembali
+sesuatu yang salah dinonaktifkan) tidak pernah hilang; (2) dependency
+graph mencegah menonaktifkan modul yang masih dibutuhkan modul aktif
+lain (§Dependency abuse di atas) — kombinasi keduanya berarti tidak ada
+urutan enable/disable yang valid yang bisa membuat tenant kehilangan
+akses ke `/admin/modules` itu sendiri. Catatan: modul lain (`identity_access`,
+`tenant_admin`, dll.) **tidak** dideklarasikan `isCore` — secara teori
+bisa dinonaktifkan bila tidak ada dependent aktif lain, tapi dependency
+graph (`identity_access` punya beberapa reverse dependent aktif secara
+default) membuat skenario ini butuh langkah eksplisit berurutan yang
+disengaja, bukan kecelakaan satu klik.

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -270,6 +270,19 @@ stack trace, or `DATABASE_URL`. Every `catch` logs the real error
 server-side via `log()` (which redacts defensively anyway) before
 returning the safe, generic `detail`.
 
+**`awcms_mini_module_health_checks` (migration 025) is written only by
+`POST .../health/check`, never `GET .../health`.** Found and fixed during
+Issue #522's documentation pass — migration 025 already provisioned this
+table explicitly for Issue #520 ("Health check result history"), but the
+original #520 implementation never wrote to it. `runModuleHealthCheck`
+now inserts one row per explicit check (`module_key`, `status`, a safe
+`message` built from failed signal _names_ only — never a signal's own
+`detail` text). That table has an FK to `awcms_mini_modules`, so `POST`
+also syncs the registry first (same reasoning as
+`tenant-module-lifecycle.ts`/`module-settings.ts`) — the one place
+`db_registry_synced` can genuinely read differently between `GET` and
+`POST` for the same module.
+
 ## Admin UI (Issue #521)
 
 `/admin/modules` (list — replaces #518's minimal stub) and

--- a/src/modules/module-management/application/health-registry.ts
+++ b/src/modules/module-management/application/health-registry.ts
@@ -24,6 +24,7 @@ import type { ModuleDescriptor } from "../../_shared/module-contract";
 import { fetchModulePermissionSyncReport } from "./permission-sync";
 import { fetchModuleSettingsView } from "./module-settings";
 import { fetchModuleJobs } from "./job-registry";
+import { syncModuleDescriptors } from "./descriptor-sync";
 import { validateJobDescriptor } from "../domain/job-registry";
 import {
   classifyHealthStatus,
@@ -374,10 +375,46 @@ async function providerHealthCheckSignal(
 }
 
 /**
+ * `awcms_mini_module_health_checks` (migration 025) — instance-level
+ * history, RLS-free (a health result is a fact about the deployed
+ * instance, not about any one tenant), written only by the explicit
+ * `POST .../health/check` action (never the passive `GET`, which would
+ * otherwise turn every admin page view into a write). `message` is a
+ * fixed, safe summary of which signal names failed — never a signal's
+ * own `detail` text, keeping the same "generic strings only" guarantee
+ * the signals themselves already provide.
+ */
+async function recordHealthCheckHistory(
+  tx: Bun.SQL,
+  moduleKey: string,
+  report: ModuleHealthReport
+): Promise<void> {
+  const failedNames = report.signals
+    .filter((signal) => signal.status === "fail")
+    .map((signal) => signal.name);
+  const message =
+    failedNames.length > 0
+      ? `Failed signals: ${failedNames.join(", ")}.`
+      : null;
+
+  await tx`
+    INSERT INTO awcms_mini_module_health_checks (module_key, status, message)
+    VALUES (${moduleKey}, ${report.status}, ${message})
+  `;
+}
+
+/**
  * The explicit, on-demand variant (`POST .../health/check`) — same
  * generic signals as `fetchModuleHealthReport`, plus the one live
  * provider check where applicable. Never called from `GET .../health`,
- * which stays fast/cheap on every call.
+ * which stays fast/cheap on every call. Records its result into
+ * `awcms_mini_module_health_checks` as a history entry — that table has
+ * an FK to `awcms_mini_modules`, so this syncs the registry first (same
+ * "sync first" reasoning as `tenant-module-lifecycle.ts`/
+ * `module-settings.ts`). This is the one place `db_registry_synced` can
+ * genuinely read differently between `GET` and `POST` for the same
+ * module — `POST` self-heals the registry as a side effect of writing
+ * history, `GET` never does (stays a pure read).
  */
 export async function runModuleHealthCheck(
   tx: Bun.SQL,
@@ -391,6 +428,8 @@ export async function runModuleHealthCheck(
     return null;
   }
 
+  await syncModuleDescriptors(tx);
+
   const signals = await computeGenericSignals(
     tx,
     tenantId,
@@ -399,10 +438,14 @@ export async function runModuleHealthCheck(
   );
   signals.push(await providerHealthCheckSignal(moduleKey, correlationId));
 
-  return {
+  const report: ModuleHealthReport = {
     moduleKey,
     status: classifyHealthStatus(signals),
     signals,
     generatedAt: new Date().toISOString()
   };
+
+  await recordHealthCheckHistory(tx, moduleKey, report);
+
+  return report;
 }

--- a/tests/integration/module-health-registry.integration.test.ts
+++ b/tests/integration/module-health-registry.integration.test.ts
@@ -175,6 +175,47 @@ suite("module health/readiness API", () => {
     expect(auditRows[0]!.resource_id).toBe("email");
   });
 
+  test("POST .../health/check records a row in awcms_mini_module_health_checks (instance-level history, RLS-free)", async () => {
+    const owner = await bootstrap();
+
+    await invoke(postHealthCheck, {
+      method: "POST",
+      path: "/api/v1/modules/email/health/check",
+      headers: authHeaders(owner),
+      params: { moduleKey: "email" }
+    });
+
+    const admin = getAdminSql();
+    const historyRows = (await admin`
+      SELECT status, message FROM awcms_mini_module_health_checks
+      WHERE module_key = 'email'
+    `) as { status: string; message: string | null }[];
+
+    expect(historyRows).toHaveLength(1);
+    expect(historyRows[0]!.status).toBe("degraded");
+    expect(historyRows[0]!.message).toBe(
+      "Failed signals: provider_health_check."
+    );
+  });
+
+  test("GET .../health never writes to awcms_mini_module_health_checks (passive read only)", async () => {
+    const owner = await bootstrap();
+
+    await invoke(getModuleHealth, {
+      method: "GET",
+      path: "/api/v1/modules/email/health",
+      headers: authHeaders(owner),
+      params: { moduleKey: "email" }
+    });
+
+    const admin = getAdminSql();
+    const historyRows = (await admin`
+      SELECT count(*)::int AS count FROM awcms_mini_module_health_checks
+    `) as { count: number }[];
+
+    expect(historyRows[0]?.count).toBe(0);
+  });
+
   test("POST .../health/check is not_applicable for a module with no provider (e.g. logging)", async () => {
     const owner = await bootstrap();
 


### PR DESCRIPTION
## Summary

Closes #522 — the documentation/contracts wrap-up for the completed Module Management epic (#510, Issues #511-#521). Almost none of the 11 referenced docs mentioned Module Management at all before this PR (confirmed by grep before starting).

- **`docs/awcms-mini/04`** — ERD entries for `awcms_mini_tenant_modules`/`_module_dependencies`/`_module_settings`/`_module_navigation`/`_module_jobs`/`_module_health_checks`, plus a table-ownership-matrix row.
- **`docs/awcms-mini/16`** — the registry-global-RLS-free vs tenant-scoped-RLS-forced contrast, and the "sync first" FK pattern generalized for future tenant-scoped tables with a registry FK.
- **`docs/awcms-mini/17`** — 7 new permission rows (Registry module & activity + role matrix).
- **`docs/awcms-mini/05`** — endpoint summary table for `/modules/*` and `/tenant/modules/*` (no new AsyncAPI events).
- **`docs/awcms-mini/10`** — the `ModuleDescriptor` contract block was still the pre-#511 3-field version; brought fully current. The `AccessAction` union in the ABAC guard section had *also* drifted out of sync for several prior issues (`restore`/`purge`/`retry`/`sync` were already added to the real type but never to this doc) — fixed that too while adding `enable`/`disable`/`check`.
- **`docs/awcms-mini/08`** — new SOP section: sync descriptors, enable/disable, settings, health inspection, a dependency-error-code reference table, job registry, misconfiguration incident handling.
- **`docs/awcms-mini/13`, `14`** — traceability/screen-inventory rows.
- **`docs/awcms-mini/20`** — new threat model section covering the 7 risks the issue named explicitly: privilege escalation, misconfiguration, dependency abuse, sensitive config leakage, provider outage, stale/orphaned permissions, admin lockout.
- **`.claude/skills/awcms-mini-new-module`** — extended descriptor template + the mandatory "sync before use" note.
- **`.claude/skills/awcms-mini-module-management`** (new) — decided this warranted its own skill (same bar as `awcms-mini-form-drafts`/`awcms-mini-email`): the dependency-graph error codes, sync-first FK ordering, settings merge semantics, health GET-vs-POST asymmetry, and permission-sync-status meaning are all genuinely non-obvious from reading one file.
- **`.changeset/module-management.md`** — epic-level changeset (minor), matching the existing per-epic changeset convention (email, form-drafts).

## A real gap found and fixed along the way

While writing the ERD section I found that migration 025 explicitly provisioned `awcms_mini_module_health_checks` ("Health check result history (Issue #520)") — but the original #520 implementation never wrote to it. `POST /api/v1/modules/{moduleKey}/health/check` now inserts a history row (`status` + a safe summary of failed signal *names*, never raw detail text); `GET .../health` still never writes (stays the cheap, pure read it was designed to be). That table has an FK to `awcms_mini_modules`, so `POST` now also syncs the registry first — documented as the one place `db_registry_synced` can legitimately read differently between `GET` and `POST` for the same module.

## Test plan
- [x] `bun run check` (lint + docs-check + api:spec:check + typecheck + test + build) — all pass
- [x] `bun test` — 694 pass against real PostgreSQL (692 prior + 2 new: health-check-history persistence, GET-never-writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)