### PR TITLE
feat(config): add online public tenant routing mode config (Issue #556)

### DIFF
--- a/.changeset/online-public-routing-config-issue-556.md
+++ b/.changeset/online-public-routing-config-issue-556.md
@@ -1,0 +1,24 @@
+---
+"awcms-mini": minor
+---
+
+Add config-only support for online public tenant routing (Issue #556,
+epic #555): `PUBLIC_TENANT_RESOLUTION_MODE`
+(`host_default`/`env_default`/`setup_default`/`tenant_code_legacy`),
+`PUBLIC_DEFAULT_TENANT_ID`, `PUBLIC_DEFAULT_TENANT_CODE`,
+`PUBLIC_CANONICAL_BASE_PATH` (default `/news`), `PUBLIC_TRUST_PROXY`
+(safe default `false`), and `PUBLIC_PLATFORM_ROOT_DOMAIN`. `bun run
+config:validate` (`scripts/validate-env.ts`) now enforces the mode enum,
+`host_default` requiring `PUBLIC_PLATFORM_ROOT_DOMAIN`, `env_default`
+requiring at least one of `PUBLIC_DEFAULT_TENANT_ID`/
+`PUBLIC_DEFAULT_TENANT_CODE`, and `PUBLIC_CANONICAL_BASE_PATH` being an
+absolute path — while leaving every new var unset still passes
+`config:validate`, so existing offline/LAN deployments are unaffected.
+Documented in `docs/awcms-mini/18_configuration_env_reference.md` §Public
+routing and `docs/awcms-mini/deployment-profiles.md` §Profil online, with
+an explicit security note that `PUBLIC_TRUST_PROXY=true` must only be set
+behind a trusted reverse proxy (a future host-based resolver, Issue #559,
+would otherwise trust a spoofable `X-Forwarded-Host` header). No
+tenant-domain schema, `/news` routes, or Cloudflare DNS integration in
+this issue — those land in epic #555's remaining child issues
+(#557-#567).

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -6,35 +6,36 @@ Skill Claude Code tingkat-proyek untuk AWCMS-Mini. Setiap skill meng-encode stan
 
 ## Katalog
 
-| Skill                                                  | Kapan dipakai                                                                    | Sumber docs                 |
-| ------------------------------------------------------ | -------------------------------------------------------------------------------- | --------------------------- |
-| `awcms-mini-implement-issue`                           | Orkestrator: kerjakan satu issue/sprint atomic end-to-end                        | 06, 11, 12                  |
-| `awcms-mini-new-module`                                | Scaffold modul baru di `src/modules/`                                            | 10, 11                      |
-| `awcms-mini-module-management`                         | Kelola/konsumsi sistem Module Management (registry, lifecycle, settings, health) | module-management/README.md |
-| `awcms-mini-new-migration`                             | Buat/ubah migration SQL (tabel, index, RLS)                                      | 04, 10                      |
-| `awcms-mini-new-endpoint`                              | Tambah/ubah endpoint REST + OpenAPI                                              | 05, 10                      |
-| `awcms-mini-new-event`                                 | Tambah/ubah domain event + AsyncAPI                                              | 05                          |
-| `awcms-mini-idempotency`                               | Mutation high-risk anti double-submit                                            | 10                          |
-| `awcms-mini-abac-guard`                                | Kontrol akses default-deny + RLS                                                 | 03, 10                      |
-| `awcms-mini-audit-log`                                 | Audit aksi high-risk + redaction                                                 | 03, 10                      |
-| `awcms-mini-observability`                             | Correlation ID otomatis, retensi/purge audit log, extension point log/audit      | 10, 16, 20                  |
-| `awcms-mini-new-migration` + `awcms-mini-new-endpoint` | Soft delete/restore/purge resource deletable                                     | 04, 05, 10, 16              |
-| `awcms-mini-sensitive-data`                            | Normalize/hash/mask identifier sensitif                                          | 04                          |
-| `awcms-mini-sync-hmac`                                 | Sync push/pull bertanda HMAC + anti-replay                                       | 08, 10                      |
-| `awcms-mini-security-review`                           | Review keamanan modul                                                            | 12, 13                      |
-| `awcms-mini-codeql-triage`                             | Triase & perbaiki temuan CodeQL code scanning (termasuk katalog false-positive)  | 20                          |
-| `awcms-mini-pr-review`                                 | Review pull request terhadap DoD                                                 | 09, 10, 12                  |
-| `awcms-mini-testing`                                   | Tulis test berlapis (unit→security)                                              | 07                          |
-| `awcms-mini-production-preflight`                      | Preflight & go-live readiness                                                    | 07, 12                      |
-| `awcms-mini-deploy`                                    | Pilih & jalankan profil deployment (LAN-first vs registry/Coolify)               | 18, deploy-coolify.md       |
-| `awcms-mini-ui-screen`                                 | Implementasi layar/komponen UI sesuai design system                              | 14, 15                      |
-| `awcms-mini-wizard-form`                               | Form multi-step (reusable wizard pattern)                                        | wizard-form-pattern.md      |
-| `awcms-mini-form-drafts`                               | Server-side draft persistence (resume lintas sesi/perangkat)                     | form-drafts/README.md       |
-| `awcms-mini-email`                                     | Kirim email transaksional (provider-neutral, template management, outbox)        | email/README.md             |
-| `awcms-mini-i18n`                                      | String UI `.po` gettext & konten multi-bahasa                                    | 14, 04, 19                  |
-| `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)                                | 09                          |
-| `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                     | 07, 06                      |
-| `awcms-mini-blog-content`                              | Kerjakan bagian mana pun epic blog_content (Issue #537-#543)                     | blog-content/README.md      |
+| Skill                                                  | Kapan dipakai                                                                         | Sumber docs                    |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------ |
+| `awcms-mini-implement-issue`                           | Orkestrator: kerjakan satu issue/sprint atomic end-to-end                             | 06, 11, 12                     |
+| `awcms-mini-new-module`                                | Scaffold modul baru di `src/modules/`                                                 | 10, 11                         |
+| `awcms-mini-module-management`                         | Kelola/konsumsi sistem Module Management (registry, lifecycle, settings, health)      | module-management/README.md    |
+| `awcms-mini-new-migration`                             | Buat/ubah migration SQL (tabel, index, RLS)                                           | 04, 10                         |
+| `awcms-mini-new-endpoint`                              | Tambah/ubah endpoint REST + OpenAPI                                                   | 05, 10                         |
+| `awcms-mini-new-event`                                 | Tambah/ubah domain event + AsyncAPI                                                   | 05                             |
+| `awcms-mini-idempotency`                               | Mutation high-risk anti double-submit                                                 | 10                             |
+| `awcms-mini-abac-guard`                                | Kontrol akses default-deny + RLS                                                      | 03, 10                         |
+| `awcms-mini-audit-log`                                 | Audit aksi high-risk + redaction                                                      | 03, 10                         |
+| `awcms-mini-observability`                             | Correlation ID otomatis, retensi/purge audit log, extension point log/audit           | 10, 16, 20                     |
+| `awcms-mini-new-migration` + `awcms-mini-new-endpoint` | Soft delete/restore/purge resource deletable                                          | 04, 05, 10, 16                 |
+| `awcms-mini-sensitive-data`                            | Normalize/hash/mask identifier sensitif                                               | 04                             |
+| `awcms-mini-sync-hmac`                                 | Sync push/pull bertanda HMAC + anti-replay                                            | 08, 10                         |
+| `awcms-mini-security-review`                           | Review keamanan modul                                                                 | 12, 13                         |
+| `awcms-mini-codeql-triage`                             | Triase & perbaiki temuan CodeQL code scanning (termasuk katalog false-positive)       | 20                             |
+| `awcms-mini-pr-review`                                 | Review pull request terhadap DoD                                                      | 09, 10, 12                     |
+| `awcms-mini-testing`                                   | Tulis test berlapis (unit→security)                                                   | 07                             |
+| `awcms-mini-production-preflight`                      | Preflight & go-live readiness                                                         | 07, 12                         |
+| `awcms-mini-deploy`                                    | Pilih & jalankan profil deployment (LAN-first vs registry/Coolify)                    | 18, deploy-coolify.md          |
+| `awcms-mini-ui-screen`                                 | Implementasi layar/komponen UI sesuai design system                                   | 14, 15                         |
+| `awcms-mini-wizard-form`                               | Form multi-step (reusable wizard pattern)                                             | wizard-form-pattern.md         |
+| `awcms-mini-form-drafts`                               | Server-side draft persistence (resume lintas sesi/perangkat)                          | form-drafts/README.md          |
+| `awcms-mini-email`                                     | Kirim email transaksional (provider-neutral, template management, outbox)             | email/README.md                |
+| `awcms-mini-i18n`                                      | String UI `.po` gettext & konten multi-bahasa                                         | 14, 04, 19                     |
+| `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)                                     | 09                             |
+| `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                          | 07, 06                         |
+| `awcms-mini-blog-content`                              | Kerjakan bagian mana pun epic blog_content (Issue #537-#543)                          | blog-content/README.md         |
+| `awcms-mini-tenant-domain-routing`                     | Kerjakan bagian mana pun epic online public routing & tenant domain (Issue #556-#567) | tenant-domain-routing/SKILL.md |
 
 ## Katalog peningkatan (improvement/hardening)
 
@@ -86,6 +87,12 @@ flowchart TD
   II --> BLOG[awcms-mini-blog-content]
   BLOG --> EP
   BLOG --> MIG
+  II --> TDR[awcms-mini-tenant-domain-routing]
+  TDR --> EP
+  TDR --> MIG
+  TDR --> NM
+  TDR --> BLOG
+  TDR --> MM[awcms-mini-module-management]
   II --> PR[awcms-mini-pr-review]
   PR --> SEC[awcms-mini-security-review]
   PR --> CQ[awcms-mini-codeql-triage]

--- a/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: awcms-mini-tenant-domain-routing
+description: Kerjakan bagian mana pun dari epic online public tenant routing & tenant domain management AWCMS-Mini (Issue #556-#567, epic #555). Gunakan saat menambah/mengubah PUBLIC_* env config, skema/API/UI tenant domain, resolver tenant berbasis host, rute publik `/news`, module presets, atau adapter Cloudflare DNS. Merangkum keputusan yang sudah dibuat supaya issue lanjutan tidak mengulang/kontradiksi.
+---
+
+# AWCMS-Mini — Online Public Tenant Routing & Tenant Domain Management
+
+Epic #555 menambah **mode routing publik online-primary** (domain/subdomain
+→ tenant, tanpa perlu `tenantCode` di path) sambil **mempertahankan**
+kapabilitas offline/LAN-first yang sudah ada (`/blog/{tenantCode}` tetap
+jalan — lihat ADR-0009 dan skill `awcms-mini-blog-content`). Target model:
+
+```txt
+Domain/Subdomain -> Public Tenant Resolver -> Tenant Context -> /news Public Routes -> blog_content
+```
+
+## Kapan pakai skill ini vs skill generik
+
+Skill ini melengkapi (bukan menggantikan) `awcms-mini-new-endpoint`,
+`awcms-mini-new-migration`, `awcms-mini-new-module`,
+`awcms-mini-blog-content` (untuk sisi `/news` di modul `blog_content`),
+dan `awcms-mini-module-management` (untuk sisi module presets/matrix UI).
+Skill ini menyediakan konteks **cross-cutting epic #555 spesifik** yang
+menjembatani beberapa modul sekaligus (config, `tenant_domain` module baru,
+`blog_content`, `module_management`).
+
+## Status per issue (jangan bangun ulang yang sudah ada)
+
+| Issue | Scope                                                         | Status                               |
+| ----- | ------------------------------------------------------------- | ------------------------------------ |
+| #556  | Online public mode config (`PUBLIC_*` env vars)               | **Selesai** — lihat §Config di bawah |
+| #557  | Tenant domain/subdomain mapping schema                        | Belum                                |
+| #558  | Register module descriptor `tenant_domain`                    | Belum                                |
+| #559  | Public host tenant resolver (dengan fallback)                 | Belum                                |
+| #560  | Rute publik `/news` untuk `blog_content`                      | Belum                                |
+| #561  | Dokumentasi legacy `/blog/{tenantCode}`                       | Belum                                |
+| #562  | Tenant domain management API                                  | Belum                                |
+| #563  | Admin UI domain/subdomain                                     | Belum                                |
+| #564  | Tenant settings untuk rute `/news` vs legacy (`blog_content`) | Belum                                |
+| #565  | Tenant module presets (online/news/LAN/minimal)               | Belum                                |
+| #566  | Tenant-module matrix admin UI                                 | Belum                                |
+| #567  | Cloudflare DNS adapter (opsional)                             | Belum                                |
+
+## Yang sudah ada — pakai ulang, jangan re-derive
+
+### Config (Issue #556, `scripts/validate-env.ts`)
+
+Enam env var baru, semuanya **opsional** dan backward-compatible — kalau
+tidak diset sama sekali, `config:validate` tetap PASS dan perilaku tetap
+offline/LAN-first (`tenant_code_legacy` implisit):
+
+- `PUBLIC_TENANT_RESOLUTION_MODE` — enum `host_default | env_default | setup_default | tenant_code_legacy`. Divalidasi `isKnownPublicTenantResolutionMode` (`scripts/validate-env.ts:114`); value lain gagal validasi dengan pesan daftar value yang sah.
+- `PUBLIC_DEFAULT_TENANT_ID` / `PUBLIC_DEFAULT_TENANT_CODE` — wajib **minimal salah satu** saat mode `env_default` (bukan keduanya).
+- `PUBLIC_PLATFORM_ROOT_DOMAIN` — wajib saat mode `host_default` (landasan untuk resolver berbasis host di Issue #559 — tanpa root domain, resolver tidak bisa membedakan subdomain tenant valid dari `Host` header sembarangan).
+- `PUBLIC_CANONICAL_BASE_PATH` — default `/news` (belum ada rute nyata di sana sampai #560), divalidasi `isValidCanonicalBasePath` (`scripts/validate-env.ts:129`): wajib absolute path (`/...`), tanpa whitespace, tanpa `//`, tanpa trailing slash kecuali `/` itu sendiri. Divalidasi **selalu**, independen dari mode.
+- `PUBLIC_TRUST_PROXY` — default `false` (aman). Kalau `true`, app **wajib** jalan di belakang reverse proxy tepercaya yang men-sanitize `X-Forwarded-Host` — jangan pernah percaya header itu tanpa proxy tepercaya di depan (catatan keamanan eksplisit epic #555, relevan untuk resolver #559).
+
+Entry point: `checkPublicRoutingConfig()` (`scripts/validate-env.ts:304`),
+dipanggil dari `runEnvValidation()`. Semua pesan fail hanya menyebut nama
+var, tidak pernah value-nya (pola sama seperti check lain di file ini) —
+kecuali `PUBLIC_CANONICAL_BASE_PATH`/`PUBLIC_TENANT_RESOLUTION_MODE` yang
+memang bukan secret dan boleh echo value untuk debuggability operator.
+
+Didokumentasikan di `docs/awcms-mini/18_configuration_env_reference.md`
+§Public routing dan `docs/awcms-mini/deployment-profiles.md` §Profil
+online. Test: `tests/validate-env.test.ts`'s
+`describe("checkPublicRoutingConfig", ...)`.
+
+## Aturan lintas-issue yang wajib diikuti
+
+1. **Backward compatibility non-negotiable**: setiap deployment offline/LAN existing yang tidak pernah set `PUBLIC_*` apa pun harus tetap `config:validate` PASS dan berperilaku persis seperti sebelum epic ini — jangan pernah membuat salah satu dari enam var config ini menjadi wajib secara default.
+2. **`PUBLIC_TRUST_PROXY=false` harus tetap default aman** di setiap lapisan baru (resolver #559, dst.) — jangan baca `X-Forwarded-Host`/`X-Forwarded-Proto` kecuali `PUBLIC_TRUST_PROXY=true` eksplisit diset.
+3. **`/blog/{tenantCode}` (ADR-0009, skill `awcms-mini-blog-content`) TIDAK dihapus** — epic #555 secara eksplisit out-of-scope untuk "removing legacy `/blog/{tenantCode}` routes in the MVP". `/news` (#560) adalah rute **tambahan**, bukan pengganti. Issue #561 mendokumentasikan `/blog/{tenantCode}` sebagai legacy, bukan menghapusnya.
+4. **Jangan trust `X-Forwarded-Host` tanpa proxy tepercaya** — ulangi dari epic #555 §Security notes, berlaku untuk resolver #559 dan API domain #562 manapun yang membaca header host.
+5. **Tenant existence tidak boleh bocor**: domain/tenant yang unknown, failed, suspended, atau inactive harus menghasilkan respons yang identik/tidak bisa dibedakan (pola sama seperti ADR-0009's 404 identik untuk `tenantCode` tak dikenal vs tenant tidak aktif) — berlaku untuk resolver #559 dan rute publik `/news` #560.
+6. **Module disabled tetap diblokir server-side** — kalau tenant module presets (#565) atau tenant-module matrix (#566) menonaktifkan sebuah modul, endpoint modul itu wajib tetap menolak di server (guard ABAC/tenant-module lifecycle yang sudah ada dari `module_management`), bukan hanya disembunyikan di UI.
+7. **Provider secret (mis. Cloudflare API token, #567) tidak pernah disimpan di module descriptor atau kolom DB biasa** — pakai environment variable seperti provider lain (Mailketing, R2), dan `configure`-only permission gate seperti pola `email`/`sync-storage` provider config.
+8. **Semua mutasi domain/module (create/update/delete domain mapping, enable/disable module preset) wajib diaudit** — pola `recordAuditEvent` yang sama dipakai modul lain, action literal sesuai konvensi modul (`tenant_domain.<resource>.<verb>` mengikuti pola `blog.<resource>.<verb>` dari blog_content).
+9. **Cloudflare DNS adapter (#567) adalah opsional/enhancement**, bukan hard dependency — epic #555 §Out of scope eksplisit menyebut "making Cloudflare DNS automation a hard dependency" di luar scope. Tenant domain mapping (#557/#562) harus tetap berfungsi tanpa Cloudflare sama sekali (manual DNS setup oleh operator).
+
+## Belum ada — jangan asumsikan sudah dikerjakan
+
+Semua isu #557-#567 (schema tenant domain, module descriptor
+`tenant_domain`, resolver host-based, rute publik `/news`, dokumentasi
+legacy, API tenant domain, admin UI domain, tenant settings rute
+`/news`/legacy di `blog_content`, module presets, matrix UI admin, dan
+adapter Cloudflare DNS) **belum ada** — hanya lapisan config (#556) yang
+selesai. Jangan asumsikan resolver host-based sudah bisa dipakai; env var
+`PUBLIC_PLATFORM_ROOT_DOMAIN`/`PUBLIC_TRUST_PROXY` baru **divalidasi dan
+didokumentasikan**, belum **dikonsumsi** oleh kode resolver apa pun.

--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,34 @@ EMAIL_SEND_MAX_RETRIES=5
 # EMAIL_MAILKETING_API_TOKEN=
 # EMAIL_MAILKETING_API_BASE_URL=
 
+# Public tenant routing (opsional, online-first — Issue #556, epic #555).
+# Config-only di sini: TIDAK ada schema tenant-domain, rute publik /news,
+# atau resolver host-based (itu issue lanjutan #557-#567). Default (var
+# PUBLIC_TENANT_RESOLUTION_MODE tidak di-set) = perilaku legacy saat ini:
+# rute publik lewat /blog/{tenantCode}, tanpa resolusi tenant dari host —
+# offline/LAN tetap default, bukan online-first. Set salah satu dari 4 mode
+# berikut hanya saat online public routing sudah disiapkan:
+#   host_default       - resolve tenant dari Host/subdomain; wajib isi
+#                         PUBLIC_PLATFORM_ROOT_DOMAIN.
+#   env_default        - satu tenant default dari env; wajib isi salah
+#                         satu PUBLIC_DEFAULT_TENANT_ID/PUBLIC_DEFAULT_TENANT_CODE.
+#   setup_default      - tenant default ditentukan lewat Setup Wizard (DB);
+#                         tidak butuh var tambahan di sini.
+#   tenant_code_legacy - eksplisit memilih rute /blog/{tenantCode} lama.
+# PUBLIC_TENANT_RESOLUTION_MODE=tenant_code_legacy
+# PUBLIC_DEFAULT_TENANT_ID=
+# PUBLIC_DEFAULT_TENANT_CODE=
+PUBLIC_CANONICAL_BASE_PATH=/news
+# PUBLIC_TRUST_PROXY=false adalah default aman wajib. Set true HANYA bila
+# app berjalan di belakang reverse proxy tepercaya (mis. nginx TLS
+# termination di deploy/nginx/) yang benar-benar mengisi/membersihkan
+# header X-Forwarded-Host. Resolver host-based (Issue #559) akan memakai
+# header ini untuk menentukan tenant — tanpa proxy tepercaya di depan,
+# host spoofing bisa mengarahkan ke tenant yang salah.
+PUBLIC_TRUST_PROXY=false
+# Wajib diisi hanya bila PUBLIC_TENANT_RESOLUTION_MODE=host_default.
+# PUBLIC_PLATFORM_ROOT_DOMAIN=
+
 # Provider eksternal opsional (default off) — base tidak menetapkan provider
 # tertentu; aplikasi turunan menambah flag provider-nya sendiri di sini
 # (lihat contoh domain retail/POS di doc 18 §Provider CRM/AI analyst).

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -123,6 +123,54 @@ planned_), tidak diubah oleh epic ini.
 | `EMAIL_MAILKETING_API_TOKEN`    | bila mailketing | –            | Ya       | Token/secret API Mailketing                           |
 | `EMAIL_MAILKETING_API_BASE_URL` | bila mailketing | –            | –        | Base URL endpoint API Mailketing                      |
 
+### Public routing (opsional, online-first — Issue #556, epic #555)
+
+**Config-only.** Menyiapkan environment variable untuk mode public tenant
+routing online, tanpa mengimplementasikan schema tenant-domain, rute publik
+`/news`, atau resolver host-based — itu issue lanjutan #557-#567 di epic
+yang sama. Default (semua var di bawah tidak di-set) tetap kompatibel
+dengan deployment offline/LAN yang sudah ada: rute publik hanya lewat
+`/blog/{tenantCode}` legacy, tanpa resolusi tenant dari host — **offline/LAN
+tetap default, bukan online-first**. `scripts/validate-env.ts`
+(`checkPublicRoutingConfig`) menegakkan tabel ini.
+
+| Var                             | Wajib                                     | Default             | Sensitif | Fungsi                                                                                                   |
+| ------------------------------- | ----------------------------------------- | ------------------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| `PUBLIC_TENANT_RESOLUTION_MODE` | –                                         | – (legacy behavior) | –        | `host_default`/`env_default`/`setup_default`/`tenant_code_legacy` — nilai lain gagal validasi            |
+| `PUBLIC_DEFAULT_TENANT_ID`      | bila env_default (salah satu dengan CODE) | –                   | –        | UUID tenant default dipakai mode `env_default`                                                           |
+| `PUBLIC_DEFAULT_TENANT_CODE`    | bila env_default (salah satu dengan ID)   | –                   | –        | Kode tenant default dipakai mode `env_default`                                                           |
+| `PUBLIC_CANONICAL_BASE_PATH`    | –                                         | `/news`             | –        | Base path publik `/news`; wajib absolute path diawali `/` bila diisi                                     |
+| `PUBLIC_TRUST_PROXY`            | –                                         | `false`             | –        | Percaya header proxy (`X-Forwarded-Host` dkk.) — **hanya** `true` di belakang reverse proxy tepercaya    |
+| `PUBLIC_PLATFORM_ROOT_DOMAIN`   | bila host_default                         | –                   | –        | Root domain platform dipakai resolver host-based (Issue #559) membedakan subdomain tenant dari host lain |
+
+Aturan validasi cross-field (keputusan desain Issue #556, didokumentasikan
+di sini karena issue tidak merincinya secara eksplisit):
+
+- `PUBLIC_TENANT_RESOLUTION_MODE` tidak di-set → **bukan error**; setara
+  perilaku `tenant_code_legacy` hari ini, tidak ada var lain yang wajib.
+- `host_default` → `PUBLIC_PLATFORM_ROOT_DOMAIN` **wajib**. Resolver
+  host-based (Issue #559) mencocokkan `Host`/subdomain masuk terhadap root
+  domain ini untuk membedakan subdomain tenant yang valid dari host asing —
+  tanpa root domain, mode ini tidak punya cara aman menentukan tenant mana
+  pun dari host.
+- `env_default` → minimal salah satu dari `PUBLIC_DEFAULT_TENANT_ID` atau
+  `PUBLIC_DEFAULT_TENANT_CODE` **wajib**.
+- `setup_default`/`tenant_code_legacy` → tidak ada var tambahan wajib pada
+  lapisan config ini (`setup_default` menentukan tenant default lewat data
+  Setup Wizard di database, bukan env — di luar scope issue ini).
+- `PUBLIC_CANONICAL_BASE_PATH` bila diisi harus absolute path: diawali `/`,
+  tanpa spasi, tanpa `//`, tanpa trailing slash kecuali persis `/`.
+
+**Catatan keamanan `PUBLIC_TRUST_PROXY`**: defaultnya **wajib** `false`.
+Set `true` **hanya** bila aplikasi berjalan di belakang reverse proxy
+tepercaya (mis. `deploy/nginx/awcms-mini.conf.example` dengan TLS
+termination) yang benar-benar memvalidasi/mengisi ulang header
+`X-Forwarded-Host` dari klien luar — jangan pernah mempercayai header ini
+langsung dari klien tanpa proxy tepercaya di depan, karena resolver
+host-based yang akan dibangun di Issue #559 memakainya untuk menentukan
+tenant, dan spoofing header bisa mengarahkan request ke tenant yang salah
+tanpa membocorkan keberadaan tenant lain (lihat epic #555 §Security notes).
+
 ### Provider CRM (opsional) — contoh domain retail/POS
 
 | Var                    | Wajib      | Default | Sensitif | Fungsi             |
@@ -152,6 +200,7 @@ flowchart LR
   Flags -->|Mailketing off| Q2[Email masuk queue - tak terkirim]
   Flags -->|AI off| NoAi[Endpoint AI nonaktif]
   Flags -->|Sync off| LanOnly[LAN-only]
+  Flags -->|PUBLIC_TENANT_RESOLUTION_MODE unset| LegacyBlog[Legacy blog per-tenantCode route]
 ```
 
 Aturan: fitur off tidak menghentikan POS; pesan/objek tetap masuk queue dan menunggu fitur diaktifkan. `EMAIL_ENABLED off` (base, Issue #493) dan `Mailketing off` (contoh domain retail/POS §Provider CRM) sama-sama "queue menunggu", tapi keduanya jalur terpisah — base tidak mengasumsikan use case "email receipt".
@@ -203,6 +252,12 @@ EMAIL_FROM_NAME=AWCMS-Mini
 EMAIL_SEND_TIMEOUT_MS=10000
 EMAIL_SEND_MAX_RETRIES=5
 
+# Public tenant routing (opsional, online-first, config-only — Issue #556,
+# epic #555). PUBLIC_TENANT_RESOLUTION_MODE tidak di-set = legacy
+# /blog/{tenantCode}, offline/LAN tetap default.
+PUBLIC_CANONICAL_BASE_PATH=/news
+PUBLIC_TRUST_PROXY=false
+
 # Provider opsional (default off) — contoh domain retail/POS
 STARSENDER_ENABLED=false
 MAILKETING_ENABLED=false
@@ -246,6 +301,12 @@ flowchart TB
 
 - Var wajib hilang → gagal start dengan pesan jelas (tanpa membocorkan nilai).
 - Flag aktif tanpa kredensial (mis. `R2_ENABLED=true` tanpa key) → gagal start.
+- `PUBLIC_TENANT_RESOLUTION_MODE` diisi nilai selain 4 mode terdokumentasi,
+  `host_default` tanpa `PUBLIC_PLATFORM_ROOT_DOMAIN`, `env_default` tanpa
+  `PUBLIC_DEFAULT_TENANT_ID`/`PUBLIC_DEFAULT_TENANT_CODE`, atau
+  `PUBLIC_CANONICAL_BASE_PATH` bukan absolute path → gagal start (Issue #556;
+  lihat §Public routing di atas). Var ini tidak di-set sama sekali tetap
+  lulus (perilaku legacy offline/LAN tidak berubah).
 - Secret tidak pernah masuk log (redaction, doc 10).
 
 ## Acceptance criteria

--- a/docs/awcms-mini/deployment-profiles.md
+++ b/docs/awcms-mini/deployment-profiles.md
@@ -34,6 +34,37 @@ proxy sama sekali. PgBouncer (`deploy/pgbouncer/`) hanya untuk skenario
 koneksi pendek bervolume tinggi (lihat
 [`database-pooling.md`](database-pooling.md) §7) — bukan kebutuhan default.
 
+## Profil online (public tenant routing) — config-only, Issue #556
+
+Epic #555 menambahkan mode routing publik online-first di atas empat
+profil di atas (bukan profil kelima yang terpisah — `production (online)`
+tetap profil yang sama, sekarang bisa dikonfigurasi lebih eksplisit).
+Issue #556 **hanya** menambahkan env var (lihat
+[`18_configuration_env_reference.md`](18_configuration_env_reference.md#public-routing-opsional-online-first--issue-556-epic-555)
+§Public routing) — schema tenant-domain, rute publik `/news`, dan resolver
+host-based menyusul di issue #557-#567.
+
+- **offline/LAN & development**: biarkan `PUBLIC_TENANT_RESOLUTION_MODE`
+  tidak di-set (default). `config:validate` tetap lulus tanpa var
+  tambahan apa pun — tidak ada perubahan pada topologi LAN-first yang
+  sudah didokumentasikan di atas.
+- **production (online)**, saat resolver host-based (Issue #559) sudah
+  siap dipakai: set `PUBLIC_TENANT_RESOLUTION_MODE=host_default` dan
+  `PUBLIC_PLATFORM_ROOT_DOMAIN=<root-domain-platform>` di environment
+  systemd/compose/registry image (lihat pola secret injection di
+  `production (online) — image registry` di bawah — env var, bukan
+  hardcode ke image).
+- **`PUBLIC_TRUST_PROXY`**: default aman **wajib** `false`. Set `true`
+  **hanya** bila deployment ini benar-benar berjalan di belakang reverse
+  proxy tepercaya yang mengisi ulang `X-Forwarded-Host` secara aman —
+  yaitu tepat topologi `deploy/nginx/awcms-mini.conf.example` (TLS
+  termination) di baris "production (online)" pada tabel di atas. Jangan
+  set `true` pada topologi offline/LAN yang melewati nginx sepenuhnya
+  (baris "offline/LAN" di atas: "nginx dapat dilewati sepenuhnya") — tanpa
+  proxy tepercaya di depan, header `X-Forwarded-Host` bisa dipalsukan
+  klien mana pun, dan resolver host-based yang akan dibangun di Issue
+  #559 akan memakainya untuk menentukan tenant.
+
 ## Cara menjalankan tiap profil
 
 ### development
@@ -198,6 +229,16 @@ menambahkan `scripts/validate-env.ts` (`bun run config:validate`):
   (Issue 10.3), bukan logika terpisah yang bisa menyimpang.
 - Kondisional: bila `R2_ENABLED=true`, maka `R2_ACCOUNT_ID`,
   `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET` wajib diisi.
+- Kondisional (Issue #556, epic #555 — config-only, lihat §Profil online
+  di bawah): bila `PUBLIC_TENANT_RESOLUTION_MODE` diisi, nilainya harus
+  salah satu dari `host_default`/`env_default`/`setup_default`/
+  `tenant_code_legacy`; `host_default` mewajibkan
+  `PUBLIC_PLATFORM_ROOT_DOMAIN`, `env_default` mewajibkan minimal salah
+  satu dari `PUBLIC_DEFAULT_TENANT_ID`/`PUBLIC_DEFAULT_TENANT_CODE`.
+  `PUBLIC_CANONICAL_BASE_PATH`, bila diisi, harus absolute path (diawali
+  `/`). Var ini semua **tidak wajib** untuk profil offline/LAN —
+  meninggalkannya kosong tetap lulus `config:validate` (perilaku default
+  legacy `/blog/{tenantCode}` tidak berubah).
 - Tidak pernah mencetak nilai secret asli — hanya nama variabel yang
   hilang/tidak valid. Exit code bukan nol bila ada kegagalan.
 

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -34,10 +34,40 @@
  *     `src/modules/email/README.md` for why these vars are namespaced
  *     `EMAIL_*`/`EMAIL_MAILKETING_*` rather than the illustrative
  *     `MAILKETING_*` rows in doc 18 §Provider CRM (opsional).
+ *  5. Public tenant routing (Issue #556, epic #555, config-only — no
+ *     tenant-domain schema/resolver/routes here yet):
+ *       - PUBLIC_TENANT_RESOLUTION_MODE, if set, must be one of
+ *         `PUBLIC_TENANT_RESOLUTION_MODES`. Left unset it is *not* an
+ *         error — that is the backward-compatible default every existing
+ *         offline/LAN deployment already runs (today's only public route
+ *         is the legacy `/blog/{tenantCode}` path; see doc 18 §Public
+ *         routing and `deployment-profiles.md`).
+ *       - mode === "host_default" requires PUBLIC_PLATFORM_ROOT_DOMAIN:
+ *         the host-based resolver landing in Issue #559 needs a root
+ *         domain to tell a tenant subdomain apart from an unrelated host.
+ *       - mode === "env_default" requires at least one of
+ *         PUBLIC_DEFAULT_TENANT_ID / PUBLIC_DEFAULT_TENANT_CODE.
+ *       - mode === "setup_default" / "tenant_code_legacy" need no extra
+ *         var here (setup_default's default tenant lives in DB via the
+ *         Setup Wizard; tenant_code_legacy is today's behavior).
+ *       - PUBLIC_CANONICAL_BASE_PATH, if set, must be an absolute path
+ *         (leading "/", no whitespace, no trailing slash unless it is
+ *         exactly "/", no "//"). Left unset it defaults to `/news`
+ *         at the code level (not enforced here, same convention as other
+ *         defaulted vars like AUDIT_LOG_RETENTION_DAYS).
+ *       - PUBLIC_TRUST_PROXY is intentionally not validated here (no
+ *         format/conditional requirement, same as other boolean flags in
+ *         this file) — its safe default is `false` in `.env.example`.
+ *         Docs (doc 18, deployment-profiles.md) spell out that
+ *         `PUBLIC_TRUST_PROXY=true` must only be used behind a trusted
+ *         reverse proxy, since a future host-based resolver (#559) would
+ *         otherwise trust a spoofable `X-Forwarded-Host` header.
  *
  * Never prints actual secret values — only which variable name is
  * missing/invalid (doc 18: "Var wajib hilang → gagal start dengan pesan
- * jelas (tanpa membocorkan nilai)"). Exits non-zero on any failure.
+ * jelas (tanpa membocorkan nilai)"). Exits non-zero on any failure. None of
+ * the public-routing vars above are secrets, but they follow the same
+ * name-only reporting style for consistency.
  */
 import { checkSyncHmacSecretNotDefault } from "./security-readiness";
 import {
@@ -67,8 +97,70 @@ const R2_REQUIRED_WHEN_ENABLED = [
   "R2_BUCKET"
 ] as const;
 
+/**
+ * The four documented public tenant resolution modes (Issue #556, epic
+ * #555). See the file header comment §5 for what each mode requires.
+ */
+const PUBLIC_TENANT_RESOLUTION_MODES = [
+  "host_default",
+  "env_default",
+  "setup_default",
+  "tenant_code_legacy"
+] as const;
+
+type PublicTenantResolutionMode =
+  (typeof PUBLIC_TENANT_RESOLUTION_MODES)[number];
+
+function isKnownPublicTenantResolutionMode(
+  value: string
+): value is PublicTenantResolutionMode {
+  return (PUBLIC_TENANT_RESOLUTION_MODES as readonly string[]).includes(value);
+}
+
 function isSet(value: string | undefined): boolean {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Absolute-path check for PUBLIC_CANONICAL_BASE_PATH: leading "/", no
+ * whitespace, no "//" collapse, and no trailing slash unless the whole
+ * value is the root "/" itself.
+ */
+function isValidCanonicalBasePath(value: string): boolean {
+  if (!value.startsWith("/")) return false;
+  if (/\s/.test(value)) return false;
+  if (value.includes("//")) return false;
+  if (value.length > 1 && value.endsWith("/")) return false;
+  return true;
+}
+
+function checkPublicCanonicalBasePath(env: NodeJS.ProcessEnv): EnvCheckResult {
+  const name = "PUBLIC_CANONICAL_BASE_PATH";
+  const raw = env.PUBLIC_CANONICAL_BASE_PATH;
+
+  if (!isSet(raw)) {
+    return {
+      name,
+      status: "pass",
+      detail: `${name} is not set — defaults to /news.`
+    };
+  }
+
+  const value = (raw as string).trim();
+
+  if (isValidCanonicalBasePath(value)) {
+    return {
+      name,
+      status: "pass",
+      detail: `${name} is a valid absolute path.`
+    };
+  }
+
+  return {
+    name,
+    status: "fail",
+    detail: `${name} must be an absolute path starting with "/" (no whitespace, no "//", no trailing slash unless it is exactly "/").`
+  };
 }
 
 export function checkRequiredVars(
@@ -209,6 +301,87 @@ export function checkEmailConfig(
   return results;
 }
 
+export function checkPublicRoutingConfig(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult[] {
+  const results: EnvCheckResult[] = [];
+  const rawMode = env.PUBLIC_TENANT_RESOLUTION_MODE;
+
+  if (!isSet(rawMode)) {
+    results.push({
+      name: "PUBLIC_TENANT_RESOLUTION_MODE",
+      status: "pass",
+      detail:
+        "PUBLIC_TENANT_RESOLUTION_MODE is not set — offline/LAN deployments keep today's legacy /blog/{tenantCode} behavior; no public-host config is required."
+    });
+    results.push(checkPublicCanonicalBasePath(env));
+    return results;
+  }
+
+  const mode = (rawMode as string).trim();
+
+  if (!isKnownPublicTenantResolutionMode(mode)) {
+    results.push({
+      name: "PUBLIC_TENANT_RESOLUTION_MODE",
+      status: "fail",
+      detail: `PUBLIC_TENANT_RESOLUTION_MODE must be one of ${PUBLIC_TENANT_RESOLUTION_MODES.join(", ")}; got "${mode}".`
+    });
+    // Unknown mode — cross-field rules below are meaningless for it.
+    results.push(checkPublicCanonicalBasePath(env));
+    return results;
+  }
+
+  results.push({
+    name: "PUBLIC_TENANT_RESOLUTION_MODE",
+    status: "pass",
+    detail: `PUBLIC_TENANT_RESOLUTION_MODE is a known mode (${mode}).`
+  });
+
+  if (mode === "host_default") {
+    if (isSet(env.PUBLIC_PLATFORM_ROOT_DOMAIN)) {
+      results.push({
+        name: "PUBLIC_PLATFORM_ROOT_DOMAIN",
+        status: "pass",
+        detail: "PUBLIC_PLATFORM_ROOT_DOMAIN is set."
+      });
+    } else {
+      results.push({
+        name: "PUBLIC_PLATFORM_ROOT_DOMAIN",
+        status: "fail",
+        detail:
+          "PUBLIC_TENANT_RESOLUTION_MODE=host_default but PUBLIC_PLATFORM_ROOT_DOMAIN is missing or empty — the host-based resolver (Issue #559) needs a root domain to tell tenant subdomains apart from unrelated hosts."
+      });
+    }
+  }
+
+  if (mode === "env_default") {
+    const hasId = isSet(env.PUBLIC_DEFAULT_TENANT_ID);
+    const hasCode = isSet(env.PUBLIC_DEFAULT_TENANT_CODE);
+
+    if (hasId || hasCode) {
+      results.push({
+        name: "PUBLIC_DEFAULT_TENANT_ID or PUBLIC_DEFAULT_TENANT_CODE",
+        status: "pass",
+        detail:
+          "At least one of PUBLIC_DEFAULT_TENANT_ID/PUBLIC_DEFAULT_TENANT_CODE is set."
+      });
+    } else {
+      results.push({
+        name: "PUBLIC_DEFAULT_TENANT_ID or PUBLIC_DEFAULT_TENANT_CODE",
+        status: "fail",
+        detail:
+          "PUBLIC_TENANT_RESOLUTION_MODE=env_default requires at least one of PUBLIC_DEFAULT_TENANT_ID or PUBLIC_DEFAULT_TENANT_CODE to be set."
+      });
+    }
+  }
+
+  // mode === "setup_default" | "tenant_code_legacy": no extra required var.
+
+  results.push(checkPublicCanonicalBasePath(env));
+
+  return results;
+}
+
 export function runEnvValidation(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -216,7 +389,8 @@ export function runEnvValidation(
     ...checkRequiredVars(env),
     checkSyncConfig(env),
     ...checkR2Config(env),
-    ...checkEmailConfig(env)
+    ...checkEmailConfig(env),
+    ...checkPublicRoutingConfig(env)
   ];
 }
 

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   checkEmailConfig,
+  checkPublicRoutingConfig,
   checkR2Config,
   checkRequiredVars,
   checkSyncConfig,
@@ -200,6 +201,138 @@ describe("checkEmailConfig", () => {
   });
 });
 
+describe("checkPublicRoutingConfig", () => {
+  test("passes (mode + base path) when PUBLIC_TENANT_RESOLUTION_MODE is not set", () => {
+    const results = checkPublicRoutingConfig({} as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(2);
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("fails when PUBLIC_TENANT_RESOLUTION_MODE is not one of the documented values", () => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_TENANT_RESOLUTION_MODE: "made_up_mode"
+    } as NodeJS.ProcessEnv);
+
+    const failed = results.find(
+      (result) => result.name === "PUBLIC_TENANT_RESOLUTION_MODE"
+    );
+    expect(failed?.status).toBe("fail");
+  });
+
+  test("host_default fails without PUBLIC_PLATFORM_ROOT_DOMAIN", () => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_TENANT_RESOLUTION_MODE: "host_default"
+    } as NodeJS.ProcessEnv);
+
+    const failed = results.find(
+      (result) => result.name === "PUBLIC_PLATFORM_ROOT_DOMAIN"
+    );
+    expect(failed?.status).toBe("fail");
+  });
+
+  test("host_default passes with PUBLIC_PLATFORM_ROOT_DOMAIN set", () => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_TENANT_RESOLUTION_MODE: "host_default",
+      PUBLIC_PLATFORM_ROOT_DOMAIN: "example.test"
+    } as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("env_default fails without PUBLIC_DEFAULT_TENANT_ID or PUBLIC_DEFAULT_TENANT_CODE", () => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_TENANT_RESOLUTION_MODE: "env_default"
+    } as NodeJS.ProcessEnv);
+
+    const failed = results.find(
+      (result) =>
+        result.name === "PUBLIC_DEFAULT_TENANT_ID or PUBLIC_DEFAULT_TENANT_CODE"
+    );
+    expect(failed?.status).toBe("fail");
+  });
+
+  test("env_default passes with only PUBLIC_DEFAULT_TENANT_ID set", () => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_TENANT_RESOLUTION_MODE: "env_default",
+      PUBLIC_DEFAULT_TENANT_ID: "11111111-1111-1111-1111-111111111111"
+    } as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("env_default passes with only PUBLIC_DEFAULT_TENANT_CODE set", () => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_TENANT_RESOLUTION_MODE: "env_default",
+      PUBLIC_DEFAULT_TENANT_CODE: "demo"
+    } as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("setup_default passes without any extra public routing var", () => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_TENANT_RESOLUTION_MODE: "setup_default"
+    } as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("tenant_code_legacy passes without any extra public routing var", () => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_TENANT_RESOLUTION_MODE: "tenant_code_legacy"
+    } as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("PUBLIC_CANONICAL_BASE_PATH passes when unset (defaults to /news)", () => {
+    const results = checkPublicRoutingConfig({} as NodeJS.ProcessEnv);
+    const check = results.find(
+      (result) => result.name === "PUBLIC_CANONICAL_BASE_PATH"
+    );
+
+    expect(check?.status).toBe("pass");
+  });
+
+  test("PUBLIC_CANONICAL_BASE_PATH passes for a valid absolute path", () => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_CANONICAL_BASE_PATH: "/news"
+    } as NodeJS.ProcessEnv);
+    const check = results.find(
+      (result) => result.name === "PUBLIC_CANONICAL_BASE_PATH"
+    );
+
+    expect(check?.status).toBe("pass");
+  });
+
+  test.each([
+    ["missing leading slash", "news"],
+    ["trailing slash", "/news/"],
+    ["whitespace", "/news blog"],
+    ["double slash", "/news//latest"]
+  ])("PUBLIC_CANONICAL_BASE_PATH fails for %s (%p)", (_label, value) => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_CANONICAL_BASE_PATH: value
+    } as NodeJS.ProcessEnv);
+    const check = results.find(
+      (result) => result.name === "PUBLIC_CANONICAL_BASE_PATH"
+    );
+
+    expect(check?.status).toBe("fail");
+  });
+
+  test("never includes PUBLIC_DEFAULT_TENANT_ID/CODE values in failure details", () => {
+    const results = checkPublicRoutingConfig({
+      PUBLIC_TENANT_RESOLUTION_MODE: "env_default"
+    } as NodeJS.ProcessEnv);
+
+    for (const result of results) {
+      expect(result.detail).not.toContain("11111111-1111-1111-1111");
+    }
+  });
+});
+
 describe("runEnvValidation", () => {
   test("passes end-to-end for a minimal valid env (sync/R2/email all off)", () => {
     const env = {
@@ -224,6 +357,31 @@ describe("runEnvValidation", () => {
     const env = {
       ...VALID_ENV,
       EMAIL_ENABLED: "true"
+    } as NodeJS.ProcessEnv;
+
+    const results = runEnvValidation(env);
+    expect(results.some((result) => result.status === "fail")).toBe(true);
+  });
+
+  test("passes end-to-end when PUBLIC_TENANT_RESOLUTION_MODE is left unset (offline/LAN default, Issue #556)", () => {
+    const env = {
+      ...VALID_ENV,
+      AWCMS_MINI_SYNC_ENABLED: "false",
+      R2_ENABLED: "false",
+      EMAIL_ENABLED: "false"
+    } as NodeJS.ProcessEnv;
+
+    const results = runEnvValidation(env);
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("fails end-to-end when PUBLIC_TENANT_RESOLUTION_MODE=host_default is missing PUBLIC_PLATFORM_ROOT_DOMAIN", () => {
+    const env = {
+      ...VALID_ENV,
+      AWCMS_MINI_SYNC_ENABLED: "false",
+      R2_ENABLED: "false",
+      EMAIL_ENABLED: "false",
+      PUBLIC_TENANT_RESOLUTION_MODE: "host_default"
     } as NodeJS.ProcessEnv;
 
     const results = runEnvValidation(env);


### PR DESCRIPTION
## Summary
- First issue of epic #555 (online public tenant routing & tenant domain management). Config-only — no schema, routes, module descriptor, or UI (those land in #557-#567).
- Adds six `PUBLIC_*` env vars for the upcoming host/domain-based tenant resolver: `PUBLIC_TENANT_RESOLUTION_MODE` (`host_default|env_default|setup_default|tenant_code_legacy`), `PUBLIC_DEFAULT_TENANT_ID`/`PUBLIC_DEFAULT_TENANT_CODE`, `PUBLIC_PLATFORM_ROOT_DOMAIN`, `PUBLIC_CANONICAL_BASE_PATH` (default `/news`), `PUBLIC_TRUST_PROXY` (default `false`).
- All six are optional and backward-compatible: existing offline/LAN deployments that never set them keep passing `config:validate` unchanged, and legacy `/blog/{tenantCode}` behavior is preserved.
- Cross-field validation: `host_default` mode requires `PUBLIC_PLATFORM_ROOT_DOMAIN` (the future host resolver, #559, needs it to distinguish a tenant subdomain from an unrelated host); `env_default` requires at least one of `PUBLIC_DEFAULT_TENANT_ID`/`CODE`; `PUBLIC_CANONICAL_BASE_PATH` is always validated as an absolute path regardless of mode.
- `PUBLIC_TRUST_PROXY` defaults to `false`; docs explain it must only be `true` behind a trusted reverse proxy that sanitizes `X-Forwarded-Host` — laying the security groundwork epic #555 requires for the resolver landing in #559.
- Adds skill `awcms-mini-tenant-domain-routing` to track this epic's cross-issue decisions as #557-#567 land, mirroring `awcms-mini-blog-content`'s role for epic #536.

## Test plan
- [x] `bun test tests/validate-env.test.ts` — 37 pass
- [x] `bun run config:validate` against a minimal offline/LAN env — PASS (backward compat confirmed)
- [x] `bun run typecheck` — PASS
- [x] `bun run lint` — PASS
- [x] `bun run check:docs` — PASS
- [x] `bun test` against real PostgreSQL — 937 pass, 0 fail
- [x] `bun run build` — PASS
- [x] Reviewed by `awcms-mini-reviewer` — approved, every acceptance criterion independently verified (manual fail-path testing, not just reading code)

## Security notes
No secrets introduced. `PUBLIC_TRUST_PROXY=false` safe default; validation error messages never leak values for sensitive checks. `X-Forwarded-Host` trust groundwork documented but not yet consumed by any resolver code (that's #559).

## Next steps
Issue #557 (tenant domain/subdomain mapping schema) or #559 (public host tenant resolver) per the epic's sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)