### PR TITLE
feat(blog-content): add admin UI, settings API, and final hardening (Issue #543)

### DIFF
--- a/.changeset/blog-content-admin-ui-hardening.md
+++ b/.changeset/blog-content-admin-ui-hardening.md
@@ -1,0 +1,21 @@
+---
+"awcms-mini": minor
+---
+
+Add the full admin UI, blog settings API, and final hardening for the
+`blog_content` module (Issue #543, epic #536 — closing the epic). New
+screens under `/admin/blog` (dashboard, posts list/editor with lifecycle
+actions and revision history, pages list/editor, categories, tags,
+settings, and optional templates/widgets/menus/ads managers), all Astro +
+vanilla JS reusing the existing `AdminLayout`/design tokens, with loading/
+empty/error/ready states, double-submit prevention, and confirm-then-
+`Idempotency-Key` on every high-risk action. New `GET`/`PATCH
+/api/v1/blog/settings` endpoint activates `awcms_mini_blog_settings`
+(schema present since migration 026, unwired until now), publishing
+`blog-content.settings.updated` — the module's AsyncAPI contract's last
+producer-less channel. RSS feed and sitemap now respect the new
+`rssEnabled`/`sitemapEnabled` settings (404 when disabled, indistinguishable
+from an unknown tenant). `module.ts` now declares its full `permissions`
+(36 entries, matching migrations 027/030) and `navigation` (`/admin/blog`)
+arrays, previously empty despite the permissions already existing in the
+database. No schema changes.

--- a/.claude/skills/awcms-mini-blog-content/SKILL.md
+++ b/.claude/skills/awcms-mini-blog-content/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: awcms-mini-blog-content
-description: Kerjakan bagian mana pun dari epic blog_content AWCMS-Mini (Issue #537-#543, epic #536) — posts, pages, taxonomi, search, rute publik, revisi/scheduled publishing, template/menu/widget/ads/theme/multilingual/gallery, atau UI admin blog. Gunakan saat menambah endpoint/logic ke src/modules/blog-content atau src/pages/blog, mengubah schema blog, atau melanjutkan issue lanjutan epic ini. Merangkum keputusan yang sudah dibuat di Issue #537-#542 supaya tidak diulang/dikontradiksi.
+description: Kerjakan bagian mana pun dari epic blog_content AWCMS-Mini (Issue #537-#543, epic #536 — SELESAI) — posts, pages, taxonomi, search, rute publik, revisi/scheduled publishing, template/menu/widget/ads/theme/multilingual/gallery, admin UI blog, atau blog settings API. Gunakan saat menambah endpoint/logic ke src/modules/blog-content, src/pages/blog, atau src/pages/admin/blog, mengubah schema blog, atau mengerjakan issue susulan di luar epic ini. Merangkum keputusan yang sudah dibuat di Issue #537-#543 supaya tidak diulang/dikontradiksi.
 ---
 
 # AWCMS-Mini — Blog Content Module
@@ -8,11 +8,12 @@ description: Kerjakan bagian mana pun dari epic blog_content AWCMS-Mini (Issue #
 `blog_content` (`src/modules/blog-content`) adalah **modul domain pertama
 yang didaftarkan langsung di repo base ini** (epic #536, bukan di aplikasi
 turunan terpisah — lihat `AGENTS.md` §Peta modul dan
-`docs/adr/0009-public-tenant-scoped-routes.md`). Skill ini merangkum
-keputusan Issue #537-#542 (semuanya sudah selesai) yang **wajib** dipakai
-ulang oleh Issue #543, bukan didesain ulang — baca
-`src/modules/blog-content/README.md` untuk detail lengkap tiap tabel dan
-endpoint.
+`docs/adr/0009-public-tenant-scoped-routes.md`). Epic #536 (Issue #537-#543)
+**sudah selesai** — modul terdaftar `status: "active"` (bukan lagi
+`experimental`). Skill ini merangkum keputusan yang sudah dibuat supaya
+issue susulan (di luar epic ini) **wajib** memakai ulang, bukan
+mendesain ulang — baca `src/modules/blog-content/README.md` untuk detail
+lengkap tiap tabel dan endpoint.
 
 ## Kapan pakai skill ini vs skill generik
 
@@ -24,15 +25,15 @@ membaca satu file migration.
 
 ## Status per issue (jangan bangun ulang yang sudah ada)
 
-| Issue | Scope                                       | Status                                                                           |
-| ----- | ------------------------------------------- | -------------------------------------------------------------------------------- |
-| #537  | Schema, domain validation, permission seed  | **Selesai** (migration 026/027)                                                  |
-| #538  | Admin API + lifecycle actions (posts)       | **Selesai** (`/api/v1/blog/posts`, lihat README)                                 |
-| #539  | Pages, taxonomi, post-term relation, search | **Selesai** (`/api/v1/blog/pages`, `/terms`, `/search`)                          |
-| #540  | Rute publik, RSS, sitemap, SEO              | **Selesai** (`/blog/{tenantCode}/...`, lihat README)                             |
-| #541  | Revisions + scheduled publishing + AsyncAPI | **Selesai** (`/posts/{id}/revisions`, `blog:publish:scheduled`, lihat README)    |
-| #542  | Template/menu/widget/media/multilingual/ads | **Selesai** (`/templates`, `/menus`, `/widgets`, `/ads`, `/theme`, lihat README) |
-| #543  | Admin UI, dokumentasi akhir, hardening      | Belum                                                                            |
+| Issue | Scope                                                     | Status                                                                           |
+| ----- | --------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| #537  | Schema, domain validation, permission seed                | **Selesai** (migration 026/027)                                                  |
+| #538  | Admin API + lifecycle actions (posts)                     | **Selesai** (`/api/v1/blog/posts`, lihat README)                                 |
+| #539  | Pages, taxonomi, post-term relation, search               | **Selesai** (`/api/v1/blog/pages`, `/terms`, `/search`)                          |
+| #540  | Rute publik, RSS, sitemap, SEO                            | **Selesai** (`/blog/{tenantCode}/...`, lihat README)                             |
+| #541  | Revisions + scheduled publishing + AsyncAPI               | **Selesai** (`/posts/{id}/revisions`, `blog:publish:scheduled`, lihat README)    |
+| #542  | Template/menu/widget/media/multilingual/ads               | **Selesai** (`/templates`, `/menus`, `/widgets`, `/ads`, `/theme`, lihat README) |
+| #543  | Admin UI, blog settings API, dokumentasi akhir, hardening | **Selesai** (14 layar `/admin/blog/...`, `/api/v1/blog/settings`, lihat README)  |
 
 ## Yang sudah ada — pakai ulang, jangan re-derive
 
@@ -46,7 +47,9 @@ membaca satu file migration.
 - **Rute publik** (`src/pages/blog/[tenantCode]/`, Issue #540): index, detail post, arsip kategori/tag, search, `feed.xml`, `sitemap-blog.xml` — 7 `APIRoute` (`.ts`, bukan `.astro`, lihat §Aturan #10). Semua anonim, resolusi tenant lewat `src/lib/tenant/public-tenant-resolver.ts`'s `resolvePublicTenantByCode` (ADR-0009). Query publik ada di `public-blog-directory.ts` (**bukan** `blog-post-directory.ts` yang admin-only), rendering aman di `content-block-rendering.ts`/`seo-rendering.ts`/`public-page-rendering.ts`. **Hanya post**, tidak ada rute publik untuk pages, widget, atau ads (helper-nya `listActiveAdsForPlacement`/`renderAdHtml`/`listWidgets({activeOnly:true})` sudah ada dan teruji, belum ada rute yang memasangnya).
 - **API presentasi** (Issue #542): `src/pages/api/v1/blog/{templates,menus,widgets,ads}/` (CRUD, satu permission `configure` menggerbangi create/update/delete, pola sama taxonomies) dan `src/pages/api/v1/blog/theme/` (`GET`/`PATCH`, satu baris per tenant, fallback ke `awcms_mini_tenants.default_theme`). Menu items dan ad placements full-replace via sub-array di payload (`items`/`placements`), sama seperti `termIds`.
 - **Gallery block** (Issue #542, `content-block-rendering.ts`): tipe block baru `{ type: "gallery", items: GalleryItem[] }` (image/video, whitelist render, `<img>`/`<video controls>` saja) — **bukan** tabel/endpoint media terpisah, karena tidak ada base media library nyata untuk diintegrasikan (`featuredMediaId` cuma UUID longgar tanpa FK).
-- **AsyncAPI domain events** (`asyncapi/awcms-mini-domain-events.asyncapi.yaml`): 26 channel `awcms-mini.blog-content.*` (13 dari #541 + 13 dari #542), terdaftar juga di `module.ts`'s `events.publishes`. **Dokumentasi kontrak saja** — produser nyatanya structured JSON logger (`log()`), bukan event bus, konvensi sama sejak Issue 0.3 (lihat pola `email.*` sebagai precedent). 25 dari 26 punya log line nyata; `settings.updated` belum (belum ada endpoint `awcms_mini_blog_settings`, beda dari `theme.updated` yang sudah punya produser sejak #542).
+- **API settings** (Issue #543, `src/pages/api/v1/blog/settings/`): `GET`/`PATCH`, satu baris per tenant (`awcms_mini_blog_settings`, migration 026 — kolom typed `default_locale`/`default_visibility`/`posts_per_page`/`seo_default_title`/`seo_default_description` ditulis/dibaca lewat route untuk pertama kali di #543; `blogTitle`/`blogDescription`/`rssEnabled`/`sitemapEnabled` di kolom jsonb `settings` catch-all). Directory `blog-settings-directory.ts` (`fetchBlogSettings`/`upsertBlogSettings`, merge-patch upsert), policy `blog-settings-policy.ts` (`validateUpdateBlogSettingsInput`). Guard `blog_content.settings.{read,configure}`, audit `blog.settings.updated`, terdaftar di OpenAPI (`paths./api/v1/blog/settings`) dan closing gap AsyncAPI `settings.updated` (lihat di bawah). `feed.xml.ts`/`sitemap-blog.xml.ts` (#540) sekarang membaca `rssEnabled`/`sitemapEnabled` dari sini — tenant yang mematikannya dapat `404` identik dengan tenant tak dikenal (sama seperti aturan #5, tidak ada sinyal pembeda).
+- **Admin UI** (Issue #543, `src/pages/admin/blog/`): 14 layar Astro (`+ vanilla JS`, tanpa framework baru), reuse `AdminLayout` + design token existing, pola SSR-read-lewat-application-layer + mutasi-lewat-fetch-ke-endpoint-terguard **identik** dengan `src/pages/admin/modules/[moduleKey].astro` (referensi utama) — dashboard (`index.astro`), posts (`posts/index.astro`, `/new`, `/[id]` — termasuk lifecycle action + revision history), pages (`pages/index.astro`, `/new`, `/[id]` — **tanpa** lifecycle action, sesuai README §Belum tersedia), `categories.astro`, `tags.astro` (tag structural tidak punya field `parentId` sama sekali, bukan cuma disembunyikan), `settings.astro`, dan layar opsional `templates.astro`/`widgets.astro`/`menus.astro`/`ads.astro` (disertakan karena #542 sudah merged). Semua aksi high-risk (publish/schedule/archive/restore/purge/revision-restore/delete) wajib `window.confirm` + `Idempotency-Key` baru per attempt (`newIdempotencyKey()` di `src/lib/ui/admin-form-client.ts`) + tombol submit terkunci selama in-flight. `module.ts`'s `navigation` array (satu entry `/admin/blog`, guard `blog_content.posts.read`) dan `permissions` array (36 entry, persis mirror migration 027+030) baru dideklarasikan di #543 — sebelumnya kosong meski permission-nya sudah lama ada di DB.
+- **AsyncAPI domain events** (`asyncapi/awcms-mini-domain-events.asyncapi.yaml`): 26 channel `awcms-mini.blog-content.*` (13 dari #541 + 13 dari #542), terdaftar juga di `module.ts`'s `events.publishes`. **Dokumentasi kontrak saja** — produser nyatanya structured JSON logger (`log()`), bukan event bus, konvensi sama sejak Issue 0.3 (lihat pola `email.*` sebagai precedent). Sejak #543 **semua 26 channel punya produser nyata** — `settings.updated` (yang sebelumnya reserved-tanpa-produser) sekarang di-log dari `PATCH /api/v1/blog/settings`.
 
 ## Aturan lintas-issue yang wajib diikuti
 
@@ -71,4 +74,16 @@ membaca satu file migration.
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Belum ada rute publik untuk pages (hanya post yang punya rute publik di #540), rute baca/restore revisi untuk pages (hanya post punya rute revisi di #541, meski page tetap mengumpulkan revisi lewat `PATCH`), endpoint `blog_content.settings.*` (AsyncAPI `settings.updated` sudah didaftarkan tapi belum ada produsernya, beda dari `theme.updated` yang sudah punya produser sejak #542), atau admin UI (#543). `src/modules/blog-content/README.md` §Belum tersedia berisi daftar lengkap per issue. Page lifecycle-action endpoints (`publish`/`schedule`/`archive`/`restore`/`purge` untuk pages) juga **belum ada** meski permission-nya sudah diseed sejak #537 — jangan asumsikan itu selesai hanya karena posts sudah punya lifecycle lengkap. Locale-aware negotiation untuk pengunjung publik (mis. `Accept-Language`) juga belum ada — rute publik saat ini tidak memfilter berdasarkan preferensi bahasa pengunjung. Optimistic-concurrency check yang membaca kolom `version` juga masih belum ada. Rute publik untuk widget/ads rendering (header/sidebar/footer nyata di halaman publik) juga **belum ada** meski #542 sudah menyediakan helper teruji (`listActiveAdsForPlacement`/`renderAdHtml`/`listWidgets({activeOnly:true})`) — jangan asumsikan iklan/widget sudah tampil di halaman publik manapun.
+Epic #536 (Issue #537-#543) sudah selesai seluruhnya, tapi beberapa hal
+tetap **di luar scope epic ini secara sengaja** — jangan asumsikan sudah
+dikerjakan hanya karena epic-nya "selesai":
+
+- Rute publik untuk pages (hanya post yang punya rute publik, #540), dan rute baca/restore revisi untuk pages (hanya post punya rute revisi, #541 — page tetap mengumpulkan revisi lewat `PATCH`, hanya tidak ada endpoint baca/restore-nya).
+- Page lifecycle-action endpoints (`publish`/`schedule`/`archive`/`restore`/`purge` untuk pages) — permission-nya sudah diseed sejak #537, tapi endpoint-nya tidak pernah dibangun di issue manapun (#538-#543). Jangan asumsikan itu selesai hanya karena posts sudah punya lifecycle lengkap dan admin UI post editor punya panel lifecycle.
+- Locale-aware negotiation untuk pengunjung publik (mis. `Accept-Language`) — rute publik tidak memfilter berdasarkan preferensi bahasa pengunjung.
+- Optimistic-concurrency check yang membaca kolom `version`.
+- Rute publik untuk widget/ads rendering (header/sidebar/footer nyata di halaman publik) — helper-nya (`listActiveAdsForPlacement`/`renderAdHtml`/`listWidgets({activeOnly:true})`) sudah ada dan teruji sejak #542, admin CRUD-nya (`/admin/blog/widgets`, `/admin/blog/ads`) sudah ada sejak #543, tapi belum ada satu rute publik pun yang memasangnya di halaman blog.
+- Layar admin dedicated untuk media/gallery — tidak ada base media library (lihat aturan #17), jadi gallery block tetap diedit lewat textarea `content_json` di post/page editor, bukan picker visual.
+- Visual/WYSIWYG editor untuk `content_json`, dan editor visual (tree/drag-drop) untuk menu items/ad placements — admin UI #543 memakai textarea JSON berlabel untuk semuanya, keputusan scope yang disengaja (lihat README §Known limitations).
+
+`src/modules/blog-content/README.md` §Belum tersedia berisi daftar lengkap dan detail per item.

--- a/docs/awcms-mini/04_erd_data_dictionary.md
+++ b/docs/awcms-mini/04_erd_data_dictionary.md
@@ -233,6 +233,23 @@ Mengubah registry modul dari code-only (`src/modules/index.ts`) jadi database-ba
 
 Tidak ada tabel `awcms_mini_module_lifecycle_events` terpisah (sempat diusulkan draft issue awal) — aksi lifecycle/config modul tetap tercatat lewat `awcms_mini_audit_events` generik yang sudah ada (`module_key = 'module_management'`, `resource_type` = `tenant_module`/`module_settings`/`module_health`), menghindari sumber kebenaran kedua yang divergen untuk fakta yang sama.
 
+### Blog Content (Issue #537–#543, epic #536, `sql/026`–`030`)
+
+Modul domain pertama yang didaftarkan langsung di repo base ini (ADR-0009), bukan di aplikasi turunan — lihat `src/modules/blog-content/README.md` untuk detail lengkap kolom/query/endpoint per tabel; ringkasan ERD di sini hanya nama tabel, tujuan, dan tenant-scoping.
+
+Skema inti (`026_awcms_mini_blog_content_schema.sql`, semua tenant-scoped `ENABLE`+`FORCE ROW LEVEL SECURITY`):
+
+- **`awcms_mini_blog_posts`** / **`awcms_mini_blog_pages`** — konten utama. `status` (`draft→review→scheduled→published→archived`), `visibility` (`public|private|unlisted`), `search_vector tsvector` **`GENERATED ALWAYS ... STORED`** (migration `028`, weighted title/excerpt/content_text) — bukan trigger, PostgreSQL sendiri yang menjaganya sinkron. Slug unik per `(tenant_id, locale)` selama aktif. Pages tambah `page_type`/`parent_page_id`/`menu_order`.
+- **`awcms_mini_blog_terms`** — kategori (`taxonomy_type='category'`, boleh `parent_id`) dan tag (`taxonomy_type='tag'`, `CHECK` menolak `parent_id`). Slug unik per `(tenant_id, taxonomy_type)`.
+- **`awcms_mini_blog_post_terms`** — relasi many-to-many post↔term, membawa `tenant_id` sendiri untuk RLS.
+- **`awcms_mini_blog_revisions`** — **append-only** (tidak pernah `UPDATE`/`DELETE`, pola sama `awcms_mini_audit_events`), revision history post/page.
+- **`awcms_mini_blog_redirects`** — soft-deletable, unik per `(tenant_id, from_path)` selama aktif.
+- **`awcms_mini_blog_settings`** — satu baris per tenant (`tenant_id` = PK, pola sama `awcms_mini_tenant_settings`), bukan soft-deletable. Diaktifkan lewat `GET`/`PATCH /api/v1/blog/settings` sejak Issue #543 (kolom sudah ada sejak migration 026).
+
+Skema presentasi (`029_awcms_mini_blog_content_presentation_schema.sql`, Issue #542, RLS FORCE juga): `awcms_mini_blog_templates` (`layout_json` whitelisted), `awcms_mini_blog_menus`+`_menu_items` (hierarki satu level), `awcms_mini_blog_widgets` (posisi tetap, body plain text), `awcms_mini_blog_ads`+`_ad_placements` (placement targeting + jadwal), `awcms_mini_blog_theme_settings` (override `awcms_mini_tenants.default_theme`, satu baris per tenant). Plus kolom `translation_group_id uuid` (nullable) di posts/pages untuk menautkan varian-locale.
+
+Permission seed: 26 permission (`027_awcms_mini_blog_content_permissions.sql`) + 10 permission presentasi (`030_awcms_mini_blog_content_presentation_permissions.sql`) = 36 total, dideklarasikan penuh di `module.ts`'s `permissions` array sejak Issue #543 (sebelumnya array kosong meski permission-nya sudah di DB).
+
 ## Konten multi-bahasa (translatable content)
 
 Berbeda dari **string UI statis** (label/tombol/pesan error) yang memakai katalog `.po` gettext di sisi aplikasi (doc 14 §i18n), **data input pengguna** yang perlu tampil multi-bahasa disimpan **di database, satu nilai per bahasa aktif**. Base generik sudah punya satu contoh nyata (`awcms_mini_email_templates.subject_template`/`text_body_template`/`html_body_template`, `sql/021`, Issue #498 — lihat §Email di atas) — bukan lagi sekadar konvensi belum-terpakai; ini **standar** yang wajib diikuti aplikasi turunan (mis. modul domain seperti `blog_content`, epic #536) saat menambah field konten translatable baru.
@@ -241,6 +258,7 @@ Pola yang diizinkan (pilih per kebutuhan, konsisten dalam satu modul):
 
 - **JSONB per-locale** — kolom `<field>_i18n jsonb` berisi `{ "en": "...", "id": "..." }` untuk semua **bahasa aktif** tenant. Cocok untuk field bebas yang jarang di-query per-bahasa. Fallback ke `default_locale` bila key locale aktif kosong.
 - **Tabel translasi terpisah** — `<entity>_translations (entity_id, locale, field, value)` dengan unique `(entity_id, locale, field)`. Cocok bila konten di-query/urut/cari per-bahasa (perlu index). Tetap tenant-scoped + RLS.
+- **Baris-per-locale + link group** (`blog_content`, Issue #542/#537) — untuk entitas yang keseluruhannya (bukan satu field) berbeda per bahasa dan tetap perlu jadi baris independen dengan slug/status/lifecycle sendiri (mis. blog post): satu kolom `locale` di baris utama (bukan field terpisah), slug unik per `(tenant_id, locale, slug)`, dan kolom penaut opsional (`translation_group_id uuid`, nullable, tanpa FK/trigger) untuk mengelompokkan beberapa baris locale-variant sebagai satu entitas logis. Dipilih ketimbang dua pola di atas karena field individual (title/content/excerpt) tidak perlu tampil serentak lintas bahasa dalam satu render — cukup satu locale per request, sama seperti halaman web pada umumnya.
 
 Aturan:
 

--- a/docs/awcms-mini/05_openapi_asyncapi_detail.md
+++ b/docs/awcms-mini/05_openapi_asyncapi_detail.md
@@ -261,6 +261,52 @@ Database-backed, tenant-aware module registry — generic infrastructure for man
 
 Tidak ada event AsyncAPI baru — perubahan lifecycle/config modul tercatat lewat `awcms_mini_audit_events` generik yang sudah ada, bukan domain event terpisah.
 
+### Blog Content (Issue #537–#543, epic #536)
+
+Modul domain pertama yang didaftarkan langsung di repo base ini (ADR-0009), bukan di aplikasi turunan. Full detail (guard/idempotency/audit per endpoint): `src/modules/blog-content/README.md`. Base path `/api/v1/blog`.
+
+| Method                    | Endpoint                                          | Fungsi                                                                  |
+| ------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------- |
+| GET                       | `/blog/posts`                                     | List post tenant (`?status=`/`?limit=`)                                 |
+| POST                      | `/blog/posts`                                     | Buat post draft                                                         |
+| GET                       | `/blog/posts/{id}`                                | Detail post                                                             |
+| PATCH                     | `/blog/posts/{id}`                                | Update post (ABAC ownership override untuk author konten belum publish) |
+| DELETE                    | `/blog/posts/{id}`                                | Soft delete (`reason` wajib)                                            |
+| POST                      | `/blog/posts/{id}/submit-review`                  | draft/review → review                                                   |
+| POST                      | `/blog/posts/{id}/publish`                        | → published (Idempotency-Key wajib)                                     |
+| POST                      | `/blog/posts/{id}/schedule`                       | → scheduled (Idempotency-Key wajib, body `scheduledAt`)                 |
+| POST                      | `/blog/posts/{id}/archive`                        | → archived (Idempotency-Key wajib)                                      |
+| POST                      | `/blog/posts/{id}/restore`                        | Pulihkan soft-delete (Idempotency-Key wajib)                            |
+| POST                      | `/blog/posts/{id}/purge`                          | Hard delete, hanya archived/soft-deleted (Idempotency-Key wajib)        |
+| GET                       | `/blog/posts/{id}/revisions`                      | List revision history                                                   |
+| GET                       | `/blog/posts/{id}/revisions/{revisionId}`         | Detail satu revisi                                                      |
+| POST                      | `/blog/posts/{id}/revisions/{revisionId}/restore` | Restore konten dari revisi lama (append-only, Idempotency-Key wajib)    |
+| GET/POST/GET/PATCH/DELETE | `/blog/pages(/{id})`                              | CRUD halaman statis — **tanpa** lifecycle-action endpoint               |
+| GET/POST/PATCH/DELETE     | `/blog/terms(/{id})`                              | CRUD kategori/tag (tanpa `GET /{id}`)                                   |
+| GET                       | `/blog/search`                                    | Full-text search admin, keyset-paginated (`?type=`/`?status=`)          |
+| GET/PATCH                 | `/blog/settings`                                  | Pengaturan blog per tenant (Issue #543)                                 |
+| GET/POST/PATCH/DELETE     | `/blog/templates(/{id})`                          | Template layout whitelisted (Issue #542)                                |
+| GET/POST/PATCH/DELETE     | `/blog/menus(/{id})`                              | Menu hierarkis satu level (Issue #542)                                  |
+| GET/POST/PATCH/DELETE     | `/blog/widgets(/{id})`                            | Widget posisi tetap (Issue #542)                                        |
+| GET/POST/PATCH/DELETE     | `/blog/ads(/{id})`                                | Iklan + placement/jadwal (Issue #542)                                   |
+| GET/PATCH                 | `/blog/theme`                                     | Override mode tema blog per tenant (Issue #542)                         |
+
+Rute publik anonim (ADR-0009, resolusi tenant lewat path `tenantCode`, bukan subdomain/header), semua `APIRoute` `.ts` (bukan `.astro`, supaya testable lewat `tests/integration/harness.ts`):
+
+| Method | Endpoint                              | Fungsi                                                  |
+| ------ | ------------------------------------- | ------------------------------------------------------- |
+| GET    | `/blog/{tenantCode}`                  | Index post publik (paginated)                           |
+| GET    | `/blog/{tenantCode}/{slug}`           | Detail post                                             |
+| GET    | `/blog/{tenantCode}/category/{slug}`  | Arsip kategori                                          |
+| GET    | `/blog/{tenantCode}/tag/{slug}`       | Arsip tag                                               |
+| GET    | `/blog/{tenantCode}/search`           | Search publik                                           |
+| GET    | `/blog/{tenantCode}/feed.xml`         | RSS 2.0 (404 kalau `rssEnabled=false`)                  |
+| GET    | `/blog/{tenantCode}/sitemap-blog.xml` | Sitemap protocol 0.9 (404 kalau `sitemapEnabled=false`) |
+
+Admin UI (Issue #543): `/admin/blog/*` — Astro + vanilla JS, tidak menambah endpoint API baru (semua mutasi lewat endpoint di atas). Lihat README modul §Admin UI.
+
+26 domain event AsyncAPI (`awcms-mini.blog-content.*`, §Event utama tidak mendaftarkan semuanya karena volumenya — lihat `asyncapi/awcms-mini-domain-events.asyncapi.yaml` dan README modul §Domain events untuk daftar lengkap + tabel produser). Sejak Issue #543 seluruh 26 channel punya produser nyata (celah terakhir, `settings.updated`, ditutup oleh `PATCH /api/v1/blog/settings`).
+
 ### AI, Reports, Logs, Workflow, Security
 
 | Modul    | Endpoint utama                                                 |

--- a/docs/awcms-mini/07_sprint_testing_production_readiness.md
+++ b/docs/awcms-mini/07_sprint_testing_production_readiness.md
@@ -169,6 +169,8 @@ Piramida: banyak unit test di dasar, sedikit end-to-end di puncak; security & pe
 
 > **Base sudah punya test.** Runner = **`bun test`** (`bun:test`), berkas di `tests/`. Tooling repositori saat ini (`scripts/`) sudah mengikuti pola ini: logika murni `scripts/lib/docs-checks.mjs` diuji unit (`tests/docs-checks.test.mjs`), dan pemeriksa penuh diuji integration (`tests/check-docs-integration.test.mjs`). Daftar target di bawah bersifat **contoh domain** — aplikasi turunan menggantinya dengan target domainnya sendiri.
 
+> **`blog_content` (epic #536) sebagai contoh nyata, bukan lagi ilustratif.** Berbeda dari target POS/warehouse di bawah (yang murni contoh untuk aplikasi turunan), `blog_content` adalah modul domain yang benar-benar berjalan di repo base ini (ADR-0009) dan sudah punya test lengkap di `tests/integration/blog-content-*.integration.test.ts` (schema/RLS, admin API posts/pages/taxonomies/search, public routes, revisions, presentation extensions, dan admin-UI list/lookup functions — Issue #543). Jalankan `bun test tests/integration/blog-content-*.integration.test.ts` (butuh `DATABASE_URL`, lihat §Migration checklist) untuk suite khusus modul ini, atau `bun test` untuk seluruh suite termasuk yang lain.
+
 ### Unit test target
 
 - ABAC evaluator.

--- a/docs/awcms-mini/08_sop_operasional_user_guide.md
+++ b/docs/awcms-mini/08_sop_operasional_user_guide.md
@@ -571,6 +571,39 @@ Kode error dari `POST .../enable` atau `.../disable` (semua `409` kecuali disebu
 4. **Curiga ada secret ter-input ke settings**: request akan **ditolak** di request time (`SETTINGS_SENSITIVE_KEY_REJECTED`) untuk key bernama secret — bila ada kebocoran nilai lewat jalur lain, audit `settings_updated` hanya berisi nama key (bukan nilai), jadi cek langsung baris `awcms_mini_module_settings` (admin DB) sebagai langkah forensik, lalu rotasi kredensial yang bersangkutan di environment variable/secret manager.
 5. **Modul core ter-disable secara tidak sengaja**: tidak mungkin — enforced server-side (`CORE_MODULE_CANNOT_BE_DISABLED`), bukan cuma UI hint.
 
+## SOP Modul Blog Content (epic #536, Issue #537-#543)
+
+Modul domain pertama yang didaftarkan langsung di repo base ini, bukan aplikasi turunan (ADR-0009, `src/modules/blog-content/README.md`). Admin UI penuh di `/admin/blog` (Issue #543), API admin di `/api/v1/blog/*` (Issue #538-#542), rute publik anonim di `/blog/{tenantCode}/*` (Issue #540).
+
+### Mengelola konten lewat admin UI
+
+1. Buka `/admin/blog` — dasbor menampilkan ringkasan post/draft/scheduled/pages dan tautan cepat. Menu ini hanya tampil di sidebar untuk role yang punya `blog_content.posts.read`.
+2. **Post baru**: `/admin/blog/posts/new` — isi title/slug/excerpt/content/visibility/SEO/kategori/tag/locale, simpan (status awal selalu `draft`). Slug bentrok (`409 SLUG_CONFLICT`) ditampilkan langsung di banner aksi.
+3. **Menerbitkan post**: dari `/admin/blog/posts/{id}`, tombol "Publish"/"Schedule"/"Archive" hanya muncul kalau transisi status itu valid dari status saat ini **dan** role pemanggil punya permission aksi tsb (`blog_content.posts.publish`/`.schedule`/`.archive`) — semuanya minta konfirmasi dulu lalu mengirim `Idempotency-Key` baru, aman dari klik ganda.
+4. **Riwayat revisi**: panel "Revision history" di editor post (bukan page — lihat §Keterbatasan di bawah) menampilkan setiap perubahan konten signifikan; tombol "Restore" (butuh `blog_content.revisions.restore` eksplisit — kepemilikan post tidak otomatis memberi izin ini) menulis kembali konten revisi lama **dan** menambah satu revisi baru mencatat pemulihan itu — riwayat tidak pernah hilang.
+5. **Kategori vs tag**: `/admin/blog/categories` (boleh hierarki satu level) dan `/admin/blog/tags` (dua layar terpisah — layar tag secara struktural tidak punya field parent sama sekali, bukan disembunyikan).
+6. **Pengaturan blog**: `/admin/blog/settings` — judul/deskripsi blog, jumlah post per halaman, aktif/nonaktifkan RSS dan sitemap, locale/visibility default, template judul SEO default, dan mode tema (override tenant, `light`/`dark`/`system`).
+7. **Halaman statis**: `/admin/blog/pages` — CRUD saja, **tidak ada** tombol publish/schedule/archive (lihat §Keterbatasan). Visibilitas/status halaman diatur manual lewat field `visibility` yang ada, bukan lifecycle action.
+8. **Layar lanjutan (opsional, aktif karena Issue #542 sudah masuk)**: `/admin/blog/templates`/`/widgets`/`/menus`/`/ads` — CRUD master data presentasi/monetisasi. `items` menu dan `placements` iklan diedit lewat textarea JSON berlabel (bukan editor visual) — baca teks bantuan di bawah tiap field sebelum menyimpan.
+
+### Menonaktifkan RSS/sitemap per tenant
+
+1. `/admin/blog/settings` — matikan centang "Enable RSS feed"/"Enable sitemap", simpan.
+2. Verifikasi: `GET /blog/{tenantCode}/feed.xml` atau `.../sitemap-blog.xml` mengembalikan `404` yang identik dengan tenant tidak dikenal — tidak ada sinyal "fitur ada tapi dimatikan" yang bocor ke pengunjung publik.
+
+### Menjadwalkan publikasi terjadwal (scheduled publishing)
+
+1. `bun run blog:publish:scheduled` (`scripts/blog-scheduled-publish.ts`) — worker internal, **bukan** endpoint HTTP dan **bukan** dipicu dari tombol UI mana pun. Publikasikan setiap post `status='scheduled'` yang `scheduled_at` sudah lewat, per tenant aktif.
+2. Jadwalkan lewat cron/systemd timer setiap 1-5 menit (lihat `docs/awcms-mini/deployment-profiles.md` §Job registry lainnya, sama pola `sync:objects:dispatch`/`logs:audit:purge`) — job ini juga muncul di `GET /api/v1/modules/blog_content/jobs` (Module Management job registry, dokumentasi murni, Issue #519) untuk operator yang memeriksa lewat API.
+3. Idempoten by construction — run berulang di waktu yang sama adalah no-op murni (post yang sudah `published` atau `scheduled_at` masih di masa depan tidak match kondisi job).
+
+### Keterbatasan yang perlu diketahui operator/editor
+
+1. **Halaman statis (pages) tidak punya lifecycle action** — tidak ada tombol publish/schedule/archive/restore/purge untuk page, berbeda dari post. Permission-nya sudah diseed di database tapi belum ada endpoint yang memakainya (backlog terbuka, bukan bug).
+2. **Tidak ada rute publik untuk halaman statis** — hanya post yang tampil di `/blog/{tenantCode}/...`; page yang sudah dibuat lewat admin UI belum bisa diakses lewat URL publik.
+3. **Tidak ada rute publik untuk widget/iklan** — CRUD-nya sudah berfungsi penuh di admin UI, tapi belum ada placement nyata di halaman publik manapun yang menampilkannya.
+4. **Editor konten memakai textarea JSON berlabel**, bukan editor visual/WYSIWYG — field "Content blocks (JSON)" mengharuskan format `{ "blocks": [...] }` valid (paragraph/heading/list/quote/gallery). Salah format ditolak sebelum submit (validasi klien) maupun di server.
+
 ## SOP Backup/Restore
 
 Backup:

--- a/docs/awcms-mini/13_final_master_index_traceability.md
+++ b/docs/awcms-mini/13_final_master_index_traceability.md
@@ -162,6 +162,7 @@ flowchart LR
 | Setup Wizard          | `025_awcms_mini_setup_wizard_extension.sql`                                    |
 | Dashboard Views       | `026_awcms_mini_dashboard_materialized_views.sql`                              |
 | Module Management     | `sql/025_awcms_mini_module_management_schema.sql` (epic #510, Issue #511-#521) |
+| Blog Content          | `sql/026`-`030_awcms_mini_blog_content_*.sql` (epic #536, Issue #537-#543)     |
 
 ## Matrix Modul vs Security Control
 
@@ -189,31 +190,32 @@ flowchart LR
 
 ## Matrix Security Control vs Skill
 
-| Control                               | Skill penegak                                                                                          |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| Tenant isolation + RBAC/ABAC + RLS    | `awcms-mini-abac-guard`                                                                                |
-| Idempotency high-risk                 | `awcms-mini-idempotency`                                                                               |
-| Audit log high-risk                   | `awcms-mini-audit-log`                                                                                 |
-| Sensitive masking                     | `awcms-mini-sensitive-data`                                                                            |
-| Sync HMAC + file checksum             | `awcms-mini-sync-hmac`                                                                                 |
-| Migration aman (RLS/index)            | `awcms-mini-new-migration`                                                                             |
-| Soft delete policy                    | `awcms-mini-new-migration`, `awcms-mini-new-endpoint`, `awcms-mini-abac-guard`, `awcms-mini-audit-log` |
-| API/event contract                    | `awcms-mini-new-endpoint`, `awcms-mini-new-event`                                                      |
-| Testing berlapis                      | `awcms-mini-testing`                                                                                   |
-| Review keamanan                       | `awcms-mini-security-review` + agent `awcms-mini-security-auditor`                                     |
-| Triase CodeQL code scanning           | `awcms-mini-codeql-triage`                                                                             |
-| Review PR / DoD                       | `awcms-mini-pr-review` + agent `awcms-mini-reviewer`                                                   |
-| Go-live gate                          | `awcms-mini-production-preflight`                                                                      |
-| Profil deployment (LAN-first/Coolify) | `awcms-mini-deploy`                                                                                    |
-| UI/design system/a11y                 | `awcms-mini-ui-screen`                                                                                 |
-| Form multi-step (wizard)              | `awcms-mini-wizard-form`                                                                               |
-| Server-side draft persistence         | `awcms-mini-form-drafts`                                                                               |
-| Kirim email transaksional             | `awcms-mini-email`                                                                                     |
-| Kelola sistem Module Management       | `awcms-mini-module-management` (+ `awcms-mini-new-module` untuk scaffold field descriptor)             |
-| Rilis/CHANGELOG                       | `awcms-mini-release`                                                                                   |
-| Legacy migration                      | `awcms-mini-legacy-migration`                                                                          |
-| Implementasi issue                    | skill `awcms-mini-implement-issue` + agent `awcms-mini-coder`                                          |
-| Snapshot docs GitHub                  | `awcms-mini-github-snapshot`                                                                           |
+| Control                                      | Skill penegak                                                                                          |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Tenant isolation + RBAC/ABAC + RLS           | `awcms-mini-abac-guard`                                                                                |
+| Idempotency high-risk                        | `awcms-mini-idempotency`                                                                               |
+| Audit log high-risk                          | `awcms-mini-audit-log`                                                                                 |
+| Sensitive masking                            | `awcms-mini-sensitive-data`                                                                            |
+| Sync HMAC + file checksum                    | `awcms-mini-sync-hmac`                                                                                 |
+| Migration aman (RLS/index)                   | `awcms-mini-new-migration`                                                                             |
+| Soft delete policy                           | `awcms-mini-new-migration`, `awcms-mini-new-endpoint`, `awcms-mini-abac-guard`, `awcms-mini-audit-log` |
+| API/event contract                           | `awcms-mini-new-endpoint`, `awcms-mini-new-event`                                                      |
+| Testing berlapis                             | `awcms-mini-testing`                                                                                   |
+| Review keamanan                              | `awcms-mini-security-review` + agent `awcms-mini-security-auditor`                                     |
+| Triase CodeQL code scanning                  | `awcms-mini-codeql-triage`                                                                             |
+| Review PR / DoD                              | `awcms-mini-pr-review` + agent `awcms-mini-reviewer`                                                   |
+| Go-live gate                                 | `awcms-mini-production-preflight`                                                                      |
+| Profil deployment (LAN-first/Coolify)        | `awcms-mini-deploy`                                                                                    |
+| UI/design system/a11y                        | `awcms-mini-ui-screen`                                                                                 |
+| Form multi-step (wizard)                     | `awcms-mini-wizard-form`                                                                               |
+| Server-side draft persistence                | `awcms-mini-form-drafts`                                                                               |
+| Kirim email transaksional                    | `awcms-mini-email`                                                                                     |
+| Kelola sistem Module Management              | `awcms-mini-module-management` (+ `awcms-mini-new-module` untuk scaffold field descriptor)             |
+| Kerjakan epic blog_content (Issue #537-#543) | `awcms-mini-blog-content`                                                                              |
+| Rilis/CHANGELOG                              | `awcms-mini-release`                                                                                   |
+| Legacy migration                             | `awcms-mini-legacy-migration`                                                                          |
+| Implementasi issue                           | skill `awcms-mini-implement-issue` + agent `awcms-mini-coder`                                          |
+| Snapshot docs GitHub                         | `awcms-mini-github-snapshot`                                                                           |
 
 ## Matrix Modul vs SOP
 
@@ -238,6 +240,7 @@ flowchart LR
 | Backup/restore        | Deployment/Database            |
 | Troubleshooting       | Observability/DB               |
 | Manajemen modul       | Module Management (epic #510)  |
+| Blog/konten           | Blog Content (epic #536)       |
 | Handover              | Semua                          |
 
 ## Matrix kesiapan implementasi

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -784,3 +784,905 @@ msgstr "Could not save your progress. Your entries are still here — try again.
 
 msgid "admin.examples.wizard.draft_resumed_notice"
 msgstr "Resumed your saved draft."
+
+#. admin.blog — Issue #543 (admin UI)
+msgid "admin.layout.nav_blog"
+msgstr "Blog"
+
+msgid "common.filter_all"
+msgstr "All"
+
+msgid "common.previous_page"
+msgstr "Previous page"
+
+msgid "common.next_page"
+msgstr "Next page"
+
+msgid "admin.blog.access_denied_title"
+msgstr "Access denied."
+
+msgid "admin.blog.access_denied_body"
+msgstr "Your account does not have permission to view this blog screen. Contact your tenant admin/owner to request access."
+
+msgid "admin.blog.dashboard.title"
+msgstr "Blog dashboard"
+
+msgid "admin.blog.dashboard.posts_title"
+msgstr "Posts"
+
+msgid "admin.blog.dashboard.total_posts_label"
+msgstr "Total posts"
+
+msgid "admin.blog.dashboard.draft_posts_label"
+msgstr "Drafts"
+
+msgid "admin.blog.dashboard.scheduled_posts_label"
+msgstr "Scheduled"
+
+msgid "admin.blog.dashboard.pages_title"
+msgstr "Pages"
+
+msgid "admin.blog.dashboard.total_pages_label"
+msgstr "Total pages"
+
+msgid "admin.blog.dashboard.quick_links_title"
+msgstr "Quick links"
+
+msgid "admin.blog.dashboard.new_post_link"
+msgstr "New post"
+
+msgid "admin.blog.dashboard.new_page_link"
+msgstr "New page"
+
+msgid "admin.blog.dashboard.manage_posts_link"
+msgstr "Manage posts"
+
+msgid "admin.blog.dashboard.manage_pages_link"
+msgstr "Manage pages"
+
+msgid "admin.blog.dashboard.manage_categories_link"
+msgstr "Manage categories"
+
+msgid "admin.blog.dashboard.manage_tags_link"
+msgstr "Manage tags"
+
+msgid "admin.blog.dashboard.manage_settings_link"
+msgstr "Blog settings"
+
+msgid "admin.blog.dashboard.recent_updates_title"
+msgstr "Recently updated"
+
+msgid "admin.blog.dashboard.no_recent_updates"
+msgstr "No posts yet."
+
+msgid "admin.blog.status.draft"
+msgstr "Draft"
+
+msgid "admin.blog.status.review"
+msgstr "In review"
+
+msgid "admin.blog.status.scheduled"
+msgstr "Scheduled"
+
+msgid "admin.blog.status.published"
+msgstr "Published"
+
+msgid "admin.blog.status.archived"
+msgstr "Archived"
+
+msgid "admin.blog.visibility.public"
+msgstr "Public"
+
+msgid "admin.blog.visibility.private"
+msgstr "Private"
+
+msgid "admin.blog.visibility.unlisted"
+msgstr "Unlisted"
+
+msgid "admin.blog.page_type.standard"
+msgstr "Standard"
+
+msgid "admin.blog.page_type.landing"
+msgstr "Landing"
+
+msgid "admin.blog.page_type.legal"
+msgstr "Legal"
+
+msgid "admin.blog.page_type.system"
+msgstr "System"
+
+msgid "admin.blog.posts.title"
+msgstr "Blog posts"
+
+msgid "admin.blog.posts.new_title"
+msgstr "New post"
+
+msgid "admin.blog.posts.new_button"
+msgstr "New post"
+
+msgid "admin.blog.posts.filters_aria_label"
+msgstr "Post filters"
+
+msgid "admin.blog.posts.search_label"
+msgstr "Search"
+
+msgid "admin.blog.posts.status_filter_label"
+msgstr "Status"
+
+msgid "admin.blog.posts.term_filter_label"
+msgstr "Category/tag"
+
+msgid "admin.blog.posts.apply_filters_button"
+msgstr "Apply filters"
+
+msgid "admin.blog.posts.reset_filters_link"
+msgstr "Reset filters"
+
+msgid "admin.blog.posts.no_posts"
+msgstr "No posts match these filters."
+
+msgid "admin.blog.posts.title_column"
+msgstr "Title"
+
+msgid "admin.blog.posts.status_column"
+msgstr "Status"
+
+msgid "admin.blog.posts.author_column"
+msgstr "Author"
+
+msgid "admin.blog.posts.locale_column"
+msgstr "Locale"
+
+msgid "admin.blog.posts.published_column"
+msgstr "Published"
+
+msgid "admin.blog.posts.updated_column"
+msgstr "Updated"
+
+msgid "admin.blog.posts.unknown_author"
+msgstr "Unknown"
+
+msgid "admin.blog.posts.pagination_aria_label"
+msgstr "Post pagination"
+
+msgid "admin.blog.posts.page_indicator"
+msgstr "Page {page} of {totalPages}"
+
+msgid "admin.blog.posts.not_found_title"
+msgstr "Post not found."
+
+msgid "admin.blog.posts.not_found_body"
+msgstr "This post id does not exist or you do not have permission to view it."
+
+msgid "admin.blog.posts.back_to_list"
+msgstr "Back to post list"
+
+msgid "admin.blog.posts.field_title"
+msgstr "Title"
+
+msgid "admin.blog.posts.field_slug"
+msgstr "Slug"
+
+msgid "admin.blog.posts.slug_hint"
+msgstr "Lowercase letters, numbers, and single hyphens only."
+
+msgid "admin.blog.posts.field_excerpt"
+msgstr "Excerpt"
+
+msgid "admin.blog.posts.field_content_text"
+msgstr "Content (plain text)"
+
+msgid "admin.blog.posts.field_content_json"
+msgstr "Content blocks (JSON)"
+
+msgid "admin.blog.posts.content_json_hint"
+msgstr "Structured content as { \"blocks\": [...] } — paragraph, heading, list, quote, and gallery blocks only. Leave as an empty blocks array if unsure."
+
+msgid "admin.blog.posts.field_visibility"
+msgstr "Visibility"
+
+msgid "admin.blog.posts.field_locale"
+msgstr "Locale"
+
+msgid "admin.blog.posts.field_featured_media_id"
+msgstr "Featured media reference (UUID)"
+
+msgid "admin.blog.posts.featured_media_hint"
+msgstr "Optional. There is no media library yet — enter a UUID reference only."
+
+msgid "admin.blog.posts.field_categories"
+msgstr "Categories"
+
+msgid "admin.blog.posts.no_categories"
+msgstr "No categories yet."
+
+msgid "admin.blog.posts.field_tags"
+msgstr "Tags"
+
+msgid "admin.blog.posts.no_tags"
+msgstr "No tags yet."
+
+msgid "admin.blog.posts.seo_legend"
+msgstr "SEO"
+
+msgid "admin.blog.posts.field_seo_title"
+msgstr "SEO title"
+
+msgid "admin.blog.posts.field_meta_description"
+msgstr "Meta description"
+
+msgid "admin.blog.posts.field_canonical_url"
+msgstr "Canonical URL"
+
+msgid "admin.blog.posts.create_submit"
+msgstr "Create post"
+
+msgid "admin.blog.posts.create_success"
+msgstr "Post created."
+
+msgid "admin.blog.posts.invalid_content_json"
+msgstr "Content blocks must be valid JSON."
+
+msgid "admin.blog.posts.save_button"
+msgstr "Save changes"
+
+msgid "admin.blog.posts.save_success"
+msgstr "Post saved."
+
+msgid "admin.blog.posts.author_label"
+msgstr "Author"
+
+msgid "admin.blog.posts.deleted_label"
+msgstr "Deleted"
+
+msgid "admin.blog.posts.submit_review_button"
+msgstr "Submit for review"
+
+msgid "admin.blog.posts.submit_review_success"
+msgstr "Post submitted for review."
+
+msgid "admin.blog.posts.publish_button"
+msgstr "Publish"
+
+msgid "admin.blog.posts.publish_confirm"
+msgstr "Publish this post now? It will become visible on the public blog if visibility is public."
+
+msgid "admin.blog.posts.publish_success"
+msgstr "Post published."
+
+msgid "admin.blog.posts.schedule_button"
+msgstr "Schedule"
+
+msgid "admin.blog.posts.scheduled_at_prompt"
+msgstr "Publish at (e.g. 2026-08-01T09:00):"
+
+msgid "admin.blog.posts.schedule_confirm"
+msgstr "Schedule this post for automatic publishing at the time you entered?"
+
+msgid "admin.blog.posts.schedule_success"
+msgstr "Post scheduled."
+
+msgid "admin.blog.posts.archive_button"
+msgstr "Archive"
+
+msgid "admin.blog.posts.archive_confirm"
+msgstr "Archive this post? It will no longer be publicly visible."
+
+msgid "admin.blog.posts.archive_success"
+msgstr "Post archived."
+
+msgid "admin.blog.posts.delete_button"
+msgstr "Delete"
+
+msgid "admin.blog.posts.delete_reason_prompt"
+msgstr "Reason for deleting this post:"
+
+msgid "admin.blog.posts.delete_success"
+msgstr "Post deleted."
+
+msgid "admin.blog.posts.restore_button"
+msgstr "Restore"
+
+msgid "admin.blog.posts.restore_confirm"
+msgstr "Restore this deleted post?"
+
+msgid "admin.blog.posts.restore_success"
+msgstr "Post restored."
+
+msgid "admin.blog.posts.purge_button"
+msgstr "Purge permanently"
+
+msgid "admin.blog.posts.purge_confirm"
+msgstr "Permanently delete this post? This cannot be undone."
+
+msgid "admin.blog.posts.purge_success"
+msgstr "Post permanently deleted."
+
+msgid "admin.blog.posts.revisions_title"
+msgstr "Revision history"
+
+msgid "admin.blog.posts.no_revisions"
+msgstr "No revisions yet."
+
+msgid "admin.blog.posts.revision_number_column"
+msgstr "#"
+
+msgid "admin.blog.posts.revision_title_column"
+msgstr "Title"
+
+msgid "admin.blog.posts.revision_status_column"
+msgstr "Status"
+
+msgid "admin.blog.posts.revision_note_column"
+msgstr "Note"
+
+msgid "admin.blog.posts.revision_created_column"
+msgstr "Created"
+
+msgid "admin.blog.posts.revision_actions_column"
+msgstr "Actions"
+
+msgid "admin.blog.posts.revision_restore_button"
+msgstr "Restore this revision"
+
+msgid "admin.blog.posts.revision_restore_confirm"
+msgstr "Restore the post's content to this revision? A new revision recording this restore will be added — no history is lost."
+
+msgid "admin.blog.posts.revision_restore_success"
+msgstr "Post restored from revision."
+
+msgid "admin.blog.pages.title"
+msgstr "Blog pages"
+
+msgid "admin.blog.pages.new_title"
+msgstr "New page"
+
+msgid "admin.blog.pages.new_button"
+msgstr "New page"
+
+msgid "admin.blog.pages.filters_aria_label"
+msgstr "Page filters"
+
+msgid "admin.blog.pages.search_label"
+msgstr "Search"
+
+msgid "admin.blog.pages.status_filter_label"
+msgstr "Status"
+
+msgid "admin.blog.pages.type_filter_label"
+msgstr "Page type"
+
+msgid "admin.blog.pages.apply_filters_button"
+msgstr "Apply filters"
+
+msgid "admin.blog.pages.reset_filters_link"
+msgstr "Reset filters"
+
+msgid "admin.blog.pages.no_pages"
+msgstr "No pages match these filters."
+
+msgid "admin.blog.pages.title_column"
+msgstr "Title"
+
+msgid "admin.blog.pages.status_column"
+msgstr "Status"
+
+msgid "admin.blog.pages.type_column"
+msgstr "Type"
+
+msgid "admin.blog.pages.menu_order_column"
+msgstr "Menu order"
+
+msgid "admin.blog.pages.locale_column"
+msgstr "Locale"
+
+msgid "admin.blog.pages.updated_column"
+msgstr "Updated"
+
+msgid "admin.blog.pages.pagination_aria_label"
+msgstr "Page pagination"
+
+msgid "admin.blog.pages.not_found_title"
+msgstr "Page not found."
+
+msgid "admin.blog.pages.not_found_body"
+msgstr "This page id does not exist or you do not have permission to view it."
+
+msgid "admin.blog.pages.back_to_list"
+msgstr "Back to page list"
+
+msgid "admin.blog.pages.field_title"
+msgstr "Title"
+
+msgid "admin.blog.pages.field_slug"
+msgstr "Slug"
+
+msgid "admin.blog.pages.field_page_type"
+msgstr "Page type"
+
+msgid "admin.blog.pages.field_parent_page"
+msgstr "Parent page"
+
+msgid "admin.blog.pages.no_parent_option"
+msgstr "No parent"
+
+msgid "admin.blog.pages.field_menu_order"
+msgstr "Menu order"
+
+msgid "admin.blog.pages.create_submit"
+msgstr "Create page"
+
+msgid "admin.blog.pages.create_success"
+msgstr "Page created."
+
+msgid "admin.blog.pages.save_button"
+msgstr "Save changes"
+
+msgid "admin.blog.pages.save_success"
+msgstr "Page saved."
+
+msgid "admin.blog.pages.delete_button"
+msgstr "Delete"
+
+msgid "admin.blog.pages.delete_reason_prompt"
+msgstr "Reason for deleting this page:"
+
+msgid "admin.blog.pages.delete_success"
+msgstr "Page deleted."
+
+msgid "admin.blog.categories.title"
+msgstr "Categories"
+
+msgid "admin.blog.categories.no_categories"
+msgstr "No categories yet."
+
+msgid "admin.blog.categories.name_column"
+msgstr "Name"
+
+msgid "admin.blog.categories.slug_column"
+msgstr "Slug"
+
+msgid "admin.blog.categories.parent_column"
+msgstr "Parent"
+
+msgid "admin.blog.categories.actions_column"
+msgstr "Actions"
+
+msgid "admin.blog.categories.edit_summary"
+msgstr "Edit"
+
+msgid "admin.blog.categories.field_name"
+msgstr "Name"
+
+msgid "admin.blog.categories.field_slug"
+msgstr "Slug"
+
+msgid "admin.blog.categories.field_description"
+msgstr "Description"
+
+msgid "admin.blog.categories.field_parent"
+msgstr "Parent category"
+
+msgid "admin.blog.categories.no_parent_option"
+msgstr "No parent"
+
+msgid "admin.blog.categories.save_button"
+msgstr "Save"
+
+msgid "admin.blog.categories.delete_button"
+msgstr "Delete"
+
+msgid "admin.blog.categories.create_summary"
+msgstr "Add category"
+
+msgid "admin.blog.categories.create_submit"
+msgstr "Create category"
+
+msgid "admin.blog.categories.create_success"
+msgstr "Category created."
+
+msgid "admin.blog.categories.update_success"
+msgstr "Category updated."
+
+msgid "admin.blog.categories.delete_reason_prompt"
+msgstr "Reason for deleting this category:"
+
+msgid "admin.blog.categories.delete_confirm"
+msgstr "Delete this category? Posts using it will keep their other terms."
+
+msgid "admin.blog.categories.delete_success"
+msgstr "Category deleted."
+
+msgid "admin.blog.tags.title"
+msgstr "Tags"
+
+msgid "admin.blog.tags.no_tags"
+msgstr "No tags yet."
+
+msgid "admin.blog.tags.name_column"
+msgstr "Name"
+
+msgid "admin.blog.tags.slug_column"
+msgstr "Slug"
+
+msgid "admin.blog.tags.actions_column"
+msgstr "Actions"
+
+msgid "admin.blog.tags.edit_summary"
+msgstr "Edit"
+
+msgid "admin.blog.tags.field_name"
+msgstr "Name"
+
+msgid "admin.blog.tags.field_slug"
+msgstr "Slug"
+
+msgid "admin.blog.tags.field_description"
+msgstr "Description"
+
+msgid "admin.blog.tags.save_button"
+msgstr "Save"
+
+msgid "admin.blog.tags.delete_button"
+msgstr "Delete"
+
+msgid "admin.blog.tags.create_summary"
+msgstr "Add tag"
+
+msgid "admin.blog.tags.create_submit"
+msgstr "Create tag"
+
+msgid "admin.blog.tags.create_success"
+msgstr "Tag created."
+
+msgid "admin.blog.tags.update_success"
+msgstr "Tag updated."
+
+msgid "admin.blog.tags.delete_reason_prompt"
+msgstr "Reason for deleting this tag:"
+
+msgid "admin.blog.tags.delete_confirm"
+msgstr "Delete this tag? Posts using it will keep their other terms."
+
+msgid "admin.blog.tags.delete_success"
+msgstr "Tag deleted."
+
+msgid "admin.blog.taxonomy.category_prefix"
+msgstr "Category: {name}"
+
+msgid "admin.blog.taxonomy.tag_prefix"
+msgstr "Tag: {name}"
+
+msgid "admin.blog.settings.title"
+msgstr "Blog settings"
+
+msgid "admin.blog.settings.general_legend"
+msgstr "General"
+
+msgid "admin.blog.settings.field_blog_title"
+msgstr "Blog title"
+
+msgid "admin.blog.settings.field_blog_description"
+msgstr "Blog description"
+
+msgid "admin.blog.settings.field_posts_per_page"
+msgstr "Posts per page"
+
+msgid "admin.blog.settings.field_rss_enabled"
+msgstr "Enable RSS feed"
+
+msgid "admin.blog.settings.field_sitemap_enabled"
+msgstr "Enable sitemap"
+
+msgid "admin.blog.settings.field_default_locale"
+msgstr "Default locale"
+
+msgid "admin.blog.settings.field_default_visibility"
+msgstr "Default visibility"
+
+msgid "admin.blog.settings.field_seo_default_title"
+msgstr "Default SEO title template"
+
+msgid "admin.blog.settings.field_seo_default_description"
+msgstr "Default meta description"
+
+msgid "admin.blog.settings.save_button"
+msgstr "Save"
+
+msgid "admin.blog.settings.save_success"
+msgstr "Blog settings saved."
+
+msgid "admin.blog.settings.theme_legend"
+msgstr "Theme mode"
+
+msgid "admin.blog.settings.theme_override_note"
+msgstr "This tenant has a blog-specific theme override in effect."
+
+msgid "admin.blog.settings.theme_inherited_note"
+msgstr "No blog-specific override — the tenant's default theme is used."
+
+msgid "admin.blog.settings.field_theme_mode"
+msgstr "Theme mode"
+
+msgid "admin.blog.settings.theme_mode_light"
+msgstr "Light"
+
+msgid "admin.blog.settings.theme_mode_dark"
+msgstr "Dark"
+
+msgid "admin.blog.settings.theme_mode_system"
+msgstr "System"
+
+msgid "admin.blog.settings.theme_save_success"
+msgstr "Theme mode saved."
+
+msgid "admin.blog.templates.title"
+msgstr "Templates"
+
+msgid "admin.blog.templates.no_templates"
+msgstr "No templates yet."
+
+msgid "admin.blog.templates.key_column"
+msgstr "Key"
+
+msgid "admin.blog.templates.name_column"
+msgstr "Name"
+
+msgid "admin.blog.templates.columns_column"
+msgstr "Columns"
+
+msgid "admin.blog.templates.sidebar_column"
+msgstr "Sidebar"
+
+msgid "admin.blog.templates.active_column"
+msgstr "Active"
+
+msgid "admin.blog.templates.actions_column"
+msgstr "Actions"
+
+msgid "admin.blog.templates.edit_summary"
+msgstr "Edit"
+
+msgid "admin.blog.templates.field_key"
+msgstr "Key"
+
+msgid "admin.blog.templates.field_name"
+msgstr "Name"
+
+msgid "admin.blog.templates.field_columns"
+msgstr "Columns"
+
+msgid "admin.blog.templates.field_sidebar"
+msgstr "Sidebar position"
+
+msgid "admin.blog.templates.sidebar_left"
+msgstr "Left"
+
+msgid "admin.blog.templates.sidebar_right"
+msgstr "Right"
+
+msgid "admin.blog.templates.sidebar_none"
+msgstr "None"
+
+msgid "admin.blog.templates.field_active"
+msgstr "Active"
+
+msgid "admin.blog.templates.save_button"
+msgstr "Save"
+
+msgid "admin.blog.templates.delete_button"
+msgstr "Delete"
+
+msgid "admin.blog.templates.create_summary"
+msgstr "Add template"
+
+msgid "admin.blog.templates.create_submit"
+msgstr "Create template"
+
+msgid "admin.blog.templates.create_success"
+msgstr "Template created."
+
+msgid "admin.blog.templates.update_success"
+msgstr "Template updated."
+
+msgid "admin.blog.templates.delete_reason_prompt"
+msgstr "Reason for deleting this template:"
+
+msgid "admin.blog.templates.delete_confirm"
+msgstr "Delete this template?"
+
+msgid "admin.blog.templates.delete_success"
+msgstr "Template deleted."
+
+msgid "admin.blog.widgets.title"
+msgstr "Widgets"
+
+msgid "admin.blog.widgets.no_widgets"
+msgstr "No widgets yet."
+
+msgid "admin.blog.widgets.title_column"
+msgstr "Title"
+
+msgid "admin.blog.widgets.position_column"
+msgstr "Position"
+
+msgid "admin.blog.widgets.sort_order_column"
+msgstr "Sort order"
+
+msgid "admin.blog.widgets.active_column"
+msgstr "Active"
+
+msgid "admin.blog.widgets.actions_column"
+msgstr "Actions"
+
+msgid "admin.blog.widgets.edit_summary"
+msgstr "Edit"
+
+msgid "admin.blog.widgets.field_title"
+msgstr "Title"
+
+msgid "admin.blog.widgets.field_position"
+msgstr "Position"
+
+msgid "admin.blog.widgets.position_header"
+msgstr "Header"
+
+msgid "admin.blog.widgets.position_sidebar"
+msgstr "Sidebar"
+
+msgid "admin.blog.widgets.position_footer"
+msgstr "Footer"
+
+msgid "admin.blog.widgets.position_content_before"
+msgstr "Before content"
+
+msgid "admin.blog.widgets.position_content_after"
+msgstr "After content"
+
+msgid "admin.blog.widgets.field_body_text"
+msgstr "Body text"
+
+msgid "admin.blog.widgets.field_sort_order"
+msgstr "Sort order"
+
+msgid "admin.blog.widgets.field_active"
+msgstr "Active"
+
+msgid "admin.blog.widgets.save_button"
+msgstr "Save"
+
+msgid "admin.blog.widgets.delete_button"
+msgstr "Delete"
+
+msgid "admin.blog.widgets.create_summary"
+msgstr "Add widget"
+
+msgid "admin.blog.widgets.create_submit"
+msgstr "Create widget"
+
+msgid "admin.blog.widgets.create_success"
+msgstr "Widget created."
+
+msgid "admin.blog.widgets.update_success"
+msgstr "Widget updated."
+
+msgid "admin.blog.widgets.delete_reason_prompt"
+msgstr "Reason for deleting this widget:"
+
+msgid "admin.blog.widgets.delete_confirm"
+msgstr "Delete this widget?"
+
+msgid "admin.blog.widgets.delete_success"
+msgstr "Widget deleted."
+
+msgid "admin.blog.menus.title"
+msgstr "Menus"
+
+msgid "admin.blog.menus.no_menus"
+msgstr "No menus yet."
+
+msgid "admin.blog.menus.field_key"
+msgstr "Key"
+
+msgid "admin.blog.menus.field_name"
+msgstr "Name"
+
+msgid "admin.blog.menus.field_items"
+msgstr "Menu items (JSON)"
+
+msgid "admin.blog.menus.items_hint"
+msgstr "Array of { id, parentItemId, label, linkType, targetId, url, sortOrder }. Each item's id must be a UUID you supply yourself (use \"Copy new id\" below) — saving replaces the whole item list. One level of nesting only."
+
+msgid "admin.blog.menus.generate_id_button"
+msgstr "Copy new id"
+
+msgid "admin.blog.menus.invalid_items_json"
+msgstr "Menu items must be valid JSON."
+
+msgid "admin.blog.menus.save_button"
+msgstr "Save"
+
+msgid "admin.blog.menus.delete_button"
+msgstr "Delete menu"
+
+msgid "admin.blog.menus.create_summary"
+msgstr "Add menu"
+
+msgid "admin.blog.menus.create_submit"
+msgstr "Create menu"
+
+msgid "admin.blog.menus.create_success"
+msgstr "Menu created."
+
+msgid "admin.blog.menus.update_success"
+msgstr "Menu updated."
+
+msgid "admin.blog.menus.delete_reason_prompt"
+msgstr "Reason for deleting this menu:"
+
+msgid "admin.blog.menus.delete_confirm"
+msgstr "Delete this menu and all its items?"
+
+msgid "admin.blog.menus.delete_success"
+msgstr "Menu deleted."
+
+msgid "admin.blog.ads.title"
+msgstr "Advertisements"
+
+msgid "admin.blog.ads.no_ads"
+msgstr "No advertisements yet."
+
+msgid "admin.blog.ads.field_name"
+msgstr "Name"
+
+msgid "admin.blog.ads.field_image_url"
+msgstr "Image URL"
+
+msgid "admin.blog.ads.field_link_url"
+msgstr "Link URL"
+
+msgid "admin.blog.ads.field_starts_at"
+msgstr "Starts at"
+
+msgid "admin.blog.ads.field_ends_at"
+msgstr "Ends at"
+
+msgid "admin.blog.ads.field_active"
+msgstr "Active"
+
+msgid "admin.blog.ads.field_placements"
+msgstr "Placements (JSON)"
+
+msgid "admin.blog.ads.placements_hint"
+msgstr "Array of { placementType, targetId }. placementType is one of global, widget, post, page — targetId is required for all except global. Saving replaces the whole placement list."
+
+msgid "admin.blog.ads.invalid_placements_json"
+msgstr "Placements must be valid JSON."
+
+msgid "admin.blog.ads.save_button"
+msgstr "Save"
+
+msgid "admin.blog.ads.delete_button"
+msgstr "Delete ad"
+
+msgid "admin.blog.ads.create_summary"
+msgstr "Add advertisement"
+
+msgid "admin.blog.ads.create_submit"
+msgstr "Create advertisement"
+
+msgid "admin.blog.ads.create_success"
+msgstr "Advertisement created."
+
+msgid "admin.blog.ads.update_success"
+msgstr "Advertisement updated."
+
+msgid "admin.blog.ads.delete_reason_prompt"
+msgstr "Reason for deleting this advertisement:"
+
+msgid "admin.blog.ads.delete_confirm"
+msgstr "Delete this advertisement?"
+
+msgid "admin.blog.ads.delete_success"
+msgstr "Advertisement deleted."
+

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -784,3 +784,905 @@ msgstr "Progres tidak bisa disimpan. Isian Anda masih ada — coba lagi."
 
 msgid "admin.examples.wizard.draft_resumed_notice"
 msgstr "Draft tersimpan Anda dilanjutkan."
+
+#. admin.blog — Issue #543 (admin UI)
+msgid "admin.layout.nav_blog"
+msgstr "Blog"
+
+msgid "common.filter_all"
+msgstr "Semua"
+
+msgid "common.previous_page"
+msgstr "Halaman sebelumnya"
+
+msgid "common.next_page"
+msgstr "Halaman berikutnya"
+
+msgid "admin.blog.access_denied_title"
+msgstr "Akses ditolak."
+
+msgid "admin.blog.access_denied_body"
+msgstr "Akun Anda tidak memiliki izin untuk melihat layar blog ini. Hubungi admin/pemilik tenant Anda untuk meminta akses."
+
+msgid "admin.blog.dashboard.title"
+msgstr "Dasbor blog"
+
+msgid "admin.blog.dashboard.posts_title"
+msgstr "Post"
+
+msgid "admin.blog.dashboard.total_posts_label"
+msgstr "Total post"
+
+msgid "admin.blog.dashboard.draft_posts_label"
+msgstr "Draf"
+
+msgid "admin.blog.dashboard.scheduled_posts_label"
+msgstr "Terjadwal"
+
+msgid "admin.blog.dashboard.pages_title"
+msgstr "Halaman"
+
+msgid "admin.blog.dashboard.total_pages_label"
+msgstr "Total halaman"
+
+msgid "admin.blog.dashboard.quick_links_title"
+msgstr "Tautan cepat"
+
+msgid "admin.blog.dashboard.new_post_link"
+msgstr "Post baru"
+
+msgid "admin.blog.dashboard.new_page_link"
+msgstr "Halaman baru"
+
+msgid "admin.blog.dashboard.manage_posts_link"
+msgstr "Kelola post"
+
+msgid "admin.blog.dashboard.manage_pages_link"
+msgstr "Kelola halaman"
+
+msgid "admin.blog.dashboard.manage_categories_link"
+msgstr "Kelola kategori"
+
+msgid "admin.blog.dashboard.manage_tags_link"
+msgstr "Kelola tag"
+
+msgid "admin.blog.dashboard.manage_settings_link"
+msgstr "Pengaturan blog"
+
+msgid "admin.blog.dashboard.recent_updates_title"
+msgstr "Baru diperbarui"
+
+msgid "admin.blog.dashboard.no_recent_updates"
+msgstr "Belum ada post."
+
+msgid "admin.blog.status.draft"
+msgstr "Draf"
+
+msgid "admin.blog.status.review"
+msgstr "Dalam peninjauan"
+
+msgid "admin.blog.status.scheduled"
+msgstr "Terjadwal"
+
+msgid "admin.blog.status.published"
+msgstr "Diterbitkan"
+
+msgid "admin.blog.status.archived"
+msgstr "Diarsipkan"
+
+msgid "admin.blog.visibility.public"
+msgstr "Publik"
+
+msgid "admin.blog.visibility.private"
+msgstr "Privat"
+
+msgid "admin.blog.visibility.unlisted"
+msgstr "Tidak terdaftar"
+
+msgid "admin.blog.page_type.standard"
+msgstr "Standar"
+
+msgid "admin.blog.page_type.landing"
+msgstr "Landing"
+
+msgid "admin.blog.page_type.legal"
+msgstr "Legal"
+
+msgid "admin.blog.page_type.system"
+msgstr "Sistem"
+
+msgid "admin.blog.posts.title"
+msgstr "Post blog"
+
+msgid "admin.blog.posts.new_title"
+msgstr "Post baru"
+
+msgid "admin.blog.posts.new_button"
+msgstr "Post baru"
+
+msgid "admin.blog.posts.filters_aria_label"
+msgstr "Filter post"
+
+msgid "admin.blog.posts.search_label"
+msgstr "Cari"
+
+msgid "admin.blog.posts.status_filter_label"
+msgstr "Status"
+
+msgid "admin.blog.posts.term_filter_label"
+msgstr "Kategori/tag"
+
+msgid "admin.blog.posts.apply_filters_button"
+msgstr "Terapkan filter"
+
+msgid "admin.blog.posts.reset_filters_link"
+msgstr "Atur ulang filter"
+
+msgid "admin.blog.posts.no_posts"
+msgstr "Tidak ada post yang cocok dengan filter ini."
+
+msgid "admin.blog.posts.title_column"
+msgstr "Judul"
+
+msgid "admin.blog.posts.status_column"
+msgstr "Status"
+
+msgid "admin.blog.posts.author_column"
+msgstr "Penulis"
+
+msgid "admin.blog.posts.locale_column"
+msgstr "Locale"
+
+msgid "admin.blog.posts.published_column"
+msgstr "Diterbitkan"
+
+msgid "admin.blog.posts.updated_column"
+msgstr "Diperbarui"
+
+msgid "admin.blog.posts.unknown_author"
+msgstr "Tidak diketahui"
+
+msgid "admin.blog.posts.pagination_aria_label"
+msgstr "Navigasi halaman post"
+
+msgid "admin.blog.posts.page_indicator"
+msgstr "Halaman {page} dari {totalPages}"
+
+msgid "admin.blog.posts.not_found_title"
+msgstr "Post tidak ditemukan."
+
+msgid "admin.blog.posts.not_found_body"
+msgstr "Id post ini tidak ada atau Anda tidak memiliki izin untuk melihatnya."
+
+msgid "admin.blog.posts.back_to_list"
+msgstr "Kembali ke daftar post"
+
+msgid "admin.blog.posts.field_title"
+msgstr "Judul"
+
+msgid "admin.blog.posts.field_slug"
+msgstr "Slug"
+
+msgid "admin.blog.posts.slug_hint"
+msgstr "Hanya huruf kecil, angka, dan tanda hubung tunggal."
+
+msgid "admin.blog.posts.field_excerpt"
+msgstr "Ringkasan"
+
+msgid "admin.blog.posts.field_content_text"
+msgstr "Konten (teks polos)"
+
+msgid "admin.blog.posts.field_content_json"
+msgstr "Blok konten (JSON)"
+
+msgid "admin.blog.posts.content_json_hint"
+msgstr "Konten terstruktur berbentuk { \"blocks\": [...] } — hanya blok paragraph, heading, list, quote, dan gallery. Biarkan array blocks kosong bila ragu."
+
+msgid "admin.blog.posts.field_visibility"
+msgstr "Visibilitas"
+
+msgid "admin.blog.posts.field_locale"
+msgstr "Locale"
+
+msgid "admin.blog.posts.field_featured_media_id"
+msgstr "Referensi media unggulan (UUID)"
+
+msgid "admin.blog.posts.featured_media_hint"
+msgstr "Opsional. Belum ada pustaka media — cukup masukkan referensi UUID."
+
+msgid "admin.blog.posts.field_categories"
+msgstr "Kategori"
+
+msgid "admin.blog.posts.no_categories"
+msgstr "Belum ada kategori."
+
+msgid "admin.blog.posts.field_tags"
+msgstr "Tag"
+
+msgid "admin.blog.posts.no_tags"
+msgstr "Belum ada tag."
+
+msgid "admin.blog.posts.seo_legend"
+msgstr "SEO"
+
+msgid "admin.blog.posts.field_seo_title"
+msgstr "Judul SEO"
+
+msgid "admin.blog.posts.field_meta_description"
+msgstr "Meta deskripsi"
+
+msgid "admin.blog.posts.field_canonical_url"
+msgstr "URL kanonis"
+
+msgid "admin.blog.posts.create_submit"
+msgstr "Buat post"
+
+msgid "admin.blog.posts.create_success"
+msgstr "Post berhasil dibuat."
+
+msgid "admin.blog.posts.invalid_content_json"
+msgstr "Blok konten harus berupa JSON yang valid."
+
+msgid "admin.blog.posts.save_button"
+msgstr "Simpan perubahan"
+
+msgid "admin.blog.posts.save_success"
+msgstr "Post berhasil disimpan."
+
+msgid "admin.blog.posts.author_label"
+msgstr "Penulis"
+
+msgid "admin.blog.posts.deleted_label"
+msgstr "Dihapus"
+
+msgid "admin.blog.posts.submit_review_button"
+msgstr "Ajukan untuk ditinjau"
+
+msgid "admin.blog.posts.submit_review_success"
+msgstr "Post diajukan untuk ditinjau."
+
+msgid "admin.blog.posts.publish_button"
+msgstr "Terbitkan"
+
+msgid "admin.blog.posts.publish_confirm"
+msgstr "Terbitkan post ini sekarang? Post akan tampil di blog publik jika visibilitasnya publik."
+
+msgid "admin.blog.posts.publish_success"
+msgstr "Post berhasil diterbitkan."
+
+msgid "admin.blog.posts.schedule_button"
+msgstr "Jadwalkan"
+
+msgid "admin.blog.posts.scheduled_at_prompt"
+msgstr "Terbitkan pada (mis. 2026-08-01T09:00):"
+
+msgid "admin.blog.posts.schedule_confirm"
+msgstr "Jadwalkan post ini untuk diterbitkan otomatis pada waktu yang Anda masukkan?"
+
+msgid "admin.blog.posts.schedule_success"
+msgstr "Post berhasil dijadwalkan."
+
+msgid "admin.blog.posts.archive_button"
+msgstr "Arsipkan"
+
+msgid "admin.blog.posts.archive_confirm"
+msgstr "Arsipkan post ini? Post tidak akan lagi tampil di publik."
+
+msgid "admin.blog.posts.archive_success"
+msgstr "Post berhasil diarsipkan."
+
+msgid "admin.blog.posts.delete_button"
+msgstr "Hapus"
+
+msgid "admin.blog.posts.delete_reason_prompt"
+msgstr "Alasan menghapus post ini:"
+
+msgid "admin.blog.posts.delete_success"
+msgstr "Post berhasil dihapus."
+
+msgid "admin.blog.posts.restore_button"
+msgstr "Pulihkan"
+
+msgid "admin.blog.posts.restore_confirm"
+msgstr "Pulihkan post yang dihapus ini?"
+
+msgid "admin.blog.posts.restore_success"
+msgstr "Post berhasil dipulihkan."
+
+msgid "admin.blog.posts.purge_button"
+msgstr "Hapus permanen"
+
+msgid "admin.blog.posts.purge_confirm"
+msgstr "Hapus post ini secara permanen? Tindakan ini tidak dapat dibatalkan."
+
+msgid "admin.blog.posts.purge_success"
+msgstr "Post berhasil dihapus permanen."
+
+msgid "admin.blog.posts.revisions_title"
+msgstr "Riwayat revisi"
+
+msgid "admin.blog.posts.no_revisions"
+msgstr "Belum ada revisi."
+
+msgid "admin.blog.posts.revision_number_column"
+msgstr "#"
+
+msgid "admin.blog.posts.revision_title_column"
+msgstr "Judul"
+
+msgid "admin.blog.posts.revision_status_column"
+msgstr "Status"
+
+msgid "admin.blog.posts.revision_note_column"
+msgstr "Catatan"
+
+msgid "admin.blog.posts.revision_created_column"
+msgstr "Dibuat"
+
+msgid "admin.blog.posts.revision_actions_column"
+msgstr "Aksi"
+
+msgid "admin.blog.posts.revision_restore_button"
+msgstr "Pulihkan revisi ini"
+
+msgid "admin.blog.posts.revision_restore_confirm"
+msgstr "Pulihkan konten post ke revisi ini? Revisi baru yang mencatat pemulihan ini akan ditambahkan — tidak ada riwayat yang hilang."
+
+msgid "admin.blog.posts.revision_restore_success"
+msgstr "Post berhasil dipulihkan dari revisi."
+
+msgid "admin.blog.pages.title"
+msgstr "Halaman blog"
+
+msgid "admin.blog.pages.new_title"
+msgstr "Halaman baru"
+
+msgid "admin.blog.pages.new_button"
+msgstr "Halaman baru"
+
+msgid "admin.blog.pages.filters_aria_label"
+msgstr "Filter halaman"
+
+msgid "admin.blog.pages.search_label"
+msgstr "Cari"
+
+msgid "admin.blog.pages.status_filter_label"
+msgstr "Status"
+
+msgid "admin.blog.pages.type_filter_label"
+msgstr "Jenis halaman"
+
+msgid "admin.blog.pages.apply_filters_button"
+msgstr "Terapkan filter"
+
+msgid "admin.blog.pages.reset_filters_link"
+msgstr "Atur ulang filter"
+
+msgid "admin.blog.pages.no_pages"
+msgstr "Tidak ada halaman yang cocok dengan filter ini."
+
+msgid "admin.blog.pages.title_column"
+msgstr "Judul"
+
+msgid "admin.blog.pages.status_column"
+msgstr "Status"
+
+msgid "admin.blog.pages.type_column"
+msgstr "Jenis"
+
+msgid "admin.blog.pages.menu_order_column"
+msgstr "Urutan menu"
+
+msgid "admin.blog.pages.locale_column"
+msgstr "Locale"
+
+msgid "admin.blog.pages.updated_column"
+msgstr "Diperbarui"
+
+msgid "admin.blog.pages.pagination_aria_label"
+msgstr "Navigasi halaman"
+
+msgid "admin.blog.pages.not_found_title"
+msgstr "Halaman tidak ditemukan."
+
+msgid "admin.blog.pages.not_found_body"
+msgstr "Id halaman ini tidak ada atau Anda tidak memiliki izin untuk melihatnya."
+
+msgid "admin.blog.pages.back_to_list"
+msgstr "Kembali ke daftar halaman"
+
+msgid "admin.blog.pages.field_title"
+msgstr "Judul"
+
+msgid "admin.blog.pages.field_slug"
+msgstr "Slug"
+
+msgid "admin.blog.pages.field_page_type"
+msgstr "Jenis halaman"
+
+msgid "admin.blog.pages.field_parent_page"
+msgstr "Halaman induk"
+
+msgid "admin.blog.pages.no_parent_option"
+msgstr "Tanpa induk"
+
+msgid "admin.blog.pages.field_menu_order"
+msgstr "Urutan menu"
+
+msgid "admin.blog.pages.create_submit"
+msgstr "Buat halaman"
+
+msgid "admin.blog.pages.create_success"
+msgstr "Halaman berhasil dibuat."
+
+msgid "admin.blog.pages.save_button"
+msgstr "Simpan perubahan"
+
+msgid "admin.blog.pages.save_success"
+msgstr "Halaman berhasil disimpan."
+
+msgid "admin.blog.pages.delete_button"
+msgstr "Hapus"
+
+msgid "admin.blog.pages.delete_reason_prompt"
+msgstr "Alasan menghapus halaman ini:"
+
+msgid "admin.blog.pages.delete_success"
+msgstr "Halaman berhasil dihapus."
+
+msgid "admin.blog.categories.title"
+msgstr "Kategori"
+
+msgid "admin.blog.categories.no_categories"
+msgstr "Belum ada kategori."
+
+msgid "admin.blog.categories.name_column"
+msgstr "Nama"
+
+msgid "admin.blog.categories.slug_column"
+msgstr "Slug"
+
+msgid "admin.blog.categories.parent_column"
+msgstr "Induk"
+
+msgid "admin.blog.categories.actions_column"
+msgstr "Aksi"
+
+msgid "admin.blog.categories.edit_summary"
+msgstr "Edit"
+
+msgid "admin.blog.categories.field_name"
+msgstr "Nama"
+
+msgid "admin.blog.categories.field_slug"
+msgstr "Slug"
+
+msgid "admin.blog.categories.field_description"
+msgstr "Deskripsi"
+
+msgid "admin.blog.categories.field_parent"
+msgstr "Kategori induk"
+
+msgid "admin.blog.categories.no_parent_option"
+msgstr "Tanpa induk"
+
+msgid "admin.blog.categories.save_button"
+msgstr "Simpan"
+
+msgid "admin.blog.categories.delete_button"
+msgstr "Hapus"
+
+msgid "admin.blog.categories.create_summary"
+msgstr "Tambah kategori"
+
+msgid "admin.blog.categories.create_submit"
+msgstr "Buat kategori"
+
+msgid "admin.blog.categories.create_success"
+msgstr "Kategori berhasil dibuat."
+
+msgid "admin.blog.categories.update_success"
+msgstr "Kategori berhasil diperbarui."
+
+msgid "admin.blog.categories.delete_reason_prompt"
+msgstr "Alasan menghapus kategori ini:"
+
+msgid "admin.blog.categories.delete_confirm"
+msgstr "Hapus kategori ini? Post yang menggunakannya akan tetap mempertahankan term lainnya."
+
+msgid "admin.blog.categories.delete_success"
+msgstr "Kategori berhasil dihapus."
+
+msgid "admin.blog.tags.title"
+msgstr "Tag"
+
+msgid "admin.blog.tags.no_tags"
+msgstr "Belum ada tag."
+
+msgid "admin.blog.tags.name_column"
+msgstr "Nama"
+
+msgid "admin.blog.tags.slug_column"
+msgstr "Slug"
+
+msgid "admin.blog.tags.actions_column"
+msgstr "Aksi"
+
+msgid "admin.blog.tags.edit_summary"
+msgstr "Edit"
+
+msgid "admin.blog.tags.field_name"
+msgstr "Nama"
+
+msgid "admin.blog.tags.field_slug"
+msgstr "Slug"
+
+msgid "admin.blog.tags.field_description"
+msgstr "Deskripsi"
+
+msgid "admin.blog.tags.save_button"
+msgstr "Simpan"
+
+msgid "admin.blog.tags.delete_button"
+msgstr "Hapus"
+
+msgid "admin.blog.tags.create_summary"
+msgstr "Tambah tag"
+
+msgid "admin.blog.tags.create_submit"
+msgstr "Buat tag"
+
+msgid "admin.blog.tags.create_success"
+msgstr "Tag berhasil dibuat."
+
+msgid "admin.blog.tags.update_success"
+msgstr "Tag berhasil diperbarui."
+
+msgid "admin.blog.tags.delete_reason_prompt"
+msgstr "Alasan menghapus tag ini:"
+
+msgid "admin.blog.tags.delete_confirm"
+msgstr "Hapus tag ini? Post yang menggunakannya akan tetap mempertahankan term lainnya."
+
+msgid "admin.blog.tags.delete_success"
+msgstr "Tag berhasil dihapus."
+
+msgid "admin.blog.taxonomy.category_prefix"
+msgstr "Kategori: {name}"
+
+msgid "admin.blog.taxonomy.tag_prefix"
+msgstr "Tag: {name}"
+
+msgid "admin.blog.settings.title"
+msgstr "Pengaturan blog"
+
+msgid "admin.blog.settings.general_legend"
+msgstr "Umum"
+
+msgid "admin.blog.settings.field_blog_title"
+msgstr "Judul blog"
+
+msgid "admin.blog.settings.field_blog_description"
+msgstr "Deskripsi blog"
+
+msgid "admin.blog.settings.field_posts_per_page"
+msgstr "Post per halaman"
+
+msgid "admin.blog.settings.field_rss_enabled"
+msgstr "Aktifkan feed RSS"
+
+msgid "admin.blog.settings.field_sitemap_enabled"
+msgstr "Aktifkan sitemap"
+
+msgid "admin.blog.settings.field_default_locale"
+msgstr "Locale default"
+
+msgid "admin.blog.settings.field_default_visibility"
+msgstr "Visibilitas default"
+
+msgid "admin.blog.settings.field_seo_default_title"
+msgstr "Template judul SEO default"
+
+msgid "admin.blog.settings.field_seo_default_description"
+msgstr "Meta deskripsi default"
+
+msgid "admin.blog.settings.save_button"
+msgstr "Simpan"
+
+msgid "admin.blog.settings.save_success"
+msgstr "Pengaturan blog berhasil disimpan."
+
+msgid "admin.blog.settings.theme_legend"
+msgstr "Mode tema"
+
+msgid "admin.blog.settings.theme_override_note"
+msgstr "Tenant ini memiliki override tema khusus blog yang sedang aktif."
+
+msgid "admin.blog.settings.theme_inherited_note"
+msgstr "Belum ada override khusus blog — tema default tenant yang digunakan."
+
+msgid "admin.blog.settings.field_theme_mode"
+msgstr "Mode tema"
+
+msgid "admin.blog.settings.theme_mode_light"
+msgstr "Terang"
+
+msgid "admin.blog.settings.theme_mode_dark"
+msgstr "Gelap"
+
+msgid "admin.blog.settings.theme_mode_system"
+msgstr "Sistem"
+
+msgid "admin.blog.settings.theme_save_success"
+msgstr "Mode tema berhasil disimpan."
+
+msgid "admin.blog.templates.title"
+msgstr "Templat"
+
+msgid "admin.blog.templates.no_templates"
+msgstr "Belum ada templat."
+
+msgid "admin.blog.templates.key_column"
+msgstr "Key"
+
+msgid "admin.blog.templates.name_column"
+msgstr "Nama"
+
+msgid "admin.blog.templates.columns_column"
+msgstr "Kolom"
+
+msgid "admin.blog.templates.sidebar_column"
+msgstr "Sidebar"
+
+msgid "admin.blog.templates.active_column"
+msgstr "Aktif"
+
+msgid "admin.blog.templates.actions_column"
+msgstr "Aksi"
+
+msgid "admin.blog.templates.edit_summary"
+msgstr "Edit"
+
+msgid "admin.blog.templates.field_key"
+msgstr "Key"
+
+msgid "admin.blog.templates.field_name"
+msgstr "Nama"
+
+msgid "admin.blog.templates.field_columns"
+msgstr "Kolom"
+
+msgid "admin.blog.templates.field_sidebar"
+msgstr "Posisi sidebar"
+
+msgid "admin.blog.templates.sidebar_left"
+msgstr "Kiri"
+
+msgid "admin.blog.templates.sidebar_right"
+msgstr "Kanan"
+
+msgid "admin.blog.templates.sidebar_none"
+msgstr "Tidak ada"
+
+msgid "admin.blog.templates.field_active"
+msgstr "Aktif"
+
+msgid "admin.blog.templates.save_button"
+msgstr "Simpan"
+
+msgid "admin.blog.templates.delete_button"
+msgstr "Hapus"
+
+msgid "admin.blog.templates.create_summary"
+msgstr "Tambah templat"
+
+msgid "admin.blog.templates.create_submit"
+msgstr "Buat templat"
+
+msgid "admin.blog.templates.create_success"
+msgstr "Templat berhasil dibuat."
+
+msgid "admin.blog.templates.update_success"
+msgstr "Templat berhasil diperbarui."
+
+msgid "admin.blog.templates.delete_reason_prompt"
+msgstr "Alasan menghapus templat ini:"
+
+msgid "admin.blog.templates.delete_confirm"
+msgstr "Hapus templat ini?"
+
+msgid "admin.blog.templates.delete_success"
+msgstr "Templat berhasil dihapus."
+
+msgid "admin.blog.widgets.title"
+msgstr "Widget"
+
+msgid "admin.blog.widgets.no_widgets"
+msgstr "Belum ada widget."
+
+msgid "admin.blog.widgets.title_column"
+msgstr "Judul"
+
+msgid "admin.blog.widgets.position_column"
+msgstr "Posisi"
+
+msgid "admin.blog.widgets.sort_order_column"
+msgstr "Urutan"
+
+msgid "admin.blog.widgets.active_column"
+msgstr "Aktif"
+
+msgid "admin.blog.widgets.actions_column"
+msgstr "Aksi"
+
+msgid "admin.blog.widgets.edit_summary"
+msgstr "Edit"
+
+msgid "admin.blog.widgets.field_title"
+msgstr "Judul"
+
+msgid "admin.blog.widgets.field_position"
+msgstr "Posisi"
+
+msgid "admin.blog.widgets.position_header"
+msgstr "Header"
+
+msgid "admin.blog.widgets.position_sidebar"
+msgstr "Sidebar"
+
+msgid "admin.blog.widgets.position_footer"
+msgstr "Footer"
+
+msgid "admin.blog.widgets.position_content_before"
+msgstr "Sebelum konten"
+
+msgid "admin.blog.widgets.position_content_after"
+msgstr "Setelah konten"
+
+msgid "admin.blog.widgets.field_body_text"
+msgstr "Isi teks"
+
+msgid "admin.blog.widgets.field_sort_order"
+msgstr "Urutan"
+
+msgid "admin.blog.widgets.field_active"
+msgstr "Aktif"
+
+msgid "admin.blog.widgets.save_button"
+msgstr "Simpan"
+
+msgid "admin.blog.widgets.delete_button"
+msgstr "Hapus"
+
+msgid "admin.blog.widgets.create_summary"
+msgstr "Tambah widget"
+
+msgid "admin.blog.widgets.create_submit"
+msgstr "Buat widget"
+
+msgid "admin.blog.widgets.create_success"
+msgstr "Widget berhasil dibuat."
+
+msgid "admin.blog.widgets.update_success"
+msgstr "Widget berhasil diperbarui."
+
+msgid "admin.blog.widgets.delete_reason_prompt"
+msgstr "Alasan menghapus widget ini:"
+
+msgid "admin.blog.widgets.delete_confirm"
+msgstr "Hapus widget ini?"
+
+msgid "admin.blog.widgets.delete_success"
+msgstr "Widget berhasil dihapus."
+
+msgid "admin.blog.menus.title"
+msgstr "Menu"
+
+msgid "admin.blog.menus.no_menus"
+msgstr "Belum ada menu."
+
+msgid "admin.blog.menus.field_key"
+msgstr "Key"
+
+msgid "admin.blog.menus.field_name"
+msgstr "Nama"
+
+msgid "admin.blog.menus.field_items"
+msgstr "Item menu (JSON)"
+
+msgid "admin.blog.menus.items_hint"
+msgstr "Array berisi { id, parentItemId, label, linkType, targetId, url, sortOrder }. Id setiap item harus UUID yang Anda tentukan sendiri (gunakan \"Salin id baru\" di bawah) — menyimpan akan mengganti seluruh daftar item. Hanya satu tingkat nesting."
+
+msgid "admin.blog.menus.generate_id_button"
+msgstr "Salin id baru"
+
+msgid "admin.blog.menus.invalid_items_json"
+msgstr "Item menu harus berupa JSON yang valid."
+
+msgid "admin.blog.menus.save_button"
+msgstr "Simpan"
+
+msgid "admin.blog.menus.delete_button"
+msgstr "Hapus menu"
+
+msgid "admin.blog.menus.create_summary"
+msgstr "Tambah menu"
+
+msgid "admin.blog.menus.create_submit"
+msgstr "Buat menu"
+
+msgid "admin.blog.menus.create_success"
+msgstr "Menu berhasil dibuat."
+
+msgid "admin.blog.menus.update_success"
+msgstr "Menu berhasil diperbarui."
+
+msgid "admin.blog.menus.delete_reason_prompt"
+msgstr "Alasan menghapus menu ini:"
+
+msgid "admin.blog.menus.delete_confirm"
+msgstr "Hapus menu ini beserta seluruh itemnya?"
+
+msgid "admin.blog.menus.delete_success"
+msgstr "Menu berhasil dihapus."
+
+msgid "admin.blog.ads.title"
+msgstr "Iklan"
+
+msgid "admin.blog.ads.no_ads"
+msgstr "Belum ada iklan."
+
+msgid "admin.blog.ads.field_name"
+msgstr "Nama"
+
+msgid "admin.blog.ads.field_image_url"
+msgstr "URL gambar"
+
+msgid "admin.blog.ads.field_link_url"
+msgstr "URL tautan"
+
+msgid "admin.blog.ads.field_starts_at"
+msgstr "Mulai pada"
+
+msgid "admin.blog.ads.field_ends_at"
+msgstr "Berakhir pada"
+
+msgid "admin.blog.ads.field_active"
+msgstr "Aktif"
+
+msgid "admin.blog.ads.field_placements"
+msgstr "Penempatan (JSON)"
+
+msgid "admin.blog.ads.placements_hint"
+msgstr "Array berisi { placementType, targetId }. placementType salah satu dari global, widget, post, page — targetId wajib diisi kecuali untuk global. Menyimpan akan mengganti seluruh daftar penempatan."
+
+msgid "admin.blog.ads.invalid_placements_json"
+msgstr "Penempatan harus berupa JSON yang valid."
+
+msgid "admin.blog.ads.save_button"
+msgstr "Simpan"
+
+msgid "admin.blog.ads.delete_button"
+msgstr "Hapus iklan"
+
+msgid "admin.blog.ads.create_summary"
+msgstr "Tambah iklan"
+
+msgid "admin.blog.ads.create_submit"
+msgstr "Buat iklan"
+
+msgid "admin.blog.ads.create_success"
+msgstr "Iklan berhasil dibuat."
+
+msgid "admin.blog.ads.update_success"
+msgstr "Iklan berhasil diperbarui."
+
+msgid "admin.blog.ads.delete_reason_prompt"
+msgstr "Alasan menghapus iklan ini:"
+
+msgid "admin.blog.ads.delete_confirm"
+msgstr "Hapus iklan ini?"
+
+msgid "admin.blog.ads.delete_success"
+msgstr "Iklan berhasil dihapus."
+

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -117,6 +117,17 @@ tags:
       rebuilds the base media library, tenant system, RBAC/ABAC, audit, or
       theme engine — the blog theme endpoint overrides
       `awcms_mini_tenants.default_theme`, it does not replace it.
+  - name: Blog Settings
+    description: >-
+      Tenant-scoped blog settings admin API (epic #536, Issue #543) — one
+      row per tenant (`awcms_mini_blog_settings`, schema present since
+      Issue #537 but unwired until this issue). Blog title/description and
+      RSS/sitemap enabled flags live in the row's catch-all `settings`
+      jsonb column; default locale/visibility and SEO title/description
+      defaults have their own typed columns. `rssEnabled`/`sitemapEnabled`
+      also gate `GET /blog/{tenantCode}/feed.xml` and
+      `.../sitemap-blog.xml` (Issue #540) — disabled looks identical to an
+      unknown tenant (404), no distinguishing signal leaked.
 paths:
   /api/v1/sync/push:
     post:
@@ -5713,6 +5724,79 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/blog/settings:
+    get:
+      tags:
+        - Blog Settings
+      summary: Read this tenant's blog settings
+      operationId: blogSettingsGet
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Blog settings, falling back to schema/domain defaults when never configured.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/BlogSettingsView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    patch:
+      tags:
+        - Blog Settings
+      summary: Update this tenant's blog settings
+      operationId: blogSettingsUpdate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateBlogSettingsInput"
+      responses:
+        "200":
+          description: Blog settings updated (partial update — only fields present in the request body are changed).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/BlogSettingsView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
 x-awcms-mini-soft-delete-pattern:
   delete:
     method: DELETE
@@ -8849,6 +8933,86 @@ components:
         isOverride:
           type: boolean
           description: false means this is the tenant's inherited default_theme, not a blog-specific override.
+    BlogSettingsView:
+      type: object
+      required:
+        - tenantId
+        - blogTitle
+        - blogDescription
+        - postsPerPage
+        - rssEnabled
+        - sitemapEnabled
+        - defaultLocale
+        - defaultVisibility
+        - seoDefaultTitle
+        - seoDefaultDescription
+        - updatedAt
+      additionalProperties: false
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        blogTitle:
+          type: string
+        blogDescription:
+          type: string
+          nullable: true
+        postsPerPage:
+          type: integer
+          minimum: 1
+          maximum: 100
+        rssEnabled:
+          type: boolean
+        sitemapEnabled:
+          type: boolean
+        defaultLocale:
+          type: string
+        defaultVisibility:
+          type: string
+          enum: [public, private, unlisted]
+        seoDefaultTitle:
+          type: string
+          nullable: true
+        seoDefaultDescription:
+          type: string
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+    UpdateBlogSettingsInput:
+      type: object
+      description: Partial update — only fields present are validated/changed. blogTitle/blogDescription/rssEnabled/sitemapEnabled live in the row's catch-all `settings` jsonb column; the rest have their own typed columns.
+      additionalProperties: false
+      properties:
+        blogTitle:
+          type: string
+          maxLength: 200
+        blogDescription:
+          type: string
+          maxLength: 500
+          nullable: true
+        postsPerPage:
+          type: integer
+          minimum: 1
+          maximum: 100
+        rssEnabled:
+          type: boolean
+        sitemapEnabled:
+          type: boolean
+        defaultLocale:
+          type: string
+        defaultVisibility:
+          type: string
+          enum: [public, private, unlisted]
+        seoDefaultTitle:
+          type: string
+          maxLength: 200
+          nullable: true
+        seoDefaultDescription:
+          type: string
+          maxLength: 300
+          nullable: true
     BlogPostListItem:
       type: object
       required:

--- a/src/lib/ui/admin-form-client.ts
+++ b/src/lib/ui/admin-form-client.ts
@@ -18,6 +18,15 @@
  * Astro bundles non-`is:inline` `<script>` blocks through Vite, so a plain
  * `import` from a page's `<script>` works the same as anywhere else in the
  * app — this file is not itself an Astro component.
+ *
+ * `extraHeaders` (Issue #543, `admin/blog/*`) — additive optional parameter
+ * on `submitJson`: the blog post/page lifecycle-action endpoints
+ * (`publish`/`schedule`/`archive`/`restore`/`purge`, revision restore) are
+ * the first admin-UI mutations that require a caller-supplied
+ * `Idempotency-Key` header (doc issue #541/#538 — same replay/conflict
+ * semantics `workflows/tasks/{id}/decisions.ts` established). Every
+ * existing call site omits the third-turned-fourth argument and is
+ * unaffected.
  */
 
 export interface SubmitResult {
@@ -55,12 +64,13 @@ export async function submitJson(
   url: string,
   method: string,
   body: unknown,
-  strings: ClientErrorStrings
+  strings: ClientErrorStrings,
+  extraHeaders?: Record<string, string>
 ): Promise<SubmitResult> {
   try {
     const res = await fetch(url, {
       method,
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...extraHeaders },
       credentials: "same-origin",
       body: JSON.stringify(body)
     });
@@ -131,4 +141,9 @@ export function lockElement(
       el.textContent = originalText;
     }
   };
+}
+
+/** One fresh `Idempotency-Key` per mutation attempt (`crypto.randomUUID()` — available in every browser this app targets, same primitive `menu-policy.ts`'s client-supplied item ids assume). A retry after a failed request must call this again, not reuse the previous value, so a genuinely new attempt is never rejected as a stale replay. */
+export function newIdempotencyKey(): string {
+  return crypto.randomUUID();
 }

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -1,6 +1,6 @@
 # Blog Content
 
-Implementasi Issue #537, #538, #539, #540, #541, dan #542 (epic #536 — `blog_content`, `docs/adr/0009-public-tenant-scoped-routes.md`). **Modul domain pertama yang didaftarkan langsung di repo base ini** — sebelumnya `AGENTS.md` §Peta modul hanya mendaftarkan modul base generik; lihat catatan di sana untuk konteks.
+Implementasi Issue #537, #538, #539, #540, #541, #542, dan #543 (epic #536 — `blog_content`, `docs/adr/0009-public-tenant-scoped-routes.md`). **Modul domain pertama yang didaftarkan langsung di repo base ini** — sebelumnya `AGENTS.md` §Peta modul hanya mendaftarkan modul base generik; lihat catatan di sana untuk konteks. Epic ini **selesai** — semua acceptance criteria issue #537-#543 terpenuhi; `module.ts`'s `status` sudah `active` (bukan lagi `experimental`).
 
 ## Scope per issue
 
@@ -16,7 +16,7 @@ Issue #541: revision history append-only untuk post/page, restore revisi (permis
 
 Issue #542: presentation/monetization extensions — template, menu hierarkis, widget, iklan (ads) dengan placement/scheduling, override tema per-tenant, `translation_group_id` untuk multilingual, dan block `gallery` baru di `content_json` untuk gambar/video publik. Migration `029`/`030`. Lihat §Presentation extensions.
 
-Admin UI (#543) masih backlog — lihat §Belum tersedia.
+Issue #543 (final hardening): admin UI penuh di bawah `/admin/blog` (dashboard, posts, pages, categories, tags, settings, dan optional advanced screens templates/widgets/menus/ads — semuanya menggunakan `AdminLayout`/design token yang sudah ada, Astro + vanilla JS saja, tanpa framework baru), endpoint `blog_content.settings.*` (`/api/v1/blog/settings`, akhirnya mengaktifkan `awcms_mini_blog_settings` yang sejak migration 026 sudah ada tapi belum punya route), `module.ts`'s `permissions`/`navigation` array (sebelumnya kosong meski 36 permission-nya sudah ada di DB sejak migration 027/030), dan dokumentasi/testing/hardening akhir. Lihat §Admin UI dan §Settings API.
 
 ## Tabel (migration `026_awcms_mini_blog_content_schema.sql`)
 
@@ -49,6 +49,8 @@ Tidak ada tabel baru untuk galeri media — lihat §Presentation extensions §Me
 
 26 permission dari migration 027 persis sesuai doc issue #537 §Permission Seed (`blog_content.posts.*`, `.pages.*`, `.taxonomies.*`, `.revisions.*`, `.settings.*`, `.seo.configure`, `.search.read`). Migration 030 (Issue #542) menambah 10 permission lagi: `templates.{read,configure}`, `menus.{read,configure}`, `widgets.{read,configure}`, `ads.{read,configure}`, `theme.{read,configure}` — satu `read` + satu `configure` per resource, pola granularitas yang sama seperti `taxonomies.{read,configure}` (master/config data admin, bukan konten dengan lifecycle). Tidak ada role grant implisit — hanya assignable lewat Access & Users yang sudah ada.
 
+Sampai Issue #543, ke-36 permission ini ada di database tapi `module.ts`'s `permissions` array kosong — Module Management's permission-sync report (`fetchModulePermissionSyncReport`, dipakai `admin/modules/[moduleKey].astro`'s panel Permissions) karena itu tidak punya apa pun untuk dibandingkan terhadap DB. Issue #543 mendeklarasikan seluruh 36 permission di `module.ts` (persis mencerminkan migration 027+030, bukan menambah permission baru) supaya sync report itu akhirnya berfungsi untuk modul ini, dan menambahkan `navigation: [{ path: "/admin/blog", ... }]` supaya `/admin/blog` muncul di sidebar admin (lihat §Admin UI).
+
 ## Domain validation (`domain/`)
 
 - `content-validation.ts` — `validateBlogContentCore`: field inti yang dipakai bersama post & page (`title`, `slug`, `excerpt`, `contentJson`, `contentText`, `locale`), plus field-level validator individual (`validateTitleField`, dst.) yang dipakai ulang oleh partial-update page/post, dan `validateDeleteReasonInput` (`{ reason: string }`) dipakai ulang oleh soft-delete post/page/term.
@@ -69,8 +71,10 @@ Tidak ada tabel baru untuk galeri media — lihat §Presentation extensions §Me
 
 ## Application (`application/`)
 
-- `blog-post-directory.ts` — dulu (Issue #537) hanya placeholder read-only; Issue #538 melengkapinya dengan seluruh mutation post (`createBlogPost`, `updateBlogPost`, `softDeleteBlogPost`, `transitionBlogPostStatus`, `restoreBlogPost`, `purgeBlogPost`) di file yang sama — konvensi "satu directory, baca+tulis" yang sama seperti `email/application/email-template-directory.ts`, bukan dipecah jadi file service terpisah. `version` (kolom integer di schema #537) di-increment tiap `updateBlogPost`/`transitionBlogPostStatus` sukses — penanda perubahan monoton saja, **belum** ada optimistic-concurrency check (If-Match/expected-version) yang membacanya.
-- `blog-page-directory.ts` (Issue #539) — struktur identik `blog-post-directory.ts` (`createBlogPage`, `fetchBlogPageById`, `listBlogPages`, `updateBlogPage`, `softDeleteBlogPage`), **tanpa** `transitionBlogPostStatus`/`restoreBlogPage`/`purgeBlogPage` — pages tidak punya lifecycle-action endpoint di issue ini (lihat §Admin API — Blog Pages).
+- `blog-post-directory.ts` — dulu (Issue #537) hanya placeholder read-only; Issue #538 melengkapinya dengan seluruh mutation post (`createBlogPost`, `updateBlogPost`, `softDeleteBlogPost`, `transitionBlogPostStatus`, `restoreBlogPost`, `purgeBlogPost`) di file yang sama — konvensi "satu directory, baca+tulis" yang sama seperti `email/application/email-template-directory.ts`, bukan dipecah jadi file service terpisah. `version` (kolom integer di schema #537) di-increment tiap `updateBlogPost`/`transitionBlogPostStatus` sukses — penanda perubahan monoton saja, **belum** ada optimistic-concurrency check (If-Match/expected-version) yang membacanya. Issue #543 menambah `listBlogPostsForAdmin` (tambahan murni, tidak mengubah fungsi lain di file ini) — `search` (`ILIKE` judul, bukan `search_vector`, supaya query kosong tetap menampilkan semua post), `status`, `termId` (via `EXISTS` terhadap `awcms_mini_blog_post_terms`, bukan `JOIN`, supaya post dengan banyak term tidak pernah muncul dobel), dan pagination bernomor halaman (`page`/`pageSize` + `total`) — dipakai `/admin/blog/posts` untuk search/filter/pagination yang `listBlogPosts`/`GET /api/v1/blog/posts` tidak sediakan. Tidak ada endpoint JSON baru untuk fungsi ini (tidak ada perubahan OpenAPI) — hanya dipanggil langsung dari SSR frontmatter `admin/blog/posts/index.astro`, pola yang sama seperti `admin/index.astro` memanggil fungsi reporting langsung.
+- `blog-page-directory.ts` (Issue #539) — struktur identik `blog-post-directory.ts` (`createBlogPage`, `fetchBlogPageById`, `listBlogPages`, `updateBlogPage`, `softDeleteBlogPage`), **tanpa** `transitionBlogPostStatus`/`restoreBlogPage`/`purgeBlogPage` — pages tidak punya lifecycle-action endpoint di issue ini (lihat §Admin API — Blog Pages). Issue #543 menambah `listBlogPagesForAdmin` — sama konvensinya seperti `listBlogPostsForAdmin` (search+status+pageType filter, pagination bernomor halaman), tanpa filter term (pages tidak punya relasi taksonomi).
+- `author-lookup.ts` (Issue #543) — `fetchAuthorDisplayNames(tx, tenantId, tenantUserIds)`, resolusi `author_tenant_user_id` -> nama tampilan untuk kolom "author" di `/admin/blog/posts` dan `/admin/blog/posts/{id}`. Join sempit `awcms_mini_tenant_users` -> `awcms_mini_identities` -> `awcms_mini_profiles` yang dipersempit dari `identity-access/application/user-directory.ts`'s `fetchTenantUsersWithRoles` (fungsi itu juga memuat role assignment dan digerbangi `identity_access.user_management.read`, permission yang tidak seharusnya jadi syarat seorang editor blog melihat nama penulis kontennya sendiri). Id yang tidak ditemukan (mis. user sudah dihapus) sengaja absen dari `Map` hasil, bukan dilempar error — pemanggil UI fallback ke placeholder "Unknown".
+- `blog-settings-directory.ts` (Issue #543) — `fetchBlogSettings`/`upsertBlogSettings` untuk `awcms_mini_blog_settings` (migration 026, satu baris per tenant), akhirnya diaktifkan lewat `GET`/`PATCH /api/v1/blog/settings` — lihat §Settings API.
 - `blog-taxonomy-directory.ts` — dulu (Issue #537) hanya `fetchBlogTermsByTaxonomyType` placeholder; Issue #539 melengkapinya dengan CRUD term penuh (`createBlogTerm`, `fetchBlogTermById`, `listBlogTerms`, `updateBlogTerm`, `softDeleteBlogTerm`) plus fungsi relasi post-term (`syncPostTermAssignments`, `fetchPostTermIds`, `countExistingTerms`) — lihat §Post-term relation handling.
 - `blog-search.ts` (Issue #539) — `searchBlogContentAdmin` (semua status, guard `search.read`) dan `searchPublicBlogContent` (predikat publik, helper murni — lihat §Search).
 - `blog-revision-directory.ts` (Issue #541) — `createBlogRevision` (INSERT-only, `revision_number` = `MAX(...)+1` scoped ke `(tenant_id, resource_type, resource_id)`), `listBlogRevisions`, `fetchBlogRevisionById` (di-scope ke `resource_id` juga, bukan cuma `id` — revisionId dari post lain tidak bisa dibaca lewat URL post ini). Tidak ada fungsi update/delete di file ini sama sekali — lihat §Revisions.
@@ -270,7 +274,7 @@ Tidak ada pemanggilan provider eksternal sama sekali di job ini (ADR-0006 tidak 
 
 `asyncapi/awcms-mini-domain-events.asyncapi.yaml` — 26 channel untuk `blog_content` (13 dari Issue #541 + 13 dari Issue #542), terdaftar juga di `module.ts`'s `events.publishes` (divalidasi `scripts/api-spec-check.ts`'s `checkModuleEventChannels`: tiap entry `publishes` module manapun wajib punya channel AsyncAPI yang cocok). Sama seperti setiap event lain di kontrak ini sejak Issue 0.3: **dokumentasi kontrak saja** — tidak ada dispatcher pub/sub nyata di repo ini; produser sebenarnya adalah structured JSON logger (`src/lib/logging/logger.ts`'s `log()`), bukan event bus. Konvensi penamaan log line: buang prefix `awcms-mini.` dari event type (`awcms-mini.blog-content.post.published` -> log message `blog-content.post.published`) — pola sama persis `email.message.queued` dkk.
 
-25 dari 26 event punya produser nyata di kode saat ini:
+Ke-26 event punya produser nyata di kode saat ini (Issue #543 menutup satu-satunya celah yang tersisa, `settings.updated`):
 
 | Event (AsyncAPI channel, tanpa prefix `awcms-mini.`)  | Log line diemisikan dari                                                                                                                                                                                         |
 | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -291,8 +295,9 @@ Tidak ada pemanggilan provider eksternal sama sekali di job ini (ADR-0006 tidak 
 | `blog-content.widget.created`/`.updated`/`.deleted`   | `pages/api/v1/blog/widgets/index.ts` (`POST`), `[id].ts` (`PATCH`/`DELETE`)                                                                                                                                      |
 | `blog-content.ad.created`/`.updated`/`.deleted`       | `pages/api/v1/blog/ads/index.ts` (`POST`), `[id].ts` (`PATCH`/`DELETE`)                                                                                                                                          |
 | `blog-content.theme.updated`                          | `pages/api/v1/blog/theme/index.ts` (`PATCH`) — **beda** dari `settings.updated` di bawah, ini tegas tentang `awcms_mini_blog_theme_settings`, bukan `awcms_mini_blog_settings`                                   |
+| `blog-content.settings.updated`                       | `pages/api/v1/blog/settings/index.ts` (`PATCH`, Issue #543) — tentang `awcms_mini_blog_settings`                                                                                                                 |
 
-Satu-satunya event **tanpa** produser saat ini: `blog-content.settings.updated` — didaftarkan sesuai daftar literal doc issue #541, tapi belum ada endpoint yang menulis `awcms_mini_blog_settings` (`blog_content.settings.configure` sudah diseed sejak Issue #537, menunggu endpoint-nya). `checkModuleEventChannels` hanya memvalidasi arah module.ts→AsyncAPI (setiap `publishes` wajib ada channel), bukan sebaliknya, jadi channel tanpa produser tidak membuat `api:spec:check` gagal.
+`checkModuleEventChannels` hanya memvalidasi arah module.ts→AsyncAPI (setiap `publishes` wajib ada channel), bukan sebaliknya — jadi sebelum Issue #543, channel `settings.updated` tanpa produser tidak sempat membuat `api:spec:check` gagal.
 
 ## Presentation extensions (Issue #542)
 
@@ -354,16 +359,122 @@ Persyaratan inti ("locale-based storage/retrieval", "slug uniqueness tenant+loca
 
 Doc issue #542 eksplisit: "Do not rebuild the base media library... Integrate with existing media/file capability where available." Base repo ini **tidak punya** media library nyata — `featuredMediaId` di posts/pages (Issue #538) cuma UUID longgar tanpa FK, tervalidasi bentuknya saja. Karena tidak ada yang nyata untuk diintegrasikan, galeri diimplementasikan sebagai tipe block baru di whitelist renderer yang sudah ada (`content-block-rendering.ts`, lihat §Content block schema di §Public routes): `{ type: "gallery", items: GalleryItem[] }`, tiap item `{ mediaType: "image"|"video", url, caption? }`. `url` divalidasi `isAbsoluteHttpUrl` saat render (defense-in-depth yang sama seperti `canonicalUrl`); item gagal validasi di-skip diam-diam (bukan throw). Render hanya `<img>`/`<video controls>` — tidak ada `<iframe>`/embed. Tidak ada endpoint/tabel gallery terpisah — galeri adalah bagian dari `content_json` post/page yang sudah ada, ditulis lewat `PATCH` yang sudah ada juga.
 
+## Settings API (Issue #543)
+
+`GET`/`PATCH /api/v1/blog/settings` (`src/pages/api/v1/blog/settings/index.ts`) — akhirnya mengaktifkan `awcms_mini_blog_settings` (migration 026, satu baris per tenant, `tenant_id` = PK) yang sejak Issue #537 sudah ada di schema tapi tidak punya route. Tidak ada `{id}` di path — sama seperti `PATCH /api/v1/blog/theme`, satu baris per tenant.
+
+```txt
+GET   /api/v1/blog/settings   -> blog_content.settings.read
+PATCH /api/v1/blog/settings   -> blog_content.settings.configure
+```
+
+Field: `defaultLocale`/`defaultVisibility`/`postsPerPage`/`seoDefaultTitle`/`seoDefaultDescription` sudah punya kolom typed sendiri sejak migration 026 (dipakai juga oleh `fetchPublicBlogSettings`, Issue #540, untuk `posts_per_page` pagination publik). `blogTitle`/`blogDescription`/`rssEnabled`/`sitemapEnabled` **tidak** punya kolom sendiri — di luar scope issue ini menambah kolom baru — jadi disimpan di kolom catch-all `settings jsonb` yang tabel itu sudah punya (shallow-merge, bukan replace, sama semantik `updateModuleSettings`). `PATCH` partial-update (hanya field yang dikirim yang divalidasi/ditulis, `domain/blog-settings-policy.ts`'s `validateUpdateBlogSettingsInput`), publish `blog-content.settings.updated` (menutup celah yang README §Domain events sebelumnya catat: channel-nya sudah terdaftar sejak Issue #541 tapi belum ada produsen sampai sekarang) dan audit `blog.settings.updated`.
+
+### RSS/sitemap sekarang menghormati `rssEnabled`/`sitemapEnabled`
+
+`GET /blog/{tenantCode}/feed.xml` dan `.../sitemap-blog.xml` (Issue #540) memanggil `fetchBlogSettings` di awal handler dan mengembalikan `404` yang identik dengan tenant-tidak-ditemukan kalau flag terkait `false` — tenant yang mematikan RSS/sitemap tidak membocorkan sinyal "fitur ini ada tapi dimatikan" vs "tenant ini tidak ada", konsisten dengan ADR-0009's "jangan bocorkan keberadaan tenant" yang sudah diterapkan §Public routes.
+
+## Admin UI (Issue #543)
+
+Seluruh layar di bawah `/admin/blog` (`src/pages/admin/blog/`), memakai `AdminLayout`/design token yang sudah ada (`docs/awcms-mini/14_ui_ux_design_system.md`), Astro + vanilla JS saja — tidak ada framework UI baru. Pola tiap layar identik `admin/modules/[moduleKey].astro`/`admin/access-users.astro` (referensi yang sudah ada sebelum issue ini): SSR read lewat fungsi application-layer yang sama yang dipakai (atau bisa dipakai) endpoint JSON, seluruh mutasi lewat `fetch()` client-side ke endpoint `/api/v1/blog/...` yang sudah ter-guard/audit/idempotency sejak Issue #538-#542 — halaman admin **tidak pernah** menulis ke database langsung atau melewati guard ABAC endpoint. Permission-gated per-section, mengikuti persis guard endpoint yang mendasarinya (defense-in-depth; enforcement sebenarnya tetap di server).
+
+```txt
+/admin/blog                    -> dashboard (ringkasan post/draft/scheduled/pages, quick link)
+/admin/blog/posts              -> daftar post (search, filter status, filter kategori/tag, pagination)
+/admin/blog/posts/new          -> editor post baru
+/admin/blog/posts/[id]         -> editor post (edit, lifecycle action, revision history)
+/admin/blog/pages              -> daftar halaman statis (search, filter status/type, pagination)
+/admin/blog/pages/new          -> editor halaman baru
+/admin/blog/pages/[id]         -> editor halaman (edit saja — tidak ada lifecycle action/revision UI)
+/admin/blog/categories         -> manajer kategori (hierarki, slug conflict terlihat)
+/admin/blog/tags               -> manajer tag (TIDAK ada field parent sama sekali)
+/admin/blog/settings           -> form pengaturan blog + mode tema
+/admin/blog/templates          -> manajer template (opsional, Issue #542)
+/admin/blog/widgets            -> manajer widget (opsional, Issue #542)
+/admin/blog/menus              -> manajer menu (opsional, Issue #542)
+/admin/blog/ads                -> manajer iklan (opsional, Issue #542)
+```
+
+Navigasi sidebar: satu entry `/admin/blog` di `module.ts`'s `navigation` array (label `admin.layout.nav_blog`, guard `blog_content.posts.read`), dirender otomatis oleh `AdminLayout.astro` lewat `fetchVisibleModuleNavigationEntries` (Issue #518) yang sudah ada — bukan ditambahkan hardcode ke `AdminLayout.astro`. Sub-navigasi antar layar `/admin/blog/*` memakai quick-link biasa di dashboard/tiap layar (repo ini tidak punya konvensi sidebar bertingkat).
+
+### Post editor — pemetaan field ke API
+
+`content` dipecah jadi dua field terpisah, sama seperti bentuk data `awcms_mini_blog_posts` sendiri: `contentText` (textarea polos, wajib) dan `contentJson` (textarea JSON berlabel, default `{"blocks":[]}`, divalidasi `JSON.parse` di klien sebelum submit + `validateContentJsonField` di server) — bukan rich-text/block editor baru (`content_json`'s schema sejak Issue #540 hanya 4+1 tipe block, `paragraph`/`heading`/`list`/`quote`/`gallery`; membangun editor visual untuk itu di luar proporsi issue ini). "Category" dan "Tags" dirender sebagai dua `<select multiple>` terpisah (difilter dari term list yang sama by `taxonomyType`) tapi digabung jadi satu array `termIds` saat submit — API sendiri tidak membedakan kategori vs tag di dalam `termIds`.
+
+Lifecycle action (`submit-review`/`publish`/`schedule`/`archive`/`restore`/`purge`) masing-masing dirender hanya kalau `isValidStatusTransition`/`canRestorePost`/`canPurgePost` (fungsi murni yang sama yang dipakai endpoint) mengizinkan transisi itu dari status post saat ini **dan** caller memegang permission aksi itu — cek ini UI-nicety saja, endpoint tetap re-validasi identik. Publish/schedule/archive/restore/purge semuanya: `window.confirm` dulu, lalu `Idempotency-Key` baru (`crypto.randomUUID()`, `lib/ui/admin-form-client.ts`'s `newIdempotencyKey`) per percobaan. Revision history (`blog_content.revisions.read`) menampilkan tabel revisi + tombol "Restore" per baris (`blog_content.revisions.restore`, guard eksplisit terpisah — TIDAK ada ownership override, sama seperti endpoint-nya), juga confirm dulu.
+
+Field "author" (post list + editor) diresolusi lewat `author-lookup.ts`'s `fetchAuthorDisplayNames`, bukan `identity-access`'s user-directory penuh (lihat §Application untuk alasannya).
+
+### Page editor — tanpa lifecycle, tanpa revision UI
+
+Sengaja tidak ada tombol status/publish sama sekali — `UpdateBlogPageInput` tidak punya field `status` (README §Admin API — Blog Pages: page selalu `draft` sejak dibuat, tidak ada endpoint yang mengubahnya). Tidak ada panel revision history untuk page juga — `createBlogRevision` tetap terpanggil dari `PATCH /api/v1/blog/pages/{id}` (baris tersimpan di `awcms_mini_blog_revisions`), tapi tidak ada rute `GET .../revisions` untuk `resource_type='page'` yang bisa dipanggil UI ini (lihat §Belum tersedia — backlog issue lain, bukan sesuatu yang bisa "ditambahkan" cukup dari sisi UI).
+
+### Category/Tag manager — pemisahan file yang disengaja
+
+`admin/blog/categories.astro` dan `admin/blog/tags.astro` adalah dua file terpisah (bukan satu layar param `?type=`) justru supaya larangan "tag tidak boleh punya parent" bisa ditegakkan secara struktural di level markup — `tags.astro` tidak pernah merender elemen form `parentId` sama sekali (bukan field yang disembunyikan lewat kondisi), jadi tidak ada jalur UI yang bisa mengirim `parentId` untuk tag. Keduanya memanggil `/api/v1/blog/terms` yang sama, hanya body `taxonomyType` yang beda. Slug conflict (`409 SLUG_CONFLICT`, tidak ada entry i18n khusus) tampil apa adanya dari pesan server via action banner — sama seperti setiap kode error tak-terpetakan lain di admin UI.
+
+### Templates/Widgets/Ads/Menus — sub-array kompleks via JSON textarea berlabel
+
+`layoutJson` template cukup sederhana (`{columns, sidebarPosition}`) untuk dua `<select>` biasa. `items` menu dan `placements` ads jauh lebih kompleks (array objek, dan `menu items` butuh id ber-UUID client-supplied yang saling mereferensi dalam satu payload, lihat README §Menus) — membangun editor tree/drag-drop khusus untuk itu di luar proporsi anggaran issue ini dan tetap harus menghasilkan bentuk JSON yang sama persis. Kedua form itu memakai textarea JSON berlabel + teks bantuan, pola yang sama seperti `admin/modules/[moduleKey].astro`'s settings panel sudah pakai untuk config terstruktur — tombol "Copy new id" di layar menu menyalin `crypto.randomUUID()` baru ke clipboard (bukan menyisipkannya ke textarea, supaya tidak pernah merusak JSON yang sedang diedit).
+
+### Theme mode masuk ke Settings, bukan layar sendiri
+
+`GET`/`PATCH /api/v1/blog/theme` (Issue #542) digabung ke `/admin/blog/settings` sebagai section tambahan, bukan `/admin/blog/theme` terpisah — ini konfigurasi tenant-wide sekelas field lain di layar itu, dan daftar layar issue #543 sendiri tidak menyebut layar theme terpisah.
+
+### Yang sengaja di-skip: layar Media/Gallery murni
+
+Issue #543's daftar layar opsional menyebut "Media/Gallery" — di-skip sebagai layar tersendiri karena tidak ada media library nyata untuk dikelola (README §Media/Gallery — Issue #542: galeri adalah bagian dari block `content_json`, bukan tabel/endpoint media terpisah). Mengelola galeri berarti mengedit array block `gallery` di dalam `contentJson` post/page — sudah bisa dilakukan lewat textarea `contentJson` yang ada di post/page editor, tidak butuh layar terpisah.
+
+### Aksesibilitas dan UX (doc 14)
+
+Setiap layar admin punya empat state eksplisit — loading (SSR, bukan spinner klien), empty (`p.empty-state`/pesan "belum ada ..."), error (`StateNotice kind="error"` dengan retry-link, dipisah dari `kind="denied"` untuk permission), dan ready (konten). Setiap aksi mutasi men-disable tombol submit-nya sendiri selama request in-flight (`lib/ui/admin-form-client.ts`'s `lockElement`, `aria-busy="true"`) supaya klik ganda/double-Enter tidak pernah mengirim dua request — bukan pengganti idempotency server-side, keduanya berlapis. Aksi high-risk (publish/schedule/archive/restore/purge/delete/purge-config/revision-restore) selalu `window.confirm` dulu. Semua `<label>` terasosiasi eksplisit dengan input-nya (markup `<label>teks<input/></label>`, bukan `aria-label` terpisah, kecuali untuk kontrol icon-only yang memang tidak punya teks visual). Fokus keyboard terlihat lewat `:focus-visible` (bukan `:focus` polos, supaya klik mouse tidak memicu outline yang tidak perlu) di setiap file `<style>` layar. Semua string tampil lewat `t()` (katalog `.po` gettext, `en`+`id`, lihat §Internationalization).
+
+### Internationalization
+
+Seluruh string UI (~300 key baru, namespace `admin.blog.*`) ditambahkan ke `i18n/en.po` **dan** `i18n/id.po` (skill `awcms-mini-i18n`, katalog gettext flat `namespace.key` di root `i18n/`, bukan per-modul) — tidak ada string hardcoded di file `.astro`. Client `<script>` tidak bisa membaca katalog `.po` langsung (server-only, `Bun.file`), jadi tiap layar menyuntikkan string yang sudah diterjemahkan lewat blob `<script type="application/json" id="i18n-strings">` (`readClientStrings()`), pola yang sama seperti `admin/access-users.astro`/`admin/modules/[moduleKey].astro` sudah pakai. `admin.layout.nav_blog` (label sidebar) dan beberapa `common.*` (`filter_all`/`previous_page`/`next_page`) baru — sisanya (`common.error_title`, `common.network_error`, dst.) memakai ulang key yang sudah ada.
+
+### Security notes (ringkasan Issue #543)
+
+- Tidak ada secret hardcoded ditambahkan — layar admin ini murni UI + panggilan ke endpoint yang sudah ada; tidak ada koneksi database langsung dari klien, tidak ada token/API key baru.
+- Tidak ada eksposur PostgreSQL publik — semua akses data tetap lewat `withTenant`/aplikasi backend yang sudah ada, SSR read di frontmatter Astro berjalan server-side (sama seperti `admin/index.astro`/`admin/sync.astro` yang sudah ada sebelum issue ini).
+- Least-privilege runtime DB access — tidak berubah; halaman admin tetap terikat koneksi role `awcms_mini_app` yang sama yang dipakai seluruh app (lihat `docs/awcms-mini/18_configuration_env_reference.md`).
+- RLS isolation — diuji ulang eksplisit di `tests/integration/blog-content-admin-ui.integration.test.ts` untuk dua fungsi baru (`listBlogPostsForAdmin` tenant-isolation test); fungsi lain yang dipanggil layar admin (`listBlogPages`, `listBlogTerms`, dst.) sudah punya cakupan RLS dari test suite Issue #538-#542.
+- Aksi admin high-risk wajib confirm + audit — lifecycle action posts sudah audit sejak Issue #538/#541 (`recordAuditEvent`, action `blog.post.<verb>`); layar admin menambah lapisan `window.confirm` di atasnya, tidak menggantikannya.
+- Rendering publik tetap aman dari XSS — tidak diubah oleh issue ini; `content_json`/`content_text`/widget `bodyText`/ad `imageUrl`/`linkUrl` tetap lewat whitelist renderer yang sama (`content-block-rendering.ts`, `ads-directory.ts`'s `renderAdHtml`). Editor admin (`contentJson` textarea) mengizinkan penulis mengetik apa pun, tapi validasi server (`validateContentJsonField`'s `containsUnsafeHtml`) tetap menolak `<script>`/`<iframe>`/`<embed>`/`<object>`/inline handler/`javascript:` sebelum tersimpan — editor tidak melonggarkan aturan itu.
+- Pesan error tidak membocorkan stack trace — action banner admin selalu menampilkan `error.message` dari respons API (yang sendiri sudah aman, doc 10) atau string generik `common.network_error`, tidak pernah `error.stack`/exception mentah dari `console.error` (yang hanya dicatat server-side).
+
+### Testing commands
+
+```bash
+bun run db:migrate                     # skema tidak berubah di issue ini (0 applied, 30 skipped)
+bun run api:spec:check                 # OpenAPI/AsyncAPI baseline (26 channel blog-content, semua terpakai)
+bun run typecheck                      # tsc --noEmit, termasuk seluruh .astro admin/blog/*
+bun test                               # unit + integration; DATABASE_URL wajib untuk suite integration
+bun test tests/integration/blog-content-admin-ui.integration.test.ts  # test baru khusus Issue #543
+bun run build                          # Astro build, termasuk seluruh layar admin/blog/*
+bun run check                          # lint + check:docs + api:spec:check + typecheck + test + build
+bun run production:preflight           # gate go-live penuh (lihat §Known limitations soal env sandbox)
+```
+
+### Operational checklist (Issue #543)
+
+- [ ] Sebelum deploy: `bun run db:migrate` (idempoten, aman dijalankan berkali-kali).
+- [ ] `bun run check` hijau di CI sebelum merge.
+- [ ] Setelah deploy, verifikasi manual: login sebagai role dengan `blog_content.posts.read` -> `/admin/blog` tampil di sidebar -> buat post draft -> publish -> cek muncul di `/blog/{tenantCode}` (kalau visibility `public`).
+- [ ] Verifikasi `rssEnabled`/`sitemapEnabled` di `/admin/blog/settings`: matikan salah satu -> `feed.xml`/`sitemap-blog.xml` tenant itu mengembalikan 404.
+- [ ] `bun run blog:publish:scheduled` tetap dijadwalkan cron/systemd timer terpisah (Issue #541, tidak berubah oleh issue ini) — bukan dipicu dari UI mana pun.
+- [ ] Audit log (`/admin` -> module audit summary atau `GET /api/v1/logs/audit`) menunjukkan `blog.post.*`/`blog.settings.updated` setelah aksi lifecycle/settings dari UI baru ini.
+
 ## Belum tersedia (backlog eksplisit, bukan kelalaian)
 
 - Public page (halaman statis) rendering — hanya post yang punya rute publik di Issue #540, lihat §Public routes.
-- Page revision list/detail/restore endpoints — `createBlogRevision` sudah dipanggil dari `PATCH /api/v1/blog/pages/{id}` (baris tersimpan), tapi tidak ada rute baca/restore untuk `resource_type = 'page'`, hanya post (lihat §Revisions).
-- `POST /api/v1/blog/settings` (atau setara) — `blog-content.settings.updated` sudah didaftarkan di kontrak AsyncAPI (Issue #541) tapi belum ada endpoint yang menulis `awcms_mini_blog_settings`.
+- Page revision list/detail/restore endpoints — `createBlogRevision` sudah dipanggil dari `PATCH /api/v1/blog/pages/{id}` (baris tersimpan), tapi tidak ada rute baca/restore untuk `resource_type = 'page'`, hanya post (lihat §Revisions). Admin UI (§Admin UI di atas) karena itu juga tidak punya panel revision untuk page.
 - Rute publik untuk widget/ads rendering (header/sidebar/footer placement nyata di halaman publik) — `listActiveAdsForPlacement`/`renderAdHtml`/`listWidgets({ activeOnly: true })` sudah ada dan teruji, belum dipasang ke rute publik manapun.
 - Rute revisi/`translationGroupId` untuk pages — `setPostTranslationGroup` hanya untuk posts di issue ini.
-- Admin UI, dokumentasi akhir, hardening — Issue #543.
-- Page lifecycle-action endpoints (`submit-review`/`publish`/`schedule`/`archive`/`restore`/`purge` untuk pages) — permission-nya sudah diseed (Issue #537) tapi tidak ada issue yang eksplisit membangun endpoint-nya; backlog terbuka, bukan bagian #539.
+- Page lifecycle-action endpoints (`submit-review`/`publish`/`schedule`/`archive`/`restore`/`purge` untuk pages) — permission-nya sudah diseed (Issue #537) tapi tidak ada issue yang eksplisit membangun endpoint-nya; backlog terbuka, bukan bagian #539. Konsekuensinya, editor page (§Admin UI) juga tidak punya tombol status apa pun.
 - Optimistic-concurrency check yang membaca kolom `version` — kolom sudah di-increment tiap write, tapi belum ada endpoint yang menolak write berdasarkan `version` mismatch.
 - Search relevance ranking (`ts_rank`) dan text search config per-locale (`english`/`indonesian`) — `search_vector` sudah weighted (A/B/C) untuk kebutuhan ini di masa depan, tapi `GET /api/v1/blog/search` (admin) dan search publik saat ini hanya mengurutkan `created_at DESC`.
 - Locale-aware negotiation untuk pengunjung publik (mis. header `Accept-Language`) — index/detail publik saat ini menampilkan semua post tanpa filter locale; `<html lang>` memakai locale post/tenant, bukan preferensi pengunjung.
 - `robots.txt` dan referensi sitemap dari `robots.txt` — hanya sitemap XML-nya sendiri yang ada, belum ada yang mereferensikannya secara otomatis.
+- Rich block editor visual untuk `content_json` — admin UI (Issue #543) memakai textarea JSON berlabel untuk `contentJson`/menu items/ad placements, bukan editor visual/drag-drop; membangun itu tetap backlog terbuka kalau suatu saat dianggap perlu.
+- Layar admin murni untuk media/gallery — tidak ada (dan tidak akan ada tanpa base media library nyata); galeri dikelola lewat block `content_json` di editor post/page yang ada.

--- a/src/modules/blog-content/application/author-lookup.ts
+++ b/src/modules/blog-content/application/author-lookup.ts
@@ -1,0 +1,53 @@
+/**
+ * Author display-name lookup for the admin UI (Issue #543 §Post List/§Post
+ * Editor — "author" column/field). A blog post/page only stores
+ * `author_tenant_user_id` (a bare id, `blog-post-directory.ts`/
+ * `blog-page-directory.ts` intentionally stay pure to their own table).
+ * Resolving that id to a human-readable name means joining
+ * `awcms_mini_tenant_users` -> `awcms_mini_identities` -> `awcms_mini_profiles`
+ * (`display_name`) — the exact join `identity-access/application/
+ * user-directory.ts`'s `fetchTenantUsersWithRoles` already does for
+ * `/admin/access-users`, but that function also loads role assignments and
+ * is gated by `identity_access.user_management.read`, a permission a blog
+ * editor need not hold just to see who authored a post. This file is a
+ * narrower, purpose-built read: tenant-scoped, bounded to the ids actually
+ * requested, no role data, and usable by anyone who can already read blog
+ * posts/pages (author names of content they can already see is not new
+ * information exposure).
+ */
+
+export type AuthorLookupRow = {
+  tenant_user_id: string;
+  display_name: string;
+};
+
+/**
+ * Returns a `Map<tenantUserId, displayName>` covering every id in
+ * `tenantUserIds` that still resolves to an active tenant-user row (a
+ * deleted/orphaned author id is simply absent from the map — callers should
+ * fall back to a placeholder, never throw).
+ */
+export async function fetchAuthorDisplayNames(
+  tx: Bun.SQL,
+  tenantId: string,
+  tenantUserIds: readonly string[]
+): Promise<Map<string, string>> {
+  const uniqueIds = [...new Set(tenantUserIds)];
+
+  if (uniqueIds.length === 0) {
+    return new Map();
+  }
+
+  const rows = (await tx`
+    SELECT tu.id AS tenant_user_id, p.display_name
+    FROM awcms_mini_tenant_users tu
+    JOIN awcms_mini_identities i
+      ON i.id = tu.identity_id AND i.tenant_id = tu.tenant_id
+    JOIN awcms_mini_profiles p
+      ON p.id = i.profile_id AND p.tenant_id = tu.tenant_id
+    WHERE tu.tenant_id = ${tenantId}
+      AND tu.id = ANY(${tx.array([...uniqueIds], "uuid")})
+  `) as AuthorLookupRow[];
+
+  return new Map(rows.map((row) => [row.tenant_user_id, row.display_name]));
+}

--- a/src/modules/blog-content/application/blog-page-directory.ts
+++ b/src/modules/blog-content/application/blog-page-directory.ts
@@ -254,6 +254,73 @@ export async function listBlogPages(
   return rows.map(toBlogPageSummary);
 }
 
+export type ListBlogPagesForAdminFilter = {
+  search?: string;
+  status?: BlogContentStatus;
+  pageType?: PageType;
+  page?: number;
+  pageSize?: number;
+};
+
+export type ListBlogPagesForAdminResult = {
+  items: BlogPageSummary[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+const DEFAULT_ADMIN_LIST_PAGE_SIZE = 20;
+const MAX_ADMIN_LIST_PAGE_SIZE = 100;
+
+/**
+ * Admin page list (Issue #543 §Page List) — additive, mirrors
+ * `blog-post-directory.ts`'s `listBlogPostsForAdmin` (`ILIKE` title search,
+ * page-number pagination with a total count) minus the term filter (pages
+ * have no taxonomy relation).
+ */
+export async function listBlogPagesForAdmin(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: ListBlogPagesForAdminFilter = {}
+): Promise<ListBlogPagesForAdminResult> {
+  const pageSize = Math.min(
+    Math.max(filter.pageSize ?? DEFAULT_ADMIN_LIST_PAGE_SIZE, 1),
+    MAX_ADMIN_LIST_PAGE_SIZE
+  );
+  const page = Math.max(filter.page ?? 1, 1);
+  const offset = (page - 1) * pageSize;
+  const search = filter.search?.trim() || null;
+  const status = filter.status ?? null;
+  const pageType = filter.pageType ?? null;
+
+  const rows = (await tx`
+    SELECT id, tenant_id, title, slug, status, visibility, page_type, parent_page_id, menu_order, locale, updated_at
+    FROM awcms_mini_blog_pages
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+      AND (${status}::text IS NULL OR status = ${status})
+      AND (${pageType}::text IS NULL OR page_type = ${pageType})
+      AND (${search}::text IS NULL OR title ILIKE '%' || ${search} || '%')
+    ORDER BY updated_at DESC
+    LIMIT ${pageSize} OFFSET ${offset}
+  `) as BlogPageSummaryRow[];
+
+  const countRows = (await tx`
+    SELECT count(*)::int AS count
+    FROM awcms_mini_blog_pages
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+      AND (${status}::text IS NULL OR status = ${status})
+      AND (${pageType}::text IS NULL OR page_type = ${pageType})
+      AND (${search}::text IS NULL OR title ILIKE '%' || ${search} || '%')
+  `) as { count: number }[];
+
+  return {
+    items: rows.map(toBlogPageSummary),
+    total: countRows[0]?.count ?? 0,
+    page,
+    pageSize
+  };
+}
+
 /** Partial update; `version` bumped on every successful write (same monotonic-counter convention as `updateBlogPost`, no optimistic-concurrency check yet). */
 export async function updateBlogPage(
   tx: Bun.SQL,

--- a/src/modules/blog-content/application/blog-post-directory.ts
+++ b/src/modules/blog-content/application/blog-post-directory.ts
@@ -371,6 +371,101 @@ export async function restoreBlogPost(
   return rows[0] ? toView(rows[0]) : null;
 }
 
+export type ListBlogPostsForAdminFilter = {
+  search?: string;
+  status?: BlogContentStatus;
+  /** Matches posts assigned this category/tag term id (via `awcms_mini_blog_post_terms`). */
+  termId?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+export type ListBlogPostsForAdminResult = {
+  items: (BlogPostSummary & { authorTenantUserId: string })[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+type BlogPostAdminListRow = BlogPostSummaryRow & {
+  author_tenant_user_id: string;
+};
+
+const DEFAULT_ADMIN_LIST_PAGE_SIZE = 20;
+const MAX_ADMIN_LIST_PAGE_SIZE = 100;
+
+/**
+ * Admin post list (Issue #543 §Post List — search, status filter,
+ * category/tag filter, pagination) — additive to this file, does not touch
+ * `listBlogPosts` (still used by `GET /api/v1/blog/posts` as-is). `search`
+ * is a plain `ILIKE` on `title` (not `search_vector`/`websearch_to_tsquery`
+ * — those reject an empty query, which the default "no filter" list view
+ * needs to tolerate). `termId` matches via `EXISTS` against
+ * `awcms_mini_blog_post_terms` rather than a `JOIN`, so a post with several
+ * terms is never returned more than once. Page-number/`LIMIT`/`OFFSET`
+ * pagination (not keyset) — this is a human-browsed admin table with
+ * "page 1, 2, 3" controls, same UX category `public-blog-directory.ts`'s
+ * index/archive pagination already chose over keyset for the same reason.
+ */
+export async function listBlogPostsForAdmin(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: ListBlogPostsForAdminFilter = {}
+): Promise<ListBlogPostsForAdminResult> {
+  const pageSize = Math.min(
+    Math.max(filter.pageSize ?? DEFAULT_ADMIN_LIST_PAGE_SIZE, 1),
+    MAX_ADMIN_LIST_PAGE_SIZE
+  );
+  const page = Math.max(filter.page ?? 1, 1);
+  const offset = (page - 1) * pageSize;
+  const search = filter.search?.trim() || null;
+  const status = filter.status ?? null;
+  const termId = filter.termId ?? null;
+
+  const rows = (await tx`
+    SELECT p.id, p.tenant_id, p.title, p.slug, p.status, p.visibility, p.locale,
+           p.author_tenant_user_id, p.published_at, p.updated_at
+    FROM awcms_mini_blog_posts p
+    WHERE p.tenant_id = ${tenantId} AND p.deleted_at IS NULL
+      AND (${status}::text IS NULL OR p.status = ${status})
+      AND (${search}::text IS NULL OR p.title ILIKE '%' || ${search} || '%')
+      AND (
+        ${termId}::uuid IS NULL
+        OR EXISTS (
+          SELECT 1 FROM awcms_mini_blog_post_terms pt
+          WHERE pt.tenant_id = p.tenant_id AND pt.post_id = p.id AND pt.term_id = ${termId}
+        )
+      )
+    ORDER BY p.updated_at DESC
+    LIMIT ${pageSize} OFFSET ${offset}
+  `) as BlogPostAdminListRow[];
+
+  const countRows = (await tx`
+    SELECT count(*)::int AS count
+    FROM awcms_mini_blog_posts p
+    WHERE p.tenant_id = ${tenantId} AND p.deleted_at IS NULL
+      AND (${status}::text IS NULL OR p.status = ${status})
+      AND (${search}::text IS NULL OR p.title ILIKE '%' || ${search} || '%')
+      AND (
+        ${termId}::uuid IS NULL
+        OR EXISTS (
+          SELECT 1 FROM awcms_mini_blog_post_terms pt
+          WHERE pt.tenant_id = p.tenant_id AND pt.post_id = p.id AND pt.term_id = ${termId}
+        )
+      )
+  `) as { count: number }[];
+
+  return {
+    items: rows.map((row) => ({
+      ...toBlogPostSummary(row),
+      authorTenantUserId: row.author_tenant_user_id
+    })),
+    total: countRows[0]?.count ?? 0,
+    page,
+    pageSize
+  };
+}
+
 /**
  * Hard delete. `awcms_mini_blog_post_terms` rows for this post are deleted
  * first — they are pure join metadata with no independent meaning once the

--- a/src/modules/blog-content/application/blog-settings-directory.ts
+++ b/src/modules/blog-content/application/blog-settings-directory.ts
@@ -1,0 +1,139 @@
+/**
+ * `awcms_mini_blog_settings` read/write (Issue #543 §Settings Page) — one
+ * row per tenant, same upsert convention `theme-settings-directory.ts`
+ * (Issue #542) uses for `awcms_mini_blog_theme_settings`. `blogTitle`,
+ * `blogDescription`, `rssEnabled`, `sitemapEnabled` are stored in the
+ * table's catch-all `settings jsonb` column (see `blog-settings-policy.ts`
+ * header comment for why); everything else has its own typed column
+ * already seeded by migration 026.
+ */
+import type { UpdateBlogSettingsInput } from "../domain/blog-settings-policy";
+import type { BlogContentVisibility } from "../domain/post-status";
+
+export type BlogSettingsView = {
+  tenantId: string;
+  blogTitle: string;
+  blogDescription: string | null;
+  postsPerPage: number;
+  rssEnabled: boolean;
+  sitemapEnabled: boolean;
+  defaultLocale: string;
+  defaultVisibility: BlogContentVisibility;
+  seoDefaultTitle: string | null;
+  seoDefaultDescription: string | null;
+  updatedAt: string | null;
+};
+
+const DEFAULT_BLOG_TITLE = "Blog";
+const DEFAULT_POSTS_PER_PAGE = 10;
+
+type BlogSettingsRow = {
+  tenant_id: string;
+  default_locale: string;
+  default_visibility: BlogContentVisibility;
+  posts_per_page: number;
+  seo_default_title: string | null;
+  seo_default_description: string | null;
+  settings: Record<string, unknown>;
+  updated_at: Date;
+};
+
+function toView(
+  tenantId: string,
+  row: BlogSettingsRow | null
+): BlogSettingsView {
+  const extras = row?.settings ?? {};
+
+  return {
+    tenantId,
+    blogTitle:
+      typeof extras.blogTitle === "string"
+        ? extras.blogTitle
+        : DEFAULT_BLOG_TITLE,
+    blogDescription:
+      typeof extras.blogDescription === "string"
+        ? extras.blogDescription
+        : null,
+    postsPerPage: row?.posts_per_page ?? DEFAULT_POSTS_PER_PAGE,
+    rssEnabled: extras.rssEnabled !== false,
+    sitemapEnabled: extras.sitemapEnabled !== false,
+    defaultLocale: row?.default_locale ?? "id",
+    defaultVisibility: row?.default_visibility ?? "public",
+    seoDefaultTitle: row?.seo_default_title ?? null,
+    seoDefaultDescription: row?.seo_default_description ?? null,
+    updatedAt: row?.updated_at.toISOString() ?? null
+  };
+}
+
+/** `null` row (tenant never configured settings) still returns a full view built from defaults — same "missing row = default" convention `fetchPublicBlogSettings` already uses. */
+export async function fetchBlogSettings(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<BlogSettingsView> {
+  const rows = (await tx`
+    SELECT tenant_id, default_locale, default_visibility, posts_per_page,
+           seo_default_title, seo_default_description, settings, updated_at
+    FROM awcms_mini_blog_settings
+    WHERE tenant_id = ${tenantId}
+  `) as BlogSettingsRow[];
+
+  return toView(tenantId, rows[0] ?? null);
+}
+
+/**
+ * Upsert — merges `patch` onto the existing row (typed columns overwritten
+ * only when present in `patch`; `blogTitle`/`blogDescription`/`rssEnabled`/
+ * `sitemapEnabled` shallow-merged into the existing `settings` jsonb blob,
+ * same merge-patch semantics `updateModuleSettings` uses).
+ */
+export async function upsertBlogSettings(
+  tx: Bun.SQL,
+  tenantId: string,
+  patch: UpdateBlogSettingsInput
+): Promise<BlogSettingsView> {
+  const existing = await fetchBlogSettings(tx, tenantId);
+
+  const defaultLocale = patch.defaultLocale ?? existing.defaultLocale;
+  const defaultVisibility =
+    patch.defaultVisibility ?? existing.defaultVisibility;
+  const postsPerPage = patch.postsPerPage ?? existing.postsPerPage;
+  const seoDefaultTitle =
+    patch.seoDefaultTitle !== undefined
+      ? patch.seoDefaultTitle
+      : existing.seoDefaultTitle;
+  const seoDefaultDescription =
+    patch.seoDefaultDescription !== undefined
+      ? patch.seoDefaultDescription
+      : existing.seoDefaultDescription;
+
+  const extras = {
+    blogTitle: patch.blogTitle ?? existing.blogTitle,
+    blogDescription:
+      patch.blogDescription !== undefined
+        ? patch.blogDescription
+        : existing.blogDescription,
+    rssEnabled: patch.rssEnabled ?? existing.rssEnabled,
+    sitemapEnabled: patch.sitemapEnabled ?? existing.sitemapEnabled
+  };
+
+  const rows = (await tx`
+    INSERT INTO awcms_mini_blog_settings
+      (tenant_id, default_locale, default_visibility, posts_per_page,
+       seo_default_title, seo_default_description, settings, updated_at)
+    VALUES
+      (${tenantId}, ${defaultLocale}, ${defaultVisibility}, ${postsPerPage},
+       ${seoDefaultTitle}, ${seoDefaultDescription}, ${extras}, now())
+    ON CONFLICT (tenant_id) DO UPDATE SET
+      default_locale = EXCLUDED.default_locale,
+      default_visibility = EXCLUDED.default_visibility,
+      posts_per_page = EXCLUDED.posts_per_page,
+      seo_default_title = EXCLUDED.seo_default_title,
+      seo_default_description = EXCLUDED.seo_default_description,
+      settings = EXCLUDED.settings,
+      updated_at = now()
+    RETURNING tenant_id, default_locale, default_visibility, posts_per_page,
+              seo_default_title, seo_default_description, settings, updated_at
+  `) as BlogSettingsRow[];
+
+  return toView(tenantId, rows[0] ?? null);
+}

--- a/src/modules/blog-content/domain/blog-settings-policy.ts
+++ b/src/modules/blog-content/domain/blog-settings-policy.ts
@@ -1,0 +1,215 @@
+/**
+ * `PATCH /api/v1/blog/settings` validator (Issue #543 §Settings Page).
+ * `awcms_mini_blog_settings` (migration 026, Issue #537) already has typed
+ * columns for `default_locale`/`default_visibility`/`posts_per_page`/
+ * `seo_default_title`/`seo_default_description` — this issue is the first
+ * to actually read/write them through an admin route. `blogTitle`,
+ * `blogDescription`, `rssEnabled`, and `sitemapEnabled` have no dedicated
+ * column (out of this issue's scope to add one — the table's existing
+ * catch-all `settings jsonb` column is exactly for this), so they live
+ * under that column instead. Partial-update shape, same convention as
+ * `validateUpdateBlogPostInput`: only fields present in the body are
+ * validated/copied.
+ */
+import { validateLocaleField } from "./content-validation";
+import {
+  isBlogContentVisibility,
+  type BlogContentVisibility
+} from "./post-status";
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const MAX_BLOG_TITLE_LENGTH = 200;
+const MAX_BLOG_DESCRIPTION_LENGTH = 500;
+const MAX_SEO_TITLE_LENGTH = 200;
+const MAX_SEO_DESCRIPTION_LENGTH = 300;
+const MIN_POSTS_PER_PAGE = 1;
+const MAX_POSTS_PER_PAGE = 100;
+
+export type UpdateBlogSettingsInput = {
+  blogTitle?: string;
+  blogDescription?: string | null;
+  postsPerPage?: number;
+  rssEnabled?: boolean;
+  sitemapEnabled?: boolean;
+  defaultLocale?: string;
+  defaultVisibility?: BlogContentVisibility;
+  seoDefaultTitle?: string | null;
+  seoDefaultDescription?: string | null;
+};
+
+export type UpdateBlogSettingsValidationResult =
+  | { valid: true; value: UpdateBlogSettingsInput }
+  | { valid: false; errors: ValidationError[] };
+
+function validateOptionalBoundedString(
+  value: unknown,
+  field: string,
+  maxLength: number,
+  requireNonEmpty: boolean
+): ValidationError | null {
+  if (value === null && !requireNonEmpty) {
+    return null;
+  }
+
+  if (
+    typeof value !== "string" ||
+    (requireNonEmpty && value.trim().length === 0)
+  ) {
+    return {
+      field,
+      message: requireNonEmpty
+        ? `${field} must be a non-empty string.`
+        : `${field} must be a string or null.`
+    };
+  }
+
+  if (value.length > maxLength) {
+    return {
+      field,
+      message: `${field} must be at most ${maxLength} characters.`
+    };
+  }
+
+  return null;
+}
+
+export function validateUpdateBlogSettingsInput(
+  body: unknown
+): UpdateBlogSettingsValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+  const value: UpdateBlogSettingsInput = {};
+
+  if (record.blogTitle !== undefined) {
+    const error = validateOptionalBoundedString(
+      record.blogTitle,
+      "blogTitle",
+      MAX_BLOG_TITLE_LENGTH,
+      true
+    );
+    if (error) {
+      errors.push(error);
+    } else {
+      value.blogTitle = (record.blogTitle as string).trim();
+    }
+  }
+
+  if (record.blogDescription !== undefined) {
+    const error = validateOptionalBoundedString(
+      record.blogDescription,
+      "blogDescription",
+      MAX_BLOG_DESCRIPTION_LENGTH,
+      false
+    );
+    if (error) {
+      errors.push(error);
+    } else {
+      value.blogDescription =
+        record.blogDescription === null
+          ? null
+          : (record.blogDescription as string).trim();
+    }
+  }
+
+  if (record.postsPerPage !== undefined) {
+    if (
+      typeof record.postsPerPage !== "number" ||
+      !Number.isInteger(record.postsPerPage) ||
+      record.postsPerPage < MIN_POSTS_PER_PAGE ||
+      record.postsPerPage > MAX_POSTS_PER_PAGE
+    ) {
+      errors.push({
+        field: "postsPerPage",
+        message: `postsPerPage must be an integer between ${MIN_POSTS_PER_PAGE} and ${MAX_POSTS_PER_PAGE}.`
+      });
+    } else {
+      value.postsPerPage = record.postsPerPage;
+    }
+  }
+
+  if (record.rssEnabled !== undefined) {
+    if (typeof record.rssEnabled !== "boolean") {
+      errors.push({
+        field: "rssEnabled",
+        message: "rssEnabled must be a boolean."
+      });
+    } else {
+      value.rssEnabled = record.rssEnabled;
+    }
+  }
+
+  if (record.sitemapEnabled !== undefined) {
+    if (typeof record.sitemapEnabled !== "boolean") {
+      errors.push({
+        field: "sitemapEnabled",
+        message: "sitemapEnabled must be a boolean."
+      });
+    } else {
+      value.sitemapEnabled = record.sitemapEnabled;
+    }
+  }
+
+  if (record.defaultLocale !== undefined) {
+    const error = validateLocaleField(record.defaultLocale);
+    if (error) {
+      errors.push({ field: "defaultLocale", message: error.message });
+    } else {
+      value.defaultLocale = (record.defaultLocale as string).trim();
+    }
+  }
+
+  if (record.defaultVisibility !== undefined) {
+    if (!isBlogContentVisibility(record.defaultVisibility)) {
+      errors.push({
+        field: "defaultVisibility",
+        message: "defaultVisibility must be one of public, private, unlisted."
+      });
+    } else {
+      value.defaultVisibility = record.defaultVisibility;
+    }
+  }
+
+  if (record.seoDefaultTitle !== undefined) {
+    const error = validateOptionalBoundedString(
+      record.seoDefaultTitle,
+      "seoDefaultTitle",
+      MAX_SEO_TITLE_LENGTH,
+      false
+    );
+    if (error) {
+      errors.push(error);
+    } else {
+      value.seoDefaultTitle =
+        record.seoDefaultTitle === null
+          ? null
+          : (record.seoDefaultTitle as string).trim();
+    }
+  }
+
+  if (record.seoDefaultDescription !== undefined) {
+    const error = validateOptionalBoundedString(
+      record.seoDefaultDescription,
+      "seoDefaultDescription",
+      MAX_SEO_DESCRIPTION_LENGTH,
+      false
+    );
+    if (error) {
+      errors.push(error);
+    } else {
+      value.seoDefaultDescription =
+        record.seoDefaultDescription === null
+          ? null
+          : (record.seoDefaultDescription as string).trim();
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -3,12 +3,194 @@ import { defineModule } from "../_shared/module-contract";
 export const blogContentModule = defineModule({
   key: "blog_content",
   name: "Blog Content",
-  version: "0.6.0",
-  status: "experimental",
+  version: "0.7.0",
+  status: "active",
   description:
-    "Tenant-scoped blog/content management (epic #536). Issue #537 laid the schema/permission foundation. Issue #538 added the blog post admin API (CRUD + lifecycle actions at /api/v1/blog/posts). Issue #539 added page/taxonomy CRUD, post-term relations, and PostgreSQL full-text search. Issue #540 added public (anonymous, no session) routes under /blog/{tenantCode}/... per ADR-0009: blog index, post detail, category/tag archives, search, RSS feed, and sitemap — every one enforcing the public visibility predicate (published + public, not deleted, published_at in the past) and safe content rendering (whitelist block renderer, no raw HTML). Issue #541 added append-only revision history for posts/pages (a significant title/contentJson/contentText change on PATCH snapshots one), revision list/detail/restore at /api/v1/blog/posts/{id}/revisions (restore requires explicit permission + Idempotency-Key, and itself appends a new revision — never overwrites one), the `bun run blog:publish:scheduled` job (idempotent, publishes due `status='scheduled'` posts per tenant), and the AsyncAPI domain-event contract for the module's full post/term/revision lifecycle (documented-contract-only, structured-logger-producer convention, same as every other module's events). Issue #542 added presentation/monetization extensions per its own Scope Control (does not rebuild the base media library, tenant system, RBAC/ABAC, audit, or theme engine): templates (/api/v1/blog/templates, whitelisted layout shape), hierarchical menus (/api/v1/blog/menus, one level of nesting, internal post/page or safe-URL items), position-based widgets (/api/v1/blog/widgets), advertisements with placement targeting and scheduling (/api/v1/blog/ads), a per-tenant blog theme override (/api/v1/blog/theme, falling back to `awcms_mini_tenants.default_theme`), an optional `translation_group_id` linking locale-variants of one post, and a new whitelisted `gallery` content_json block type for public image/video display (no new media table — reuses the existing safe-rendering convention). Admin UI (#543) is still to come. First domain module registered directly in this base repo (see ADR-0009).",
+    "Tenant-scoped blog/content management (epic #536). Issue #537 laid the schema/permission foundation. Issue #538 added the blog post admin API (CRUD + lifecycle actions at /api/v1/blog/posts). Issue #539 added page/taxonomy CRUD, post-term relations, and PostgreSQL full-text search. Issue #540 added public (anonymous, no session) routes under /blog/{tenantCode}/... per ADR-0009: blog index, post detail, category/tag archives, search, RSS feed, and sitemap — every one enforcing the public visibility predicate (published + public, not deleted, published_at in the past) and safe content rendering (whitelist block renderer, no raw HTML). Issue #541 added append-only revision history for posts/pages (a significant title/contentJson/contentText change on PATCH snapshots one), revision list/detail/restore at /api/v1/blog/posts/{id}/revisions (restore requires explicit permission + Idempotency-Key, and itself appends a new revision — never overwrites one), the `bun run blog:publish:scheduled` job (idempotent, publishes due `status='scheduled'` posts per tenant), and the AsyncAPI domain-event contract for the module's full post/term/revision lifecycle (documented-contract-only, structured-logger-producer convention, same as every other module's events). Issue #542 added presentation/monetization extensions per its own Scope Control (does not rebuild the base media library, tenant system, RBAC/ABAC, audit, or theme engine): templates (/api/v1/blog/templates, whitelisted layout shape), hierarchical menus (/api/v1/blog/menus, one level of nesting, internal post/page or safe-URL items), position-based widgets (/api/v1/blog/widgets), advertisements with placement targeting and scheduling (/api/v1/blog/ads), a per-tenant blog theme override (/api/v1/blog/theme, falling back to `awcms_mini_tenants.default_theme`), an optional `translation_group_id` linking locale-variants of one post, and a new whitelisted `gallery` content_json block type for public image/video display (no new media table — reuses the existing safe-rendering convention). Issue #543 (final hardening) added the admin UI (dashboard, posts, pages, categories/tags, templates/widgets/menus/ads, settings — all under /admin/blog, reusing the existing AdminLayout shell and design tokens, no new UI framework), the blog settings API (/api/v1/blog/settings, backed by `awcms_mini_blog_settings` since migration 026 but unwired until now — blog title/description/RSS-enabled/sitemap-enabled live in that table's catch-all `settings` jsonb column, everything else in its own typed column), RSS/sitemap now respect the new enabled flags, and this descriptor's own `permissions`/`navigation` arrays (previously undeclared — every permission below already existed in the database via migrations 027/030, but the module catalog had no code-side declaration to sync/report against). No longer `experimental`: the full epic's acceptance criteria are met and it registers a working admin surface. First domain module registered directly in this base repo (see ADR-0009).",
   dependencies: ["tenant_admin", "identity_access"],
   type: "domain",
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_blog",
+      path: "/admin/blog",
+      order: 40,
+      requiredPermission: "blog_content.posts.read"
+    }
+  ],
+  permissions: [
+    { activityCode: "posts", action: "read", description: "Read blog posts" },
+    {
+      activityCode: "posts",
+      action: "create",
+      description: "Create blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "update",
+      description: "Update blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "publish",
+      description: "Publish blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "schedule",
+      description: "Schedule blog posts for future publishing"
+    },
+    {
+      activityCode: "posts",
+      action: "archive",
+      description: "Archive blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "delete",
+      description: "Soft delete blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "restore",
+      description: "Restore soft-deleted blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "purge",
+      description: "Purge soft-deleted blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "export",
+      description: "Export blog posts"
+    },
+    { activityCode: "pages", action: "read", description: "Read blog pages" },
+    {
+      activityCode: "pages",
+      action: "create",
+      description: "Create blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "update",
+      description: "Update blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "publish",
+      description: "Publish blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "archive",
+      description: "Archive blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "delete",
+      description: "Soft delete blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "restore",
+      description: "Restore soft-deleted blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "purge",
+      description: "Purge soft-deleted blog pages"
+    },
+    {
+      activityCode: "taxonomies",
+      action: "read",
+      description: "Read blog categories and tags"
+    },
+    {
+      activityCode: "taxonomies",
+      action: "configure",
+      description: "Create, update, or delete blog categories and tags"
+    },
+    {
+      activityCode: "revisions",
+      action: "read",
+      description: "Read blog post/page revision history"
+    },
+    {
+      activityCode: "revisions",
+      action: "restore",
+      description: "Restore a blog post/page revision"
+    },
+    {
+      activityCode: "settings",
+      action: "read",
+      description: "Read blog module settings"
+    },
+    {
+      activityCode: "settings",
+      action: "configure",
+      description: "Update blog module settings"
+    },
+    {
+      activityCode: "seo",
+      action: "configure",
+      description: "Configure blog SEO metadata defaults"
+    },
+    {
+      activityCode: "search",
+      action: "read",
+      description: "Search blog posts and pages"
+    },
+    {
+      activityCode: "templates",
+      action: "read",
+      description: "Read blog presentation templates"
+    },
+    {
+      activityCode: "templates",
+      action: "configure",
+      description: "Create, update, or delete blog presentation templates"
+    },
+    {
+      activityCode: "menus",
+      action: "read",
+      description: "Read blog navigation menus"
+    },
+    {
+      activityCode: "menus",
+      action: "configure",
+      description: "Create, update, or delete blog navigation menus"
+    },
+    {
+      activityCode: "widgets",
+      action: "read",
+      description: "Read blog widgets"
+    },
+    {
+      activityCode: "widgets",
+      action: "configure",
+      description: "Create, update, or delete blog widgets"
+    },
+    {
+      activityCode: "ads",
+      action: "read",
+      description: "Read blog advertisements"
+    },
+    {
+      activityCode: "ads",
+      action: "configure",
+      description: "Create, update, or delete blog advertisements"
+    },
+    {
+      activityCode: "theme",
+      action: "read",
+      description: "Read blog theme mode setting"
+    },
+    {
+      activityCode: "theme",
+      action: "configure",
+      description: "Update blog theme mode setting"
+    }
+  ],
   api: {
     openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
     basePath: "/api/v1/blog"

--- a/src/pages/admin/blog/ads.astro
+++ b/src/pages/admin/blog/ads.astro
@@ -1,0 +1,532 @@
+---
+/**
+ * Advertisement manager (Issue #543 §Optional advanced screens, Issue #542
+ * merged). `imageUrl`/`linkUrl` are validated absolute http(s) URLs
+ * server-side (`domain/ad-policy.ts`'s `isAbsoluteHttpUrl`) — this form
+ * uses `type="url"` inputs as a first line of client-side feedback, the
+ * server check remains authoritative. `placements` (full replace, no
+ * hierarchy) is a JSON textarea, same "structured JSON in a labeled
+ * textarea" convention `admin/blog/menus.astro` uses for menu items, minus
+ * the client-id complication (`ads-directory.ts`'s `syncAdPlacements` uses
+ * plain DB-generated ids since placements have no parent/child relation).
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import {
+  fetchAdPlacements,
+  listAds
+} from "../../../modules/blog-content/application/ads-directory";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/ads.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_READ_ADS = context.permissions.has(
+  permissionKey("blog_content", "ads", "read")
+);
+const CAN_CONFIGURE_ADS = context.permissions.has(
+  permissionKey("blog_content", "ads", "configure")
+);
+
+const clientStrings = {
+  createSuccess: t("admin.blog.ads.create_success"),
+  updateSuccess: t("admin.blog.ads.update_success"),
+  deleteSuccess: t("admin.blog.ads.delete_success"),
+  deleteReasonPrompt: t("admin.blog.ads.delete_reason_prompt"),
+  deleteConfirm: t("admin.blog.ads.delete_confirm"),
+  invalidPlacementsJson: t("admin.blog.ads.invalid_placements_json"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+type AdRow = Awaited<ReturnType<typeof listAds>>[number] & {
+  placementsJson: string;
+};
+
+let ads: AdRow[] = [];
+let loadError = false;
+
+if (CAN_READ_ADS) {
+  try {
+    ads = await withTenant(
+      getDatabaseClient(),
+      context.tenantId,
+      async (tx) => {
+        const list = await listAds(tx, context.tenantId);
+        const withPlacements: AdRow[] = [];
+        for (const ad of list) {
+          const placements = await fetchAdPlacements(
+            tx,
+            context.tenantId,
+            ad.id
+          );
+          withPlacements.push({
+            ...ad,
+            placementsJson: JSON.stringify(
+              placements.map((p) => ({
+                placementType: p.placementType,
+                targetId: p.targetId
+              })),
+              null,
+              2
+            )
+          });
+        }
+        return withPlacements;
+      }
+    );
+  } catch (error) {
+    console.error("admin/blog/ads.astro: failed to load ads", error);
+    loadError = true;
+  }
+}
+
+function toDateTimeLocal(date: Date | null): string {
+  if (!date) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+---
+
+<AdminLayout title={t("admin.blog.ads.title")}>
+  {
+    !CAN_READ_ADS && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_ADS && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ_ADS && !loadError && (
+      <div class="config-manager">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        {ads.length === 0 ? (
+          <p class="empty-state">{t("admin.blog.ads.no_ads")}</p>
+        ) : (
+          ads.map((ad) => (
+            <section class="menu-card">
+              <h2>{ad.name}</h2>
+              {CAN_CONFIGURE_ADS && (
+                <form class="edit-config-form" data-id={ad.id}>
+                  <label>
+                    {t("admin.blog.ads.field_name")}
+                    <input type="text" name="name" required value={ad.name} />
+                  </label>
+                  <label>
+                    {t("admin.blog.ads.field_image_url")}
+                    <input
+                      type="url"
+                      name="imageUrl"
+                      required
+                      value={ad.imageUrl}
+                    />
+                  </label>
+                  <label>
+                    {t("admin.blog.ads.field_link_url")}
+                    <input type="url" name="linkUrl" value={ad.linkUrl ?? ""} />
+                  </label>
+                  <label>
+                    {t("admin.blog.ads.field_starts_at")}
+                    <input
+                      type="datetime-local"
+                      name="startsAt"
+                      value={toDateTimeLocal(ad.startsAt)}
+                    />
+                  </label>
+                  <label>
+                    {t("admin.blog.ads.field_ends_at")}
+                    <input
+                      type="datetime-local"
+                      name="endsAt"
+                      value={toDateTimeLocal(ad.endsAt)}
+                    />
+                  </label>
+                  <label class="checkbox-label">
+                    <input
+                      type="checkbox"
+                      name="isActive"
+                      checked={ad.isActive}
+                    />
+                    {t("admin.blog.ads.field_active")}
+                  </label>
+                  <label>
+                    {t("admin.blog.ads.field_placements")}
+                    <textarea name="placements" rows="6" spellcheck="false">
+                      {ad.placementsJson}
+                    </textarea>
+                    <span class="field-hint">
+                      {t("admin.blog.ads.placements_hint")}
+                    </span>
+                  </label>
+                  <button type="submit">
+                    {t("admin.blog.ads.save_button")}
+                  </button>
+                </form>
+              )}
+              {CAN_CONFIGURE_ADS && (
+                <button
+                  type="button"
+                  class="delete-config-button"
+                  data-id={ad.id}
+                >
+                  {t("admin.blog.ads.delete_button")}
+                </button>
+              )}
+            </section>
+          ))
+        )}
+
+        {CAN_CONFIGURE_ADS && (
+          <details class="create-config">
+            <summary>{t("admin.blog.ads.create_summary")}</summary>
+            <form id="create-config-form" class="create-config-form">
+              <label>
+                {t("admin.blog.ads.field_name")}
+                <input type="text" name="name" required />
+              </label>
+              <label>
+                {t("admin.blog.ads.field_image_url")}
+                <input type="url" name="imageUrl" required />
+              </label>
+              <label>
+                {t("admin.blog.ads.field_link_url")}
+                <input type="url" name="linkUrl" />
+              </label>
+              <label>
+                {t("admin.blog.ads.field_starts_at")}
+                <input type="datetime-local" name="startsAt" />
+              </label>
+              <label>
+                {t("admin.blog.ads.field_ends_at")}
+                <input type="datetime-local" name="endsAt" />
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" name="isActive" checked />
+                {t("admin.blog.ads.field_active")}
+              </label>
+              <button type="submit">{t("admin.blog.ads.create_submit")}</button>
+            </form>
+          </details>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .config-manager {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .empty-state {
+    color: var(--color-text-muted);
+  }
+
+  .menu-card {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .menu-card h2 {
+    font-size: var(--fs-md);
+    margin: 0 0 var(--sp-2);
+  }
+
+  .edit-config-form,
+  .create-config-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+    max-width: 560px;
+  }
+
+  .edit-config-form label,
+  .create-config-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .checkbox-label {
+    flex-direction: row !important;
+    align-items: center;
+    gap: var(--sp-2) !important;
+  }
+
+  .edit-config-form input,
+  .edit-config-form textarea,
+  .create-config-form input {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .edit-config-form textarea {
+    font-family: var(--font-mono);
+    font-size: var(--fs-sm);
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+  }
+
+  .edit-config-form button,
+  .create-config-form button {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .delete-config-button {
+    margin-top: var(--sp-2);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-danger-strong);
+    color: var(--color-danger-strong);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-2);
+    min-height: 44px;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+  }
+
+  .create-config {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .create-config summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  input:focus-visible,
+  textarea:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface AdManagerStrings {
+    createSuccess: string;
+    updateSuccess: string;
+    deleteSuccess: string;
+    deleteReasonPrompt: string;
+    deleteConfirm: string;
+    invalidPlacementsJson: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<AdManagerStrings>();
+
+  function submitButtonOf(form: HTMLFormElement): HTMLButtonElement | null {
+    return form.querySelector('button[type="submit"]');
+  }
+
+  function isoOrNull(value: FormDataEntryValue | null): string | null {
+    const raw = String(value ?? "").trim();
+    if (!raw) return null;
+    const date = new Date(raw);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+
+  document
+    .getElementById("create-config-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = submitButtonOf(form);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const formData = new FormData(form);
+        const res = await fetch("/api/v1/blog/ads", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({
+            name: formData.get("name"),
+            imageUrl: formData.get("imageUrl"),
+            linkUrl: String(formData.get("linkUrl") ?? "").trim() || null,
+            startsAt: isoOrNull(formData.get("startsAt")),
+            endsAt: isoOrNull(formData.get("endsAt")),
+            isActive: formData.get("isActive") === "on"
+          })
+        });
+        const json = await res.json().catch(() => null);
+
+        if (!res.ok) {
+          const code = json?.error?.code as string | undefined;
+          const message =
+            (code && strings.errorMessages?.[code]) ??
+            json?.error?.message ??
+            `Request failed (${res.status}).`;
+          showBanner("action-banner", message, "error");
+          return;
+        }
+
+        showBanner("action-banner", strings.createSuccess, "success");
+        reloadAfterDelay();
+      } catch {
+        showBanner("action-banner", strings.networkError, "error");
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document.querySelectorAll(".edit-config-form").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const el = event.target as HTMLFormElement;
+      const button = submitButtonOf(el);
+      if (button?.disabled) return;
+
+      const formData = new FormData(el);
+      let placements: unknown;
+      try {
+        placements = JSON.parse(String(formData.get("placements") ?? "[]"));
+      } catch {
+        showBanner("action-banner", strings.invalidPlacementsJson, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const id = el.dataset.id!;
+        const result = await submitJson(
+          `/api/v1/blog/ads/${id}`,
+          "PATCH",
+          {
+            name: formData.get("name"),
+            imageUrl: formData.get("imageUrl"),
+            linkUrl: String(formData.get("linkUrl") ?? "").trim() || null,
+            startsAt: isoOrNull(formData.get("startsAt")),
+            endsAt: isoOrNull(formData.get("endsAt")),
+            isActive: formData.get("isActive") === "on",
+            placements
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.updateSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+  });
+
+  document.querySelectorAll(".delete-config-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+
+      const reason = window.prompt(strings.deleteReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+      if (!window.confirm(strings.deleteConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const id = el.dataset.id!;
+        const result = await submitJson(
+          `/api/v1/blog/ads/${id}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+</script>

--- a/src/pages/admin/blog/categories.astro
+++ b/src/pages/admin/blog/categories.astro
@@ -1,0 +1,524 @@
+---
+/**
+ * Category manager (Issue #543 §Category/Tag Manager) — `taxonomyType =
+ * 'category'` only, via the existing `/api/v1/blog/terms` endpoints (Issue
+ * #539) filtered client- and server-side to categories. Categories support
+ * hierarchy (`parentId`, one level — `domain/taxonomy-policy.ts`'s
+ * `validateTermParent` and the schema's self-FK both allow it); the tag
+ * screen (`admin/blog/tags.astro`) is a separate file that never renders a
+ * parent field at all, per the issue's explicit "Tags must not support
+ * parent assignment" (UI-level enforcement on top of the existing
+ * DB constraint + `validateTermParent` server-side check).
+ *
+ * Slug-conflict validation is visible: `POST`/`PATCH` failures surface the
+ * server's own `SLUG_CONFLICT` message text via the action banner (that
+ * code has no dedicated i18n catalog entry — `error-messages.ts`'s
+ * `translateErrorCode` falls back to the server's already-safe message,
+ * same as every other admin screen's unmapped-error-code path).
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { listBlogTerms } from "../../../modules/blog-content/application/blog-taxonomy-directory";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/categories.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_READ_TAXONOMIES = context.permissions.has(
+  permissionKey("blog_content", "taxonomies", "read")
+);
+const CAN_CONFIGURE_TAXONOMIES = context.permissions.has(
+  permissionKey("blog_content", "taxonomies", "configure")
+);
+
+const clientStrings = {
+  createSuccess: t("admin.blog.categories.create_success"),
+  updateSuccess: t("admin.blog.categories.update_success"),
+  deleteSuccess: t("admin.blog.categories.delete_success"),
+  deleteReasonPrompt: t("admin.blog.categories.delete_reason_prompt"),
+  deleteConfirm: t("admin.blog.categories.delete_confirm"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+let categories: Awaited<ReturnType<typeof listBlogTerms>> = [];
+let loadError = false;
+
+if (CAN_READ_TAXONOMIES) {
+  try {
+    categories = await withTenant(getDatabaseClient(), context.tenantId, (tx) =>
+      listBlogTerms(tx, context.tenantId, { taxonomyType: "category" })
+    );
+  } catch (error) {
+    console.error(
+      "admin/blog/categories.astro: failed to load categories",
+      error
+    );
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title={t("admin.blog.categories.title")}>
+  {
+    !CAN_READ_TAXONOMIES && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_TAXONOMIES && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ_TAXONOMIES && !loadError && (
+      <div class="term-manager" data-taxonomy-type="category">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        {categories.length === 0 ? (
+          <p class="empty-state">{t("admin.blog.categories.no_categories")}</p>
+        ) : (
+          <div class="table-scroll">
+            <table class="blog-table">
+              <thead>
+                <tr>
+                  <th>{t("admin.blog.categories.name_column")}</th>
+                  <th>{t("admin.blog.categories.slug_column")}</th>
+                  <th>{t("admin.blog.categories.parent_column")}</th>
+                  {CAN_CONFIGURE_TAXONOMIES && (
+                    <th>{t("admin.blog.categories.actions_column")}</th>
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {categories.map((category) => (
+                  <tr>
+                    <td>{category.name}</td>
+                    <td>
+                      <code>{category.slug}</code>
+                    </td>
+                    <td>
+                      {category.parentId
+                        ? (categories.find((c) => c.id === category.parentId)
+                            ?.name ?? "-")
+                        : "-"}
+                    </td>
+                    {CAN_CONFIGURE_TAXONOMIES && (
+                      <td>
+                        <details>
+                          <summary>
+                            {t("admin.blog.categories.edit_summary")}
+                          </summary>
+                          <form
+                            class="edit-term-form"
+                            data-term-id={category.id}
+                          >
+                            <label>
+                              {t("admin.blog.categories.field_name")}
+                              <input
+                                type="text"
+                                name="name"
+                                required
+                                maxlength="100"
+                                value={category.name}
+                              />
+                            </label>
+                            <label>
+                              {t("admin.blog.categories.field_slug")}
+                              <input
+                                type="text"
+                                name="slug"
+                                required
+                                pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                                value={category.slug}
+                              />
+                            </label>
+                            <label>
+                              {t("admin.blog.categories.field_description")}
+                              <textarea
+                                name="description"
+                                rows="2"
+                                maxlength="500"
+                              >
+                                {category.description ?? ""}
+                              </textarea>
+                            </label>
+                            <label>
+                              {t("admin.blog.categories.field_parent")}
+                              <select name="parentId">
+                                <option value="">
+                                  {t("admin.blog.categories.no_parent_option")}
+                                </option>
+                                {categories
+                                  .filter(
+                                    (candidate) => candidate.id !== category.id
+                                  )
+                                  .map((candidate) => (
+                                    <option
+                                      value={candidate.id}
+                                      selected={
+                                        category.parentId === candidate.id
+                                      }
+                                    >
+                                      {candidate.name}
+                                    </option>
+                                  ))}
+                              </select>
+                            </label>
+                            <button type="submit">
+                              {t("admin.blog.categories.save_button")}
+                            </button>
+                          </form>
+                        </details>
+                        <button
+                          type="button"
+                          class="delete-term-button"
+                          data-term-id={category.id}
+                        >
+                          {t("admin.blog.categories.delete_button")}
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {CAN_CONFIGURE_TAXONOMIES && (
+          <details class="create-term">
+            <summary>{t("admin.blog.categories.create_summary")}</summary>
+            <form id="create-term-form" class="create-term-form">
+              <label>
+                {t("admin.blog.categories.field_name")}
+                <input type="text" name="name" required maxlength="100" />
+              </label>
+              <label>
+                {t("admin.blog.categories.field_slug")}
+                <input
+                  type="text"
+                  name="slug"
+                  required
+                  pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                />
+              </label>
+              <label>
+                {t("admin.blog.categories.field_description")}
+                <textarea name="description" rows="2" maxlength="500" />
+              </label>
+              <label>
+                {t("admin.blog.categories.field_parent")}
+                <select name="parentId">
+                  <option value="">
+                    {t("admin.blog.categories.no_parent_option")}
+                  </option>
+                  {categories.map((candidate) => (
+                    <option value={candidate.id}>{candidate.name}</option>
+                  ))}
+                </select>
+              </label>
+              <button type="submit">
+                {t("admin.blog.categories.create_submit")}
+              </button>
+            </form>
+          </details>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .term-manager {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .empty-state {
+    color: var(--color-text-muted);
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .blog-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .blog-table th,
+  .blog-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .edit-term-form,
+  .create-term-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+    margin-top: var(--sp-2);
+    max-width: 420px;
+  }
+
+  .edit-term-form label,
+  .create-term-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .edit-term-form input,
+  .edit-term-form select,
+  .edit-term-form textarea,
+  .create-term-form input,
+  .create-term-form select,
+  .create-term-form textarea {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .edit-term-form button,
+  .create-term-form button {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .delete-term-button {
+    margin-top: var(--sp-2);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-danger-strong);
+    color: var(--color-danger-strong);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-2);
+    min-height: 44px;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+  }
+
+  .create-term {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .create-term summary,
+  details summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface TermManagerStrings {
+    createSuccess: string;
+    updateSuccess: string;
+    deleteSuccess: string;
+    deleteReasonPrompt: string;
+    deleteConfirm: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<TermManagerStrings>();
+  const taxonomyType =
+    document.querySelector<HTMLElement>(".term-manager")?.dataset
+      .taxonomyType ?? "category";
+
+  function submitButtonOf(form: HTMLFormElement): HTMLButtonElement | null {
+    return form.querySelector('button[type="submit"]');
+  }
+
+  document
+    .getElementById("create-term-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = submitButtonOf(form);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const formData = new FormData(form);
+        const parentId = String(formData.get("parentId") ?? "").trim() || null;
+
+        const result = await submitJson(
+          "/api/v1/blog/terms",
+          "POST",
+          {
+            taxonomyType,
+            name: formData.get("name"),
+            slug: formData.get("slug"),
+            description:
+              String(formData.get("description") ?? "").trim() || null,
+            parentId: taxonomyType === "tag" ? null : parentId
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.createSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document.querySelectorAll(".edit-term-form").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const el = event.target as HTMLFormElement;
+      const button = submitButtonOf(el);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const termId = el.dataset.termId!;
+        const formData = new FormData(el);
+        const parentId = String(formData.get("parentId") ?? "").trim() || null;
+
+        const body: Record<string, unknown> = {
+          name: formData.get("name"),
+          slug: formData.get("slug"),
+          description: String(formData.get("description") ?? "").trim() || null
+        };
+        if (taxonomyType !== "tag") {
+          body.parentId = parentId;
+        }
+
+        const result = await submitJson(
+          `/api/v1/blog/terms/${termId}`,
+          "PATCH",
+          body,
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.updateSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+  });
+
+  document.querySelectorAll(".delete-term-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+
+      const reason = window.prompt(strings.deleteReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+      if (!window.confirm(strings.deleteConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const termId = el.dataset.termId!;
+        const result = await submitJson(
+          `/api/v1/blog/terms/${termId}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+</script>

--- a/src/pages/admin/blog/index.astro
+++ b/src/pages/admin/blog/index.astro
@@ -1,0 +1,387 @@
+---
+/**
+ * Blog admin dashboard (Issue #543 §Blog Dashboard, epic #536).
+ *
+ * Summary counts (posts total/draft/scheduled, pages total) are plain
+ * tenant-scoped `COUNT(*)` queries run directly in this page's own
+ * `withTenant` transaction — same "small ad-hoc query, no dedicated
+ * reporting module" precedent `admin/sync.astro` sets for its open-conflicts
+ * table, since there is no existing `blog-content` reporting/aggregation
+ * function to reuse and building one for four counts would be over-scoped
+ * for a dashboard card. "Recent updates" reuses `listBlogPosts` (Issue
+ * #538, already used by `GET /api/v1/blog/posts`), bounded to 5.
+ *
+ * Permission-gated per section (defense-in-depth — the real enforcement is
+ * each linked screen's own guard and each API endpoint's own guard):
+ *   - blog_content.posts.read     -> post/draft/scheduled counts, recent updates, "New post" link
+ *   - blog_content.pages.read     -> page count, "New page" link
+ *   - blog_content.taxonomies.read -> "Categories"/"Tags" quick link
+ *   - blog_content.settings.read  -> "Settings" quick link
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { listBlogPosts } from "../../../modules/blog-content/application/blog-post-directory";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { formatDateTime } from "../../../lib/i18n/format";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/index.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const locale = Astro.locals.locale;
+const t = await createTranslator(locale);
+
+const CAN_READ_POSTS = context.permissions.has(
+  permissionKey("blog_content", "posts", "read")
+);
+const CAN_CREATE_POSTS = context.permissions.has(
+  permissionKey("blog_content", "posts", "create")
+);
+const CAN_READ_PAGES = context.permissions.has(
+  permissionKey("blog_content", "pages", "read")
+);
+const CAN_CREATE_PAGES = context.permissions.has(
+  permissionKey("blog_content", "pages", "create")
+);
+const CAN_READ_TAXONOMIES = context.permissions.has(
+  permissionKey("blog_content", "taxonomies", "read")
+);
+const CAN_READ_SETTINGS = context.permissions.has(
+  permissionKey("blog_content", "settings", "read")
+);
+
+const hasAnyAccess = CAN_READ_POSTS || CAN_READ_PAGES;
+
+type CountRow = { count: number };
+
+let data: {
+  totalPosts: number;
+  draftPosts: number;
+  scheduledPosts: number;
+  totalPages: number;
+  recentUpdates: Awaited<ReturnType<typeof listBlogPosts>>;
+} | null = null;
+let loadError = false;
+
+if (hasAnyAccess) {
+  try {
+    data = await withTenant(
+      getDatabaseClient(),
+      context.tenantId,
+      async (tx) => {
+        const [
+          totalPostsRows,
+          draftPostsRows,
+          scheduledPostsRows,
+          totalPagesRows
+        ] = await Promise.all([
+          CAN_READ_POSTS
+            ? (tx`
+                SELECT count(*)::int AS count FROM awcms_mini_blog_posts
+                WHERE tenant_id = ${context.tenantId} AND deleted_at IS NULL
+              ` as Promise<CountRow[]>)
+            : Promise.resolve([{ count: 0 }]),
+          CAN_READ_POSTS
+            ? (tx`
+                SELECT count(*)::int AS count FROM awcms_mini_blog_posts
+                WHERE tenant_id = ${context.tenantId} AND deleted_at IS NULL AND status = 'draft'
+              ` as Promise<CountRow[]>)
+            : Promise.resolve([{ count: 0 }]),
+          CAN_READ_POSTS
+            ? (tx`
+                SELECT count(*)::int AS count FROM awcms_mini_blog_posts
+                WHERE tenant_id = ${context.tenantId} AND deleted_at IS NULL AND status = 'scheduled'
+              ` as Promise<CountRow[]>)
+            : Promise.resolve([{ count: 0 }]),
+          CAN_READ_PAGES
+            ? (tx`
+                SELECT count(*)::int AS count FROM awcms_mini_blog_pages
+                WHERE tenant_id = ${context.tenantId} AND deleted_at IS NULL
+              ` as Promise<CountRow[]>)
+            : Promise.resolve([{ count: 0 }])
+        ]);
+
+        const recentUpdates = CAN_READ_POSTS
+          ? await listBlogPosts(tx, context.tenantId, { limit: 5 })
+          : [];
+
+        return {
+          totalPosts: totalPostsRows[0]?.count ?? 0,
+          draftPosts: draftPostsRows[0]?.count ?? 0,
+          scheduledPosts: scheduledPostsRows[0]?.count ?? 0,
+          totalPages: totalPagesRows[0]?.count ?? 0,
+          recentUpdates
+        };
+      }
+    );
+  } catch (error) {
+    console.error("admin/blog/index.astro: failed to load dashboard", error);
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title={t("admin.blog.dashboard.title")}>
+  {
+    !hasAnyAccess && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    hasAnyAccess && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    data && (
+      <div class="blog-dashboard">
+        <div class="dashboard-grid">
+          {CAN_READ_POSTS && (
+            <section class="dashboard-card">
+              <h2>{t("admin.blog.dashboard.posts_title")}</h2>
+              <dl>
+                <dt>{t("admin.blog.dashboard.total_posts_label")}</dt>
+                <dd>{data.totalPosts}</dd>
+                <dt>{t("admin.blog.dashboard.draft_posts_label")}</dt>
+                <dd>{data.draftPosts}</dd>
+                <dt>{t("admin.blog.dashboard.scheduled_posts_label")}</dt>
+                <dd>{data.scheduledPosts}</dd>
+              </dl>
+            </section>
+          )}
+          {CAN_READ_PAGES && (
+            <section class="dashboard-card">
+              <h2>{t("admin.blog.dashboard.pages_title")}</h2>
+              <dl>
+                <dt>{t("admin.blog.dashboard.total_pages_label")}</dt>
+                <dd>{data.totalPages}</dd>
+              </dl>
+            </section>
+          )}
+          <section class="dashboard-card">
+            <h2>{t("admin.blog.dashboard.quick_links_title")}</h2>
+            <ul class="quick-links">
+              {CAN_CREATE_POSTS && (
+                <li>
+                  <a href="/admin/blog/posts/new">
+                    {t("admin.blog.dashboard.new_post_link")}
+                  </a>
+                </li>
+              )}
+              {CAN_CREATE_PAGES && (
+                <li>
+                  <a href="/admin/blog/pages/new">
+                    {t("admin.blog.dashboard.new_page_link")}
+                  </a>
+                </li>
+              )}
+              {CAN_READ_POSTS && (
+                <li>
+                  <a href="/admin/blog/posts">
+                    {t("admin.blog.dashboard.manage_posts_link")}
+                  </a>
+                </li>
+              )}
+              {CAN_READ_PAGES && (
+                <li>
+                  <a href="/admin/blog/pages">
+                    {t("admin.blog.dashboard.manage_pages_link")}
+                  </a>
+                </li>
+              )}
+              {CAN_READ_TAXONOMIES && (
+                <li>
+                  <a href="/admin/blog/categories">
+                    {t("admin.blog.dashboard.manage_categories_link")}
+                  </a>
+                </li>
+              )}
+              {CAN_READ_TAXONOMIES && (
+                <li>
+                  <a href="/admin/blog/tags">
+                    {t("admin.blog.dashboard.manage_tags_link")}
+                  </a>
+                </li>
+              )}
+              {CAN_READ_SETTINGS && (
+                <li>
+                  <a href="/admin/blog/settings">
+                    {t("admin.blog.dashboard.manage_settings_link")}
+                  </a>
+                </li>
+              )}
+            </ul>
+          </section>
+        </div>
+
+        {CAN_READ_POSTS && (
+          <section class="dashboard-recent">
+            <h2>{t("admin.blog.dashboard.recent_updates_title")}</h2>
+            {data.recentUpdates.length === 0 ? (
+              <p>{t("admin.blog.dashboard.no_recent_updates")}</p>
+            ) : (
+              <div class="table-scroll">
+                <table class="blog-table">
+                  <thead>
+                    <tr>
+                      <th>{t("admin.blog.posts.title_column")}</th>
+                      <th>{t("admin.blog.posts.status_column")}</th>
+                      <th>{t("admin.blog.posts.updated_column")}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.recentUpdates.map((post) => (
+                      <tr>
+                        <td>
+                          <a href={`/admin/blog/posts/${post.id}`}>
+                            {post.title}
+                          </a>
+                        </td>
+                        <td>
+                          <span class="status-pill" data-status={post.status}>
+                            {t(`admin.blog.status.${post.status}`)}
+                          </span>
+                        </td>
+                        <td>{formatDateTime(post.updatedAt, locale)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .blog-dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-6);
+  }
+
+  .dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: var(--sp-4);
+  }
+
+  .dashboard-card {
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-4);
+  }
+
+  .dashboard-card h2 {
+    margin-top: 0;
+    font-size: var(--fs-md);
+  }
+
+  .dashboard-card dl {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--sp-1) var(--sp-3);
+    margin: 0;
+  }
+
+  .dashboard-card dt {
+    color: var(--color-text-muted);
+    font-size: var(--fs-sm);
+  }
+
+  .dashboard-card dd {
+    margin: 0;
+    font-weight: 600;
+    text-align: right;
+  }
+
+  .quick-links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+  }
+
+  .quick-links a {
+    color: var(--color-primary);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .quick-links a:hover {
+    text-decoration: underline;
+  }
+
+  .dashboard-recent h2 {
+    font-size: var(--fs-md);
+    margin: 0 0 var(--sp-3);
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .blog-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .blog-table th,
+  .blog-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .status-pill {
+    display: inline-block;
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-full);
+    font-size: var(--fs-xs);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+  }
+
+  .status-pill[data-status="published"] {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .status-pill[data-status="archived"] {
+    background: var(--color-danger-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-danger-strong);
+  }
+
+  .status-pill[data-status="scheduled"],
+  .status-pill[data-status="review"] {
+    background: var(--color-warning);
+    border-color: var(--color-warning);
+  }
+</style>

--- a/src/pages/admin/blog/menus.astro
+++ b/src/pages/admin/blog/menus.astro
@@ -1,0 +1,492 @@
+---
+/**
+ * Menu manager (Issue #543 §Optional advanced screens, Issue #542 merged).
+ * `items` (Issue #542) is a full-replace sub-array whose entries need
+ * client-supplied UUIDs and a `parentItemId` that can reference a sibling
+ * in the same batch (`domain/menu-policy.ts`'s docblock, README §Menus —
+ * "id wajib client-supplied"). Building a drag/drop tree editor for that is
+ * out of proportion for this issue's budget and would still need to end up
+ * producing exactly this JSON shape; a labeled, hinted JSON textarea is the
+ * same pattern `admin/modules/[moduleKey].astro`'s settings panel already
+ * established for structured config, so `items` is edited that way here
+ * too, with an inline "generate id" helper button per new item row driven
+ * by `crypto.randomUUID()` — the same primitive `menu-policy.ts` assumes
+ * client ids come from.
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import {
+  fetchMenuItems,
+  listMenus
+} from "../../../modules/blog-content/application/menu-directory";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/menus.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_READ_MENUS = context.permissions.has(
+  permissionKey("blog_content", "menus", "read")
+);
+const CAN_CONFIGURE_MENUS = context.permissions.has(
+  permissionKey("blog_content", "menus", "configure")
+);
+
+const clientStrings = {
+  createSuccess: t("admin.blog.menus.create_success"),
+  updateSuccess: t("admin.blog.menus.update_success"),
+  deleteSuccess: t("admin.blog.menus.delete_success"),
+  deleteReasonPrompt: t("admin.blog.menus.delete_reason_prompt"),
+  deleteConfirm: t("admin.blog.menus.delete_confirm"),
+  invalidItemsJson: t("admin.blog.menus.invalid_items_json"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+let menus: { id: string; key: string; name: string; itemsJson: string }[] = [];
+let loadError = false;
+
+if (CAN_READ_MENUS) {
+  try {
+    menus = await withTenant(
+      getDatabaseClient(),
+      context.tenantId,
+      async (tx) => {
+        const list = await listMenus(tx, context.tenantId);
+        const withItems = [];
+        for (const menu of list) {
+          const items = await fetchMenuItems(tx, context.tenantId, menu.id);
+          withItems.push({
+            id: menu.id,
+            key: menu.key,
+            name: menu.name,
+            itemsJson: JSON.stringify(
+              items.map((item) => ({
+                id: item.id,
+                parentItemId: item.parentItemId,
+                label: item.label,
+                linkType: item.linkType,
+                targetId: item.targetId,
+                url: item.url,
+                sortOrder: item.sortOrder
+              })),
+              null,
+              2
+            )
+          });
+        }
+        return withItems;
+      }
+    );
+  } catch (error) {
+    console.error("admin/blog/menus.astro: failed to load menus", error);
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title={t("admin.blog.menus.title")}>
+  {
+    !CAN_READ_MENUS && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_MENUS && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ_MENUS && !loadError && (
+      <div class="config-manager">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        {menus.length === 0 ? (
+          <p class="empty-state">{t("admin.blog.menus.no_menus")}</p>
+        ) : (
+          menus.map((menu) => (
+            <section class="menu-card">
+              <h2>
+                {menu.name} <code>{menu.key}</code>
+              </h2>
+              {CAN_CONFIGURE_MENUS && (
+                <form class="edit-config-form" data-id={menu.id}>
+                  <label>
+                    {t("admin.blog.menus.field_name")}
+                    <input type="text" name="name" required value={menu.name} />
+                  </label>
+                  <label>
+                    {t("admin.blog.menus.field_items")}
+                    <textarea name="items" rows="10" spellcheck="false">
+                      {menu.itemsJson}
+                    </textarea>
+                    <span class="field-hint">
+                      {t("admin.blog.menus.items_hint")}
+                    </span>
+                  </label>
+                  <div class="menu-actions">
+                    <button type="submit">
+                      {t("admin.blog.menus.save_button")}
+                    </button>
+                    <button type="button" class="generate-id-button">
+                      {t("admin.blog.menus.generate_id_button")}
+                    </button>
+                  </div>
+                </form>
+              )}
+              {CAN_CONFIGURE_MENUS && (
+                <button
+                  type="button"
+                  class="delete-config-button"
+                  data-id={menu.id}
+                >
+                  {t("admin.blog.menus.delete_button")}
+                </button>
+              )}
+            </section>
+          ))
+        )}
+
+        {CAN_CONFIGURE_MENUS && (
+          <details class="create-config">
+            <summary>{t("admin.blog.menus.create_summary")}</summary>
+            <form id="create-config-form" class="create-config-form">
+              <label>
+                {t("admin.blog.menus.field_key")}
+                <input
+                  type="text"
+                  name="key"
+                  required
+                  pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                />
+              </label>
+              <label>
+                {t("admin.blog.menus.field_name")}
+                <input type="text" name="name" required />
+              </label>
+              <button type="submit">
+                {t("admin.blog.menus.create_submit")}
+              </button>
+            </form>
+          </details>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .config-manager {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .empty-state {
+    color: var(--color-text-muted);
+  }
+
+  .menu-card {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .menu-card h2 {
+    font-size: var(--fs-md);
+    margin: 0 0 var(--sp-2);
+  }
+
+  .edit-config-form,
+  .create-config-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+    max-width: 560px;
+  }
+
+  .edit-config-form label,
+  .create-config-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .edit-config-form input,
+  .edit-config-form textarea,
+  .create-config-form input {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .edit-config-form textarea {
+    font-family: var(--font-mono);
+    font-size: var(--fs-sm);
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+  }
+
+  .menu-actions {
+    display: flex;
+    gap: var(--sp-2);
+  }
+
+  .edit-config-form button,
+  .create-config-form button,
+  .menu-actions button {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .generate-id-button {
+    background: var(--color-surface-2) !important;
+    color: var(--color-text) !important;
+    border: 1px solid var(--color-border) !important;
+  }
+
+  .delete-config-button {
+    margin-top: var(--sp-2);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-danger-strong);
+    color: var(--color-danger-strong);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-2);
+    min-height: 44px;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+  }
+
+  .create-config {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .create-config summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  input:focus-visible,
+  textarea:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface MenuManagerStrings {
+    createSuccess: string;
+    updateSuccess: string;
+    deleteSuccess: string;
+    deleteReasonPrompt: string;
+    deleteConfirm: string;
+    invalidItemsJson: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<MenuManagerStrings>();
+
+  function submitButtonOf(form: HTMLFormElement): HTMLButtonElement | null {
+    return form.querySelector('button[type="submit"]');
+  }
+
+  document
+    .getElementById("create-config-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = submitButtonOf(form);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const formData = new FormData(form);
+        const res = await fetch("/api/v1/blog/menus", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({
+            key: formData.get("key"),
+            name: formData.get("name")
+          })
+        });
+        const json = await res.json().catch(() => null);
+
+        if (!res.ok) {
+          const code = json?.error?.code as string | undefined;
+          const message =
+            (code && strings.errorMessages?.[code]) ??
+            json?.error?.message ??
+            `Request failed (${res.status}).`;
+          showBanner("action-banner", message, "error");
+          return;
+        }
+
+        showBanner("action-banner", strings.createSuccess, "success");
+        reloadAfterDelay();
+      } catch {
+        showBanner("action-banner", strings.networkError, "error");
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document.querySelectorAll(".edit-config-form").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const el = event.target as HTMLFormElement;
+      const button = submitButtonOf(el);
+      if (button?.disabled) return;
+
+      const formData = new FormData(el);
+      let items: unknown;
+      try {
+        items = JSON.parse(String(formData.get("items") ?? "[]"));
+      } catch {
+        showBanner("action-banner", strings.invalidItemsJson, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const id = el.dataset.id!;
+        const result = await submitJson(
+          `/api/v1/blog/menus/${id}`,
+          "PATCH",
+          { name: formData.get("name"), items },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.updateSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+  });
+
+  document.querySelectorAll(".generate-id-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      // Copies a fresh UUID to the clipboard for pasting into a new item's
+      // "id" field — never mutates the `items` textarea directly, since
+      // anything inserted there that isn't valid JSON would break
+      // `JSON.parse` on next save.
+      const id = crypto.randomUUID();
+      try {
+        await navigator.clipboard.writeText(id);
+        showBanner("action-banner", id, "success");
+      } catch {
+        window.prompt("UUID", id);
+      }
+    });
+  });
+
+  document.querySelectorAll(".delete-config-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+
+      const reason = window.prompt(strings.deleteReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+      if (!window.confirm(strings.deleteConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const id = el.dataset.id!;
+        const result = await submitJson(
+          `/api/v1/blog/menus/${id}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+</script>

--- a/src/pages/admin/blog/pages/[id].astro
+++ b/src/pages/admin/blog/pages/[id].astro
@@ -1,0 +1,565 @@
+---
+/**
+ * Blog static page editor — edit existing page (Issue #543 §Page Editor).
+ * No lifecycle actions (no publish/schedule/archive/restore/purge endpoint
+ * for pages, README §Admin API — Blog Pages) and no revision list/restore
+ * UI (README §Belum tersedia: "Page revision list/detail/restore
+ * endpoints" — `createBlogRevision` is called on significant PATCH but
+ * there is no route to read/restore a page revision). Only edit + soft
+ * delete, same `evaluateContentUpdateAccess` ownership override as posts
+ * (`page-access-policy.ts`'s `evaluatePageUpdateAccess`, same rule).
+ */
+import AdminLayout from "../../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { permissionKey } from "../../../../modules/identity-access/domain/access-control";
+import {
+  fetchBlogPageById,
+  listBlogPages
+} from "../../../../modules/blog-content/application/blog-page-directory";
+import { BLOG_CONTENT_VISIBILITIES } from "../../../../modules/blog-content/domain/post-status";
+import { PAGE_TYPES } from "../../../../modules/blog-content/domain/page-type";
+import { createTranslator } from "../../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/pages/[id].astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+const pageId = Astro.params.id!;
+
+const CAN_READ_PAGES = context.permissions.has(
+  permissionKey("blog_content", "pages", "read")
+);
+const CAN_UPDATE_PAGES = context.permissions.has(
+  permissionKey("blog_content", "pages", "update")
+);
+const CAN_DELETE_PAGES = context.permissions.has(
+  permissionKey("blog_content", "pages", "delete")
+);
+
+const clientStrings = {
+  saveSuccess: t("admin.blog.pages.save_success"),
+  invalidContentJson: t("admin.blog.posts.invalid_content_json"),
+  deleteSuccess: t("admin.blog.pages.delete_success"),
+  deleteReasonPrompt: t("admin.blog.pages.delete_reason_prompt"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+type Data = {
+  page: NonNullable<Awaited<ReturnType<typeof fetchBlogPageById>>>;
+  otherPages: Awaited<ReturnType<typeof listBlogPages>>;
+};
+
+let data: Data | null = null;
+let loadError = false;
+let notFound = false;
+
+if (CAN_READ_PAGES) {
+  try {
+    data = await withTenant(
+      getDatabaseClient(),
+      context.tenantId,
+      async (tx) => {
+        const page = await fetchBlogPageById(tx, context.tenantId, pageId, {
+          includeDeleted: true
+        });
+
+        if (!page) {
+          return null;
+        }
+
+        const otherPages = (
+          await listBlogPages(tx, context.tenantId, { limit: 100 })
+        ).filter((candidate) => candidate.id !== pageId);
+
+        return { page, otherPages };
+      }
+    );
+
+    if (!data) {
+      notFound = true;
+    }
+  } catch (error) {
+    console.error("admin/blog/pages/[id].astro: failed to load page", error);
+    loadError = true;
+  }
+}
+
+const canEditFields =
+  data !== null &&
+  (CAN_UPDATE_PAGES ||
+    (data.page.authorTenantUserId === context.tenantUserId &&
+      data.page.status !== "published"));
+const canSoftDelete = data !== null && !data.page.deletedAt && CAN_DELETE_PAGES;
+---
+
+<AdminLayout title={data ? data.page.title : t("admin.blog.pages.title")}>
+  {
+    !CAN_READ_PAGES && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_PAGES && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ_PAGES && !loadError && notFound && (
+      <StateNotice
+        kind="error"
+        title={t("admin.blog.pages.not_found_title")}
+        body={t("admin.blog.pages.not_found_body")}
+        retryLabel={t("admin.blog.pages.back_to_list")}
+        retryHref="/admin/blog/pages"
+      />
+    )
+  }
+  {
+    data && (
+      <div class="page-editor" data-page-id={data.page.id}>
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        <div class="editor-meta">
+          <span class="status-pill" data-status={data.page.status}>
+            {t(`admin.blog.status.${data.page.status}`)}
+          </span>
+          {data.page.deletedAt && (
+            <span class="status-pill" data-status="deleted">
+              {t("admin.blog.posts.deleted_label")}
+            </span>
+          )}
+        </div>
+
+        {canSoftDelete && (
+          <div class="lifecycle-actions">
+            <button type="button" id="delete-button" class="danger-button">
+              {t("admin.blog.pages.delete_button")}
+            </button>
+          </div>
+        )}
+
+        <form id="page-form" class="editor-form">
+          <fieldset disabled={!canEditFields}>
+            <label>
+              {t("admin.blog.pages.field_title")}
+              <input
+                type="text"
+                name="title"
+                required
+                maxlength="200"
+                value={data.page.title}
+              />
+            </label>
+            <label>
+              {t("admin.blog.pages.field_slug")}
+              <input
+                type="text"
+                name="slug"
+                required
+                pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                value={data.page.slug}
+              />
+            </label>
+            <label>
+              {t("admin.blog.posts.field_content_text")}
+              <textarea name="contentText" rows="8" required>
+                {data.page.contentText}
+              </textarea>
+            </label>
+            <label>
+              {t("admin.blog.posts.field_content_json")}
+              <textarea name="contentJson" rows="6" spellcheck="false">
+                {JSON.stringify(data.page.contentJson, null, 2)}
+              </textarea>
+              <span class="field-hint">
+                {t("admin.blog.posts.content_json_hint")}
+              </span>
+            </label>
+            <label>
+              {t("admin.blog.pages.field_page_type")}
+              <select name="pageType">
+                {PAGE_TYPES.map((value) => (
+                  <option
+                    value={value}
+                    selected={data!.page.pageType === value}
+                  >
+                    {t(`admin.blog.page_type.${value}`)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              {t("admin.blog.pages.field_parent_page")}
+              <select name="parentPageId">
+                <option value="">
+                  {t("admin.blog.pages.no_parent_option")}
+                </option>
+                {data.otherPages.map((candidate) => (
+                  <option
+                    value={candidate.id}
+                    selected={data!.page.parentPageId === candidate.id}
+                  >
+                    {candidate.title}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              {t("admin.blog.pages.field_menu_order")}
+              <input
+                type="number"
+                name="menuOrder"
+                min="0"
+                step="1"
+                value={data.page.menuOrder}
+              />
+            </label>
+            <label>
+              {t("admin.blog.posts.field_visibility")}
+              <select name="visibility">
+                {BLOG_CONTENT_VISIBILITIES.map((value) => (
+                  <option
+                    value={value}
+                    selected={data!.page.visibility === value}
+                  >
+                    {t(`admin.blog.visibility.${value}`)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              {t("admin.blog.posts.field_locale")}
+              <input
+                type="text"
+                name="locale"
+                required
+                value={data.page.locale}
+              />
+            </label>
+
+            <fieldset class="seo-fieldset">
+              <legend>{t("admin.blog.posts.seo_legend")}</legend>
+              <label>
+                {t("admin.blog.posts.field_seo_title")}
+                <input
+                  type="text"
+                  name="seoTitle"
+                  maxlength="70"
+                  value={data.page.seoTitle ?? ""}
+                />
+              </label>
+              <label>
+                {t("admin.blog.posts.field_meta_description")}
+                <textarea name="metaDescription" rows="2" maxlength="160">
+                  {data.page.metaDescription ?? ""}
+                </textarea>
+              </label>
+              <label>
+                {t("admin.blog.posts.field_canonical_url")}
+                <input
+                  type="url"
+                  name="canonicalUrl"
+                  value={data.page.canonicalUrl ?? ""}
+                />
+              </label>
+            </fieldset>
+
+            {canEditFields && (
+              <button type="submit">{t("admin.blog.pages.save_button")}</button>
+            )}
+          </fieldset>
+        </form>
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .page-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .editor-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-3);
+  }
+
+  .status-pill {
+    display: inline-block;
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-full);
+    font-size: var(--fs-xs);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+  }
+
+  .status-pill[data-status="published"] {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .status-pill[data-status="archived"],
+  .status-pill[data-status="deleted"] {
+    background: var(--color-danger-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-danger-strong);
+  }
+
+  .lifecycle-actions button {
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .lifecycle-actions button.danger-button {
+    color: var(--color-danger-strong);
+    border-color: var(--color-danger-strong);
+  }
+
+  .editor-form fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+    max-width: 720px;
+  }
+
+  .editor-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .editor-form input,
+  .editor-form select,
+  .editor-form textarea {
+    padding: var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-family: inherit;
+  }
+
+  .editor-form textarea[name="contentJson"] {
+    font-family: var(--font-mono);
+    font-size: var(--fs-sm);
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+    margin: 0;
+  }
+
+  .seo-fieldset {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+  }
+
+  .seo-fieldset legend {
+    font-weight: 600;
+    font-size: var(--fs-sm);
+    padding: 0 var(--sp-1);
+  }
+
+  .editor-form button[type="submit"] {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-5);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .editor-form button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  .editor-form input:focus-visible,
+  .editor-form select:focus-visible,
+  .editor-form textarea:focus-visible,
+  .editor-form button:focus-visible,
+  .lifecycle-actions button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../../lib/ui/admin-form-client";
+
+  interface PageEditorStrings {
+    saveSuccess: string;
+    invalidContentJson: string;
+    deleteSuccess: string;
+    deleteReasonPrompt: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<PageEditorStrings>();
+  const pageId =
+    document.querySelector<HTMLElement>(".page-editor")?.dataset.pageId;
+
+  document
+    .getElementById("page-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!pageId) return;
+      const form = event.target as HTMLFormElement;
+      const button = form.querySelector<HTMLButtonElement>(
+        'button[type="submit"]'
+      );
+      if (button?.disabled) return;
+
+      const formData = new FormData(form);
+      let contentJson: unknown;
+      try {
+        contentJson = JSON.parse(String(formData.get("contentJson") ?? "{}"));
+      } catch {
+        showBanner("action-banner", strings.invalidContentJson, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/pages/${pageId}`,
+          "PATCH",
+          {
+            title: formData.get("title"),
+            slug: formData.get("slug"),
+            contentJson,
+            contentText: formData.get("contentText"),
+            locale: formData.get("locale"),
+            visibility: formData.get("visibility"),
+            pageType: formData.get("pageType"),
+            parentPageId:
+              String(formData.get("parentPageId") ?? "").trim() || null,
+            menuOrder: Number(formData.get("menuOrder") ?? 0),
+            seoTitle: String(formData.get("seoTitle") ?? "").trim() || null,
+            metaDescription:
+              String(formData.get("metaDescription") ?? "").trim() || null,
+            canonicalUrl:
+              String(formData.get("canonicalUrl") ?? "").trim() || null
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.saveSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document
+    .getElementById("delete-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !pageId) return;
+
+      const reason = window.prompt(strings.deleteReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/pages/${pageId}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) {
+          window.setTimeout(() => {
+            window.location.href = "/admin/blog/pages";
+          }, 400);
+        }
+      } finally {
+        unlock();
+      }
+    });
+</script>

--- a/src/pages/admin/blog/pages/index.astro
+++ b/src/pages/admin/blog/pages/index.astro
@@ -1,0 +1,359 @@
+---
+/**
+ * Blog static-page list (Issue #543 §Page List). Same GET query-string
+ * filter/pagination pattern as `admin/blog/posts/index.astro`, backed by
+ * `listBlogPagesForAdmin` (Issue #543 addition to `blog-page-directory.ts`).
+ * No category/tag filter here — pages have no taxonomy relation (README
+ * §Post-term relation handling: `termIds` only exists on the post payload).
+ */
+import AdminLayout from "../../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { permissionKey } from "../../../../modules/identity-access/domain/access-control";
+import {
+  listBlogPagesForAdmin,
+  type ListBlogPagesForAdminResult
+} from "../../../../modules/blog-content/application/blog-page-directory";
+import {
+  BLOG_CONTENT_STATUSES,
+  isBlogContentStatus
+} from "../../../../modules/blog-content/domain/post-status";
+import {
+  PAGE_TYPES,
+  isPageType
+} from "../../../../modules/blog-content/domain/page-type";
+import { createTranslator } from "../../../../lib/i18n/translate";
+import { formatDateTime } from "../../../../lib/i18n/format";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/pages/index.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const locale = Astro.locals.locale;
+const t = await createTranslator(locale);
+
+const CAN_READ_PAGES = context.permissions.has(
+  permissionKey("blog_content", "pages", "read")
+);
+const CAN_CREATE_PAGES = context.permissions.has(
+  permissionKey("blog_content", "pages", "create")
+);
+
+const searchParams = Astro.url.searchParams;
+const q = searchParams.get("q")?.trim() || undefined;
+const statusParam = searchParams.get("status");
+const status = isBlogContentStatus(statusParam) ? statusParam : undefined;
+const pageTypeParam = searchParams.get("pageType");
+const pageType = isPageType(pageTypeParam) ? pageTypeParam : undefined;
+const pageParam = Number(searchParams.get("page") ?? "1");
+const page = Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1;
+
+let result: ListBlogPagesForAdminResult | null = null;
+let loadError = false;
+
+if (CAN_READ_PAGES) {
+  try {
+    result = await withTenant(getDatabaseClient(), context.tenantId, (tx) =>
+      listBlogPagesForAdmin(tx, context.tenantId, {
+        search: q,
+        status,
+        pageType,
+        page
+      })
+    );
+  } catch (error) {
+    console.error("admin/blog/pages/index.astro: failed to load pages", error);
+    loadError = true;
+  }
+}
+
+const totalPages = result
+  ? Math.max(Math.ceil(result.total / result.pageSize), 1)
+  : 1;
+
+function pageHref(targetPage: number): string {
+  const params = new URLSearchParams(searchParams);
+  params.set("page", String(targetPage));
+  return `${Astro.url.pathname}?${params.toString()}`;
+}
+---
+
+<AdminLayout title={t("admin.blog.pages.title")}>
+  {
+    !CAN_READ_PAGES && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_PAGES && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    result && (
+      <div class="blog-pages-list">
+        <div class="list-header">
+          <h1 class="visually-hidden">{t("admin.blog.pages.title")}</h1>
+          {CAN_CREATE_PAGES && (
+            <a class="primary-link" href="/admin/blog/pages/new">
+              {t("admin.blog.pages.new_button")}
+            </a>
+          )}
+        </div>
+
+        <form
+          method="get"
+          class="filter-form"
+          aria-label={t("admin.blog.pages.filters_aria_label")}
+        >
+          <label>
+            {t("admin.blog.pages.search_label")}
+            <input type="search" name="q" value={q ?? ""} />
+          </label>
+          <label>
+            {t("admin.blog.pages.status_filter_label")}
+            <select name="status">
+              <option value="">{t("common.filter_all")}</option>
+              {BLOG_CONTENT_STATUSES.map((value) => (
+                <option value={value} selected={status === value}>
+                  {t(`admin.blog.status.${value}`)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            {t("admin.blog.pages.type_filter_label")}
+            <select name="pageType">
+              <option value="">{t("common.filter_all")}</option>
+              {PAGE_TYPES.map((value) => (
+                <option value={value} selected={pageType === value}>
+                  {t(`admin.blog.page_type.${value}`)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="submit">
+            {t("admin.blog.pages.apply_filters_button")}
+          </button>
+          <a class="reset-link" href="/admin/blog/pages">
+            {t("admin.blog.pages.reset_filters_link")}
+          </a>
+        </form>
+
+        {result.items.length === 0 ? (
+          <p class="empty-state">{t("admin.blog.pages.no_pages")}</p>
+        ) : (
+          <div class="table-scroll">
+            <table class="blog-table">
+              <thead>
+                <tr>
+                  <th>{t("admin.blog.pages.title_column")}</th>
+                  <th>{t("admin.blog.pages.status_column")}</th>
+                  <th>{t("admin.blog.pages.type_column")}</th>
+                  <th>{t("admin.blog.pages.menu_order_column")}</th>
+                  <th>{t("admin.blog.pages.locale_column")}</th>
+                  <th>{t("admin.blog.pages.updated_column")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.items.map((page) => (
+                  <tr>
+                    <td>
+                      <a href={`/admin/blog/pages/${page.id}`}>{page.title}</a>
+                    </td>
+                    <td>
+                      <span class="status-pill" data-status={page.status}>
+                        {t(`admin.blog.status.${page.status}`)}
+                      </span>
+                    </td>
+                    <td>{t(`admin.blog.page_type.${page.pageType}`)}</td>
+                    <td>{page.menuOrder}</td>
+                    <td>{page.locale}</td>
+                    <td>{formatDateTime(page.updatedAt, locale)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {totalPages > 1 && (
+          <nav
+            class="pagination"
+            aria-label={t("admin.blog.pages.pagination_aria_label")}
+          >
+            {page > 1 && (
+              <a href={pageHref(page - 1)}>{t("common.previous_page")}</a>
+            )}
+            <span>
+              {t("admin.blog.posts.page_indicator", { page, totalPages })}
+            </span>
+            {page < totalPages && (
+              <a href={pageHref(page + 1)}>{t("common.next_page")}</a>
+            )}
+          </nav>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .blog-pages-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .list-header {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .primary-link {
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-4);
+    text-decoration: none;
+    font-weight: 600;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .filter-form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: end;
+    gap: var(--sp-3);
+    padding: var(--sp-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-2);
+  }
+
+  .filter-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .filter-form input,
+  .filter-form select {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    min-height: 40px;
+  }
+
+  .filter-form button {
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-4);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .reset-link {
+    font-size: var(--fs-sm);
+    color: var(--color-text-muted);
+  }
+
+  .empty-state {
+    color: var(--color-text-muted);
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .blog-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .blog-table th,
+  .blog-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .status-pill {
+    display: inline-block;
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-full);
+    font-size: var(--fs-xs);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+  }
+
+  .status-pill[data-status="published"] {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .status-pill[data-status="archived"] {
+    background: var(--color-danger-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-danger-strong);
+  }
+
+  .status-pill[data-status="scheduled"],
+  .status-pill[data-status="review"] {
+    background: var(--color-warning);
+    border-color: var(--color-warning);
+  }
+
+  .pagination {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-3);
+    font-size: var(--fs-sm);
+  }
+
+  .pagination a {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  @media (max-width: 768px) {
+    .filter-form select,
+    .filter-form input {
+      min-height: 44px;
+    }
+  }
+</style>

--- a/src/pages/admin/blog/pages/new.astro
+++ b/src/pages/admin/blog/pages/new.astro
@@ -1,0 +1,375 @@
+---
+/**
+ * New blog static page (Issue #543 §Page Editor). Fields: title, slug,
+ * content, page type, parent page, menu order, visibility, SEO, locale —
+ * pages have no lifecycle-action endpoints (README §Admin API — Blog
+ * Pages: "Beda dari posts: hanya CRUD"), so there is no status/publish
+ * control here at all, and no category/tag pickers (pages carry no term
+ * relation).
+ */
+import AdminLayout from "../../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { permissionKey } from "../../../../modules/identity-access/domain/access-control";
+import { listBlogPages } from "../../../../modules/blog-content/application/blog-page-directory";
+import { fetchBlogSettings } from "../../../../modules/blog-content/application/blog-settings-directory";
+import { BLOG_CONTENT_VISIBILITIES } from "../../../../modules/blog-content/domain/post-status";
+import { PAGE_TYPES } from "../../../../modules/blog-content/domain/page-type";
+import { createTranslator } from "../../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/pages/new.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_CREATE_PAGES = context.permissions.has(
+  permissionKey("blog_content", "pages", "create")
+);
+
+const clientStrings = {
+  createSuccess: t("admin.blog.pages.create_success"),
+  invalidContentJson: t("admin.blog.posts.invalid_content_json"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+let existingPages: Awaited<ReturnType<typeof listBlogPages>> = [];
+let defaultLocale = "id";
+let loadError = false;
+
+if (CAN_CREATE_PAGES) {
+  try {
+    await withTenant(getDatabaseClient(), context.tenantId, async (tx) => {
+      existingPages = await listBlogPages(tx, context.tenantId, { limit: 100 });
+      const settings = await fetchBlogSettings(tx, context.tenantId);
+      defaultLocale = settings.defaultLocale;
+    });
+  } catch (error) {
+    console.error(
+      "admin/blog/pages/new.astro: failed to load form data",
+      error
+    );
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title={t("admin.blog.pages.new_title")}>
+  {
+    !CAN_CREATE_PAGES && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_CREATE_PAGES && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_CREATE_PAGES && !loadError && (
+      <div class="page-editor">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        <form id="page-form" class="editor-form">
+          <label>
+            {t("admin.blog.pages.field_title")}
+            <input type="text" name="title" required maxlength="200" />
+          </label>
+          <label>
+            {t("admin.blog.pages.field_slug")}
+            <input
+              type="text"
+              name="slug"
+              required
+              pattern="[a-z0-9]+(-[a-z0-9]+)*"
+            />
+          </label>
+          <label>
+            {t("admin.blog.posts.field_content_text")}
+            <textarea name="contentText" rows="8" required />
+          </label>
+          <label>
+            {t("admin.blog.posts.field_content_json")}
+            <textarea name="contentJson" rows="6" spellcheck="false">{`{
+  "blocks": []
+}`}</textarea>
+            <span class="field-hint">
+              {t("admin.blog.posts.content_json_hint")}
+            </span>
+          </label>
+          <label>
+            {t("admin.blog.pages.field_page_type")}
+            <select name="pageType">
+              {PAGE_TYPES.map((value) => (
+                <option value={value} selected={value === "standard"}>
+                  {t(`admin.blog.page_type.${value}`)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            {t("admin.blog.pages.field_parent_page")}
+            <select name="parentPageId">
+              <option value="">{t("admin.blog.pages.no_parent_option")}</option>
+              {existingPages.map((page) => (
+                <option value={page.id}>{page.title}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            {t("admin.blog.pages.field_menu_order")}
+            <input type="number" name="menuOrder" min="0" step="1" value="0" />
+          </label>
+          <label>
+            {t("admin.blog.posts.field_visibility")}
+            <select name="visibility">
+              {BLOG_CONTENT_VISIBILITIES.map((value) => (
+                <option value={value} selected={value === "public"}>
+                  {t(`admin.blog.visibility.${value}`)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            {t("admin.blog.posts.field_locale")}
+            <input type="text" name="locale" value={defaultLocale} required />
+          </label>
+
+          <fieldset class="seo-fieldset">
+            <legend>{t("admin.blog.posts.seo_legend")}</legend>
+            <label>
+              {t("admin.blog.posts.field_seo_title")}
+              <input type="text" name="seoTitle" maxlength="70" />
+            </label>
+            <label>
+              {t("admin.blog.posts.field_meta_description")}
+              <textarea name="metaDescription" rows="2" maxlength="160" />
+            </label>
+            <label>
+              {t("admin.blog.posts.field_canonical_url")}
+              <input type="url" name="canonicalUrl" />
+            </label>
+          </fieldset>
+
+          <button type="submit">{t("admin.blog.pages.create_submit")}</button>
+        </form>
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .page-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .editor-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+    max-width: 720px;
+  }
+
+  .editor-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .editor-form input,
+  .editor-form select,
+  .editor-form textarea {
+    padding: var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-family: inherit;
+  }
+
+  .editor-form textarea[name="contentJson"] {
+    font-family: var(--font-mono);
+    font-size: var(--fs-sm);
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+    margin: 0;
+  }
+
+  .seo-fieldset {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+  }
+
+  .seo-fieldset legend {
+    font-weight: 600;
+    font-size: var(--fs-sm);
+    padding: 0 var(--sp-1);
+  }
+
+  .editor-form button[type="submit"] {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-5);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .editor-form button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  .editor-form input:focus-visible,
+  .editor-form select:focus-visible,
+  .editor-form textarea:focus-visible,
+  .editor-form button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    showBanner
+  } from "../../../../lib/ui/admin-form-client";
+
+  interface NewPageStrings {
+    createSuccess: string;
+    invalidContentJson: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<NewPageStrings>();
+
+  document
+    .getElementById("page-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = form.querySelector<HTMLButtonElement>(
+        'button[type="submit"]'
+      );
+      if (button?.disabled) return;
+
+      const formData = new FormData(form);
+      let contentJson: unknown;
+      try {
+        contentJson = JSON.parse(String(formData.get("contentJson") ?? "{}"));
+      } catch {
+        showBanner("action-banner", strings.invalidContentJson, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const res = await fetch("/api/v1/blog/pages", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({
+            title: formData.get("title"),
+            slug: formData.get("slug"),
+            excerpt: null,
+            contentJson,
+            contentText: formData.get("contentText"),
+            locale: formData.get("locale"),
+            visibility: formData.get("visibility"),
+            pageType: formData.get("pageType"),
+            parentPageId:
+              String(formData.get("parentPageId") ?? "").trim() || null,
+            menuOrder: Number(formData.get("menuOrder") ?? 0),
+            seoTitle: String(formData.get("seoTitle") ?? "").trim() || null,
+            metaDescription:
+              String(formData.get("metaDescription") ?? "").trim() || null,
+            canonicalUrl:
+              String(formData.get("canonicalUrl") ?? "").trim() || null
+          })
+        });
+        const json = await res.json().catch(() => null);
+
+        if (!res.ok) {
+          const code = json?.error?.code as string | undefined;
+          const message =
+            (code && strings.errorMessages?.[code]) ??
+            json?.error?.message ??
+            `Request failed (${res.status}).`;
+          showBanner("action-banner", message, "error");
+          return;
+        }
+
+        showBanner("action-banner", strings.createSuccess, "success");
+        const newPageId = json?.data?.id as string | undefined;
+        window.location.href = newPageId
+          ? `/admin/blog/pages/${newPageId}`
+          : "/admin/blog/pages";
+      } catch {
+        showBanner("action-banner", strings.networkError, "error");
+      } finally {
+        unlock?.();
+      }
+    });
+</script>

--- a/src/pages/admin/blog/posts/[id].astro
+++ b/src/pages/admin/blog/posts/[id].astro
@@ -1,0 +1,1052 @@
+---
+/**
+ * Blog post editor — edit existing post (Issue #543 §Post Editor). SSR read
+ * reuses `fetchBlogPostById`/`fetchPostTermIds` (Issue #538/#539, the same
+ * functions `GET /api/v1/blog/posts/{id}` calls) plus `listBlogRevisions`
+ * (Issue #541). Every mutation (field save, lifecycle actions, revision
+ * restore, soft delete) goes through the real already-guarded/audited
+ * `/api/v1/blog/posts/{id}...` endpoints via client-side `fetch` — this page
+ * never writes to the database directly.
+ *
+ * `canEditFields` mirrors `domain/content-access-policy.ts`'s
+ * `evaluateContentUpdateAccess` (README §ABAC — author boleh edit draft
+ * sendiri): the role permission `blog_content.posts.update`, OR the caller
+ * is the post's author and it is not yet `published`. This is UI-nicety
+ * gating only — `PATCH /api/v1/blog/posts/{id}` re-evaluates the identical
+ * rule server-side regardless of what this page shows.
+ *
+ * Lifecycle action buttons (publish/schedule/archive/restore/purge) are
+ * shown only when `isValidStatusTransition`/`canRestorePost`/`canPurgePost`
+ * (the same pure functions the API endpoints themselves call) say the
+ * transition is legal *and* the caller holds that action's own permission
+ * (no ownership override for these — doc issue #538 §ABAC Rules: "Author
+ * may not publish unless granted `blog_content.posts.publish`"). Each is a
+ * high-risk mutation: `window.confirm` first, then a fresh
+ * `Idempotency-Key` per attempt.
+ */
+import AdminLayout from "../../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { permissionKey } from "../../../../modules/identity-access/domain/access-control";
+import { fetchBlogPostById } from "../../../../modules/blog-content/application/blog-post-directory";
+import {
+  fetchPostTermIds,
+  listBlogTerms
+} from "../../../../modules/blog-content/application/blog-taxonomy-directory";
+import { listBlogRevisions } from "../../../../modules/blog-content/application/blog-revision-directory";
+import { fetchAuthorDisplayNames } from "../../../../modules/blog-content/application/author-lookup";
+import {
+  BLOG_CONTENT_VISIBILITIES,
+  canPurgePost,
+  canRestorePost,
+  isValidStatusTransition
+} from "../../../../modules/blog-content/domain/post-status";
+import { createTranslator } from "../../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../../lib/i18n/error-messages";
+import { formatDateTime } from "../../../../lib/i18n/format";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/posts/[id].astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const locale = Astro.locals.locale;
+const t = await createTranslator(locale);
+const postId = Astro.params.id!;
+
+const CAN_READ_POSTS = context.permissions.has(
+  permissionKey("blog_content", "posts", "read")
+);
+const CAN_UPDATE_POSTS = context.permissions.has(
+  permissionKey("blog_content", "posts", "update")
+);
+const CAN_PUBLISH = context.permissions.has(
+  permissionKey("blog_content", "posts", "publish")
+);
+const CAN_SCHEDULE = context.permissions.has(
+  permissionKey("blog_content", "posts", "schedule")
+);
+const CAN_ARCHIVE = context.permissions.has(
+  permissionKey("blog_content", "posts", "archive")
+);
+const CAN_DELETE = context.permissions.has(
+  permissionKey("blog_content", "posts", "delete")
+);
+const CAN_RESTORE = context.permissions.has(
+  permissionKey("blog_content", "posts", "restore")
+);
+const CAN_PURGE = context.permissions.has(
+  permissionKey("blog_content", "posts", "purge")
+);
+const CAN_READ_TAXONOMIES = context.permissions.has(
+  permissionKey("blog_content", "taxonomies", "read")
+);
+const CAN_READ_REVISIONS = context.permissions.has(
+  permissionKey("blog_content", "revisions", "read")
+);
+const CAN_RESTORE_REVISIONS = context.permissions.has(
+  permissionKey("blog_content", "revisions", "restore")
+);
+
+const clientStrings = {
+  saveSuccess: t("admin.blog.posts.save_success"),
+  invalidContentJson: t("admin.blog.posts.invalid_content_json"),
+  submitReviewSuccess: t("admin.blog.posts.submit_review_success"),
+  publishSuccess: t("admin.blog.posts.publish_success"),
+  scheduleSuccess: t("admin.blog.posts.schedule_success"),
+  archiveSuccess: t("admin.blog.posts.archive_success"),
+  restoreSuccess: t("admin.blog.posts.restore_success"),
+  purgeSuccess: t("admin.blog.posts.purge_success"),
+  deleteSuccess: t("admin.blog.posts.delete_success"),
+  revisionRestoreSuccess: t("admin.blog.posts.revision_restore_success"),
+  deleteReasonPrompt: t("admin.blog.posts.delete_reason_prompt"),
+  publishConfirm: t("admin.blog.posts.publish_confirm"),
+  scheduleConfirm: t("admin.blog.posts.schedule_confirm"),
+  archiveConfirm: t("admin.blog.posts.archive_confirm"),
+  restoreConfirm: t("admin.blog.posts.restore_confirm"),
+  purgeConfirm: t("admin.blog.posts.purge_confirm"),
+  revisionRestoreConfirm: t("admin.blog.posts.revision_restore_confirm"),
+  scheduledAtPrompt: t("admin.blog.posts.scheduled_at_prompt"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+type Data = {
+  post: NonNullable<Awaited<ReturnType<typeof fetchBlogPostById>>>;
+  termIds: string[];
+  terms: Awaited<ReturnType<typeof listBlogTerms>>;
+  revisions: Awaited<ReturnType<typeof listBlogRevisions>>;
+  authorName: string | null;
+};
+
+let data: Data | null = null;
+let loadError = false;
+let notFound = false;
+
+if (CAN_READ_POSTS) {
+  try {
+    data = await withTenant(
+      getDatabaseClient(),
+      context.tenantId,
+      async (tx) => {
+        const post = await fetchBlogPostById(tx, context.tenantId, postId, {
+          includeDeleted: true
+        });
+
+        if (!post) {
+          return null;
+        }
+
+        const [termIds, terms, revisions, authorNames] = await Promise.all([
+          fetchPostTermIds(tx, context.tenantId, postId),
+          CAN_READ_TAXONOMIES
+            ? listBlogTerms(tx, context.tenantId)
+            : Promise.resolve([]),
+          CAN_READ_REVISIONS
+            ? listBlogRevisions(tx, context.tenantId, "post", postId)
+            : Promise.resolve([]),
+          fetchAuthorDisplayNames(tx, context.tenantId, [
+            post.authorTenantUserId
+          ])
+        ]);
+
+        return {
+          post,
+          termIds,
+          terms,
+          revisions,
+          authorName: authorNames.get(post.authorTenantUserId) ?? null
+        };
+      }
+    );
+
+    if (!data) {
+      notFound = true;
+    }
+  } catch (error) {
+    console.error("admin/blog/posts/[id].astro: failed to load post", error);
+    loadError = true;
+  }
+}
+
+const canEditFields =
+  data !== null &&
+  (CAN_UPDATE_POSTS ||
+    (data.post.authorTenantUserId === context.tenantUserId &&
+      data.post.status !== "published"));
+
+const categories = data
+  ? data.terms.filter((term) => term.taxonomyType === "category")
+  : [];
+const tags = data
+  ? data.terms.filter((term) => term.taxonomyType === "tag")
+  : [];
+
+const canSubmitReview =
+  data !== null &&
+  !data.post.deletedAt &&
+  canEditFields &&
+  isValidStatusTransition(data.post.status, "review") &&
+  data.post.status === "draft";
+const canPublish =
+  data !== null &&
+  !data.post.deletedAt &&
+  CAN_PUBLISH &&
+  isValidStatusTransition(data.post.status, "published");
+const canSchedule =
+  data !== null &&
+  !data.post.deletedAt &&
+  CAN_SCHEDULE &&
+  isValidStatusTransition(data.post.status, "scheduled");
+const canArchive =
+  data !== null &&
+  !data.post.deletedAt &&
+  CAN_ARCHIVE &&
+  isValidStatusTransition(data.post.status, "archived");
+const canRestore =
+  data !== null && CAN_RESTORE && canRestorePost(data.post.deletedAt);
+const canPurge =
+  data !== null &&
+  CAN_PURGE &&
+  canPurgePost(data.post.status, data.post.deletedAt);
+const canSoftDelete = data !== null && !data.post.deletedAt && CAN_DELETE;
+---
+
+<AdminLayout title={data ? data.post.title : t("admin.blog.posts.title")}>
+  {
+    !CAN_READ_POSTS && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_POSTS && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ_POSTS && !loadError && notFound && (
+      <StateNotice
+        kind="error"
+        title={t("admin.blog.posts.not_found_title")}
+        body={t("admin.blog.posts.not_found_body")}
+        retryLabel={t("admin.blog.posts.back_to_list")}
+        retryHref="/admin/blog/posts"
+      />
+    )
+  }
+  {
+    data && (
+      <div class="post-editor" data-post-id={data.post.id}>
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        <div class="editor-meta">
+          <span class="status-pill" data-status={data.post.status}>
+            {t(`admin.blog.status.${data.post.status}`)}
+          </span>
+          {data.post.deletedAt && (
+            <span class="status-pill" data-status="deleted">
+              {t("admin.blog.posts.deleted_label")}
+            </span>
+          )}
+          <span class="field-hint">
+            {t("admin.blog.posts.author_label")}:{" "}
+            {data.authorName ?? t("admin.blog.posts.unknown_author")}
+          </span>
+        </div>
+
+        <div class="lifecycle-actions">
+          {canSubmitReview && (
+            <button type="button" id="submit-review-button">
+              {t("admin.blog.posts.submit_review_button")}
+            </button>
+          )}
+          {canPublish && (
+            <button type="button" id="publish-button">
+              {t("admin.blog.posts.publish_button")}
+            </button>
+          )}
+          {canSchedule && (
+            <button type="button" id="schedule-button">
+              {t("admin.blog.posts.schedule_button")}
+            </button>
+          )}
+          {canArchive && (
+            <button type="button" id="archive-button">
+              {t("admin.blog.posts.archive_button")}
+            </button>
+          )}
+          {canSoftDelete && (
+            <button type="button" id="delete-button" class="danger-button">
+              {t("admin.blog.posts.delete_button")}
+            </button>
+          )}
+          {canRestore && (
+            <button type="button" id="restore-button">
+              {t("admin.blog.posts.restore_button")}
+            </button>
+          )}
+          {canPurge && (
+            <button type="button" id="purge-button" class="danger-button">
+              {t("admin.blog.posts.purge_button")}
+            </button>
+          )}
+        </div>
+
+        <form id="post-form" class="editor-form">
+          <fieldset disabled={!canEditFields}>
+            <label>
+              {t("admin.blog.posts.field_title")}
+              <input
+                type="text"
+                name="title"
+                required
+                maxlength="200"
+                value={data.post.title}
+              />
+            </label>
+            <label>
+              {t("admin.blog.posts.field_slug")}
+              <input
+                type="text"
+                name="slug"
+                required
+                pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                value={data.post.slug}
+              />
+            </label>
+            <label>
+              {t("admin.blog.posts.field_excerpt")}
+              <textarea name="excerpt" rows="3" maxlength="500">
+                {data.post.excerpt ?? ""}
+              </textarea>
+            </label>
+            <label>
+              {t("admin.blog.posts.field_content_text")}
+              <textarea name="contentText" rows="8" required>
+                {data.post.contentText}
+              </textarea>
+            </label>
+            <label>
+              {t("admin.blog.posts.field_content_json")}
+              <textarea name="contentJson" rows="6" spellcheck="false">
+                {JSON.stringify(data.post.contentJson, null, 2)}
+              </textarea>
+              <span class="field-hint">
+                {t("admin.blog.posts.content_json_hint")}
+              </span>
+            </label>
+            <label>
+              {t("admin.blog.posts.field_visibility")}
+              <select name="visibility">
+                {BLOG_CONTENT_VISIBILITIES.map((value) => (
+                  <option
+                    value={value}
+                    selected={data!.post.visibility === value}
+                  >
+                    {t(`admin.blog.visibility.${value}`)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              {t("admin.blog.posts.field_locale")}
+              <input
+                type="text"
+                name="locale"
+                required
+                value={data.post.locale}
+              />
+            </label>
+            <label>
+              {t("admin.blog.posts.field_featured_media_id")}
+              <input
+                type="text"
+                name="featuredMediaId"
+                value={data.post.featuredMediaId ?? ""}
+              />
+            </label>
+
+            <fieldset class="term-picker">
+              <legend>{t("admin.blog.posts.field_categories")}</legend>
+              {categories.length === 0 ? (
+                <p class="field-hint">{t("admin.blog.posts.no_categories")}</p>
+              ) : (
+                <select
+                  name="categoryIds"
+                  multiple
+                  size={Math.min(categories.length, 6)}
+                >
+                  {categories.map((term) => (
+                    <option
+                      value={term.id}
+                      selected={data!.termIds.includes(term.id)}
+                    >
+                      {term.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </fieldset>
+
+            <fieldset class="term-picker">
+              <legend>{t("admin.blog.posts.field_tags")}</legend>
+              {tags.length === 0 ? (
+                <p class="field-hint">{t("admin.blog.posts.no_tags")}</p>
+              ) : (
+                <select name="tagIds" multiple size={Math.min(tags.length, 6)}>
+                  {tags.map((term) => (
+                    <option
+                      value={term.id}
+                      selected={data!.termIds.includes(term.id)}
+                    >
+                      {term.name}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </fieldset>
+
+            <fieldset class="seo-fieldset">
+              <legend>{t("admin.blog.posts.seo_legend")}</legend>
+              <label>
+                {t("admin.blog.posts.field_seo_title")}
+                <input
+                  type="text"
+                  name="seoTitle"
+                  maxlength="70"
+                  value={data.post.seoTitle ?? ""}
+                />
+              </label>
+              <label>
+                {t("admin.blog.posts.field_meta_description")}
+                <textarea name="metaDescription" rows="2" maxlength="160">
+                  {data.post.metaDescription ?? ""}
+                </textarea>
+              </label>
+              <label>
+                {t("admin.blog.posts.field_canonical_url")}
+                <input
+                  type="url"
+                  name="canonicalUrl"
+                  value={data.post.canonicalUrl ?? ""}
+                />
+              </label>
+            </fieldset>
+
+            {canEditFields && (
+              <button type="submit">{t("admin.blog.posts.save_button")}</button>
+            )}
+          </fieldset>
+        </form>
+
+        {CAN_READ_REVISIONS && (
+          <section class="revisions-section">
+            <h2>{t("admin.blog.posts.revisions_title")}</h2>
+            {data.revisions.length === 0 ? (
+              <p class="field-hint">{t("admin.blog.posts.no_revisions")}</p>
+            ) : (
+              <div class="table-scroll">
+                <table class="blog-table">
+                  <thead>
+                    <tr>
+                      <th>{t("admin.blog.posts.revision_number_column")}</th>
+                      <th>{t("admin.blog.posts.revision_title_column")}</th>
+                      <th>{t("admin.blog.posts.revision_status_column")}</th>
+                      <th>{t("admin.blog.posts.revision_note_column")}</th>
+                      <th>{t("admin.blog.posts.revision_created_column")}</th>
+                      {CAN_RESTORE_REVISIONS && (
+                        <th>{t("admin.blog.posts.revision_actions_column")}</th>
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.revisions.map((revision) => (
+                      <tr>
+                        <td>{revision.revisionNumber}</td>
+                        <td>{revision.title}</td>
+                        <td>{t(`admin.blog.status.${revision.status}`)}</td>
+                        <td>{revision.changeNote ?? "-"}</td>
+                        <td>{formatDateTime(revision.createdAt, locale)}</td>
+                        {CAN_RESTORE_REVISIONS && (
+                          <td>
+                            <button
+                              type="button"
+                              class="revision-restore-button"
+                              data-revision-id={revision.id}
+                              data-revision-number={revision.revisionNumber}
+                            >
+                              {t("admin.blog.posts.revision_restore_button")}
+                            </button>
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .post-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .editor-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-3);
+    flex-wrap: wrap;
+  }
+
+  .status-pill {
+    display: inline-block;
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-full);
+    font-size: var(--fs-xs);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+  }
+
+  .status-pill[data-status="published"] {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .status-pill[data-status="archived"],
+  .status-pill[data-status="deleted"] {
+    background: var(--color-danger-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-danger-strong);
+  }
+
+  .status-pill[data-status="scheduled"],
+  .status-pill[data-status="review"] {
+    background: var(--color-warning);
+    border-color: var(--color-warning);
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+    margin: 0;
+  }
+
+  .lifecycle-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-2);
+  }
+
+  .lifecycle-actions button {
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .lifecycle-actions button.danger-button {
+    color: var(--color-danger-strong);
+    border-color: var(--color-danger-strong);
+  }
+
+  .lifecycle-actions button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  .editor-form fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+    max-width: 720px;
+  }
+
+  .editor-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .editor-form input,
+  .editor-form select,
+  .editor-form textarea {
+    padding: var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-family: inherit;
+  }
+
+  .editor-form textarea[name="contentJson"] {
+    font-family: var(--font-mono);
+    font-size: var(--fs-sm);
+  }
+
+  .term-picker,
+  .seo-fieldset {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+  }
+
+  .term-picker legend,
+  .seo-fieldset legend {
+    font-weight: 600;
+    font-size: var(--fs-sm);
+    padding: 0 var(--sp-1);
+  }
+
+  .editor-form button[type="submit"] {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-5);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .editor-form button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  .revisions-section h2 {
+    font-size: var(--fs-md);
+    margin: 0 0 var(--sp-3);
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .blog-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .blog-table th,
+  .blog-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .revision-restore-button {
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-2);
+    min-height: 44px;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+  }
+
+  /* Keyboard focus visible (doc 14 §Aksesibilitas). */
+  .editor-form input:focus-visible,
+  .editor-form select:focus-visible,
+  .editor-form textarea:focus-visible,
+  .editor-form button:focus-visible,
+  .lifecycle-actions button:focus-visible,
+  .revision-restore-button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    newIdempotencyKey,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../../lib/ui/admin-form-client";
+
+  interface PostEditorStrings {
+    saveSuccess: string;
+    invalidContentJson: string;
+    submitReviewSuccess: string;
+    publishSuccess: string;
+    scheduleSuccess: string;
+    archiveSuccess: string;
+    restoreSuccess: string;
+    purgeSuccess: string;
+    deleteSuccess: string;
+    revisionRestoreSuccess: string;
+    deleteReasonPrompt: string;
+    publishConfirm: string;
+    scheduleConfirm: string;
+    archiveConfirm: string;
+    restoreConfirm: string;
+    purgeConfirm: string;
+    revisionRestoreConfirm: string;
+    scheduledAtPrompt: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<PostEditorStrings>();
+  const postId =
+    document.querySelector<HTMLElement>(".post-editor")?.dataset.postId;
+
+  document
+    .getElementById("post-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!postId) return;
+      const form = event.target as HTMLFormElement;
+      const button = form.querySelector<HTMLButtonElement>(
+        'button[type="submit"]'
+      );
+      if (button?.disabled) return;
+
+      const formData = new FormData(form);
+      let contentJson: unknown;
+      try {
+        contentJson = JSON.parse(String(formData.get("contentJson") ?? "{}"));
+      } catch {
+        showBanner("action-banner", strings.invalidContentJson, "error");
+        return;
+      }
+
+      const categoryIds = Array.from(
+        form.querySelectorAll<HTMLOptionElement>(
+          'select[name="categoryIds"] option:checked'
+        )
+      ).map((option) => option.value);
+      const tagIds = Array.from(
+        form.querySelectorAll<HTMLOptionElement>(
+          'select[name="tagIds"] option:checked'
+        )
+      ).map((option) => option.value);
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/posts/${postId}`,
+          "PATCH",
+          {
+            title: formData.get("title"),
+            slug: formData.get("slug"),
+            excerpt: String(formData.get("excerpt") ?? "").trim() || null,
+            contentJson,
+            contentText: formData.get("contentText"),
+            locale: formData.get("locale"),
+            visibility: formData.get("visibility"),
+            featuredMediaId:
+              String(formData.get("featuredMediaId") ?? "").trim() || null,
+            seoTitle: String(formData.get("seoTitle") ?? "").trim() || null,
+            metaDescription:
+              String(formData.get("metaDescription") ?? "").trim() || null,
+            canonicalUrl:
+              String(formData.get("canonicalUrl") ?? "").trim() || null,
+            termIds: [...categoryIds, ...tagIds]
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.saveSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document
+    .getElementById("submit-review-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !postId) return;
+      const unlock = lockElement(el, strings.pleaseWait);
+
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/posts/${postId}/submit-review`,
+          "POST",
+          {},
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.submitReviewSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+
+  document
+    .getElementById("publish-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !postId) return;
+      if (!window.confirm(strings.publishConfirm)) return;
+      const unlock = lockElement(el, strings.pleaseWait);
+
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/posts/${postId}/publish`,
+          "POST",
+          {},
+          strings,
+          { "Idempotency-Key": newIdempotencyKey() }
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.publishSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+
+  document
+    .getElementById("schedule-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !postId) return;
+
+      const scheduledAtRaw = window.prompt(strings.scheduledAtPrompt);
+      if (!scheduledAtRaw) return;
+      const scheduledAt = new Date(scheduledAtRaw);
+      if (Number.isNaN(scheduledAt.getTime())) return;
+      if (!window.confirm(strings.scheduleConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/posts/${postId}/schedule`,
+          "POST",
+          { scheduledAt: scheduledAt.toISOString() },
+          strings,
+          { "Idempotency-Key": newIdempotencyKey() }
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.scheduleSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+
+  document
+    .getElementById("archive-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !postId) return;
+      if (!window.confirm(strings.archiveConfirm)) return;
+      const unlock = lockElement(el, strings.pleaseWait);
+
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/posts/${postId}/archive`,
+          "POST",
+          {},
+          strings,
+          { "Idempotency-Key": newIdempotencyKey() }
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.archiveSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+
+  document
+    .getElementById("restore-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !postId) return;
+      if (!window.confirm(strings.restoreConfirm)) return;
+      const unlock = lockElement(el, strings.pleaseWait);
+
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/posts/${postId}/restore`,
+          "POST",
+          {},
+          strings,
+          { "Idempotency-Key": newIdempotencyKey() }
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.restoreSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+
+  document
+    .getElementById("purge-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !postId) return;
+      if (!window.confirm(strings.purgeConfirm)) return;
+      const unlock = lockElement(el, strings.pleaseWait);
+
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/posts/${postId}/purge`,
+          "POST",
+          {},
+          strings,
+          { "Idempotency-Key": newIdempotencyKey() }
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.purgeSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) {
+          window.setTimeout(() => {
+            window.location.href = "/admin/blog/posts";
+          }, 400);
+        }
+      } finally {
+        unlock();
+      }
+    });
+
+  document
+    .getElementById("delete-button")
+    ?.addEventListener("click", async (event) => {
+      const el = event.currentTarget as HTMLButtonElement;
+      if (el.disabled || !postId) return;
+
+      const reason = window.prompt(strings.deleteReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/posts/${postId}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+
+  document.querySelectorAll(".revision-restore-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled || !postId) return;
+      if (!window.confirm(strings.revisionRestoreConfirm)) return;
+
+      const revisionId = el.dataset.revisionId!;
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const result = await submitJson(
+          `/api/v1/blog/posts/${postId}/revisions/${revisionId}/restore`,
+          "POST",
+          {},
+          strings,
+          { "Idempotency-Key": newIdempotencyKey() }
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.revisionRestoreSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+</script>

--- a/src/pages/admin/blog/posts/index.astro
+++ b/src/pages/admin/blog/posts/index.astro
@@ -1,0 +1,407 @@
+---
+/**
+ * Blog post list (Issue #543 §Post List). Filters (`q` search, `status`,
+ * `termId` category/tag) and pagination (`page`) are plain GET query-string
+ * params — the filter form uses `method="get"` so the browser itself
+ * navigates to a new URL and Astro re-renders server-side; no client-side
+ * JS is needed for filtering/paging (doc 14 §Progressive enhancement: a
+ * GET form works with JS disabled too). SSR read is the same
+ * `listBlogPostsForAdmin` function a JSON endpoint could call (Issue #543
+ * addition to `blog-post-directory.ts`) — no such JSON endpoint exists yet
+ * since nothing outside this admin screen currently needs search/category
+ * filter/paged listing (`GET /api/v1/blog/posts` keeps its simpler
+ * status+limit shape).
+ *
+ * Permission-gated:
+ *   - blog_content.posts.read   -> the whole screen
+ *   - blog_content.posts.create -> "New post" link
+ *   - blog_content.taxonomies.read -> category/tag filter dropdown
+ */
+import AdminLayout from "../../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { permissionKey } from "../../../../modules/identity-access/domain/access-control";
+import {
+  listBlogPostsForAdmin,
+  type ListBlogPostsForAdminResult
+} from "../../../../modules/blog-content/application/blog-post-directory";
+import { listBlogTerms } from "../../../../modules/blog-content/application/blog-taxonomy-directory";
+import { fetchAuthorDisplayNames } from "../../../../modules/blog-content/application/author-lookup";
+import {
+  BLOG_CONTENT_STATUSES,
+  isBlogContentStatus
+} from "../../../../modules/blog-content/domain/post-status";
+import { createTranslator } from "../../../../lib/i18n/translate";
+import { formatDateTime } from "../../../../lib/i18n/format";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/posts/index.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const locale = Astro.locals.locale;
+const t = await createTranslator(locale);
+
+const CAN_READ_POSTS = context.permissions.has(
+  permissionKey("blog_content", "posts", "read")
+);
+const CAN_CREATE_POSTS = context.permissions.has(
+  permissionKey("blog_content", "posts", "create")
+);
+const CAN_READ_TAXONOMIES = context.permissions.has(
+  permissionKey("blog_content", "taxonomies", "read")
+);
+
+const searchParams = Astro.url.searchParams;
+const q = searchParams.get("q")?.trim() || undefined;
+const statusParam = searchParams.get("status");
+const status = isBlogContentStatus(statusParam) ? statusParam : undefined;
+const termId = searchParams.get("termId") || undefined;
+const pageParam = Number(searchParams.get("page") ?? "1");
+const page = Number.isFinite(pageParam) && pageParam > 0 ? pageParam : 1;
+
+let data: {
+  result: ListBlogPostsForAdminResult;
+  authorNames: Map<string, string>;
+  terms: Awaited<ReturnType<typeof listBlogTerms>>;
+} | null = null;
+let loadError = false;
+
+if (CAN_READ_POSTS) {
+  try {
+    data = await withTenant(
+      getDatabaseClient(),
+      context.tenantId,
+      async (tx) => {
+        const result = await listBlogPostsForAdmin(tx, context.tenantId, {
+          search: q,
+          status,
+          termId,
+          page
+        });
+        const authorNames = await fetchAuthorDisplayNames(
+          tx,
+          context.tenantId,
+          result.items.map((item) => item.authorTenantUserId)
+        );
+        const terms = CAN_READ_TAXONOMIES
+          ? await listBlogTerms(tx, context.tenantId)
+          : [];
+
+        return { result, authorNames, terms };
+      }
+    );
+  } catch (error) {
+    console.error("admin/blog/posts/index.astro: failed to load posts", error);
+    loadError = true;
+  }
+}
+
+const totalPages = data
+  ? Math.max(Math.ceil(data.result.total / data.result.pageSize), 1)
+  : 1;
+
+function pageHref(targetPage: number): string {
+  const params = new URLSearchParams(searchParams);
+  params.set("page", String(targetPage));
+  return `${Astro.url.pathname}?${params.toString()}`;
+}
+---
+
+<AdminLayout title={t("admin.blog.posts.title")}>
+  {
+    !CAN_READ_POSTS && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_POSTS && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    data && (
+      <div class="blog-posts-list">
+        <div class="list-header">
+          <h1 class="visually-hidden">{t("admin.blog.posts.title")}</h1>
+          {CAN_CREATE_POSTS && (
+            <a class="primary-link" href="/admin/blog/posts/new">
+              {t("admin.blog.posts.new_button")}
+            </a>
+          )}
+        </div>
+
+        <form
+          method="get"
+          class="filter-form"
+          aria-label={t("admin.blog.posts.filters_aria_label")}
+        >
+          <label>
+            {t("admin.blog.posts.search_label")}
+            <input type="search" name="q" value={q ?? ""} />
+          </label>
+          <label>
+            {t("admin.blog.posts.status_filter_label")}
+            <select name="status">
+              <option value="">{t("common.filter_all")}</option>
+              {BLOG_CONTENT_STATUSES.map((value) => (
+                <option value={value} selected={status === value}>
+                  {t(`admin.blog.status.${value}`)}
+                </option>
+              ))}
+            </select>
+          </label>
+          {CAN_READ_TAXONOMIES && (
+            <label>
+              {t("admin.blog.posts.term_filter_label")}
+              <select name="termId">
+                <option value="">{t("common.filter_all")}</option>
+                {data.terms.map((term) => (
+                  <option value={term.id} selected={termId === term.id}>
+                    {term.taxonomyType === "category"
+                      ? t("admin.blog.taxonomy.category_prefix", {
+                          name: term.name
+                        })
+                      : t("admin.blog.taxonomy.tag_prefix", {
+                          name: term.name
+                        })}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          <button type="submit">
+            {t("admin.blog.posts.apply_filters_button")}
+          </button>
+          <a class="reset-link" href="/admin/blog/posts">
+            {t("admin.blog.posts.reset_filters_link")}
+          </a>
+        </form>
+
+        {data.result.items.length === 0 ? (
+          <p class="empty-state">{t("admin.blog.posts.no_posts")}</p>
+        ) : (
+          <div class="table-scroll">
+            <table class="blog-table">
+              <thead>
+                <tr>
+                  <th>{t("admin.blog.posts.title_column")}</th>
+                  <th>{t("admin.blog.posts.status_column")}</th>
+                  <th>{t("admin.blog.posts.author_column")}</th>
+                  <th>{t("admin.blog.posts.locale_column")}</th>
+                  <th>{t("admin.blog.posts.published_column")}</th>
+                  <th>{t("admin.blog.posts.updated_column")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.result.items.map((post) => (
+                  <tr>
+                    <td>
+                      <a href={`/admin/blog/posts/${post.id}`}>{post.title}</a>
+                    </td>
+                    <td>
+                      <span class="status-pill" data-status={post.status}>
+                        {t(`admin.blog.status.${post.status}`)}
+                      </span>
+                    </td>
+                    <td>
+                      {data!.authorNames.get(post.authorTenantUserId) ??
+                        t("admin.blog.posts.unknown_author")}
+                    </td>
+                    <td>{post.locale}</td>
+                    <td>
+                      {post.publishedAt
+                        ? formatDateTime(post.publishedAt, locale)
+                        : "-"}
+                    </td>
+                    <td>{formatDateTime(post.updatedAt, locale)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {totalPages > 1 && (
+          <nav
+            class="pagination"
+            aria-label={t("admin.blog.posts.pagination_aria_label")}
+          >
+            {page > 1 && (
+              <a href={pageHref(page - 1)}>{t("common.previous_page")}</a>
+            )}
+            <span>
+              {t("admin.blog.posts.page_indicator", {
+                page,
+                totalPages
+              })}
+            </span>
+            {page < totalPages && (
+              <a href={pageHref(page + 1)}>{t("common.next_page")}</a>
+            )}
+          </nav>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .blog-posts-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .list-header {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .primary-link {
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-4);
+    text-decoration: none;
+    font-weight: 600;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .filter-form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: end;
+    gap: var(--sp-3);
+    padding: var(--sp-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-2);
+  }
+
+  .filter-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .filter-form input,
+  .filter-form select {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    min-height: 40px;
+  }
+
+  .filter-form button {
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-4);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .reset-link {
+    font-size: var(--fs-sm);
+    color: var(--color-text-muted);
+  }
+
+  .empty-state {
+    color: var(--color-text-muted);
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .blog-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .blog-table th,
+  .blog-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .status-pill {
+    display: inline-block;
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-full);
+    font-size: var(--fs-xs);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+  }
+
+  .status-pill[data-status="published"] {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .status-pill[data-status="archived"] {
+    background: var(--color-danger-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-danger-strong);
+  }
+
+  .status-pill[data-status="scheduled"],
+  .status-pill[data-status="review"] {
+    background: var(--color-warning);
+    border-color: var(--color-warning);
+  }
+
+  .pagination {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-3);
+    font-size: var(--fs-sm);
+  }
+
+  .pagination a {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  /* Touch target >= 44px on tablet/mobile (doc 14 §Aksesibilitas). */
+  @media (max-width: 768px) {
+    .filter-form select,
+    .filter-form input {
+      min-height: 44px;
+    }
+  }
+</style>

--- a/src/pages/admin/blog/posts/new.astro
+++ b/src/pages/admin/blog/posts/new.astro
@@ -1,0 +1,423 @@
+---
+/**
+ * New blog post (Issue #543 §Post Editor). Fields per the issue's field
+ * list: title, slug, excerpt, content, status (implicit — a new post always
+ * starts `draft`, same as `POST /api/v1/blog/posts` hardcodes), visibility,
+ * SEO title, meta description, canonical URL, category, tags, featured
+ * media reference, locale. `content` is split into `contentText` (plain,
+ * required, used for search/excerpt-fallback) and `contentJson` (the
+ * `{ blocks: [...] }` shape `content-block-rendering.ts` whitelists) — a
+ * raw JSON textarea, same "structured JSON in a labeled textarea" pattern
+ * `admin/modules/[moduleKey].astro`'s settings panel already established,
+ * not a new rich-text/block editor (out of scope: "no new UI framework").
+ *
+ * Category/tags are rendered as two separate multi-selects over the same
+ * `blog_content.taxonomies.read` term list (filtered client-side by
+ * `taxonomyType`) and merged into one `termIds` array on submit — the API
+ * itself does not distinguish "category" vs "tag" within `termIds`, this
+ * split is purely a UX affordance matching the issue's field list.
+ *
+ * Mutation goes through the real, already-guarded/audited
+ * `POST /api/v1/blog/posts` (Issue #538) via client-side `fetch` — this
+ * page has no privileged shortcut.
+ */
+import AdminLayout from "../../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { permissionKey } from "../../../../modules/identity-access/domain/access-control";
+import { listBlogTerms } from "../../../../modules/blog-content/application/blog-taxonomy-directory";
+import { fetchBlogSettings } from "../../../../modules/blog-content/application/blog-settings-directory";
+import { BLOG_CONTENT_VISIBILITIES } from "../../../../modules/blog-content/domain/post-status";
+import { createTranslator } from "../../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/posts/new.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_CREATE_POSTS = context.permissions.has(
+  permissionKey("blog_content", "posts", "create")
+);
+
+const clientStrings = {
+  createSuccess: t("admin.blog.posts.create_success"),
+  invalidContentJson: t("admin.blog.posts.invalid_content_json"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+let terms: Awaited<ReturnType<typeof listBlogTerms>> = [];
+let defaultLocale = "id";
+let loadError = false;
+
+if (CAN_CREATE_POSTS) {
+  try {
+    await withTenant(getDatabaseClient(), context.tenantId, async (tx) => {
+      terms = await listBlogTerms(tx, context.tenantId);
+      const settings = await fetchBlogSettings(tx, context.tenantId);
+      defaultLocale = settings.defaultLocale;
+    });
+  } catch (error) {
+    console.error(
+      "admin/blog/posts/new.astro: failed to load form data",
+      error
+    );
+    loadError = true;
+  }
+}
+
+const categories = terms.filter((term) => term.taxonomyType === "category");
+const tags = terms.filter((term) => term.taxonomyType === "tag");
+---
+
+<AdminLayout title={t("admin.blog.posts.new_title")}>
+  {
+    !CAN_CREATE_POSTS && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_CREATE_POSTS && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_CREATE_POSTS && !loadError && (
+      <div class="post-editor">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        <form id="post-form" class="editor-form">
+          <label>
+            {t("admin.blog.posts.field_title")}
+            <input type="text" name="title" required maxlength="200" />
+          </label>
+          <label>
+            {t("admin.blog.posts.field_slug")}
+            <input
+              type="text"
+              name="slug"
+              required
+              pattern="[a-z0-9]+(-[a-z0-9]+)*"
+            />
+            <span class="field-hint">{t("admin.blog.posts.slug_hint")}</span>
+          </label>
+          <label>
+            {t("admin.blog.posts.field_excerpt")}
+            <textarea name="excerpt" rows="3" maxlength="500" />
+          </label>
+          <label>
+            {t("admin.blog.posts.field_content_text")}
+            <textarea name="contentText" rows="8" required />
+          </label>
+          <label>
+            {t("admin.blog.posts.field_content_json")}
+            <textarea name="contentJson" rows="6" spellcheck="false">{`{
+  "blocks": []
+}`}</textarea>
+            <span class="field-hint">
+              {t("admin.blog.posts.content_json_hint")}
+            </span>
+          </label>
+          <label>
+            {t("admin.blog.posts.field_visibility")}
+            <select name="visibility">
+              {BLOG_CONTENT_VISIBILITIES.map((value) => (
+                <option value={value} selected={value === "public"}>
+                  {t(`admin.blog.visibility.${value}`)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            {t("admin.blog.posts.field_locale")}
+            <input type="text" name="locale" value={defaultLocale} required />
+          </label>
+          <label>
+            {t("admin.blog.posts.field_featured_media_id")}
+            <input type="text" name="featuredMediaId" />
+            <span class="field-hint">
+              {t("admin.blog.posts.featured_media_hint")}
+            </span>
+          </label>
+
+          <fieldset class="term-picker">
+            <legend>{t("admin.blog.posts.field_categories")}</legend>
+            {categories.length === 0 ? (
+              <p class="field-hint">{t("admin.blog.posts.no_categories")}</p>
+            ) : (
+              <select
+                name="categoryIds"
+                multiple
+                size={Math.min(categories.length, 6)}
+              >
+                {categories.map((term) => (
+                  <option value={term.id}>{term.name}</option>
+                ))}
+              </select>
+            )}
+          </fieldset>
+
+          <fieldset class="term-picker">
+            <legend>{t("admin.blog.posts.field_tags")}</legend>
+            {tags.length === 0 ? (
+              <p class="field-hint">{t("admin.blog.posts.no_tags")}</p>
+            ) : (
+              <select name="tagIds" multiple size={Math.min(tags.length, 6)}>
+                {tags.map((term) => (
+                  <option value={term.id}>{term.name}</option>
+                ))}
+              </select>
+            )}
+          </fieldset>
+
+          <fieldset class="seo-fieldset">
+            <legend>{t("admin.blog.posts.seo_legend")}</legend>
+            <label>
+              {t("admin.blog.posts.field_seo_title")}
+              <input type="text" name="seoTitle" maxlength="70" />
+            </label>
+            <label>
+              {t("admin.blog.posts.field_meta_description")}
+              <textarea name="metaDescription" rows="2" maxlength="160" />
+            </label>
+            <label>
+              {t("admin.blog.posts.field_canonical_url")}
+              <input type="url" name="canonicalUrl" />
+            </label>
+          </fieldset>
+
+          <button type="submit">{t("admin.blog.posts.create_submit")}</button>
+        </form>
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .post-editor {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .editor-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+    max-width: 720px;
+  }
+
+  .editor-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .editor-form input,
+  .editor-form select,
+  .editor-form textarea {
+    padding: var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-family: inherit;
+  }
+
+  .editor-form textarea[name="contentJson"] {
+    font-family: var(--font-mono);
+    font-size: var(--fs-sm);
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+    margin: 0;
+  }
+
+  .term-picker,
+  .seo-fieldset {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+  }
+
+  .term-picker legend,
+  .seo-fieldset legend {
+    font-weight: 600;
+    font-size: var(--fs-sm);
+    padding: 0 var(--sp-1);
+  }
+
+  .editor-form button[type="submit"] {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-5);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .editor-form button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  /* Keyboard focus visible (doc 14 §Aksesibilitas). */
+  .editor-form input:focus-visible,
+  .editor-form select:focus-visible,
+  .editor-form textarea:focus-visible,
+  .editor-form button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    showBanner
+  } from "../../../../lib/ui/admin-form-client";
+
+  interface NewPostStrings {
+    createSuccess: string;
+    invalidContentJson: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<NewPostStrings>();
+
+  document
+    .getElementById("post-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = form.querySelector<HTMLButtonElement>(
+        'button[type="submit"]'
+      );
+      if (button?.disabled) return;
+
+      const formData = new FormData(form);
+      let contentJson: unknown;
+      try {
+        contentJson = JSON.parse(String(formData.get("contentJson") ?? "{}"));
+      } catch {
+        showBanner("action-banner", strings.invalidContentJson, "error");
+        return;
+      }
+
+      const categoryIds = Array.from(
+        form.querySelectorAll<HTMLOptionElement>(
+          'select[name="categoryIds"] option:checked'
+        )
+      ).map((option) => option.value);
+      const tagIds = Array.from(
+        form.querySelectorAll<HTMLOptionElement>(
+          'select[name="tagIds"] option:checked'
+        )
+      ).map((option) => option.value);
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const res = await fetch("/api/v1/blog/posts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({
+            title: formData.get("title"),
+            slug: formData.get("slug"),
+            excerpt: String(formData.get("excerpt") ?? "").trim() || null,
+            contentJson,
+            contentText: formData.get("contentText"),
+            locale: formData.get("locale"),
+            visibility: formData.get("visibility"),
+            featuredMediaId:
+              String(formData.get("featuredMediaId") ?? "").trim() || undefined,
+            seoTitle: String(formData.get("seoTitle") ?? "").trim() || null,
+            metaDescription:
+              String(formData.get("metaDescription") ?? "").trim() || null,
+            canonicalUrl:
+              String(formData.get("canonicalUrl") ?? "").trim() || null,
+            termIds: [...categoryIds, ...tagIds]
+          })
+        });
+        const json = await res.json().catch(() => null);
+
+        if (!res.ok) {
+          const code = json?.error?.code as string | undefined;
+          const message =
+            (code && strings.errorMessages?.[code]) ??
+            json?.error?.message ??
+            `Request failed (${res.status}).`;
+          showBanner("action-banner", message, "error");
+          return;
+        }
+
+        showBanner("action-banner", strings.createSuccess, "success");
+        const newPostId = json?.data?.id as string | undefined;
+        window.location.href = newPostId
+          ? `/admin/blog/posts/${newPostId}`
+          : "/admin/blog/posts";
+      } catch {
+        showBanner("action-banner", strings.networkError, "error");
+      } finally {
+        unlock?.();
+      }
+    });
+</script>

--- a/src/pages/admin/blog/settings.astro
+++ b/src/pages/admin/blog/settings.astro
@@ -1,0 +1,441 @@
+---
+/**
+ * Blog settings (Issue #543 §Settings Page). `GET`/`PATCH
+ * /api/v1/blog/settings` (also new in this issue, `blog-settings-directory.ts`
+ * + `blog-settings-policy.ts`) backs every field the issue lists: blog
+ * title, blog description, posts per page, RSS enabled, sitemap enabled,
+ * default locale, default SEO title template (`seoDefaultTitle`), default
+ * meta description (`seoDefaultDescription`). `defaultVisibility` is not in
+ * the issue's explicit field list but exists on the backend (migration 026)
+ * and is exposed here too, since leaving a real, already-guarded field
+ * completely unreachable from any UI would be a worse outcome than one
+ * extra select.
+ *
+ * Theme mode (`GET`/`PATCH /api/v1/blog/theme`, Issue #542) is folded into
+ * this same screen rather than getting its own route — it is tenant-wide
+ * presentation configuration exactly like the rest of this page, and the
+ * issue's screen list does not call for a dedicated `/admin/blog/theme`.
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { fetchBlogSettings } from "../../../modules/blog-content/application/blog-settings-directory";
+import { fetchBlogThemeSettings } from "../../../modules/blog-content/application/theme-settings-directory";
+import { BLOG_CONTENT_VISIBILITIES } from "../../../modules/blog-content/domain/post-status";
+import { BLOG_THEME_MODES } from "../../../modules/blog-content/domain/theme-policy";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/settings.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_READ_SETTINGS = context.permissions.has(
+  permissionKey("blog_content", "settings", "read")
+);
+const CAN_CONFIGURE_SETTINGS = context.permissions.has(
+  permissionKey("blog_content", "settings", "configure")
+);
+const CAN_READ_THEME = context.permissions.has(
+  permissionKey("blog_content", "theme", "read")
+);
+const CAN_CONFIGURE_THEME = context.permissions.has(
+  permissionKey("blog_content", "theme", "configure")
+);
+
+const clientStrings = {
+  settingsSaveSuccess: t("admin.blog.settings.save_success"),
+  themeSaveSuccess: t("admin.blog.settings.theme_save_success"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+let settings: Awaited<ReturnType<typeof fetchBlogSettings>> | null = null;
+let theme: Awaited<ReturnType<typeof fetchBlogThemeSettings>> | null = null;
+let loadError = false;
+
+if (CAN_READ_SETTINGS || CAN_READ_THEME) {
+  try {
+    await withTenant(getDatabaseClient(), context.tenantId, async (tx) => {
+      if (CAN_READ_SETTINGS) {
+        settings = await fetchBlogSettings(tx, context.tenantId);
+      }
+      if (CAN_READ_THEME) {
+        theme = await fetchBlogThemeSettings(tx, context.tenantId);
+      }
+    });
+  } catch (error) {
+    console.error("admin/blog/settings.astro: failed to load settings", error);
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title={t("admin.blog.settings.title")}>
+  {
+    !CAN_READ_SETTINGS && !CAN_READ_THEME && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    (CAN_READ_SETTINGS || CAN_READ_THEME) && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    !loadError && (CAN_READ_SETTINGS || CAN_READ_THEME) && (
+      <div class="blog-settings">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        {CAN_READ_SETTINGS && settings && (
+          <section class="settings-section">
+            <h2>{t("admin.blog.settings.general_legend")}</h2>
+            <form id="settings-form" class="settings-form">
+              <fieldset disabled={!CAN_CONFIGURE_SETTINGS}>
+                <label>
+                  {t("admin.blog.settings.field_blog_title")}
+                  <input
+                    type="text"
+                    name="blogTitle"
+                    required
+                    maxlength="200"
+                    value={settings.blogTitle}
+                  />
+                </label>
+                <label>
+                  {t("admin.blog.settings.field_blog_description")}
+                  <textarea name="blogDescription" rows="3" maxlength="500">
+                    {settings.blogDescription ?? ""}
+                  </textarea>
+                </label>
+                <label>
+                  {t("admin.blog.settings.field_posts_per_page")}
+                  <input
+                    type="number"
+                    name="postsPerPage"
+                    min="1"
+                    max="100"
+                    step="1"
+                    value={settings.postsPerPage}
+                  />
+                </label>
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    name="rssEnabled"
+                    checked={settings.rssEnabled}
+                  />
+                  {t("admin.blog.settings.field_rss_enabled")}
+                </label>
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    name="sitemapEnabled"
+                    checked={settings.sitemapEnabled}
+                  />
+                  {t("admin.blog.settings.field_sitemap_enabled")}
+                </label>
+                <label>
+                  {t("admin.blog.settings.field_default_locale")}
+                  <input
+                    type="text"
+                    name="defaultLocale"
+                    required
+                    value={settings.defaultLocale}
+                  />
+                </label>
+                <label>
+                  {t("admin.blog.settings.field_default_visibility")}
+                  <select name="defaultVisibility">
+                    {BLOG_CONTENT_VISIBILITIES.map((value) => (
+                      <option
+                        value={value}
+                        selected={settings!.defaultVisibility === value}
+                      >
+                        {t(`admin.blog.visibility.${value}`)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  {t("admin.blog.settings.field_seo_default_title")}
+                  <input
+                    type="text"
+                    name="seoDefaultTitle"
+                    maxlength="200"
+                    value={settings.seoDefaultTitle ?? ""}
+                  />
+                </label>
+                <label>
+                  {t("admin.blog.settings.field_seo_default_description")}
+                  <textarea
+                    name="seoDefaultDescription"
+                    rows="2"
+                    maxlength="300"
+                  >
+                    {settings.seoDefaultDescription ?? ""}
+                  </textarea>
+                </label>
+              </fieldset>
+              {CAN_CONFIGURE_SETTINGS && (
+                <button type="submit">
+                  {t("admin.blog.settings.save_button")}
+                </button>
+              )}
+            </form>
+          </section>
+        )}
+
+        {CAN_READ_THEME && theme && (
+          <section class="settings-section">
+            <h2>{t("admin.blog.settings.theme_legend")}</h2>
+            <p class="field-hint">
+              {theme.isOverride
+                ? t("admin.blog.settings.theme_override_note")
+                : t("admin.blog.settings.theme_inherited_note")}
+            </p>
+            <form id="theme-form" class="settings-form">
+              <fieldset disabled={!CAN_CONFIGURE_THEME}>
+                <label>
+                  {t("admin.blog.settings.field_theme_mode")}
+                  <select name="mode">
+                    {BLOG_THEME_MODES.map((value) => (
+                      <option value={value} selected={theme!.mode === value}>
+                        {t(`admin.blog.settings.theme_mode_${value}`)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </fieldset>
+              {CAN_CONFIGURE_THEME && (
+                <button type="submit">
+                  {t("admin.blog.settings.save_button")}
+                </button>
+              )}
+            </form>
+          </section>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .blog-settings {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-6);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .settings-section h2 {
+    margin: 0 0 var(--sp-3);
+    font-size: var(--fs-md);
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+  }
+
+  .settings-form fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+    max-width: 560px;
+  }
+
+  .settings-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .settings-form .checkbox-label {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--sp-2);
+  }
+
+  .settings-form input,
+  .settings-form select,
+  .settings-form textarea {
+    padding: var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-family: inherit;
+  }
+
+  .settings-form button[type="submit"] {
+    align-self: flex-start;
+    margin-top: var(--sp-3);
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-5);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .settings-form button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface SettingsStrings {
+    settingsSaveSuccess: string;
+    themeSaveSuccess: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<SettingsStrings>();
+
+  document
+    .getElementById("settings-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = form.querySelector<HTMLButtonElement>(
+        'button[type="submit"]'
+      );
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const formData = new FormData(form);
+        const result = await submitJson(
+          "/api/v1/blog/settings",
+          "PATCH",
+          {
+            blogTitle: formData.get("blogTitle"),
+            blogDescription:
+              String(formData.get("blogDescription") ?? "").trim() || null,
+            postsPerPage: Number(formData.get("postsPerPage") ?? 10),
+            rssEnabled: formData.get("rssEnabled") === "on",
+            sitemapEnabled: formData.get("sitemapEnabled") === "on",
+            defaultLocale: formData.get("defaultLocale"),
+            defaultVisibility: formData.get("defaultVisibility"),
+            seoDefaultTitle:
+              String(formData.get("seoDefaultTitle") ?? "").trim() || null,
+            seoDefaultDescription:
+              String(formData.get("seoDefaultDescription") ?? "").trim() || null
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.settingsSaveSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document
+    .getElementById("theme-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = form.querySelector<HTMLButtonElement>(
+        'button[type="submit"]'
+      );
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const formData = new FormData(form);
+        const result = await submitJson(
+          "/api/v1/blog/theme",
+          "PATCH",
+          { mode: formData.get("mode") },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.themeSaveSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+</script>

--- a/src/pages/admin/blog/tags.astro
+++ b/src/pages/admin/blog/tags.astro
@@ -1,0 +1,457 @@
+---
+/**
+ * Tag manager (Issue #543 §Category/Tag Manager) — `taxonomyType = 'tag'`
+ * only, same `/api/v1/blog/terms` endpoints as `admin/blog/categories.astro`
+ * but with **no parent field anywhere in this file** — the issue's explicit
+ * "Tags must not support parent assignment" is enforced here at the UI
+ * layer too (not just the DB `CHECK` constraint and
+ * `domain/taxonomy-policy.ts`'s `validateTermParent`, skill rule #2): the
+ * create/edit forms below never render a `parentId` control, and the
+ * client script never sends one for this screen.
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { listBlogTerms } from "../../../modules/blog-content/application/blog-taxonomy-directory";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/tags.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_READ_TAXONOMIES = context.permissions.has(
+  permissionKey("blog_content", "taxonomies", "read")
+);
+const CAN_CONFIGURE_TAXONOMIES = context.permissions.has(
+  permissionKey("blog_content", "taxonomies", "configure")
+);
+
+const clientStrings = {
+  createSuccess: t("admin.blog.tags.create_success"),
+  updateSuccess: t("admin.blog.tags.update_success"),
+  deleteSuccess: t("admin.blog.tags.delete_success"),
+  deleteReasonPrompt: t("admin.blog.tags.delete_reason_prompt"),
+  deleteConfirm: t("admin.blog.tags.delete_confirm"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+let tags: Awaited<ReturnType<typeof listBlogTerms>> = [];
+let loadError = false;
+
+if (CAN_READ_TAXONOMIES) {
+  try {
+    tags = await withTenant(getDatabaseClient(), context.tenantId, (tx) =>
+      listBlogTerms(tx, context.tenantId, { taxonomyType: "tag" })
+    );
+  } catch (error) {
+    console.error("admin/blog/tags.astro: failed to load tags", error);
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title={t("admin.blog.tags.title")}>
+  {
+    !CAN_READ_TAXONOMIES && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_TAXONOMIES && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ_TAXONOMIES && !loadError && (
+      <div class="term-manager" data-taxonomy-type="tag">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        {tags.length === 0 ? (
+          <p class="empty-state">{t("admin.blog.tags.no_tags")}</p>
+        ) : (
+          <div class="table-scroll">
+            <table class="blog-table">
+              <thead>
+                <tr>
+                  <th>{t("admin.blog.tags.name_column")}</th>
+                  <th>{t("admin.blog.tags.slug_column")}</th>
+                  {CAN_CONFIGURE_TAXONOMIES && (
+                    <th>{t("admin.blog.tags.actions_column")}</th>
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {tags.map((tag) => (
+                  <tr>
+                    <td>{tag.name}</td>
+                    <td>
+                      <code>{tag.slug}</code>
+                    </td>
+                    {CAN_CONFIGURE_TAXONOMIES && (
+                      <td>
+                        <details>
+                          <summary>{t("admin.blog.tags.edit_summary")}</summary>
+                          <form class="edit-term-form" data-term-id={tag.id}>
+                            <label>
+                              {t("admin.blog.tags.field_name")}
+                              <input
+                                type="text"
+                                name="name"
+                                required
+                                maxlength="100"
+                                value={tag.name}
+                              />
+                            </label>
+                            <label>
+                              {t("admin.blog.tags.field_slug")}
+                              <input
+                                type="text"
+                                name="slug"
+                                required
+                                pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                                value={tag.slug}
+                              />
+                            </label>
+                            <label>
+                              {t("admin.blog.tags.field_description")}
+                              <textarea
+                                name="description"
+                                rows="2"
+                                maxlength="500"
+                              >
+                                {tag.description ?? ""}
+                              </textarea>
+                            </label>
+                            <button type="submit">
+                              {t("admin.blog.tags.save_button")}
+                            </button>
+                          </form>
+                        </details>
+                        <button
+                          type="button"
+                          class="delete-term-button"
+                          data-term-id={tag.id}
+                        >
+                          {t("admin.blog.tags.delete_button")}
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {CAN_CONFIGURE_TAXONOMIES && (
+          <details class="create-term">
+            <summary>{t("admin.blog.tags.create_summary")}</summary>
+            <form id="create-term-form" class="create-term-form">
+              <label>
+                {t("admin.blog.tags.field_name")}
+                <input type="text" name="name" required maxlength="100" />
+              </label>
+              <label>
+                {t("admin.blog.tags.field_slug")}
+                <input
+                  type="text"
+                  name="slug"
+                  required
+                  pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                />
+              </label>
+              <label>
+                {t("admin.blog.tags.field_description")}
+                <textarea name="description" rows="2" maxlength="500" />
+              </label>
+              <button type="submit">
+                {t("admin.blog.tags.create_submit")}
+              </button>
+            </form>
+          </details>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .term-manager {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .empty-state {
+    color: var(--color-text-muted);
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .blog-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .blog-table th,
+  .blog-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .edit-term-form,
+  .create-term-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+    margin-top: var(--sp-2);
+    max-width: 420px;
+  }
+
+  .edit-term-form label,
+  .create-term-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .edit-term-form input,
+  .edit-term-form textarea,
+  .create-term-form input,
+  .create-term-form textarea {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .edit-term-form button,
+  .create-term-form button {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .delete-term-button {
+    margin-top: var(--sp-2);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-danger-strong);
+    color: var(--color-danger-strong);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-2);
+    min-height: 44px;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+  }
+
+  .create-term {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .create-term summary,
+  details summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  input:focus-visible,
+  textarea:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface TermManagerStrings {
+    createSuccess: string;
+    updateSuccess: string;
+    deleteSuccess: string;
+    deleteReasonPrompt: string;
+    deleteConfirm: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<TermManagerStrings>();
+
+  function submitButtonOf(form: HTMLFormElement): HTMLButtonElement | null {
+    return form.querySelector('button[type="submit"]');
+  }
+
+  document
+    .getElementById("create-term-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = submitButtonOf(form);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const formData = new FormData(form);
+
+        const result = await submitJson(
+          "/api/v1/blog/terms",
+          "POST",
+          {
+            taxonomyType: "tag",
+            name: formData.get("name"),
+            slug: formData.get("slug"),
+            description:
+              String(formData.get("description") ?? "").trim() || null,
+            parentId: null
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.createSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document.querySelectorAll(".edit-term-form").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const el = event.target as HTMLFormElement;
+      const button = submitButtonOf(el);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const termId = el.dataset.termId!;
+        const formData = new FormData(el);
+
+        const result = await submitJson(
+          `/api/v1/blog/terms/${termId}`,
+          "PATCH",
+          {
+            name: formData.get("name"),
+            slug: formData.get("slug"),
+            description:
+              String(formData.get("description") ?? "").trim() || null
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.updateSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+  });
+
+  document.querySelectorAll(".delete-term-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+
+      const reason = window.prompt(strings.deleteReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+      if (!window.confirm(strings.deleteConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const termId = el.dataset.termId!;
+        const result = await submitJson(
+          `/api/v1/blog/terms/${termId}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+</script>

--- a/src/pages/admin/blog/templates.astro
+++ b/src/pages/admin/blog/templates.astro
@@ -1,0 +1,518 @@
+---
+/**
+ * Presentation template manager (Issue #543 §Optional advanced screens,
+ * included since Issue #542 is merged). `layoutJson` is the whitelisted
+ * `{ columns: 1|2|3, sidebarPosition: 'left'|'right'|'none' }` shape
+ * (`domain/template-policy.ts`) — rendered as two plain `<select>`s, never
+ * a free-form JSON textarea, since the whole point of that whitelist is
+ * that no client (including this admin UI) can express anything outside
+ * it.
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { listTemplates } from "../../../modules/blog-content/application/template-directory";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/templates.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_READ_TEMPLATES = context.permissions.has(
+  permissionKey("blog_content", "templates", "read")
+);
+const CAN_CONFIGURE_TEMPLATES = context.permissions.has(
+  permissionKey("blog_content", "templates", "configure")
+);
+
+const clientStrings = {
+  createSuccess: t("admin.blog.templates.create_success"),
+  updateSuccess: t("admin.blog.templates.update_success"),
+  deleteSuccess: t("admin.blog.templates.delete_success"),
+  deleteReasonPrompt: t("admin.blog.templates.delete_reason_prompt"),
+  deleteConfirm: t("admin.blog.templates.delete_confirm"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+let templates: Awaited<ReturnType<typeof listTemplates>> = [];
+let loadError = false;
+
+if (CAN_READ_TEMPLATES) {
+  try {
+    templates = await withTenant(getDatabaseClient(), context.tenantId, (tx) =>
+      listTemplates(tx, context.tenantId)
+    );
+  } catch (error) {
+    console.error(
+      "admin/blog/templates.astro: failed to load templates",
+      error
+    );
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title={t("admin.blog.templates.title")}>
+  {
+    !CAN_READ_TEMPLATES && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_TEMPLATES && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ_TEMPLATES && !loadError && (
+      <div class="config-manager">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        {templates.length === 0 ? (
+          <p class="empty-state">{t("admin.blog.templates.no_templates")}</p>
+        ) : (
+          <div class="table-scroll">
+            <table class="blog-table">
+              <thead>
+                <tr>
+                  <th>{t("admin.blog.templates.key_column")}</th>
+                  <th>{t("admin.blog.templates.name_column")}</th>
+                  <th>{t("admin.blog.templates.columns_column")}</th>
+                  <th>{t("admin.blog.templates.sidebar_column")}</th>
+                  <th>{t("admin.blog.templates.active_column")}</th>
+                  {CAN_CONFIGURE_TEMPLATES && (
+                    <th>{t("admin.blog.templates.actions_column")}</th>
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {templates.map((template) => (
+                  <tr>
+                    <td>
+                      <code>{template.key}</code>
+                    </td>
+                    <td>{template.name}</td>
+                    <td>{template.layoutJson.columns}</td>
+                    <td>{template.layoutJson.sidebarPosition}</td>
+                    <td>
+                      {template.isActive ? t("common.yes") : t("common.no")}
+                    </td>
+                    {CAN_CONFIGURE_TEMPLATES && (
+                      <td>
+                        <details>
+                          <summary>
+                            {t("admin.blog.templates.edit_summary")}
+                          </summary>
+                          <form class="edit-config-form" data-id={template.id}>
+                            <label>
+                              {t("admin.blog.templates.field_name")}
+                              <input
+                                type="text"
+                                name="name"
+                                required
+                                value={template.name}
+                              />
+                            </label>
+                            <label>
+                              {t("admin.blog.templates.field_columns")}
+                              <select name="columns">
+                                {[1, 2, 3].map((value) => (
+                                  <option
+                                    value={value}
+                                    selected={
+                                      template.layoutJson.columns === value
+                                    }
+                                  >
+                                    {value}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <label>
+                              {t("admin.blog.templates.field_sidebar")}
+                              <select name="sidebarPosition">
+                                {["left", "right", "none"].map((value) => (
+                                  <option
+                                    value={value}
+                                    selected={
+                                      template.layoutJson.sidebarPosition ===
+                                      value
+                                    }
+                                  >
+                                    {t(`admin.blog.templates.sidebar_${value}`)}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <label class="checkbox-label">
+                              <input
+                                type="checkbox"
+                                name="isActive"
+                                checked={template.isActive}
+                              />
+                              {t("admin.blog.templates.field_active")}
+                            </label>
+                            <button type="submit">
+                              {t("admin.blog.templates.save_button")}
+                            </button>
+                          </form>
+                        </details>
+                        <button
+                          type="button"
+                          class="delete-config-button"
+                          data-id={template.id}
+                        >
+                          {t("admin.blog.templates.delete_button")}
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {CAN_CONFIGURE_TEMPLATES && (
+          <details class="create-config">
+            <summary>{t("admin.blog.templates.create_summary")}</summary>
+            <form id="create-config-form" class="create-config-form">
+              <label>
+                {t("admin.blog.templates.field_key")}
+                <input
+                  type="text"
+                  name="key"
+                  required
+                  pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                />
+              </label>
+              <label>
+                {t("admin.blog.templates.field_name")}
+                <input type="text" name="name" required />
+              </label>
+              <label>
+                {t("admin.blog.templates.field_columns")}
+                <select name="columns">
+                  <option value="1">1</option>
+                  <option value="2" selected>
+                    2
+                  </option>
+                  <option value="3">3</option>
+                </select>
+              </label>
+              <label>
+                {t("admin.blog.templates.field_sidebar")}
+                <select name="sidebarPosition">
+                  <option value="left">
+                    {t("admin.blog.templates.sidebar_left")}
+                  </option>
+                  <option value="right" selected>
+                    {t("admin.blog.templates.sidebar_right")}
+                  </option>
+                  <option value="none">
+                    {t("admin.blog.templates.sidebar_none")}
+                  </option>
+                </select>
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" name="isActive" checked />
+                {t("admin.blog.templates.field_active")}
+              </label>
+              <button type="submit">
+                {t("admin.blog.templates.create_submit")}
+              </button>
+            </form>
+          </details>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .config-manager {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .empty-state {
+    color: var(--color-text-muted);
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .blog-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .blog-table th,
+  .blog-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .edit-config-form,
+  .create-config-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+    margin-top: var(--sp-2);
+    max-width: 420px;
+  }
+
+  .edit-config-form label,
+  .create-config-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .checkbox-label {
+    flex-direction: row !important;
+    align-items: center;
+    gap: var(--sp-2) !important;
+  }
+
+  .edit-config-form input,
+  .edit-config-form select,
+  .create-config-form input,
+  .create-config-form select {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .edit-config-form button,
+  .create-config-form button {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .delete-config-button {
+    margin-top: var(--sp-2);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-danger-strong);
+    color: var(--color-danger-strong);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-2);
+    min-height: 44px;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+  }
+
+  .create-config {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .create-config summary,
+  details summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  input:focus-visible,
+  select:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface TemplateManagerStrings {
+    createSuccess: string;
+    updateSuccess: string;
+    deleteSuccess: string;
+    deleteReasonPrompt: string;
+    deleteConfirm: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<TemplateManagerStrings>();
+
+  function submitButtonOf(form: HTMLFormElement): HTMLButtonElement | null {
+    return form.querySelector('button[type="submit"]');
+  }
+
+  document
+    .getElementById("create-config-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = submitButtonOf(form);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const formData = new FormData(form);
+        const result = await submitJson(
+          "/api/v1/blog/templates",
+          "POST",
+          {
+            key: formData.get("key"),
+            name: formData.get("name"),
+            layoutJson: {
+              columns: Number(formData.get("columns")),
+              sidebarPosition: formData.get("sidebarPosition")
+            },
+            isActive: formData.get("isActive") === "on"
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.createSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document.querySelectorAll(".edit-config-form").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const el = event.target as HTMLFormElement;
+      const button = submitButtonOf(el);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const id = el.dataset.id!;
+        const formData = new FormData(el);
+        const result = await submitJson(
+          `/api/v1/blog/templates/${id}`,
+          "PATCH",
+          {
+            name: formData.get("name"),
+            layoutJson: {
+              columns: Number(formData.get("columns")),
+              sidebarPosition: formData.get("sidebarPosition")
+            },
+            isActive: formData.get("isActive") === "on"
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.updateSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+  });
+
+  document.querySelectorAll(".delete-config-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+
+      const reason = window.prompt(strings.deleteReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+      if (!window.confirm(strings.deleteConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const id = el.dataset.id!;
+        const result = await submitJson(
+          `/api/v1/blog/templates/${id}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+</script>

--- a/src/pages/admin/blog/widgets.astro
+++ b/src/pages/admin/blog/widgets.astro
@@ -1,0 +1,494 @@
+---
+/**
+ * Widget manager (Issue #543 §Optional advanced screens, Issue #542
+ * merged). `bodyText` is plain text, rendered escaped everywhere
+ * (`domain/widget-policy.ts` rejects — not sanitizes — unsafe HTML
+ * patterns, same list `content-validation.ts`'s `containsUnsafeHtml` uses)
+ * — this form is a plain `<textarea>`, never `set:html`.
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { listWidgets } from "../../../modules/blog-content/application/widget-directory";
+import { WIDGET_POSITIONS } from "../../../modules/blog-content/domain/widget-policy";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/blog/widgets.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_READ_WIDGETS = context.permissions.has(
+  permissionKey("blog_content", "widgets", "read")
+);
+const CAN_CONFIGURE_WIDGETS = context.permissions.has(
+  permissionKey("blog_content", "widgets", "configure")
+);
+
+const clientStrings = {
+  createSuccess: t("admin.blog.widgets.create_success"),
+  updateSuccess: t("admin.blog.widgets.update_success"),
+  deleteSuccess: t("admin.blog.widgets.delete_success"),
+  deleteReasonPrompt: t("admin.blog.widgets.delete_reason_prompt"),
+  deleteConfirm: t("admin.blog.widgets.delete_confirm"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+let widgets: Awaited<ReturnType<typeof listWidgets>> = [];
+let loadError = false;
+
+if (CAN_READ_WIDGETS) {
+  try {
+    widgets = await withTenant(getDatabaseClient(), context.tenantId, (tx) =>
+      listWidgets(tx, context.tenantId)
+    );
+  } catch (error) {
+    console.error("admin/blog/widgets.astro: failed to load widgets", error);
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title={t("admin.blog.widgets.title")}>
+  {
+    !CAN_READ_WIDGETS && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.blog.access_denied_title")}
+        body={t("admin.blog.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ_WIDGETS && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ_WIDGETS && !loadError && (
+      <div class="config-manager">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        {widgets.length === 0 ? (
+          <p class="empty-state">{t("admin.blog.widgets.no_widgets")}</p>
+        ) : (
+          <div class="table-scroll">
+            <table class="blog-table">
+              <thead>
+                <tr>
+                  <th>{t("admin.blog.widgets.title_column")}</th>
+                  <th>{t("admin.blog.widgets.position_column")}</th>
+                  <th>{t("admin.blog.widgets.sort_order_column")}</th>
+                  <th>{t("admin.blog.widgets.active_column")}</th>
+                  {CAN_CONFIGURE_WIDGETS && (
+                    <th>{t("admin.blog.widgets.actions_column")}</th>
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {widgets.map((widget) => (
+                  <tr>
+                    <td>{widget.title}</td>
+                    <td>
+                      {t(`admin.blog.widgets.position_${widget.position}`)}
+                    </td>
+                    <td>{widget.sortOrder}</td>
+                    <td>
+                      {widget.isActive ? t("common.yes") : t("common.no")}
+                    </td>
+                    {CAN_CONFIGURE_WIDGETS && (
+                      <td>
+                        <details>
+                          <summary>
+                            {t("admin.blog.widgets.edit_summary")}
+                          </summary>
+                          <form class="edit-config-form" data-id={widget.id}>
+                            <label>
+                              {t("admin.blog.widgets.field_title")}
+                              <input
+                                type="text"
+                                name="title"
+                                required
+                                value={widget.title}
+                              />
+                            </label>
+                            <label>
+                              {t("admin.blog.widgets.field_position")}
+                              <select name="position">
+                                {WIDGET_POSITIONS.map((value) => (
+                                  <option
+                                    value={value}
+                                    selected={widget.position === value}
+                                  >
+                                    {t(`admin.blog.widgets.position_${value}`)}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <label>
+                              {t("admin.blog.widgets.field_body_text")}
+                              <textarea name="bodyText" rows="4">
+                                {widget.bodyText}
+                              </textarea>
+                            </label>
+                            <label>
+                              {t("admin.blog.widgets.field_sort_order")}
+                              <input
+                                type="number"
+                                name="sortOrder"
+                                step="1"
+                                value={widget.sortOrder}
+                              />
+                            </label>
+                            <label class="checkbox-label">
+                              <input
+                                type="checkbox"
+                                name="isActive"
+                                checked={widget.isActive}
+                              />
+                              {t("admin.blog.widgets.field_active")}
+                            </label>
+                            <button type="submit">
+                              {t("admin.blog.widgets.save_button")}
+                            </button>
+                          </form>
+                        </details>
+                        <button
+                          type="button"
+                          class="delete-config-button"
+                          data-id={widget.id}
+                        >
+                          {t("admin.blog.widgets.delete_button")}
+                        </button>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {CAN_CONFIGURE_WIDGETS && (
+          <details class="create-config">
+            <summary>{t("admin.blog.widgets.create_summary")}</summary>
+            <form id="create-config-form" class="create-config-form">
+              <label>
+                {t("admin.blog.widgets.field_title")}
+                <input type="text" name="title" required />
+              </label>
+              <label>
+                {t("admin.blog.widgets.field_position")}
+                <select name="position">
+                  {WIDGET_POSITIONS.map((value) => (
+                    <option value={value}>
+                      {t(`admin.blog.widgets.position_${value}`)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                {t("admin.blog.widgets.field_body_text")}
+                <textarea name="bodyText" rows="4" />
+              </label>
+              <label>
+                {t("admin.blog.widgets.field_sort_order")}
+                <input type="number" name="sortOrder" step="1" value="0" />
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" name="isActive" checked />
+                {t("admin.blog.widgets.field_active")}
+              </label>
+              <button type="submit">
+                {t("admin.blog.widgets.create_submit")}
+              </button>
+            </form>
+          </details>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .config-manager {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .empty-state {
+    color: var(--color-text-muted);
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .blog-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .blog-table th,
+  .blog-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .edit-config-form,
+  .create-config-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+    margin-top: var(--sp-2);
+    max-width: 420px;
+  }
+
+  .edit-config-form label,
+  .create-config-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .checkbox-label {
+    flex-direction: row !important;
+    align-items: center;
+    gap: var(--sp-2) !important;
+  }
+
+  .edit-config-form input,
+  .edit-config-form select,
+  .edit-config-form textarea,
+  .create-config-form input,
+  .create-config-form select,
+  .create-config-form textarea {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .edit-config-form button,
+  .create-config-form button {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .delete-config-button {
+    margin-top: var(--sp-2);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-danger-strong);
+    color: var(--color-danger-strong);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-2);
+    min-height: 44px;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+  }
+
+  .create-config {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .create-config summary,
+  details summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface WidgetManagerStrings {
+    createSuccess: string;
+    updateSuccess: string;
+    deleteSuccess: string;
+    deleteReasonPrompt: string;
+    deleteConfirm: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<WidgetManagerStrings>();
+
+  function submitButtonOf(form: HTMLFormElement): HTMLButtonElement | null {
+    return form.querySelector('button[type="submit"]');
+  }
+
+  document
+    .getElementById("create-config-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = submitButtonOf(form);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const formData = new FormData(form);
+        const result = await submitJson(
+          "/api/v1/blog/widgets",
+          "POST",
+          {
+            position: formData.get("position"),
+            title: formData.get("title"),
+            bodyText: formData.get("bodyText") ?? "",
+            sortOrder: Number(formData.get("sortOrder") ?? 0),
+            isActive: formData.get("isActive") === "on"
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.createSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document.querySelectorAll(".edit-config-form").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const el = event.target as HTMLFormElement;
+      const button = submitButtonOf(el);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const id = el.dataset.id!;
+        const formData = new FormData(el);
+        const result = await submitJson(
+          `/api/v1/blog/widgets/${id}`,
+          "PATCH",
+          {
+            position: formData.get("position"),
+            title: formData.get("title"),
+            bodyText: formData.get("bodyText") ?? "",
+            sortOrder: Number(formData.get("sortOrder") ?? 0),
+            isActive: formData.get("isActive") === "on"
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.updateSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+  });
+
+  document.querySelectorAll(".delete-config-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+
+      const reason = window.prompt(strings.deleteReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+      if (!window.confirm(strings.deleteConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const id = el.dataset.id!;
+        const result = await submitJson(
+          `/api/v1/blog/widgets/${id}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+</script>

--- a/src/pages/api/v1/blog/settings/index.ts
+++ b/src/pages/api/v1/blog/settings/index.ts
@@ -1,0 +1,132 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchBlogSettings,
+  upsertBlogSettings
+} from "../../../../../modules/blog-content/application/blog-settings-directory";
+import { validateUpdateBlogSettingsInput } from "../../../../../modules/blog-content/domain/blog-settings-policy";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "settings",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "settings",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/blog/settings` (Issue #543) — this tenant's blog settings, falling back to schema/domain defaults when never configured. Permission `blog_content.settings.read` was seeded by migration 027 (Issue #537) but had no route consuming it until now. */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const settings = await fetchBlogSettings(tx, tenantId);
+
+    return ok(settings);
+  });
+};
+
+/** `PATCH /api/v1/blog/settings` (Issue #543) — partial-update upsert, no `id` param (one row per tenant, same convention `PATCH /api/v1/blog/theme` uses). Publishes `blog-content.settings.updated`, closing the gap the Issue #541 AsyncAPI channel left reserved-but-producer-less. */
+export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const validation = validateUpdateBlogSettingsInput(
+    await request.json().catch(() => null)
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Blog settings are invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const settings = await upsertBlogSettings(tx, tenantId, input);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.settings.updated",
+      resourceType: "blog_settings",
+      severity: "info",
+      message: "Blog settings updated.",
+      correlationId
+    });
+
+    log("info", "blog-content.settings.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content"
+    });
+
+    return ok(settings);
+  });
+};

--- a/src/pages/blog/[tenantCode]/feed.xml.ts
+++ b/src/pages/blog/[tenantCode]/feed.xml.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../lib/html/error-responses";
 import { log } from "../../../lib/logging/logger";
 import { listPublicBlogPostsForFeed } from "../../../modules/blog-content/application/public-blog-directory";
+import { fetchBlogSettings } from "../../../modules/blog-content/application/blog-settings-directory";
 import { resolveMetaDescription } from "../../../modules/blog-content/domain/seo-rendering";
 
 /**
@@ -19,7 +20,10 @@ import { resolveMetaDescription } from "../../../modules/blog-content/domain/seo
  * scheduled-future/draft/review/deleted). Hand-built XML string (no RSS
  * library dependency — Bun-only, AGENTS.md rule 14), escaped through the
  * same `escapeHtml` used for HTML (XML and HTML share the same five
- * entity escapes).
+ * entity escapes). Issue #543 §Settings Page adds `rssEnabled` — a tenant
+ * that has turned the feed off gets the same 404 shape as an unknown
+ * tenant/post (no distinguishable signal for a disabled vs. nonexistent
+ * feed).
  */
 export const GET: APIRoute = async ({ params, url }) => {
   const tenantCode = params.tenantCode;
@@ -37,6 +41,12 @@ export const GET: APIRoute = async ({ params, url }) => {
     }
 
     return await withTenant(sql, tenant.tenantId, async (tx) => {
+      const settings = await fetchBlogSettings(tx, tenant.tenantId);
+
+      if (!settings.rssEnabled) {
+        return notFoundXmlResponse();
+      }
+
       const posts = await listPublicBlogPostsForFeed(tx, tenant.tenantId);
       const channelLink = `${url.origin}/blog/${tenantCode}`;
 

--- a/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
+++ b/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
@@ -10,11 +10,14 @@ import {
 } from "../../../lib/html/error-responses";
 import { log } from "../../../lib/logging/logger";
 import { listPublicBlogPostsForFeed } from "../../../modules/blog-content/application/public-blog-directory";
+import { fetchBlogSettings } from "../../../modules/blog-content/application/blog-settings-directory";
 
 /**
  * `GET /blog/{tenantCode}/sitemap-blog.xml` (Issue #540) — sitemap
  * protocol 0.9, same public visibility predicate as the RSS feed/index
  * (doc issue #540 §Sitemap Requirements: same exclusion list as RSS).
+ * Issue #543 §Settings Page adds `sitemapEnabled` — same disabled-looks-
+ * like-404 behavior as the RSS feed above.
  */
 export const GET: APIRoute = async ({ params, url }) => {
   const tenantCode = params.tenantCode;
@@ -32,6 +35,12 @@ export const GET: APIRoute = async ({ params, url }) => {
     }
 
     return await withTenant(sql, tenant.tenantId, async (tx) => {
+      const settings = await fetchBlogSettings(tx, tenant.tenantId);
+
+      if (!settings.sitemapEnabled) {
+        return notFoundXmlResponse();
+      }
+
       const posts = await listPublicBlogPostsForFeed(tx, tenant.tenantId);
       const channelLink = `${url.origin}/blog/${tenantCode}`;
 

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -113,8 +113,8 @@ describe("module registry", () => {
     });
     expect(getModuleByKey("blog_content")).toMatchObject({
       key: "blog_content",
-      version: "0.6.0",
-      status: "experimental",
+      version: "0.7.0",
+      status: "active",
       type: "domain",
       dependencies: ["tenant_admin", "identity_access"]
     });

--- a/tests/integration/blog-content-admin-ui.integration.test.ts
+++ b/tests/integration/blog-content-admin-ui.integration.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Integration tests for the admin-UI-only read functions Issue #543 added
+ * to `blog-content`'s application layer — `listBlogPostsForAdmin` and
+ * `listBlogPagesForAdmin` (`blog-post-directory.ts`/`blog-page-directory.ts`,
+ * backing `/admin/blog/posts` and `/admin/blog/pages`'s search/filter/
+ * pagination) and `fetchAuthorDisplayNames` (`author-lookup.ts`, backing the
+ * "author" column/field on those same screens). None of these are exposed
+ * as new JSON API endpoints (no OpenAPI change needed — see the module
+ * README), so they are called directly here the same way
+ * `blog-content-pages-taxonomy-search.integration.test.ts` calls
+ * `searchPublicBlogContent` directly.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { POST as createPost } from "../../src/pages/api/v1/blog/posts/index";
+import { PATCH as updatePost } from "../../src/pages/api/v1/blog/posts/[id]";
+import { POST as archivePostTransition } from "../../src/pages/api/v1/blog/posts/[id]/archive";
+import { POST as createPage } from "../../src/pages/api/v1/blog/pages/index";
+import { POST as createTerm } from "../../src/pages/api/v1/blog/terms/index";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { listBlogPostsForAdmin } from "../../src/modules/blog-content/application/blog-post-directory";
+import { listBlogPagesForAdmin } from "../../src/modules/blog-content/application/blog-page-directory";
+import { fetchAuthorDisplayNames } from "../../src/modules/blog-content/application/author-lookup";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string; tenantUserId: string };
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const setup = await invoke<{
+    data: { tenantId: string; ownerTenantUserId: string };
+  }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: `${tenantCode}-${OWNER_LOGIN}`,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: {
+      loginIdentifier: `${tenantCode}-${OWNER_LOGIN}`,
+      password: OWNER_PASSWORD
+    },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return {
+    tenantId: setup.body.data.tenantId,
+    token: login.body.data.token,
+    tenantUserId: setup.body.data.ownerTenantUserId
+  };
+}
+
+function authHeaders(b: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": b.tenantId,
+    authorization: `Bearer ${b.token}`
+  };
+}
+
+function corePostBody(overrides: Record<string, unknown> = {}) {
+  return {
+    title: "Hello World",
+    slug: "hello-world",
+    excerpt: null,
+    contentJson: { blocks: [] },
+    contentText: "Hello world body.",
+    locale: "en",
+    ...overrides
+  };
+}
+
+function corePageBody(overrides: Record<string, unknown> = {}) {
+  return {
+    title: "About Us",
+    slug: "about-us",
+    contentJson: { blocks: [] },
+    contentText: "About us body.",
+    locale: "en",
+    ...overrides
+  };
+}
+
+/**
+ * `POST /setup/initialize` is a once-per-database singleton lock — it
+ * cannot be called twice to bootstrap two tenants in the same test (same
+ * constraint `email-templates.integration.test.ts`'s
+ * `provisionSecondTenantWithTemplateReadAccess` and
+ * `blog-content-posts-api.integration.test.ts`'s docblock both document).
+ * A second tenant is provisioned directly via `getAdminSql()` instead,
+ * granted `blog_content.posts.{create,read}` so the RLS-isolation test
+ * proves row-level tenant scoping specifically, not an ABAC 403.
+ */
+async function provisionSecondTenantWithBlogPostAccess(): Promise<Bootstrap> {
+  const tenantId = crypto.randomUUID();
+  const password = "integration-test-tenant-b-password";
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_mini_tenants (id, tenant_code, tenant_name)
+    VALUES (${tenantId}, 'tenant-b-raw', 'Tenant B Raw')
+  `;
+
+  const passwordHash = await Bun.password.hash(password);
+  let tenantUserId = "";
+
+  await admin.begin(async (tx) => {
+    await tx.unsafe(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+    const profile = (await tx`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', 'Tenant B User') RETURNING id
+    `) as { id: string }[];
+    const identity = (await tx`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profile[0]!.id}, 'tenant-b-user@example.com', ${passwordHash})
+      RETURNING id
+    `) as { id: string }[];
+    const tenantUser = (await tx`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${tenantId}, ${identity[0]!.id}) RETURNING id
+    `) as { id: string }[];
+    tenantUserId = tenantUser[0]!.id;
+    const role = (await tx`
+      INSERT INTO awcms_mini_roles (tenant_id, role_code, role_name)
+      VALUES (${tenantId}, 'blog_post_writer', 'Blog Post Writer') RETURNING id
+    `) as { id: string }[];
+    const permissions = (await tx`
+      SELECT id FROM awcms_mini_permissions
+      WHERE module_key = 'blog_content' AND activity_code = 'posts' AND action IN ('create', 'read')
+    `) as { id: string }[];
+
+    for (const permission of permissions) {
+      await tx`
+        INSERT INTO awcms_mini_role_permissions (tenant_id, role_id, permission_id)
+        VALUES (${tenantId}, ${role[0]!.id}, ${permission.id})
+      `;
+    }
+    await tx`
+      INSERT INTO awcms_mini_access_assignments (tenant_id, tenant_user_id, role_id)
+      VALUES (${tenantId}, ${tenantUser[0]!.id}, ${role[0]!.id})
+    `;
+  });
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier: "tenant-b-user@example.com", password },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId, token: login.body.data.token, tenantUserId };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("blog admin UI list/lookup functions (Issue #543)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("listBlogPostsForAdmin: search, status filter, and pagination", async () => {
+    const owner = await bootstrap();
+
+    const alpha = await invoke<{ data: { id: string } }>(createPost, {
+      method: "POST",
+      path: "/api/v1/blog/posts",
+      headers: authHeaders(owner),
+      body: corePostBody({ title: "Alpha release notes", slug: "alpha-notes" })
+    });
+    expect(alpha.status).toBe(200);
+
+    const beta = await invoke<{ data: { id: string } }>(createPost, {
+      method: "POST",
+      path: "/api/v1/blog/posts",
+      headers: authHeaders(owner),
+      body: corePostBody({
+        title: "Beta announcement",
+        slug: "beta-announcement"
+      })
+    });
+    expect(beta.status).toBe(200);
+
+    // Move one post to `archived` so the status filter has something to
+    // distinguish (draft -> archived is a valid transition).
+    const archived = await invoke(archivePostTransition, {
+      method: "POST",
+      path: `/api/v1/blog/posts/${beta.body.data.id}/archive`,
+      params: { id: beta.body.data.id },
+      headers: {
+        ...authHeaders(owner),
+        "idempotency-key": crypto.randomUUID()
+      },
+      body: {}
+    });
+    expect(archived.status).toBe(200);
+
+    const sql = getDatabaseClient();
+
+    // Unfiltered listing sees both posts, newest-updated first.
+    const all = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPostsForAdmin(tx, owner.tenantId, {})
+    );
+    expect(all.total).toBe(2);
+    expect(all.items.map((item) => item.slug).sort()).toEqual([
+      "alpha-notes",
+      "beta-announcement"
+    ]);
+
+    // Search matches title via ILIKE, case-insensitive substring.
+    const searched = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPostsForAdmin(tx, owner.tenantId, { search: "alpha" })
+    );
+    expect(searched.total).toBe(1);
+    expect(searched.items[0]!.slug).toBe("alpha-notes");
+
+    // Status filter isolates the archived post.
+    const archivedOnly = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPostsForAdmin(tx, owner.tenantId, { status: "archived" })
+    );
+    expect(archivedOnly.total).toBe(1);
+    expect(archivedOnly.items[0]!.slug).toBe("beta-announcement");
+
+    // Pagination: pageSize 1 returns one item per page, total stays 2.
+    const page1 = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPostsForAdmin(tx, owner.tenantId, { pageSize: 1, page: 1 })
+    );
+    const page2 = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPostsForAdmin(tx, owner.tenantId, { pageSize: 1, page: 2 })
+    );
+    expect(page1.items).toHaveLength(1);
+    expect(page2.items).toHaveLength(1);
+    expect(page1.total).toBe(2);
+    expect(page2.total).toBe(2);
+    expect(page1.items[0]!.id).not.toBe(page2.items[0]!.id);
+  });
+
+  test("listBlogPostsForAdmin: termId filter matches only posts assigned that term", async () => {
+    const owner = await bootstrap();
+
+    const term = await invoke<{ data: { id: string } }>(createTerm, {
+      method: "POST",
+      path: "/api/v1/blog/terms",
+      headers: authHeaders(owner),
+      body: {
+        taxonomyType: "category",
+        name: "News",
+        slug: "news",
+        description: null,
+        parentId: null
+      }
+    });
+    expect(term.status).toBe(200);
+    const termId = term.body.data.id;
+
+    const tagged = await invoke<{ data: { id: string } }>(createPost, {
+      method: "POST",
+      path: "/api/v1/blog/posts",
+      headers: authHeaders(owner),
+      body: corePostBody({
+        title: "Tagged post",
+        slug: "tagged-post",
+        termIds: [termId]
+      })
+    });
+    expect(tagged.status).toBe(200);
+
+    const untagged = await invoke<{ data: { id: string } }>(createPost, {
+      method: "POST",
+      path: "/api/v1/blog/posts",
+      headers: authHeaders(owner),
+      body: corePostBody({ title: "Untagged post", slug: "untagged-post" })
+    });
+    expect(untagged.status).toBe(200);
+
+    const sql = getDatabaseClient();
+    const filtered = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPostsForAdmin(tx, owner.tenantId, { termId })
+    );
+
+    expect(filtered.total).toBe(1);
+    expect(filtered.items[0]!.slug).toBe("tagged-post");
+  });
+
+  test("listBlogPostsForAdmin: tenant isolation (RLS) — one tenant never sees another's posts", async () => {
+    const tenantA = await bootstrap();
+    const tenantB = await provisionSecondTenantWithBlogPostAccess();
+
+    await invoke(createPost, {
+      method: "POST",
+      path: "/api/v1/blog/posts",
+      headers: authHeaders(tenantA),
+      body: corePostBody({ title: "Tenant A post", slug: "tenant-a-post" })
+    });
+    await invoke(createPost, {
+      method: "POST",
+      path: "/api/v1/blog/posts",
+      headers: authHeaders(tenantB),
+      body: corePostBody({ title: "Tenant B post", slug: "tenant-b-post" })
+    });
+
+    const sql = getDatabaseClient();
+    const forA = await withTenant(sql, tenantA.tenantId, (tx) =>
+      listBlogPostsForAdmin(tx, tenantA.tenantId, {})
+    );
+
+    expect(forA.total).toBe(1);
+    expect(forA.items[0]!.slug).toBe("tenant-a-post");
+  });
+
+  test("listBlogPagesForAdmin: search, status filter, pageType filter, and pagination", async () => {
+    const owner = await bootstrap();
+
+    const standard = await invoke<{ data: { id: string } }>(createPage, {
+      method: "POST",
+      path: "/api/v1/blog/pages",
+      headers: authHeaders(owner),
+      body: corePageBody({ title: "About the team", slug: "about-team" })
+    });
+    expect(standard.status).toBe(200);
+
+    const legal = await invoke<{ data: { id: string } }>(createPage, {
+      method: "POST",
+      path: "/api/v1/blog/pages",
+      headers: authHeaders(owner),
+      body: corePageBody({
+        title: "Privacy policy",
+        slug: "privacy-policy",
+        pageType: "legal"
+      })
+    });
+    expect(legal.status).toBe(200);
+
+    const sql = getDatabaseClient();
+
+    const all = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPagesForAdmin(tx, owner.tenantId, {})
+    );
+    expect(all.total).toBe(2);
+
+    const searched = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPagesForAdmin(tx, owner.tenantId, { search: "privacy" })
+    );
+    expect(searched.total).toBe(1);
+    expect(searched.items[0]!.slug).toBe("privacy-policy");
+
+    const legalOnly = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPagesForAdmin(tx, owner.tenantId, { pageType: "legal" })
+    );
+    expect(legalOnly.total).toBe(1);
+    expect(legalOnly.items[0]!.slug).toBe("privacy-policy");
+
+    const draftOnly = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPagesForAdmin(tx, owner.tenantId, { status: "draft" })
+    );
+    expect(draftOnly.total).toBe(2);
+
+    const page1 = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPagesForAdmin(tx, owner.tenantId, { pageSize: 1, page: 1 })
+    );
+    expect(page1.items).toHaveLength(1);
+    expect(page1.total).toBe(2);
+  });
+
+  test("fetchAuthorDisplayNames: resolves known tenant-user ids, omits unknown ones", async () => {
+    const owner = await bootstrap();
+
+    const sql = getDatabaseClient();
+    const names = await withTenant(sql, owner.tenantId, (tx) =>
+      fetchAuthorDisplayNames(tx, owner.tenantId, [
+        owner.tenantUserId,
+        "00000000-0000-0000-0000-000000000000"
+      ])
+    );
+
+    expect(names.get(owner.tenantUserId)).toBe("Owner");
+    expect(names.has("00000000-0000-0000-0000-000000000000")).toBe(false);
+  });
+
+  test("fetchAuthorDisplayNames: empty id list returns an empty map without querying", async () => {
+    const owner = await bootstrap();
+
+    const sql = getDatabaseClient();
+    const names = await withTenant(sql, owner.tenantId, (tx) =>
+      fetchAuthorDisplayNames(tx, owner.tenantId, [])
+    );
+
+    expect(names.size).toBe(0);
+  });
+
+  test("listBlogPostsForAdmin PATCH-updated title is searchable immediately", async () => {
+    const owner = await bootstrap();
+
+    const created = await invoke<{ data: { id: string } }>(createPost, {
+      method: "POST",
+      path: "/api/v1/blog/posts",
+      headers: authHeaders(owner),
+      body: corePostBody({ title: "Original title", slug: "original-title" })
+    });
+    expect(created.status).toBe(200);
+
+    const updated = await invoke(updatePost, {
+      method: "PATCH",
+      path: `/api/v1/blog/posts/${created.body.data.id}`,
+      headers: authHeaders(owner),
+      params: { id: created.body.data.id },
+      body: { title: "Renamed title" }
+    });
+    expect(updated.status).toBe(200);
+
+    const sql = getDatabaseClient();
+    const searched = await withTenant(sql, owner.tenantId, (tx) =>
+      listBlogPostsForAdmin(tx, owner.tenantId, { search: "Renamed" })
+    );
+
+    expect(searched.total).toBe(1);
+    expect(searched.items[0]!.title).toBe("Renamed title");
+  });
+});

--- a/tests/integration/blog-content-presentation.integration.test.ts
+++ b/tests/integration/blog-content-presentation.integration.test.ts
@@ -1,12 +1,14 @@
 /**
  * Integration tests for presentation/monetization extensions (Issue #542,
- * epic #536). Exercises the real handlers against a real PostgreSQL —
- * templates, menus (with hierarchical items), widgets, ads (with
- * placements), and the per-tenant theme override. RBAC (single `configure`
- * permission gates create/update/delete, same as taxonomies), RLS tenant
+ * epic #536) plus blog settings (Issue #543). Exercises the real handlers
+ * against a real PostgreSQL — templates, menus (with hierarchical items),
+ * widgets, ads (with placements), the per-tenant theme override, and
+ * `/api/v1/blog/settings` (GET default fallback, PATCH merge-patch
+ * semantics, guard, validation, audit). RBAC (single `configure`/`update`
+ * permission gates the relevant mutation, same as taxonomies), RLS tenant
  * isolation, and audit are covered per resource rather than exhaustively
  * for every resource (the underlying guard/audit wiring is identical
- * across all five, proven once by the taxonomy/post suites already in this
+ * across all six, proven once by the taxonomy/post suites already in this
  * epic).
  *
  * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
@@ -55,6 +57,10 @@ import {
   GET as getTheme,
   PATCH as updateTheme
 } from "../../src/pages/api/v1/blog/theme/index";
+import {
+  GET as getSettings,
+  PATCH as updateSettings
+} from "../../src/pages/api/v1/blog/settings/index";
 
 const OWNER_LOGIN = "owner@example.com";
 const OWNER_PASSWORD = "integration-test-owner-password";
@@ -665,6 +671,129 @@ suite("blog presentation extensions", () => {
       body: { mode: "blue" }
     });
     expect(updated.status).toBe(400);
+  });
+
+  test("settings: GET returns schema/domain defaults when never configured", async () => {
+    const owner = await bootstrap();
+
+    const before = await invoke<{
+      data: {
+        blogTitle: string;
+        postsPerPage: number;
+        rssEnabled: boolean;
+        sitemapEnabled: boolean;
+        defaultLocale: string;
+        defaultVisibility: string;
+      };
+    }>(getSettings, {
+      method: "GET",
+      path: "/api/v1/blog/settings",
+      headers: authHeaders(owner)
+    });
+
+    expect(before.status).toBe(200);
+    expect(before.body.data.blogTitle).toBe("Blog");
+    expect(before.body.data.postsPerPage).toBe(10);
+    expect(before.body.data.rssEnabled).toBe(true);
+    expect(before.body.data.sitemapEnabled).toBe(true);
+  });
+
+  test("settings: PATCH is a merge-patch — only fields sent are changed, audit event recorded", async () => {
+    const owner = await bootstrap();
+
+    const first = await invoke<{
+      data: { blogTitle: string; postsPerPage: number };
+    }>(updateSettings, {
+      method: "PATCH",
+      path: "/api/v1/blog/settings",
+      headers: authHeaders(owner),
+      body: { blogTitle: "Acme Blog", postsPerPage: 25 }
+    });
+    expect(first.status).toBe(200);
+    expect(first.body.data.blogTitle).toBe("Acme Blog");
+    expect(first.body.data.postsPerPage).toBe(25);
+
+    // Second PATCH only touches rssEnabled — blogTitle/postsPerPage from the
+    // first PATCH must survive untouched (merge-patch, not replace).
+    const second = await invoke<{
+      data: {
+        blogTitle: string;
+        postsPerPage: number;
+        rssEnabled: boolean;
+      };
+    }>(updateSettings, {
+      method: "PATCH",
+      path: "/api/v1/blog/settings",
+      headers: authHeaders(owner),
+      body: { rssEnabled: false }
+    });
+    expect(second.status).toBe(200);
+    expect(second.body.data.rssEnabled).toBe(false);
+    expect(second.body.data.blogTitle).toBe("Acme Blog");
+    expect(second.body.data.postsPerPage).toBe(25);
+
+    const after = await invoke<{ data: { blogTitle: string } }>(getSettings, {
+      method: "GET",
+      path: "/api/v1/blog/settings",
+      headers: authHeaders(owner)
+    });
+    expect(after.body.data.blogTitle).toBe("Acme Blog");
+
+    const admin = getAdminSql();
+    const auditRows = (await admin`
+      SELECT action FROM awcms_mini_audit_events
+      WHERE tenant_id = ${owner.tenantId} AND resource_type = 'blog_settings'
+      ORDER BY created_at ASC
+    `) as { action: string }[];
+    expect(auditRows.map((row) => row.action)).toEqual([
+      "blog.settings.updated",
+      "blog.settings.updated"
+    ]);
+  });
+
+  test("settings: rejects an out-of-range postsPerPage (400)", async () => {
+    const owner = await bootstrap();
+
+    const updated = await invoke(updateSettings, {
+      method: "PATCH",
+      path: "/api/v1/blog/settings",
+      headers: authHeaders(owner),
+      body: { postsPerPage: 0 }
+    });
+    expect(updated.status).toBe(400);
+  });
+
+  test("settings: reading requires blog_content.settings.read", async () => {
+    const owner = await bootstrap();
+    const noPermUser = await provisionScopedTenantUser(
+      owner.tenantId,
+      "noperm-settings@example.com",
+      []
+    );
+
+    const get = await invoke(getSettings, {
+      method: "GET",
+      path: "/api/v1/blog/settings",
+      headers: authHeaders(noPermUser)
+    });
+    expect(get.status).toBe(403);
+  });
+
+  test("settings: reader without settings.configure cannot PATCH", async () => {
+    const owner = await bootstrap();
+    const reader = await provisionScopedTenantUser(
+      owner.tenantId,
+      "settings-reader@example.com",
+      [{ activityCode: "settings", action: "read" }]
+    );
+
+    const patch = await invoke(updateSettings, {
+      method: "PATCH",
+      path: "/api/v1/blog/settings",
+      headers: authHeaders(reader),
+      body: { blogTitle: "Hijacked" }
+    });
+    expect(patch.status).toBe(403);
   });
 
   test("tenant B cannot read tenant A's templates (RLS FORCE)", async () => {

--- a/tests/integration/blog-content-public-routes.integration.test.ts
+++ b/tests/integration/blog-content-public-routes.integration.test.ts
@@ -4,8 +4,10 @@
  * visibility leakage (draft/review/scheduled-future/archived/private/
  * unlisted/soft-deleted must never appear where the issue says they
  * shouldn't), SEO rendering fallbacks, canonical URL safety, category/tag
- * archive filtering, RSS/sitemap content filtering, and tenant-code
- * resolution 404s (unknown tenant, inactive tenant).
+ * archive filtering, RSS/sitemap content filtering, tenant-code resolution
+ * 404s (unknown tenant, inactive tenant), and the `rssEnabled`/
+ * `sitemapEnabled` settings gate (Issue #543) — disabled must 404
+ * identically to an unknown tenant, no distinguishable signal leaked.
  *
  * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
  */
@@ -31,6 +33,7 @@ import { POST as scheduleBlogPost } from "../../src/pages/api/v1/blog/posts/[id]
 import { POST as archivePost } from "../../src/pages/api/v1/blog/posts/[id]/archive";
 import { DELETE as deletePost } from "../../src/pages/api/v1/blog/posts/[id]";
 import { POST as createTerm } from "../../src/pages/api/v1/blog/terms/index";
+import { PATCH as updateSettings } from "../../src/pages/api/v1/blog/settings/index";
 
 import { GET as publicIndex } from "../../src/pages/blog/[tenantCode]/index";
 import { GET as publicDetail } from "../../src/pages/blog/[tenantCode]/[slug]";
@@ -591,6 +594,78 @@ suite("public blog routes", () => {
     expect(sitemap.text).toContain(publicPost.slug);
     expect(sitemap.text).not.toContain("sitemap-unlisted");
     expect(sitemap.text).toContain("<urlset");
+  });
+
+  test("feed.xml 404s the same as an unknown tenant when rssEnabled is false", async () => {
+    const owner = await bootstrap();
+    await createAndPublishPost(owner, { slug: "rss-disabled-post" });
+
+    const enabled = await invokeRaw(publicFeed, {
+      method: "GET",
+      path: `/blog/${owner.tenantCode}/feed.xml`,
+      params: { tenantCode: owner.tenantCode }
+    });
+    expect(enabled.status).toBe(200);
+
+    const disable = await invoke(updateSettings, {
+      method: "PATCH",
+      path: "/api/v1/blog/settings",
+      headers: authHeaders(owner),
+      body: { rssEnabled: false }
+    });
+    expect(disable.status).toBe(200);
+
+    const disabled = await invokeRaw(publicFeed, {
+      method: "GET",
+      path: `/blog/${owner.tenantCode}/feed.xml`,
+      params: { tenantCode: owner.tenantCode }
+    });
+    expect(disabled.status).toBe(404);
+
+    // Same shape as the unknown-tenant 404 — no distinguishable signal that
+    // the feed exists but was turned off.
+    const unknown = await invokeRaw(publicFeed, {
+      method: "GET",
+      path: "/blog/does-not-exist/feed.xml",
+      params: { tenantCode: "does-not-exist" }
+    });
+    expect(unknown.status).toBe(404);
+    expect(disabled.text).toBe(unknown.text);
+  });
+
+  test("sitemap-blog.xml 404s the same as an unknown tenant when sitemapEnabled is false", async () => {
+    const owner = await bootstrap();
+    await createAndPublishPost(owner, { slug: "sitemap-disabled-post" });
+
+    const enabled = await invokeRaw(publicSitemap, {
+      method: "GET",
+      path: `/blog/${owner.tenantCode}/sitemap-blog.xml`,
+      params: { tenantCode: owner.tenantCode }
+    });
+    expect(enabled.status).toBe(200);
+
+    const disable = await invoke(updateSettings, {
+      method: "PATCH",
+      path: "/api/v1/blog/settings",
+      headers: authHeaders(owner),
+      body: { sitemapEnabled: false }
+    });
+    expect(disable.status).toBe(200);
+
+    const disabled = await invokeRaw(publicSitemap, {
+      method: "GET",
+      path: `/blog/${owner.tenantCode}/sitemap-blog.xml`,
+      params: { tenantCode: owner.tenantCode }
+    });
+    expect(disabled.status).toBe(404);
+
+    const unknown = await invokeRaw(publicSitemap, {
+      method: "GET",
+      path: "/blog/does-not-exist/sitemap-blog.xml",
+      params: { tenantCode: "does-not-exist" }
+    });
+    expect(unknown.status).toBe(404);
+    expect(disabled.text).toBe(unknown.text);
   });
 
   test("tenant A's posts never leak into tenant B's public routes", async () => {


### PR DESCRIPTION
## Summary
- Adds the full admin UI for `blog_content` under `/admin/blog` — 14 Astro + vanilla-JS screens: dashboard, posts (list/new/editor with lifecycle actions + revision history), pages (list/new/editor), categories, tags, settings, and the optional templates/widgets/menus/ads managers (included since #542 is already merged). All screens reuse the existing `AdminLayout`/design tokens and the SSR-read + fetch-to-guarded-endpoint pattern from `src/pages/admin/modules/[moduleKey].astro`.
- Activates the blog settings API (`GET`/`PATCH /api/v1/blog/settings`), wiring the `awcms_mini_blog_settings` table (present since migration 026 but unwired until now) and closing the AsyncAPI contract's last producer-less channel (`blog-content.settings.updated`).
- `feed.xml`/`sitemap-blog.xml` now respect the new `rssEnabled`/`sitemapEnabled` settings (404 when disabled, indistinguishable from an unknown tenant).
- `module.ts` now declares its full `permissions` (36 entries, mirroring migrations 027/030) and `navigation` (`/admin/blog`) arrays — previously empty despite the permissions already existing in the database. Module status flips from `experimental` to `active`; epic #536 is now complete.
- Adds the missing OpenAPI path for `/api/v1/blog/settings` and closes two test-coverage gaps (settings endpoint route tests, RSS/sitemap disabled-gating tests) found in review.
- Updates docs (README, ERD, API/event contract, sprint test plan, SOP, traceability matrix) and the `awcms-mini-blog-content` skill to reflect the epic's completion.

## Test plan
- [x] `bun run db:migrate` — no schema change, 0 applied
- [x] `bun run api:spec:check` — PASS
- [x] `bun run typecheck` — PASS
- [x] `bun test` against real PostgreSQL — **919 pass, 0 fail**
- [x] `bun run build` — PASS
- [x] `bun run check` (lint + check:docs + api:spec:check + typecheck + test + build) — PASS
- [x] Reviewed by `awcms-mini-reviewer` (one blocking OpenAPI gap + two test gaps found and fixed; re-verified independently)
- [ ] `bun run production:preflight` — `config:validate` needs a configured `.env` not present in this sandbox; `security:readiness` passes when run against the least-privilege app role. Recommend re-running in a properly configured staging environment before go-live sign-off.

## Security notes
No new secrets, no client-side DB access — all admin-UI mutations flow through the already-guarded/audited `/api/v1/blog/*` endpoints. High-risk lifecycle actions (publish/schedule/archive/restore/purge/revision-restore) require confirmation + a fresh `Idempotency-Key` per attempt; deletes require a reason prompt. No raw `set:html` of user content anywhere; `content_json` stays behind the existing whitelist renderer.

## Known limitations
- Menu items / ad placements are edited via a labeled JSON textarea, not a visual tree/drag-drop editor.
- No visual/WYSIWYG editor for `content_json`.
- Page editor has no lifecycle actions or revision-history panel (matches backend: no such endpoints exist for pages — out of scope for this issue).
- No dedicated media/gallery screen (no base media library exists; gallery is edited via the existing `content_json` block).

## Next steps
Re-run `bun run production:preflight` in a properly configured staging environment (real `.env`, app-role `DATABASE_URL`, running preview server) before go-live sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)