### PR TITLE
feat(blog-content): scaffold blog_content module foundation (Issue #537)

### DIFF
--- a/.changeset/blog-content-foundation.md
+++ b/.changeset/blog-content-foundation.md
@@ -1,0 +1,14 @@
+---
+"awcms-mini": minor
+---
+
+Add the `blog_content` module foundation (Issue #537, epic #536) — the
+first domain module registered directly in this base repo (see
+`docs/adr/0009-public-tenant-scoped-routes.md`). Adds `src/modules/blog-content`
+(module descriptor, domain validation for content/slug/status/SEO/taxonomy
+rules, read-only application query placeholders) and the core schema
+(migrations `026`/`027`): tenant-scoped, RLS-`FORCE`d tables for posts,
+pages, categories/tags, post-term relations, append-only revisions,
+redirects, and per-tenant settings, plus the 26-entry `blog_content.*`
+permission seed. No admin/public API, OpenAPI/AsyncAPI, or UI yet —
+those land in Issues #538-#543.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -34,6 +34,7 @@ Skill Claude Code tingkat-proyek untuk AWCMS-Mini. Setiap skill meng-encode stan
 | `awcms-mini-i18n`                                      | String UI `.po` gettext & konten multi-bahasa                                    | 14, 04, 19                  |
 | `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)                                | 09                          |
 | `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                     | 07, 06                      |
+| `awcms-mini-blog-content`                              | Kerjakan bagian mana pun epic blog_content (Issue #537-#543)                     | blog-content/README.md      |
 
 ## Katalog peningkatan (improvement/hardening)
 
@@ -82,6 +83,9 @@ flowchart TD
   DRAFT --> IDEM
   DRAFT --> ABAC
   II --> LEG[awcms-mini-legacy-migration]
+  II --> BLOG[awcms-mini-blog-content]
+  BLOG --> EP
+  BLOG --> MIG
   II --> PR[awcms-mini-pr-review]
   PR --> SEC[awcms-mini-security-review]
   PR --> CQ[awcms-mini-codeql-triage]

--- a/.claude/skills/awcms-mini-blog-content/SKILL.md
+++ b/.claude/skills/awcms-mini-blog-content/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: awcms-mini-blog-content
+description: Kerjakan bagian mana pun dari epic blog_content AWCMS-Mini (Issue #537-#543, epic #536) — posts, pages, taxonomi, search, revisi/scheduled publishing, rute publik, atau UI admin blog. Gunakan saat menambah endpoint/logic ke src/modules/blog-content, mengubah schema blog, atau melanjutkan issue lanjutan epic ini. Merangkum keputusan yang sudah dibuat di Issue #537 supaya tidak diulang/dikontradiksi.
+---
+
+# AWCMS-Mini — Blog Content Module
+
+`blog_content` (`src/modules/blog-content`) adalah **modul domain pertama
+yang didaftarkan langsung di repo base ini** (epic #536, bukan di aplikasi
+turunan terpisah — lihat `AGENTS.md` §Peta modul dan
+`docs/adr/0009-public-tenant-scoped-routes.md`). Skill ini merangkum
+keputusan Issue #537 (fondasi, sudah selesai) yang **wajib** dipakai ulang
+oleh Issue #538-#543, bukan didesain ulang — baca
+`src/modules/blog-content/README.md` untuk detail lengkap tiap tabel.
+
+## Kapan pakai skill ini vs skill generik
+
+Skill ini melengkapi (bukan menggantikan) `awcms-mini-new-endpoint`,
+`awcms-mini-new-migration`, `awcms-mini-testing`, dll. — itu tetap dipakai
+untuk cara **membangun** endpoint/migration/test. Skill ini menyediakan
+konteks **domain blog_content spesifik** yang tidak jelas dari sekadar
+membaca satu file migration.
+
+## Status per issue (jangan bangun ulang yang sudah ada)
+
+| Issue | Scope                                       | Status                          |
+| ----- | ------------------------------------------- | ------------------------------- |
+| #537  | Schema, domain validation, permission seed  | **Selesai** (migration 026/027) |
+| #538  | Admin API + lifecycle actions (posts)       | Belum                           |
+| #539  | Pages, taxonomi, PostgreSQL search          | Belum                           |
+| #540  | Rute publik, RSS, sitemap, SEO              | Belum                           |
+| #541  | Revisions + scheduled publishing            | Belum                           |
+| #542  | Template/menu/widget/media/multilingual/ads | Belum                           |
+| #543  | Admin UI, dokumentasi akhir, hardening      | Belum                           |
+
+## Yang sudah ada — pakai ulang, jangan re-derive
+
+- **Tabel** (migration `026_awcms_mini_blog_content_schema.sql`): `awcms_mini_blog_posts`, `_pages`, `_terms`, `_post_terms`, `_revisions` (append-only), `_redirects`, `_settings` (1 row/tenant, `tenant_id` = PK). Semua `ENABLE`+`FORCE ROW LEVEL SECURITY`, tanpa `GRANT` eksplisit (migration 013's `ALTER DEFAULT PRIVILEGES` sudah meng-cover).
+- **Permission seed** (migration `027`): 26 permission `blog_content.<posts|pages|taxonomies|revisions|settings|seo|search>.<action>` — kalau endpoint baru butuh permission di luar daftar ini, itu berarti scope-nya salah atau butuh migration permission baru, bukan improvisasi module_key/activity_code baru.
+- **Domain validation** (`src/modules/blog-content/domain/`): `content-validation.ts` (field inti), `post-status.ts` (`isValidStatusTransition` — satu sumber kebenaran transisi lifecycle, dipakai #538 dan #541), `slug-policy.ts` (`isValidSlug`/`slugify`), `seo-validation.ts`, `taxonomy-policy.ts` (`validateTermParent`). **Panggil fungsi-fungsi ini**, jangan tulis ulang regex/aturan yang sama di endpoint handler.
+- **Application placeholders** (`src/modules/blog-content/application/`): `blog-post-directory.ts`, `blog-taxonomy-directory.ts` — query read-only tenant-scoped siap pakai untuk endpoint list/detail.
+
+## Aturan lintas-issue yang wajib diikuti
+
+1. **Slug uniqueness**: posts/pages unik per `(tenant_id, locale, slug)` selama `deleted_at IS NULL`; terms unik per `(tenant_id, taxonomy_type, slug)`. Jangan tambah constraint unik baru yang lebih longgar/ketat tanpa migration baru + update README.
+2. **Tag tidak boleh punya `parent_id`** — sudah di-enforce di constraint DB (`awcms_mini_blog_terms_tag_no_parent_check`) dan aplikasi (`validateTermParent`). Endpoint create/update term wajib panggil `validateTermParent` sebelum insert/update.
+3. **Revisions append-only** — tidak pernah `UPDATE`/`DELETE` baris `awcms_mini_blog_revisions`. "Restore revisi" (Issue #541) = insert revisi baru berisi konten lama, lalu update baris post/page aktif dari revisi itu.
+4. **`search_vector` belum dipopulasikan** — kolom+index GIN sudah ada di posts/pages (Issue #537), tapi trigger/maintenance-nya Issue #539. Jangan asumsikan kolom ini sudah terisi sebelum #539 selesai.
+5. **Rute publik tenant-scoped** (Issue #540) **wajib** ikuti ADR-0009: resolusi tenant lewat segmen path `tenant_code` (`/blog/{tenantCode}/...`), **bukan** subdomain/header — base ini LAN-first, tidak boleh berasumsi ada DNS/TLS publik.
+6. **Idempotency**: mutation high-risk (publish, schedule, archive, restore revisi, purge) ikuti `awcms-mini-idempotency` — cek doc 10 apakah aksi tersebut masuk daftar wajib `Idempotency-Key`.
+7. **Audit**: publish/unpublish, delete/restore/purge, dan resolusi konflik revisi adalah aksi high-risk — pakai `awcms-mini-audit-log`.
+8. **Multilingual** (Issue #542): kolom `locale` di posts/pages sekarang cuma satu nilai per baris (bukan JSONB per-locale). Kalau #542 butuh konten multi-locale per satu post, contoh pola yang sudah ada dan divalidasi di repo ini adalah `sql/021_awcms_mini_email_template_i18n_schema.sql` (JSONB per-locale) — pakai itu sebagai referensi, bukan mendesain skema baru dari nol.
+
+## Belum ada — jangan asumsikan sudah dikerjakan
+
+Tidak ada endpoint admin/publik, OpenAPI/AsyncAPI, atau UI apa pun untuk `blog_content` sampai Issue #538 (API pertama) menambahkannya. `src/modules/blog-content/README.md` §Belum tersedia berisi daftar lengkap per issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ AWCMS-Mini menyediakan **skill Claude Code tingkat-proyek** yang meng-encode sta
 | String UI `.po` gettext & konten multi-bahasa                          | `awcms-mini-i18n`                 |
 | Rilis versi (Changesets, tag, CHANGELOG)                               | `awcms-mini-release`              |
 | Migrasi data legacy (dry-run, backfill)                                | `awcms-mini-legacy-migration`     |
+| Kerjakan bagian mana pun epic blog_content (Issue #537-#543)           | `awcms-mini-blog-content`         |
 
 **Peningkatan (audit & hardening artefak yang sudah ada):**
 
@@ -161,6 +162,9 @@ flowchart LR
   EP --> EMAIL[email]
   EMAIL --> INT
   EMAIL --> SD
+  II --> BLOG[blog-content]
+  BLOG --> EP
+  BLOG --> MIG
 ```
 
 Skill merujuk `docs/awcms-mini/*` sebagai sumber kebenaran; bila standar berubah, perbarui doc **dan** skill terkait.
@@ -264,7 +268,9 @@ awcms-mini/
 
 `_shared`, `tenant-admin`, `identity-access`, `profile-identity`, `sync-storage`, `localization-ui`, `observability-logging`, `database-connectivity`, `workflow-approval`, `management-reporting`, `ui-experience`, `production-security-readiness`.
 
-Ini adalah modul **base generik** milik AWCMS-Mini sendiri. Modul domain (mis. katalog produk, POS, gudang, pajak, CRM, AI analyst) **bukan bagian repo ini** — itu ditambahkan di aplikasi turunan contoh (mis. AWPOS) di atas base ini; lihat `docs/awcms-mini/README.md` §Reusable vs domain turunan.
+Ini adalah modul **base generik** milik AWCMS-Mini sendiri. Modul domain (mis. katalog produk, POS, gudang, pajak, CRM, AI analyst) pada umumnya **bukan bagian repo ini** — itu ditambahkan di aplikasi turunan contoh (mis. AWPOS) di atas base ini; lihat `docs/awcms-mini/README.md` §Reusable vs domain turunan.
+
+**Pengecualian:** `blog-content` (`src/modules/blog-content`, key `blog_content`) adalah modul domain pertama yang didaftarkan **langsung** di repo base ini (epic #536, Issue #537 dst., `docs/adr/0009-public-tenant-scoped-routes.md`) — bukan di aplikasi turunan terpisah. Perlakukan sebagai contoh referensi domain module di atas base, bukan preseden untuk memindahkan modul domain lain (POS, gudang, dst.) ke repo ini.
 
 Struktur tiap modul: `module.ts`, `domain/`, `application/`, `infrastructure/`, `api/`, `README.md`.
 

--- a/sql/026_awcms_mini_blog_content_schema.sql
+++ b/sql/026_awcms_mini_blog_content_schema.sql
@@ -1,0 +1,299 @@
+-- Issue #537 (epic #536, blog_content) — foundation schema for the first
+-- domain module registered directly in this base repo (ADR-0009). Seven
+-- tables per doc issue #537 §Database Tables: posts, pages, terms
+-- (categories/tags), post-term relations, append-only revisions, redirects,
+-- and per-tenant settings. Admin/public API, search population, and
+-- scheduled-publishing automation are out of scope here (Issues #538-#543) —
+-- this only lays down the tenant-isolated, least-privilege schema they build
+-- on.
+--
+-- No explicit `GRANT` statements are needed for `awcms_mini_app` on the new
+-- tables below: migration 013 already set
+-- `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE,
+-- DELETE ON TABLES TO awcms_mini_app`, so every table the owning role creates
+-- from here on is auto-granted (same reasoning migration 025 relied on for
+-- module management's new tables).
+
+CREATE TABLE IF NOT EXISTS awcms_mini_blog_posts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  author_tenant_user_id uuid NOT NULL,
+  title text NOT NULL,
+  slug text NOT NULL,
+  excerpt text,
+  content_json jsonb NOT NULL,
+  content_text text NOT NULL,
+  status text NOT NULL DEFAULT 'draft',
+  visibility text NOT NULL DEFAULT 'public',
+  featured_media_id uuid,
+  seo_title text,
+  meta_description text,
+  canonical_url text,
+  locale text NOT NULL DEFAULT 'id',
+  published_at timestamptz,
+  scheduled_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  restored_at timestamptz,
+  restored_by uuid,
+  version integer NOT NULL DEFAULT 1,
+  search_vector tsvector,
+  CONSTRAINT awcms_mini_blog_posts_status_check
+    CHECK (status IN ('draft', 'review', 'scheduled', 'published', 'archived')),
+  CONSTRAINT awcms_mini_blog_posts_visibility_check
+    CHECK (visibility IN ('public', 'private', 'unlisted'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_blog_posts_slug_dedup
+  ON awcms_mini_blog_posts (tenant_id, locale, slug)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_posts_tenant_status_published_idx
+  ON awcms_mini_blog_posts (tenant_id, status, published_at DESC);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_posts_tenant_author_idx
+  ON awcms_mini_blog_posts (tenant_id, author_tenant_user_id);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_posts_tenant_deleted_idx
+  ON awcms_mini_blog_posts (tenant_id, deleted_at);
+
+-- Populated by Issue #539's search-vector maintenance (trigger or
+-- application-managed) — the column/index exist now so #539 needs no new
+-- migration just to add the index.
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_posts_search_vector_idx
+  ON awcms_mini_blog_posts USING GIN (search_vector);
+
+ALTER TABLE awcms_mini_blog_posts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_blog_posts FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_blog_posts_tenant_isolation
+  ON awcms_mini_blog_posts
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Same core shape as posts, plus page_type/parent_page_id/menu_order (doc
+-- issue #537 §Pages).
+CREATE TABLE IF NOT EXISTS awcms_mini_blog_pages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  author_tenant_user_id uuid NOT NULL,
+  title text NOT NULL,
+  slug text NOT NULL,
+  excerpt text,
+  content_json jsonb NOT NULL,
+  content_text text NOT NULL,
+  status text NOT NULL DEFAULT 'draft',
+  visibility text NOT NULL DEFAULT 'public',
+  featured_media_id uuid,
+  seo_title text,
+  meta_description text,
+  canonical_url text,
+  locale text NOT NULL DEFAULT 'id',
+  published_at timestamptz,
+  scheduled_at timestamptz,
+  page_type text NOT NULL DEFAULT 'standard',
+  parent_page_id uuid REFERENCES awcms_mini_blog_pages (id),
+  menu_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  restored_at timestamptz,
+  restored_by uuid,
+  version integer NOT NULL DEFAULT 1,
+  search_vector tsvector,
+  CONSTRAINT awcms_mini_blog_pages_status_check
+    CHECK (status IN ('draft', 'review', 'scheduled', 'published', 'archived')),
+  CONSTRAINT awcms_mini_blog_pages_visibility_check
+    CHECK (visibility IN ('public', 'private', 'unlisted')),
+  CONSTRAINT awcms_mini_blog_pages_page_type_check
+    CHECK (page_type IN ('standard', 'landing', 'legal', 'system'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_blog_pages_slug_dedup
+  ON awcms_mini_blog_pages (tenant_id, locale, slug)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_pages_tenant_status_published_idx
+  ON awcms_mini_blog_pages (tenant_id, status, published_at DESC);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_pages_tenant_author_idx
+  ON awcms_mini_blog_pages (tenant_id, author_tenant_user_id);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_pages_tenant_deleted_idx
+  ON awcms_mini_blog_pages (tenant_id, deleted_at);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_pages_parent_idx
+  ON awcms_mini_blog_pages (parent_page_id);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_pages_search_vector_idx
+  ON awcms_mini_blog_pages USING GIN (search_vector);
+
+ALTER TABLE awcms_mini_blog_pages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_blog_pages FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_blog_pages_tenant_isolation
+  ON awcms_mini_blog_pages
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Categories and tags (doc issue #537 §Terms). A tag must never carry a
+-- parent_id (also re-checked at the application layer by
+-- `domain/taxonomy-policy.ts`'s `validateTermParent` before this constraint
+-- is ever reached).
+CREATE TABLE IF NOT EXISTS awcms_mini_blog_terms (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  taxonomy_type text NOT NULL,
+  parent_id uuid REFERENCES awcms_mini_blog_terms (id),
+  name text NOT NULL,
+  slug text NOT NULL,
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_mini_blog_terms_taxonomy_type_check
+    CHECK (taxonomy_type IN ('category', 'tag')),
+  CONSTRAINT awcms_mini_blog_terms_tag_no_parent_check
+    CHECK (taxonomy_type <> 'tag' OR parent_id IS NULL)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_blog_terms_slug_dedup
+  ON awcms_mini_blog_terms (tenant_id, taxonomy_type, slug)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_terms_tenant_idx
+  ON awcms_mini_blog_terms (tenant_id, taxonomy_type);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_terms_parent_idx
+  ON awcms_mini_blog_terms (parent_id);
+
+ALTER TABLE awcms_mini_blog_terms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_blog_terms FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_blog_terms_tenant_isolation
+  ON awcms_mini_blog_terms
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Post <-> term assignment (doc issue #537 §Post-term relations). Join
+-- table still carries its own `tenant_id` (not just derivable through the
+-- FKs) so RLS can isolate it directly, same convention as every other
+-- tenant-scoped table in this base.
+CREATE TABLE IF NOT EXISTS awcms_mini_blog_post_terms (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  post_id uuid NOT NULL REFERENCES awcms_mini_blog_posts (id),
+  term_id uuid NOT NULL REFERENCES awcms_mini_blog_terms (id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_mini_blog_post_terms_unique UNIQUE (post_id, term_id)
+);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_post_terms_tenant_idx
+  ON awcms_mini_blog_post_terms (tenant_id);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_post_terms_term_idx
+  ON awcms_mini_blog_post_terms (term_id);
+
+ALTER TABLE awcms_mini_blog_post_terms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_blog_post_terms FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_blog_post_terms_tenant_isolation
+  ON awcms_mini_blog_post_terms
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Append-only revision history (doc issue #537 §Revisions: "Revisions are
+-- append-only... Restoring a revision must create a new revision"). Same
+-- convention as `awcms_mini_workflow_decisions`/`awcms_mini_audit_events`: a
+-- single tenant-isolation policy, no UPDATE ever issued by application code.
+CREATE TABLE IF NOT EXISTS awcms_mini_blog_revisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  resource_type text NOT NULL,
+  resource_id uuid NOT NULL,
+  revision_number integer NOT NULL,
+  title text NOT NULL,
+  content_json jsonb NOT NULL,
+  content_text text NOT NULL,
+  excerpt text,
+  seo_title text,
+  meta_description text,
+  canonical_url text,
+  status text NOT NULL,
+  change_note text,
+  created_by_tenant_user_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_mini_blog_revisions_resource_type_check
+    CHECK (resource_type IN ('post', 'page')),
+  CONSTRAINT awcms_mini_blog_revisions_unique
+    UNIQUE (tenant_id, resource_type, resource_id, revision_number)
+);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_revisions_resource_idx
+  ON awcms_mini_blog_revisions (tenant_id, resource_type, resource_id, revision_number DESC);
+
+ALTER TABLE awcms_mini_blog_revisions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_blog_revisions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_blog_revisions_tenant_isolation
+  ON awcms_mini_blog_revisions
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- URL redirects (e.g. slug changes) — soft-deletable like other
+-- master/config data (AGENTS.md rule 13), not append-only.
+CREATE TABLE IF NOT EXISTS awcms_mini_blog_redirects (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  from_path text NOT NULL,
+  to_path text NOT NULL,
+  status_code integer NOT NULL DEFAULT 301,
+  reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_mini_blog_redirects_status_code_check
+    CHECK (status_code IN (301, 302, 307, 308))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_blog_redirects_from_path_dedup
+  ON awcms_mini_blog_redirects (tenant_id, from_path)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_redirects_tenant_idx
+  ON awcms_mini_blog_redirects (tenant_id);
+
+ALTER TABLE awcms_mini_blog_redirects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_blog_redirects FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_blog_redirects_tenant_isolation
+  ON awcms_mini_blog_redirects
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- One row per tenant, same shape/convention as `awcms_mini_tenant_settings`
+-- (migration 002): `tenant_id` itself is the primary key, no separate soft
+-- delete (a settings row is configured, not deleted).
+CREATE TABLE IF NOT EXISTS awcms_mini_blog_settings (
+  tenant_id uuid PRIMARY KEY REFERENCES awcms_mini_tenants (id),
+  default_locale text NOT NULL DEFAULT 'id',
+  default_visibility text NOT NULL DEFAULT 'public',
+  posts_per_page integer NOT NULL DEFAULT 10,
+  seo_default_title text,
+  seo_default_description text,
+  settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_mini_blog_settings_default_visibility_check
+    CHECK (default_visibility IN ('public', 'private', 'unlisted'))
+);
+
+ALTER TABLE awcms_mini_blog_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_blog_settings FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_blog_settings_tenant_isolation
+  ON awcms_mini_blog_settings
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/sql/027_awcms_mini_blog_content_permissions.sql
+++ b/sql/027_awcms_mini_blog_content_permissions.sql
@@ -1,0 +1,33 @@
+-- Issue #537 (epic #536, blog_content) — permission catalog seed, exactly
+-- the list from doc issue #537 §Permission Seed. No implicit role grants;
+-- assignable through the existing Access & Users management (RBAC/ABAC),
+-- same as every other module's permission seed.
+INSERT INTO awcms_mini_permissions (module_key, activity_code, action, description)
+VALUES
+  ('blog_content', 'posts', 'read', 'Read blog posts'),
+  ('blog_content', 'posts', 'create', 'Create blog posts'),
+  ('blog_content', 'posts', 'update', 'Update blog posts'),
+  ('blog_content', 'posts', 'publish', 'Publish blog posts'),
+  ('blog_content', 'posts', 'schedule', 'Schedule blog posts for future publishing'),
+  ('blog_content', 'posts', 'archive', 'Archive blog posts'),
+  ('blog_content', 'posts', 'delete', 'Soft delete blog posts'),
+  ('blog_content', 'posts', 'restore', 'Restore soft-deleted blog posts'),
+  ('blog_content', 'posts', 'purge', 'Purge soft-deleted blog posts'),
+  ('blog_content', 'posts', 'export', 'Export blog posts'),
+  ('blog_content', 'pages', 'read', 'Read blog pages'),
+  ('blog_content', 'pages', 'create', 'Create blog pages'),
+  ('blog_content', 'pages', 'update', 'Update blog pages'),
+  ('blog_content', 'pages', 'publish', 'Publish blog pages'),
+  ('blog_content', 'pages', 'archive', 'Archive blog pages'),
+  ('blog_content', 'pages', 'delete', 'Soft delete blog pages'),
+  ('blog_content', 'pages', 'restore', 'Restore soft-deleted blog pages'),
+  ('blog_content', 'pages', 'purge', 'Purge soft-deleted blog pages'),
+  ('blog_content', 'taxonomies', 'read', 'Read blog categories and tags'),
+  ('blog_content', 'taxonomies', 'configure', 'Create, update, or delete blog categories and tags'),
+  ('blog_content', 'revisions', 'read', 'Read blog post/page revision history'),
+  ('blog_content', 'revisions', 'restore', 'Restore a blog post/page revision'),
+  ('blog_content', 'settings', 'read', 'Read blog module settings'),
+  ('blog_content', 'settings', 'configure', 'Update blog module settings'),
+  ('blog_content', 'seo', 'configure', 'Configure blog SEO metadata defaults'),
+  ('blog_content', 'search', 'read', 'Search blog posts and pages')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -1,0 +1,47 @@
+# Blog Content
+
+Implementasi Issue #537 (epic #536 — `blog_content`, `docs/adr/0009-public-tenant-scoped-routes.md`). **Modul domain pertama yang didaftarkan langsung di repo base ini** — sebelumnya `AGENTS.md` §Peta modul hanya mendaftarkan modul base generik; lihat catatan di sana untuk konteks.
+
+## Scope Issue #537 (foundation only)
+
+Hanya fondasi: module descriptor, domain validation, application placeholder read-only, dan schema database. **Tidak ada** endpoint admin/publik, OpenAPI/AsyncAPI, atau UI — itu Issue #538-#543 (lihat §Belum tersedia).
+
+## Tabel (migration `026_awcms_mini_blog_content_schema.sql`)
+
+Tujuh tabel persis sesuai doc issue #537 §Database Tables, semuanya tenant-scoped (`ENABLE` + `FORCE ROW LEVEL SECURITY`, satu policy `tenant_isolation` per tabel):
+
+1. **`awcms_mini_blog_posts`** — `status`: `draft → review → scheduled → published → archived` (`domain/post-status.ts` `isValidStatusTransition`), `visibility`: `public | private | unlisted`. Slug unik per `(tenant_id, locale)` selama `deleted_at IS NULL` (partial unique index). `search_vector tsvector` + index GIN sudah ada di sini, tapi **belum dipopulasikan** — trigger/maintenance-nya Issue #539.
+2. **`awcms_mini_blog_pages`** — struktur core sama seperti posts, plus `page_type` (`standard | landing | legal | system`), `parent_page_id` (self-FK), `menu_order`.
+3. **`awcms_mini_blog_terms`** — kategori (`taxonomy_type = 'category'`, boleh `parent_id`) dan tag (`taxonomy_type = 'tag'`, `CHECK` menolak `parent_id` — lihat juga `domain/taxonomy-policy.ts` untuk cek pre-insert di level aplikasi). Slug unik per `(tenant_id, taxonomy_type)`.
+4. **`awcms_mini_blog_post_terms`** — relasi many-to-many post↔term, tetap membawa `tenant_id` sendiri (bukan hanya lewat FK) supaya RLS bisa langsung mengisolasi baris join ini, konvensi yang sama seperti tabel relasi lain di base ini.
+5. **`awcms_mini_blog_revisions`** — **append-only**, tidak pernah di-`UPDATE` aplikasi (pola sama seperti `awcms_mini_workflow_decisions`/`awcms_mini_audit_events`). "Restore revisi" berarti membuat revisi baru berisi konten lama, bukan menimpa baris manapun — jalur kode restore-nya sendiri Issue #541.
+6. **`awcms_mini_blog_redirects`** — soft-deletable (bukan append-only), unik per `(tenant_id, from_path)` selama aktif.
+7. **`awcms_mini_blog_settings`** — satu baris per tenant, `tenant_id` sendiri jadi primary key (pola sama seperti `awcms_mini_tenant_settings`, migration 002), bukan soft-deletable (dikonfigurasi, bukan dihapus).
+
+Tidak ada `GRANT` eksplisit ke `awcms_mini_app` di migration 026 — migration 013 sudah memasang `ALTER DEFAULT PRIVILEGES` yang otomatis meng-grant tabel baru apa pun yang dibuat role pemilik (dipakai ulang oleh migration 025 untuk alasan yang sama).
+
+## Permission seed (migration `027_awcms_mini_blog_content_permissions.sql`)
+
+26 permission persis sesuai doc issue #537 §Permission Seed (`blog_content.posts.*`, `.pages.*`, `.taxonomies.*`, `.revisions.*`, `.settings.*`, `.seo.configure`, `.search.read`). Tidak ada role grant implisit — hanya assignable lewat Access & Users yang sudah ada.
+
+## Domain validation (`domain/`)
+
+- `content-validation.ts` — `validateBlogContentCore`: field inti yang dipakai bersama post & page (`title`, `slug`, `excerpt`, `contentJson`, `contentText`, `locale`).
+- `post-status.ts` — enum status/visibility + `isValidStatusTransition` (satu sumber kebenaran dipakai ulang oleh endpoint lifecycle Issue #538 dan scheduled-publishing Issue #541).
+- `slug-policy.ts` — `isValidSlug` (format) + `slugify` (derivasi dari title; pemanggil tetap wajib cek keunikan sendiri).
+- `seo-validation.ts` — `validateSeoFields` (`seoTitle` ≤70 char, `metaDescription` ≤160 char, `canonicalUrl` harus URL http(s) absolut).
+- `taxonomy-policy.ts` — `validateTermParent` (tag tidak boleh punya parent, term tidak boleh jadi parent dirinya sendiri) — pre-check aplikasi sebelum constraint DB `awcms_mini_blog_terms_tag_no_parent_check` tersentuh.
+
+## Application placeholders (`application/`)
+
+`blog-post-directory.ts` (`fetchBlogPostById`, `listBlogPostsByStatus`) dan `blog-taxonomy-directory.ts` (`fetchBlogTermsByTaxonomyType`) — query read-only tenant-scoped (filter `tenant_id` eksplisit + RLS, defense-in-depth sama seperti `identity-access/application/user-directory.ts`). Belum dipanggil endpoint manapun; disediakan supaya Issue #538/#539 langsung memakai ulang, bukan menulis query baru dari nol.
+
+## Belum tersedia (backlog eksplisit, bukan kelalaian)
+
+- Admin API (`POST/PATCH/DELETE /api/v1/blog/posts`, lifecycle actions) — Issue #538.
+- Halaman, taksonomi, dan PostgreSQL full-text search sungguhan (trigger `search_vector`) — Issue #539.
+- Rute publik, RSS, sitemap, SEO rendering — Issue #540 (lihat ADR-0009 untuk resolusi tenant tanpa sesi via `/blog/{tenantCode}/...`).
+- Endpoint restore revisi dan scheduled-publishing dispatcher — Issue #541.
+- Template, menu, widget, media/gallery, multilingual, theme mode, ads — Issue #542.
+- Admin UI, dokumentasi akhir, hardening — Issue #543.
+- OpenAPI/AsyncAPI belum diperbarui — tidak relevan sampai ada endpoint sungguhan (Issue #538 yang pertama menambahkannya).

--- a/src/modules/blog-content/application/blog-post-directory.ts
+++ b/src/modules/blog-content/application/blog-post-directory.ts
@@ -1,0 +1,81 @@
+/**
+ * Read-only query placeholder (Issue #537, foundation only). No admin API
+ * exists yet — Issue #538 adds the guarded `/api/v1/blog/posts` endpoints
+ * and will call these same functions, the same pattern
+ * `tenant-admin/application/tenant-settings-directory.ts` established for
+ * sharing a query between an endpoint and an SSR admin page.
+ */
+export type BlogPostSummary = {
+  id: string;
+  tenantId: string;
+  title: string;
+  slug: string;
+  status: string;
+  visibility: string;
+  locale: string;
+  publishedAt: Date | null;
+  updatedAt: Date;
+};
+
+type BlogPostRow = {
+  id: string;
+  tenant_id: string;
+  title: string;
+  slug: string;
+  status: string;
+  visibility: string;
+  locale: string;
+  published_at: Date | null;
+  updated_at: Date;
+};
+
+function toBlogPostSummary(row: BlogPostRow): BlogPostSummary {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    title: row.title,
+    slug: row.slug,
+    status: row.status,
+    visibility: row.visibility,
+    locale: row.locale,
+    publishedAt: row.published_at,
+    updatedAt: row.updated_at
+  };
+}
+
+export async function fetchBlogPostById(
+  tx: Bun.SQL,
+  tenantId: string,
+  postId: string
+): Promise<BlogPostSummary | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, title, slug, status, visibility, locale, published_at, updated_at
+    FROM awcms_mini_blog_posts
+    WHERE tenant_id = ${tenantId} AND id = ${postId} AND deleted_at IS NULL
+  `) as BlogPostRow[];
+
+  const row = rows[0];
+  return row ? toBlogPostSummary(row) : null;
+}
+
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 100;
+
+export async function listBlogPostsByStatus(
+  tx: Bun.SQL,
+  tenantId: string,
+  status: string,
+  limit: number = DEFAULT_LIST_LIMIT
+): Promise<BlogPostSummary[]> {
+  const boundedLimit = Math.min(Math.max(limit, 1), MAX_LIST_LIMIT);
+
+  const rows = (await tx`
+    SELECT id, tenant_id, title, slug, status, visibility, locale, published_at, updated_at
+    FROM awcms_mini_blog_posts
+    WHERE tenant_id = ${tenantId} AND status = ${status} AND deleted_at IS NULL
+    ORDER BY published_at DESC NULLS LAST, updated_at DESC
+    LIMIT ${boundedLimit}
+  `) as BlogPostRow[];
+
+  return rows.map(toBlogPostSummary);
+}

--- a/src/modules/blog-content/application/blog-taxonomy-directory.ts
+++ b/src/modules/blog-content/application/blog-taxonomy-directory.ts
@@ -1,0 +1,51 @@
+/**
+ * Read-only query placeholder (Issue #537, foundation only). No admin API
+ * exists yet — Issue #539 adds the guarded `/api/v1/blog/terms` endpoints
+ * and will call these same functions, same reasoning as
+ * `blog-post-directory.ts`.
+ */
+export type BlogTermSummary = {
+  id: string;
+  tenantId: string;
+  taxonomyType: string;
+  parentId: string | null;
+  name: string;
+  slug: string;
+};
+
+type BlogTermRow = {
+  id: string;
+  tenant_id: string;
+  taxonomy_type: string;
+  parent_id: string | null;
+  name: string;
+  slug: string;
+};
+
+function toBlogTermSummary(row: BlogTermRow): BlogTermSummary {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    taxonomyType: row.taxonomy_type,
+    parentId: row.parent_id,
+    name: row.name,
+    slug: row.slug
+  };
+}
+
+export async function fetchBlogTermsByTaxonomyType(
+  tx: Bun.SQL,
+  tenantId: string,
+  taxonomyType: string
+): Promise<BlogTermSummary[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, taxonomy_type, parent_id, name, slug
+    FROM awcms_mini_blog_terms
+    WHERE tenant_id = ${tenantId}
+      AND taxonomy_type = ${taxonomyType}
+      AND deleted_at IS NULL
+    ORDER BY name ASC
+  `) as BlogTermRow[];
+
+  return rows.map(toBlogTermSummary);
+}

--- a/src/modules/blog-content/domain/content-validation.ts
+++ b/src/modules/blog-content/domain/content-validation.ts
@@ -1,0 +1,112 @@
+import { isValidSlug } from "./slug-policy";
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+/**
+ * Core fields shared by posts and pages (doc issue #537 §Core Data Rules).
+ * Lifecycle fields (`status`, `visibility`), SEO fields, and page-only
+ * fields (`pageType`, `parentPageId`, `menuOrder`) are validated separately
+ * (`post-status.ts`, `seo-validation.ts`) so each concern stays independently
+ * testable — Issue #538/#539's create/update handlers compose all of them.
+ */
+export type BlogContentCoreInput = {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  contentJson: Record<string, unknown>;
+  contentText: string;
+  locale: string;
+};
+
+export type BlogContentCoreValidationResult =
+  | { valid: true; value: BlogContentCoreInput }
+  | { valid: false; errors: ValidationError[] };
+
+const MAX_TITLE_LENGTH = 200;
+const MAX_EXCERPT_LENGTH = 500;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function validateBlogContentCore(
+  body: unknown
+): BlogContentCoreValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+
+  if (!isNonEmptyString(record.title)) {
+    errors.push({ field: "title", message: "title is required." });
+  } else if (record.title.length > MAX_TITLE_LENGTH) {
+    errors.push({
+      field: "title",
+      message: `title must be at most ${MAX_TITLE_LENGTH} characters.`
+    });
+  }
+
+  if (!isNonEmptyString(record.slug)) {
+    errors.push({ field: "slug", message: "slug is required." });
+  } else if (!isValidSlug(record.slug)) {
+    errors.push({
+      field: "slug",
+      message:
+        "slug must be lowercase alphanumeric segments separated by single hyphens."
+    });
+  }
+
+  if (
+    record.excerpt !== undefined &&
+    record.excerpt !== null &&
+    (typeof record.excerpt !== "string" ||
+      record.excerpt.length > MAX_EXCERPT_LENGTH)
+  ) {
+    errors.push({
+      field: "excerpt",
+      message: `excerpt must be a string of at most ${MAX_EXCERPT_LENGTH} characters.`
+    });
+  }
+
+  if (
+    typeof record.contentJson !== "object" ||
+    record.contentJson === null ||
+    Array.isArray(record.contentJson)
+  ) {
+    errors.push({
+      field: "contentJson",
+      message: "contentJson is required and must be an object."
+    });
+  }
+
+  if (!isNonEmptyString(record.contentText)) {
+    errors.push({ field: "contentText", message: "contentText is required." });
+  }
+
+  if (record.locale !== undefined && !isNonEmptyString(record.locale)) {
+    errors.push({
+      field: "locale",
+      message: "locale must be a non-empty string when provided."
+    });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      title: (record.title as string).trim(),
+      slug: (record.slug as string).trim(),
+      excerpt:
+        record.excerpt === undefined || record.excerpt === null
+          ? null
+          : (record.excerpt as string).trim(),
+      contentJson: record.contentJson as Record<string, unknown>,
+      contentText: record.contentText as string,
+      locale: isNonEmptyString(record.locale) ? record.locale.trim() : "id"
+    }
+  };
+}

--- a/src/modules/blog-content/domain/post-status.ts
+++ b/src/modules/blog-content/domain/post-status.ts
@@ -1,0 +1,64 @@
+export type BlogContentStatus =
+  "draft" | "review" | "scheduled" | "published" | "archived";
+
+export const BLOG_CONTENT_STATUSES: readonly BlogContentStatus[] = [
+  "draft",
+  "review",
+  "scheduled",
+  "published",
+  "archived"
+];
+
+export type BlogContentVisibility = "public" | "private" | "unlisted";
+
+export const BLOG_CONTENT_VISIBILITIES: readonly BlogContentVisibility[] = [
+  "public",
+  "private",
+  "unlisted"
+];
+
+export function isBlogContentStatus(
+  value: unknown
+): value is BlogContentStatus {
+  return (
+    typeof value === "string" &&
+    (BLOG_CONTENT_STATUSES as string[]).includes(value)
+  );
+}
+
+export function isBlogContentVisibility(
+  value: unknown
+): value is BlogContentVisibility {
+  return (
+    typeof value === "string" &&
+    (BLOG_CONTENT_VISIBILITIES as string[]).includes(value)
+  );
+}
+
+/**
+ * Allowed forward/back transitions between lifecycle states. Applied by the
+ * lifecycle-action endpoints landing in Issue #538 (publish/schedule/archive)
+ * and Issue #541 (scheduled publishing) — kept here as the single source of
+ * truth so both issues reuse the same rule instead of re-deriving it.
+ */
+const ALLOWED_STATUS_TRANSITIONS: Record<
+  BlogContentStatus,
+  readonly BlogContentStatus[]
+> = {
+  draft: ["review", "scheduled", "published", "archived"],
+  review: ["draft", "scheduled", "published", "archived"],
+  scheduled: ["draft", "published", "archived"],
+  published: ["archived", "draft"],
+  archived: ["draft"]
+};
+
+export function isValidStatusTransition(
+  from: BlogContentStatus,
+  to: BlogContentStatus
+): boolean {
+  if (from === to) {
+    return true;
+  }
+
+  return ALLOWED_STATUS_TRANSITIONS[from].includes(to);
+}

--- a/src/modules/blog-content/domain/seo-validation.ts
+++ b/src/modules/blog-content/domain/seo-validation.ts
@@ -1,0 +1,101 @@
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+export type SeoFieldsInput = {
+  seoTitle?: string | null;
+  metaDescription?: string | null;
+  canonicalUrl?: string | null;
+};
+
+export type SeoValidationResult =
+  | { valid: true; value: SeoFieldsInput }
+  | { valid: false; errors: ValidationError[] };
+
+const MAX_SEO_TITLE_LENGTH = 70;
+const MAX_META_DESCRIPTION_LENGTH = 160;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates the optional SEO metadata shared by posts and pages
+ * (`seo_title`, `meta_description`, `canonical_url`). All three fields are
+ * optional/nullable — this only rejects a *present* value that violates the
+ * shape/length rule, matching how `blog_content.seo.configure` gates just
+ * these fields independent of the rest of the content payload.
+ */
+export function validateSeoFields(input: unknown): SeoValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (input ?? {}) as Record<string, unknown>;
+  const value: SeoFieldsInput = {};
+
+  if (record.seoTitle !== undefined && record.seoTitle !== null) {
+    if (!isNonEmptyString(record.seoTitle)) {
+      errors.push({
+        field: "seoTitle",
+        message: "seoTitle must be a non-empty string."
+      });
+    } else if (record.seoTitle.length > MAX_SEO_TITLE_LENGTH) {
+      errors.push({
+        field: "seoTitle",
+        message: `seoTitle must be at most ${MAX_SEO_TITLE_LENGTH} characters.`
+      });
+    } else {
+      value.seoTitle = record.seoTitle.trim();
+    }
+  } else if (record.seoTitle === null) {
+    value.seoTitle = null;
+  }
+
+  if (record.metaDescription !== undefined && record.metaDescription !== null) {
+    if (!isNonEmptyString(record.metaDescription)) {
+      errors.push({
+        field: "metaDescription",
+        message: "metaDescription must be a non-empty string."
+      });
+    } else if (record.metaDescription.length > MAX_META_DESCRIPTION_LENGTH) {
+      errors.push({
+        field: "metaDescription",
+        message: `metaDescription must be at most ${MAX_META_DESCRIPTION_LENGTH} characters.`
+      });
+    } else {
+      value.metaDescription = record.metaDescription.trim();
+    }
+  } else if (record.metaDescription === null) {
+    value.metaDescription = null;
+  }
+
+  if (record.canonicalUrl !== undefined && record.canonicalUrl !== null) {
+    if (
+      !isNonEmptyString(record.canonicalUrl) ||
+      !isAbsoluteHttpUrl(record.canonicalUrl)
+    ) {
+      errors.push({
+        field: "canonicalUrl",
+        message: "canonicalUrl must be an absolute http(s) URL."
+      });
+    } else {
+      value.canonicalUrl = record.canonicalUrl.trim();
+    }
+  } else if (record.canonicalUrl === null) {
+    value.canonicalUrl = null;
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/blog-content/domain/slug-policy.ts
+++ b/src/modules/blog-content/domain/slug-policy.ts
@@ -1,0 +1,35 @@
+/**
+ * Slug format shared by posts, pages, and terms: lowercase ASCII
+ * alphanumerics separated by single hyphens, no leading/trailing/duplicate
+ * hyphens. Uniqueness itself (`tenant_id, locale, slug` for posts/pages;
+ * `tenant_id, taxonomy_type, slug` for terms) is enforced by the migration's
+ * partial unique index — this only validates the string shape.
+ */
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const MAX_SLUG_LENGTH = 200;
+
+// Combining diacritical marks (U+0300-U+036F) left behind by NFKD
+// normalization, e.g. turning "café" into "cafe" before slugifying.
+const COMBINING_DIACRITICS_PATTERN = /[̀-ͯ]/g;
+
+export function isValidSlug(slug: string): boolean {
+  return (
+    slug.length > 0 && slug.length <= MAX_SLUG_LENGTH && SLUG_PATTERN.test(slug)
+  );
+}
+
+/**
+ * Derives a candidate slug from a title. Callers (Issue #538's create
+ * endpoint) still must check `isValidSlug` and dedup against existing rows —
+ * this is a convenience default, not a guarantee of uniqueness or validity
+ * (e.g. a title with no ASCII alphanumerics yields an empty string).
+ */
+export function slugify(title: string): string {
+  return title
+    .normalize("NFKD")
+    .replace(COMBINING_DIACRITICS_PATTERN, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/src/modules/blog-content/domain/taxonomy-policy.ts
+++ b/src/modules/blog-content/domain/taxonomy-policy.ts
@@ -1,0 +1,55 @@
+export type TaxonomyType = "category" | "tag";
+
+export const TAXONOMY_TYPES: readonly TaxonomyType[] = ["category", "tag"];
+
+export function isTaxonomyType(value: unknown): value is TaxonomyType {
+  return (
+    typeof value === "string" && (TAXONOMY_TYPES as string[]).includes(value)
+  );
+}
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+export type TermParentValidationResult =
+  { valid: true } | { valid: false; errors: ValidationError[] };
+
+/**
+ * Enforces the two term-hierarchy rules from Issue #537/#539: a `tag` must
+ * never have a `parentId` (schema `CHECK` in
+ * `026_awcms_mini_blog_content_schema.sql` backs this up at the DB level —
+ * this is the pre-insert application-layer check that returns a field-level
+ * error instead of a raw constraint violation), and a term can never be its
+ * own parent. Cross-taxonomy-type parents (a tag id used as a category's
+ * parent) and cycles beyond one level are Issue #539's admin-endpoint
+ * concern, once terms are actually mutable through an API.
+ */
+export function validateTermParent(
+  taxonomyType: TaxonomyType,
+  termId: string | null,
+  parentId: string | null | undefined
+): TermParentValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (taxonomyType === "tag" && parentId != null) {
+    errors.push({
+      field: "parentId",
+      message: "A tag must not have a parentId."
+    });
+  }
+
+  if (parentId != null && termId != null && parentId === termId) {
+    errors.push({
+      field: "parentId",
+      message: "A term cannot be its own parent."
+    });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true };
+}

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -1,0 +1,12 @@
+import { defineModule } from "../_shared/module-contract";
+
+export const blogContentModule = defineModule({
+  key: "blog_content",
+  name: "Blog Content",
+  version: "0.1.0",
+  status: "experimental",
+  description:
+    "Tenant-scoped blog/content management (Issue #537, epic #536) — foundation only: core schema for posts, pages, categories/tags, post-term relations, append-only revisions, redirects, and per-tenant blog settings, plus domain validation (slug, status/visibility lifecycle, SEO fields, taxonomy rules) and read-only application placeholders. No admin/public API, no OpenAPI/AsyncAPI contract, and no UI yet — those land in Issues #538-#543. First domain module registered directly in this base repo (see ADR-0009).",
+  dependencies: ["tenant_admin", "identity_access"],
+  type: "domain"
+});

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,4 +1,5 @@
 import type { ModuleDescriptor } from "./_shared/module-contract";
+import { blogContentModule } from "./blog-content/module";
 import { emailModule } from "./email/module";
 import { formDraftsModule } from "./form-drafts/module";
 import { identityAccessModule } from "./identity-access/module";
@@ -20,7 +21,8 @@ export const modules: ModuleDescriptor[] = [
   workflowApprovalModule,
   formDraftsModule,
   emailModule,
-  moduleManagementModule
+  moduleManagementModule,
+  blogContentModule
 ];
 
 export function getModuleByKey(

--- a/tests/blog-content-domain.test.ts
+++ b/tests/blog-content-domain.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateBlogContentCore } from "../src/modules/blog-content/domain/content-validation";
+import {
+  isValidStatusTransition,
+  isBlogContentStatus,
+  isBlogContentVisibility
+} from "../src/modules/blog-content/domain/post-status";
+import {
+  isValidSlug,
+  slugify
+} from "../src/modules/blog-content/domain/slug-policy";
+import { validateSeoFields } from "../src/modules/blog-content/domain/seo-validation";
+import {
+  isTaxonomyType,
+  validateTermParent
+} from "../src/modules/blog-content/domain/taxonomy-policy";
+
+describe("validateBlogContentCore", () => {
+  test("accepts a valid core payload and trims/defaults fields", () => {
+    const result = validateBlogContentCore({
+      title: "  Hello World  ",
+      slug: "hello-world",
+      excerpt: null,
+      contentJson: { blocks: [] },
+      contentText: "Hello world body."
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({
+        title: "Hello World",
+        slug: "hello-world",
+        excerpt: null,
+        contentJson: { blocks: [] },
+        contentText: "Hello world body.",
+        locale: "id"
+      });
+    }
+  });
+
+  test("rejects a missing title and an invalid slug together", () => {
+    const result = validateBlogContentCore({
+      slug: "Not A Valid Slug!",
+      contentJson: {},
+      contentText: "body"
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      const fields = result.errors.map((error) => error.field);
+      expect(fields).toContain("title");
+      expect(fields).toContain("slug");
+    }
+  });
+
+  test("rejects a non-object contentJson", () => {
+    const result = validateBlogContentCore({
+      title: "Title",
+      slug: "title",
+      contentJson: "not-an-object",
+      contentText: "body"
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain(
+        "contentJson"
+      );
+    }
+  });
+});
+
+describe("post-status", () => {
+  test("recognizes valid status/visibility values", () => {
+    expect(isBlogContentStatus("published")).toBe(true);
+    expect(isBlogContentStatus("bogus")).toBe(false);
+    expect(isBlogContentVisibility("unlisted")).toBe(true);
+    expect(isBlogContentVisibility("bogus")).toBe(false);
+  });
+
+  test("allows draft -> review -> published lifecycle transitions", () => {
+    expect(isValidStatusTransition("draft", "review")).toBe(true);
+    expect(isValidStatusTransition("review", "published")).toBe(true);
+    expect(isValidStatusTransition("published", "archived")).toBe(true);
+  });
+
+  test("rejects an archived -> published transition", () => {
+    expect(isValidStatusTransition("archived", "published")).toBe(false);
+  });
+
+  test("allows a no-op same-state transition", () => {
+    expect(isValidStatusTransition("draft", "draft")).toBe(true);
+  });
+});
+
+describe("slug-policy", () => {
+  test("accepts a well-formed slug", () => {
+    expect(isValidSlug("hello-world-2026")).toBe(true);
+  });
+
+  test("rejects uppercase, spaces, and leading/trailing hyphens", () => {
+    expect(isValidSlug("Hello World")).toBe(false);
+    expect(isValidSlug("-hello-")).toBe(false);
+    expect(isValidSlug("")).toBe(false);
+  });
+
+  test("slugify derives a valid slug from a title with punctuation and accents", () => {
+    const slug = slugify("Café: à la Mode!!");
+    expect(isValidSlug(slug)).toBe(true);
+    expect(slug).toBe("cafe-a-la-mode");
+  });
+});
+
+describe("validateSeoFields", () => {
+  test("accepts an empty payload (all fields optional)", () => {
+    const result = validateSeoFields({});
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a seoTitle over the length limit", () => {
+    const result = validateSeoFields({ seoTitle: "x".repeat(71) });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain("seoTitle");
+    }
+  });
+
+  test("rejects a non-absolute canonicalUrl", () => {
+    const result = validateSeoFields({ canonicalUrl: "/relative/path" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain(
+        "canonicalUrl"
+      );
+    }
+  });
+
+  test("accepts an absolute https canonicalUrl", () => {
+    const result = validateSeoFields({
+      canonicalUrl: "https://example.com/post"
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("taxonomy-policy", () => {
+  test("isTaxonomyType recognizes category and tag only", () => {
+    expect(isTaxonomyType("category")).toBe(true);
+    expect(isTaxonomyType("tag")).toBe(true);
+    expect(isTaxonomyType("bogus")).toBe(false);
+  });
+
+  test("rejects a tag with a parentId", () => {
+    const result = validateTermParent("tag", "term-1", "term-2");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors[0]?.field).toBe("parentId");
+    }
+  });
+
+  test("allows a category with a distinct parentId", () => {
+    const result = validateTermParent("category", "term-1", "term-2");
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a term being its own parent", () => {
+    const result = validateTermParent("category", "term-1", "term-1");
+    expect(result.valid).toBe(false);
+  });
+});

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -58,8 +58,8 @@ describe("soft delete helper", () => {
 });
 
 describe("module registry", () => {
-  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, email, and module_management are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498, #511-#513", () => {
-    expect(listModules()).toHaveLength(10);
+  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, email, module_management, and blog_content are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498, #511-#513, #537", () => {
+    expect(listModules()).toHaveLength(11);
     expect(getModuleByKey("tenant_admin")).toMatchObject({
       key: "tenant_admin",
       status: "active"
@@ -109,6 +109,13 @@ describe("module registry", () => {
       status: "active",
       type: "system",
       isCore: true,
+      dependencies: ["tenant_admin", "identity_access"]
+    });
+    expect(getModuleByKey("blog_content")).toMatchObject({
+      key: "blog_content",
+      version: "0.1.0",
+      status: "experimental",
+      type: "domain",
       dependencies: ["tenant_admin", "identity_access"]
     });
     expect(getModuleByKey("unknown_module")).toBeUndefined();
@@ -215,7 +222,9 @@ describe("database migration runner helpers", () => {
       "022_awcms_mini_password_reset_schema.sql",
       "023_awcms_mini_email_announcement_permission_schema.sql",
       "024_awcms_mini_email_message_cancel_permission_schema.sql",
-      "025_awcms_mini_module_management_schema.sql"
+      "025_awcms_mini_module_management_schema.sql",
+      "026_awcms_mini_blog_content_schema.sql",
+      "027_awcms_mini_blog_content_permissions.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/blog-content-schema.integration.test.ts
+++ b/tests/integration/blog-content-schema.integration.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Integration tests for the blog_content foundation schema/RLS (Issue #537,
+ * epic #536) against a real PostgreSQL. No endpoints exist yet (Issue #538
+ * onward add them) — this exercises migration 026/027's constraints and RLS
+ * enforcement directly via `withTenant`/raw admin SQL, same pattern
+ * `module-management-schema.integration.test.ts` (#512) used.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+
+const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const AUTHOR_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+async function seedTenants(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES
+      (${TENANT_A}, 'tenant-a', 'Tenant A', 'Tenant A Legal', 'active', 'en', 'light'),
+      (${TENANT_B}, 'tenant-b', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("blog_content schema — RLS isolation and constraints", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+  });
+
+  test("blog_content permission catalog is seeded", async () => {
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT activity_code, action FROM awcms_mini_permissions
+      WHERE module_key = 'blog_content'
+      ORDER BY activity_code, action
+    `) as { activity_code: string; action: string }[];
+
+    expect(rows.map((row) => `${row.activity_code}.${row.action}`)).toEqual([
+      "pages.archive",
+      "pages.create",
+      "pages.delete",
+      "pages.publish",
+      "pages.purge",
+      "pages.read",
+      "pages.restore",
+      "pages.update",
+      "posts.archive",
+      "posts.create",
+      "posts.delete",
+      "posts.export",
+      "posts.publish",
+      "posts.purge",
+      "posts.read",
+      "posts.restore",
+      "posts.schedule",
+      "posts.update",
+      "revisions.read",
+      "revisions.restore",
+      "search.read",
+      "seo.configure",
+      "settings.configure",
+      "settings.read",
+      "taxonomies.configure",
+      "taxonomies.read"
+    ]);
+  });
+
+  test("tenant A cannot see tenant B's posts (RLS isolation)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_blog_posts
+        (tenant_id, author_tenant_user_id, title, slug, content_json, content_text, status)
+      VALUES
+        (${TENANT_A}, ${AUTHOR_ID}, 'A post', 'a-post', '{}'::jsonb, 'body', 'draft'),
+        (${TENANT_B}, ${AUTHOR_ID}, 'B post', 'b-post', '{}'::jsonb, 'body', 'draft')
+    `;
+
+    const sql = getDatabaseClient();
+    const tenantARows = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT slug FROM awcms_mini_blog_posts`
+    );
+    expect(tenantARows).toHaveLength(1);
+    expect((tenantARows as { slug: string }[])[0]?.slug).toBe("a-post");
+  });
+
+  test("querying posts without a tenant GUC set returns no rows (fail-closed)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_blog_posts
+        (tenant_id, author_tenant_user_id, title, slug, content_json, content_text, status)
+      VALUES (${TENANT_A}, ${AUTHOR_ID}, 'A post', 'a-post', '{}'::jsonb, 'body', 'draft')
+    `;
+
+    const sql = getDatabaseClient();
+    const rows = await sql`SELECT slug FROM awcms_mini_blog_posts`;
+    expect(rows).toHaveLength(0);
+  });
+
+  test("posts rejects an unknown status", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+
+    try {
+      await admin`
+        INSERT INTO awcms_mini_blog_posts
+          (tenant_id, author_tenant_user_id, title, slug, content_json, content_text, status)
+        VALUES (${TENANT_A}, ${AUTHOR_ID}, 'A post', 'a-post', '{}'::jsonb, 'body', 'bogus')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("posts enforces unique slug per tenant+locale among non-deleted rows", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_blog_posts
+        (tenant_id, author_tenant_user_id, title, slug, content_json, content_text, status, locale)
+      VALUES (${TENANT_A}, ${AUTHOR_ID}, 'A post', 'dup-slug', '{}'::jsonb, 'body', 'draft', 'id')
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_blog_posts
+          (tenant_id, author_tenant_user_id, title, slug, content_json, content_text, status, locale)
+        VALUES (${TENANT_A}, ${AUTHOR_ID}, 'Another post', 'dup-slug', '{}'::jsonb, 'body', 'draft', 'id')
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+
+    // Different locale is allowed to reuse the same slug.
+    const rows = await admin`
+      INSERT INTO awcms_mini_blog_posts
+        (tenant_id, author_tenant_user_id, title, slug, content_json, content_text, status, locale)
+      VALUES (${TENANT_A}, ${AUTHOR_ID}, 'Another post', 'dup-slug', '{}'::jsonb, 'body', 'draft', 'en')
+      RETURNING id
+    `;
+    expect(rows).toHaveLength(1);
+  });
+
+  test("terms rejects a tag with a parent_id", async () => {
+    const admin = getAdminSql();
+    const categoryRows = await admin`
+      INSERT INTO awcms_mini_blog_terms (tenant_id, taxonomy_type, name, slug)
+      VALUES (${TENANT_A}, 'category', 'News', 'news')
+      RETURNING id
+    `;
+    const categoryId = (categoryRows as { id: string }[])[0]!.id;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_blog_terms (tenant_id, taxonomy_type, parent_id, name, slug)
+        VALUES (${TENANT_A}, 'tag', ${categoryId}, 'Breaking', 'breaking')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("terms allows a category with a parent_id and enforces slug dedup per taxonomy type", async () => {
+    const admin = getAdminSql();
+    const parentRows = await admin`
+      INSERT INTO awcms_mini_blog_terms (tenant_id, taxonomy_type, name, slug)
+      VALUES (${TENANT_A}, 'category', 'News', 'news')
+      RETURNING id
+    `;
+    const parentId = (parentRows as { id: string }[])[0]!.id;
+
+    const childRows = await admin`
+      INSERT INTO awcms_mini_blog_terms (tenant_id, taxonomy_type, parent_id, name, slug)
+      VALUES (${TENANT_A}, 'category', ${parentId}, 'World News', 'world-news')
+      RETURNING id
+    `;
+    expect(childRows).toHaveLength(1);
+
+    // Same slug but different taxonomy_type ('tag') is allowed to coexist.
+    const tagRows = await admin`
+      INSERT INTO awcms_mini_blog_terms (tenant_id, taxonomy_type, name, slug)
+      VALUES (${TENANT_A}, 'tag', 'News', 'news')
+      RETURNING id
+    `;
+    expect(tagRows).toHaveLength(1);
+  });
+
+  test("post_terms enforces one row per (post, term) and is tenant-isolated", async () => {
+    const admin = getAdminSql();
+    const postRows = await admin`
+      INSERT INTO awcms_mini_blog_posts
+        (tenant_id, author_tenant_user_id, title, slug, content_json, content_text, status)
+      VALUES (${TENANT_A}, ${AUTHOR_ID}, 'A post', 'a-post', '{}'::jsonb, 'body', 'draft')
+      RETURNING id
+    `;
+    const postId = (postRows as { id: string }[])[0]!.id;
+
+    const termRows = await admin`
+      INSERT INTO awcms_mini_blog_terms (tenant_id, taxonomy_type, name, slug)
+      VALUES (${TENANT_A}, 'tag', 'Featured', 'featured')
+      RETURNING id
+    `;
+    const termId = (termRows as { id: string }[])[0]!.id;
+
+    await admin`
+      INSERT INTO awcms_mini_blog_post_terms (tenant_id, post_id, term_id)
+      VALUES (${TENANT_A}, ${postId}, ${termId})
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_blog_post_terms (tenant_id, post_id, term_id)
+        VALUES (${TENANT_A}, ${postId}, ${termId})
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+  });
+
+  test("revisions enforces one row per (tenant, resource, revision_number)", async () => {
+    const admin = getAdminSql();
+    const postRows = await admin`
+      INSERT INTO awcms_mini_blog_posts
+        (tenant_id, author_tenant_user_id, title, slug, content_json, content_text, status)
+      VALUES (${TENANT_A}, ${AUTHOR_ID}, 'A post', 'a-post', '{}'::jsonb, 'body', 'draft')
+      RETURNING id
+    `;
+    const postId = (postRows as { id: string }[])[0]!.id;
+
+    await admin`
+      INSERT INTO awcms_mini_blog_revisions
+        (tenant_id, resource_type, resource_id, revision_number, title, content_json, content_text, status, created_by_tenant_user_id)
+      VALUES (${TENANT_A}, 'post', ${postId}, 1, 'A post', '{}'::jsonb, 'body', 'draft', ${AUTHOR_ID})
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_blog_revisions
+          (tenant_id, resource_type, resource_id, revision_number, title, content_json, content_text, status, created_by_tenant_user_id)
+        VALUES (${TENANT_A}, 'post', ${postId}, 1, 'A post again', '{}'::jsonb, 'body', 'draft', ${AUTHOR_ID})
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+  });
+
+  test("redirects enforces unique from_path per tenant among active rows", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_blog_redirects (tenant_id, from_path, to_path)
+      VALUES (${TENANT_A}, '/old-path', '/new-path')
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_blog_redirects (tenant_id, from_path, to_path)
+        VALUES (${TENANT_A}, '/old-path', '/another-path')
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+  });
+
+  test("settings is one row per tenant and tenant-isolated", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_blog_settings (tenant_id, default_locale)
+      VALUES (${TENANT_A}, 'en'), (${TENANT_B}, 'id')
+    `;
+
+    const sql = getDatabaseClient();
+    const tenantARows = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT default_locale FROM awcms_mini_blog_settings`
+    );
+    expect(tenantARows).toHaveLength(1);
+    expect(
+      (tenantARows as { default_locale: string }[])[0]?.default_locale
+    ).toBe("en");
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_blog_settings (tenant_id, default_locale)
+        VALUES (${TENANT_A}, 'en')
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Scaffolds the `blog_content` module foundation (Issue #537, epic #536) — the first domain module registered directly in this base repo (see `docs/adr/0009-public-tenant-scoped-routes.md`).
- `src/modules/blog-content/`: module descriptor (`key: blog_content`, `version: 0.1.0`, `status: experimental`), domain validation (`content-validation`, `post-status`, `slug-policy`, `seo-validation`, `taxonomy-policy`), and read-only application query placeholders (`blog-post-directory`, `blog-taxonomy-directory`).
- `sql/026_awcms_mini_blog_content_schema.sql`: 7 tenant-scoped tables (posts, pages, terms, post-term relations, append-only revisions, redirects, per-tenant settings), all `ENABLE`+`FORCE ROW LEVEL SECURITY` with a `tenant_isolation` policy each.
- `sql/027_awcms_mini_blog_content_permissions.sql`: the 26-entry `blog_content.*` permission seed exactly per the issue spec.
- Registers the module in `src/modules/index.ts`; updates `tests/foundation.test.ts`'s registry/migration-list assertions accordingly.
- Adds a project skill `.claude/skills/awcms-mini-blog-content` (wired into `AGENTS.md`/`.claude/skills/README.md`) capturing the decisions this issue made, so Issues #538-#543 reuse rather than re-derive them.
- Updates `AGENTS.md`'s module map to note `blog_content` as an explicit exception to "domain modules live in derived apps."
- Adds a changeset.

No admin/public API, OpenAPI/AsyncAPI, or UI — out of scope per the issue (Issues #538-#543).

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun run check:docs`
- [x] `bun run api:spec:check`
- [x] `bun run db:migrate` against a real PostgreSQL (migrations 026/027 apply cleanly)
- [x] `bun test` against the same real PostgreSQL — 723 pass, 0 fail (includes new unit test `tests/blog-content-domain.test.ts` and new RLS integration test `tests/integration/blog-content-schema.integration.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)