### PR TITLE
chore(skills): fix stale AccessAction union and REDACTION_KEYS list

### DIFF
--- a/.claude/skills/awcms-mini-abac-guard/SKILL.md
+++ b/.claude/skills/awcms-mini-abac-guard/SKILL.md
@@ -34,7 +34,14 @@ type AccessRequest = {
     | "send"
     | "configure"
     | "analyze"
-    | "assign";
+    | "assign"
+    | "restore"
+    | "purge"
+    | "retry"
+    | "sync"
+    | "enable"
+    | "disable"
+    | "check";
   resourceType?: string;
   resourceId?: string;
   resourceAttributes?: Record<string, unknown>;

--- a/.claude/skills/awcms-mini-audit-log/SKILL.md
+++ b/.claude/skills/awcms-mini-audit-log/SKILL.md
@@ -39,7 +39,7 @@ Login failed/success · access assignment · profile merge · product price chan
 
 ## Redaction keys
 
-`password`, `passwordHash`, `token`, `accessToken`, `refreshToken`, `apiKey`, `secret`, `authorization`, `npwp`, `nik`, `phone`, `whatsapp`, `email`.
+`password`, `passwordHash`, `token`, `accessToken`, `refreshToken`, `apiKey`, `secret`, `credential`, `authorization`, `npwp`, `nik`, `phone`, `whatsapp`, `email`.
 
 ## Verifikasi
 


### PR DESCRIPTION
## Summary

Repository-wide skill/doc drift audit requested after epic #510 closed out the backlog. Method:
- Mechanical scan: every backtick-quoted file path referenced across all 29 `.claude/skills/*/SKILL.md` and all `docs/awcms-mini/*.md` actually exists (no broken references found — the two "misses" were `sql/020`-style migration-number shorthand, not real paths, and one forward-looking `src/lib/api-client.ts` reference in doc 15 describing planned frontend architecture for a derived app, not a stale link).
- Targeted scan for embedded canonical lists (type unions, key lists) that could drift from their real source — found two real gaps in `awcms-mini-abac-guard` and `awcms-mini-audit-log`.

## Findings fixed

- **`awcms-mini-abac-guard`**: the `AccessRequest.action` union still only had the original 12 actions — missing `restore`/`purge`/`retry`/`sync`/`enable`/`disable`/`check`, all added to the real `AccessAction` type across several prior issues. (The same gap was already found and fixed in `docs/awcms-mini/10_template_kode_coding_standard.md` during issue #522 — this skill file carries its own separate copy that was missed at the time.)
- **`awcms-mini-audit-log`**: the redaction key list was missing `credential`, added to the real `REDACTION_KEYS` list in issue #516.

No other skill or doc carries a stale copy of either list.

## Test plan
- [x] `bun run lint` / `bun run check:docs` / `bun run typecheck` — all pass (doc/skill-only change, no src/ touched, so the full DB-backed test suite is unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)