### PR TITLE
feat(tenant-domain): add tenant domain and subdomain mapping schema (Issue #557)

### DIFF
--- a/.changeset/tenant-domain-schema-issue-557.md
+++ b/.changeset/tenant-domain-schema-issue-557.md
@@ -1,0 +1,22 @@
+---
+"awcms-mini": minor
+---
+
+Add the tenant domain/subdomain mapping schema (Issue #557, epic #555):
+`awcms_mini_tenant_domains` (`sql/031_awcms_mini_tenant_domain_schema.sql`)
+maps a public hostname to a tenant, with a separate `normalized_hostname`
+column (lowercase/trimmed, kept in sync by a CHECK constraint) that is
+globally unique among non-deleted rows, a partial unique index enforcing
+at most one active primary domain per tenant, `domain_type`
+(`subdomain`/`custom_domain`) and `route_mode` (`canonical`/`legacy_blog`)
+extension points for the future resolver (#559) and `/news` routes
+(#560), `verification_method`/`verification_token_hash` (hashed, never
+the raw token)/`verification_record_name`/`verification_record_value` for
+DNS ownership verification (no provider credential ever stored here),
+soft delete, and `ENABLE`+`FORCE` row-level security with the standard
+`tenant_isolation` policy. `sql/032_awcms_mini_tenant_domain_permissions.sql`
+seeds six new `tenant_domain.domains.*` permissions
+(`read`/`create`/`update`/`delete`/`verify`/`set_primary`). Schema only —
+no module descriptor, resolver, API, or admin UI in this issue (those are
+#558/#559/#562/#563). Covered by
+`tests/integration/tenant-domain-schema.integration.test.ts`.

--- a/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
@@ -29,7 +29,7 @@ menjembatani beberapa modul sekaligus (config, `tenant_domain` module baru,
 | Issue | Scope                                                         | Status                               |
 | ----- | ------------------------------------------------------------- | ------------------------------------ |
 | #556  | Online public mode config (`PUBLIC_*` env vars)               | **Selesai** — lihat §Config di bawah |
-| #557  | Tenant domain/subdomain mapping schema                        | Belum                                |
+| #557  | Tenant domain/subdomain mapping schema                        | **Selesai** — lihat §Schema di bawah |
 | #558  | Register module descriptor `tenant_domain`                    | Belum                                |
 | #559  | Public host tenant resolver (dengan fallback)                 | Belum                                |
 | #560  | Rute publik `/news` untuk `blog_content`                      | Belum                                |
@@ -66,6 +66,65 @@ Didokumentasikan di `docs/awcms-mini/18_configuration_env_reference.md`
 online. Test: `tests/validate-env.test.ts`'s
 `describe("checkPublicRoutingConfig", ...)`.
 
+### Schema (Issue #557, `sql/031`/`sql/032`)
+
+Tabel `awcms_mini_tenant_domains` — pemetaan hostname/domain/subdomain →
+tenant. **Schema saja**, belum ada module descriptor (#558), resolver
+(#559), atau API (#562) yang mengonsumsinya.
+
+- Migration di-split dua file mengikuti pola `blog_content` (026 schema /
+  027 permission, diulang lagi di 029/030): `sql/031_awcms_mini_tenant_domain_schema.sql`
+  (tabel) dan `sql/032_awcms_mini_tenant_domain_permissions.sql`
+  (permission seed).
+- Kolom kunci: `hostname` (raw, case asli) + `normalized_hostname` (kolom
+  terpisah, bukan functional index — `lower(btrim(hostname))`, dijaga
+  konsisten oleh CHECK constraint
+  `awcms_mini_tenant_domains_normalized_hostname_matches_check`);
+  `domain_type` (`subdomain` | `custom_domain`); `route_mode`
+  (`canonical` → rute `/news` #560, | `legacy_blog` → rute
+  `/blog/{tenantCode}` ADR-0009 — kolom disiapkan, belum dikonsumsi
+  resolver manapun); `status` (`pending_verification` | `active` |
+  `suspended` | `failed` — soft delete via `deleted_at` adalah state
+  kelima "tidak resolve traffic", tidak digabung ke enum ini);
+  `verification_method` (`dns_txt` | `dns_cname` | `file` | `manual`,
+  nullable); `verification_token_hash` (sha256 hex, prefix `sha256:`,
+  konstruksi sama seperti `lib/auth/password-reset-token.ts`'s
+  `hashResetToken` — token CSPRNG high-entropy jadi fast hash sudah benar,
+  bukan bcrypt/argon2; raw token tidak pernah disimpan);
+  `verification_record_name`/`verification_record_value` (nilai DNS
+  publik yang dipublish tenant, BUKAN secret provider); `is_primary` +
+  `redirect_to_primary`.
+- Constraint kunci: `awcms_mini_tenant_domains_normalized_hostname_dedup`
+  (unique index global — LINTAS tenant, bukan per-tenant — pada
+  `normalized_hostname` `WHERE deleted_at IS NULL`, karena satu hostname
+  cuma boleh milik satu tenant); `awcms_mini_tenant_domains_primary_dedup`
+  (unique index pada `tenant_id` `WHERE is_primary = true AND deleted_at IS NULL`
+  — satu primary aktif per tenant); soft delete standar
+  (`deleted_at`/`deleted_by`/`delete_reason`) membebaskan
+  `normalized_hostname` untuk dipakai ulang.
+- RLS: `ENABLE` + `FORCE` + policy `tenant_isolation` standar (sama pola
+  semua tabel tenant-scoped lain) — **tapi ini menciptakan bootstrap gap
+  yang wajib diselesaikan #559**: query hostname→tenant_id butuh
+  dijalankan SEBELUM tenant context ada, sementara FORCE RLS + fail-closed
+  GUC (migration 013) membuat query tanpa `withTenant` selalu 0 baris.
+  `awcms_mini_tenants` (migration 013) sengaja RLS-free untuk masalah
+  bootstrap yang sama persis (lookup `tenantCode → tenant_id`, ADR-0009),
+  tapi `tenant_domains` TIDAK BOLEH ikut jadi RLS-free (kolom
+  `verification_token_hash` dkk. tenant-manageable). Resolusi yang
+  didokumentasikan di migration 031's komentar untuk #559: buat jalur baca
+  khusus (mis. fungsi `SECURITY DEFINER` yang cuma return `(tenant_id,
+status, is_primary)`, atau role baca least-privilege terpisah) untuk
+  satu query bootstrap ini — jangan lepas `FORCE ROW LEVEL SECURITY` dari
+  tabel ini untuk mengakalinya.
+- Permission seed: `module_key` `tenant_domain`, `activity_code` `domains`
+  — `read`/`create`/`update`/`delete`/`verify`/`set_primary` (persis
+  §Seed permissions issue #557). Belum ada role/access assignment yang
+  memakainya (menunggu #562 dkk.).
+- Test: `tests/integration/tenant-domain-schema.integration.test.ts`
+  (idempotency, unique constraint case-insensitive, primary-per-tenant,
+  soft-delete-frees-hostname, RLS isolation, fail-closed tanpa GUC, tidak
+  ada kolom secret provider).
+
 ## Aturan lintas-issue yang wajib diikuti
 
 1. **Backward compatibility non-negotiable**: setiap deployment offline/LAN existing yang tidak pernah set `PUBLIC_*` apa pun harus tetap `config:validate` PASS dan berperilaku persis seperti sebelum epic ini — jangan pernah membuat salah satu dari enam var config ini menjadi wajib secara default.
@@ -80,11 +139,17 @@ online. Test: `tests/validate-env.test.ts`'s
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Semua isu #557-#567 (schema tenant domain, module descriptor
-`tenant_domain`, resolver host-based, rute publik `/news`, dokumentasi
-legacy, API tenant domain, admin UI domain, tenant settings rute
-`/news`/legacy di `blog_content`, module presets, matrix UI admin, dan
-adapter Cloudflare DNS) **belum ada** — hanya lapisan config (#556) yang
-selesai. Jangan asumsikan resolver host-based sudah bisa dipakai; env var
-`PUBLIC_PLATFORM_ROOT_DOMAIN`/`PUBLIC_TRUST_PROXY` baru **divalidasi dan
-didokumentasikan**, belum **dikonsumsi** oleh kode resolver apa pun.
+Semua isu #558-#567 (module descriptor `tenant_domain`, resolver
+host-based, rute publik `/news`, dokumentasi legacy, API tenant domain,
+admin UI domain, tenant settings rute `/news`/legacy di `blog_content`,
+module presets, matrix UI admin, dan adapter Cloudflare DNS) **belum ada**
+— hanya lapisan config (#556) dan schema `awcms_mini_tenant_domains`
+(#557) yang selesai. Jangan asumsikan resolver host-based sudah bisa
+dipakai; env var `PUBLIC_PLATFORM_ROOT_DOMAIN`/`PUBLIC_TRUST_PROXY` baru
+**divalidasi dan didokumentasikan**, belum **dikonsumsi** oleh kode
+resolver apa pun. Tabel `awcms_mini_tenant_domains` baru berisi schema +
+constraint + RLS + permission catalog seed — belum ada baris yang pernah
+ditulis lewat kode aplikasi (menunggu #562's API), dan belum ada resolver
+yang membacanya (menunggu #559, yang juga harus menyelesaikan RLS
+bootstrap gap yang didokumentasikan di §Schema di atas dan di migration
+031's komentar sebelum bisa query tabel ini tanpa tenant context).

--- a/sql/031_awcms_mini_tenant_domain_schema.sql
+++ b/sql/031_awcms_mini_tenant_domain_schema.sql
@@ -1,0 +1,167 @@
+-- Issue #557 (epic #555, online public tenant routing & tenant domain
+-- management) — database foundation for mapping a public hostname/domain/
+-- subdomain to a tenant. Schema-only: no module descriptor (#558), no
+-- host-based resolver (#559), no API (#562), no admin UI (#563). This
+-- table is the input the future resolver reads to answer
+-- "hostname -> tenant_id" without requiring `tenantCode` in the path
+-- (`docs/awcms-mini/12_generator_prompt.md`'s epic target model, see
+-- `.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md`).
+--
+-- Numbering note: the issue's own §Scope only names this one file
+-- (`sql/031_awcms_mini_tenant_domain_schema.sql`), but this migration
+-- follows the same "schema then permissions, two files" split
+-- `blog_content` used for its own module foundation (026=schema,
+-- 027=permissions; repeated again for 029/030's presentation extension) —
+-- the closest precedent in this repo for "new module foundation table +
+-- its permission catalog seed" landing together. Permission seed is
+-- `sql/032_awcms_mini_tenant_domain_permissions.sql`.
+--
+-- Column design notes:
+--   - `hostname` is the raw value as entered/observed (case preserved for
+--     display); `normalized_hostname` is a separate stored column (not a
+--     functional index on `lower(hostname)` — issue explicitly asks for a
+--     column) holding the lowercase+trimmed form used for uniqueness and
+--     resolver lookups. A CHECK constraint keeps the two in sync at the DB
+--     layer as defense-in-depth (application code is still responsible for
+--     populating both correctly on insert/update).
+--   - `domain_type`: `subdomain` (under the operator's
+--     `PUBLIC_PLATFORM_ROOT_DOMAIN`, config-only today per Issue #556) vs
+--     `custom_domain` (tenant-owned external domain requiring its own DNS
+--     verification).
+--   - `route_mode`: which public route family this domain resolves into —
+--     `canonical` (the new `/news` routes, Issue #560, under
+--     `PUBLIC_CANONICAL_BASE_PATH`) vs `legacy_blog` (the existing
+--     `/blog/{tenantCode}` routes, ADR-0009, documented as legacy but not
+--     removed per epic #555's explicit out-of-scope). Not consumed by any
+--     resolver yet — this issue only lays the column down.
+--   - `status`: `pending_verification` (default; newly added, not yet
+--     proven), `active` (verified and eligible to resolve tenant traffic),
+--     `suspended` (operator/tenant paused it), `failed` (verification
+--     failed or repeatedly errors on recheck). Soft delete
+--     (`deleted_at`/`deleted_by`/`delete_reason`) is the fourth "does not
+--     resolve traffic" state, not folded into this enum — same convention
+--     `blog_content` posts/pages use (status enum + separate soft delete).
+--     Security note from the issue is binding on whoever builds the
+--     resolver (#559): suspended/failed/deleted rows must never resolve
+--     public tenant traffic, and per the epic's tenant-existence-leak rule
+--     (SKILL.md rule #5) an unknown/inactive host must look identical to
+--     any other non-resolving host, not reveal which case it is.
+--   - `is_primary` + `redirect_to_primary`: exactly one active primary
+--     domain per tenant (enforced below by a partial unique index) is
+--     where canonical URLs/redirects point; non-primary active domains can
+--     optionally redirect to it (`redirect_to_primary`), enforcement of the
+--     actual HTTP redirect is application-layer (future resolver/API
+--     issue), not this migration's concern.
+--   - `verification_method`: how ownership is being/was proven —
+--     `dns_txt`/`dns_cname` (public DNS record, `verification_record_name`/
+--     `verification_record_value` hold the record the tenant must publish,
+--     never a secret), `file` (well-known file upload), or `manual`
+--     (operator-attested, no automated check).
+--   - `verification_token_hash`: sha256 hex, `sha256:`-prefixed — same
+--     construction as `lib/auth/password-reset-token.ts`'s
+--     `hashResetToken`/`profile-identity/domain/identifier.ts`'s
+--     `hashIdentifier` (a CSPRNG-generated verification token is
+--     high-entropy, so a fast hash is correct — no bcrypt/argon2 needed,
+--     see those files' own comments for the full reasoning). The raw
+--     token itself is never persisted; token generation/hashing/comparison
+--     is application code for a later issue (#562), out of scope here.
+--     `verification_record_value` is intentionally distinct: it is the
+--     PUBLIC DNS record value the tenant publishes (not a secret), while
+--     `verification_token_hash` is the hash of an internal bearer token
+--     used for a different verification method. Neither column, nor any
+--     other column on this table, ever stores a DNS provider API
+--     credential/secret — those belong only in env/secret manager
+--     (Cloudflare adapter, Issue #567, will follow the same
+--     env-var-only pattern as the Mailketing/R2 provider config).
+--
+-- RLS bootstrap gotcha flagged for Issue #559 (resolver), not solved here:
+-- FORCE RLS below with the standard `tenant_isolation` policy means a
+-- query against this table with no `app.current_tenant_id` GUC set (the
+-- `awcms_mini_app` role's fail-closed default, migration 013) returns zero
+-- rows. That is correct and required for tenant-authenticated access
+-- (#562's admin API must never see another tenant's domains), but the
+-- whole point of the public host resolver is to discover tenant_id from
+-- hostname BEFORE any tenant context exists — the same bootstrap problem
+-- ADR-0009's `tenantCode -> tenant_id` lookup solves by querying
+-- `awcms_mini_tenants`, which migration 013 deliberately left RLS-free
+-- ("shared by design") for exactly this reason. This table cannot be
+-- RLS-free the same way (it holds tenant-manageable fields like
+-- `verification_token_hash`), so #559 will need its own bootstrap read
+-- path for the hostname lookup step specifically — e.g. a narrowly-scoped
+-- SECURITY DEFINER function returning only `(tenant_id, status,
+-- is_primary)`, or a dedicated least-privilege read role for that one
+-- query — rather than widening this table's RLS or having the app
+-- connection bypass RLS generally. Do not remove FORCE RLS from this
+-- table to work around it.
+--
+-- No explicit `GRANT` needed for `awcms_mini_app` on the new table below:
+-- migration 013's `ALTER DEFAULT PRIVILEGES` already covers every table
+-- the owning role creates from here on (same reasoning 025/026 relied on).
+
+CREATE TABLE IF NOT EXISTS awcms_mini_tenant_domains (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  hostname text NOT NULL,
+  normalized_hostname text NOT NULL,
+  domain_type text NOT NULL DEFAULT 'custom_domain',
+  route_mode text NOT NULL DEFAULT 'canonical',
+  status text NOT NULL DEFAULT 'pending_verification',
+  is_primary boolean NOT NULL DEFAULT false,
+  redirect_to_primary boolean NOT NULL DEFAULT false,
+  verification_method text,
+  verification_token_hash text,
+  verification_record_name text,
+  verification_record_value text,
+  verified_at timestamptz,
+  last_checked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  updated_by uuid,
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_mini_tenant_domains_domain_type_check
+    CHECK (domain_type IN ('subdomain', 'custom_domain')),
+  CONSTRAINT awcms_mini_tenant_domains_route_mode_check
+    CHECK (route_mode IN ('canonical', 'legacy_blog')),
+  CONSTRAINT awcms_mini_tenant_domains_status_check
+    CHECK (status IN ('pending_verification', 'active', 'suspended', 'failed')),
+  CONSTRAINT awcms_mini_tenant_domains_verification_method_check
+    CHECK (verification_method IS NULL
+      OR verification_method IN ('dns_txt', 'dns_cname', 'file', 'manual')),
+  CONSTRAINT awcms_mini_tenant_domains_hostname_not_blank_check
+    CHECK (btrim(hostname) <> ''),
+  CONSTRAINT awcms_mini_tenant_domains_normalized_hostname_matches_check
+    CHECK (normalized_hostname = lower(btrim(hostname)))
+);
+
+-- Case-insensitive global uniqueness among active (non-deleted) rows — a
+-- hostname can only ever map to one tenant, so this is intentionally NOT
+-- scoped by tenant_id. Soft-deleting a row frees its normalized_hostname
+-- for reuse (e.g. a domain moved off this platform, then re-added later).
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_tenant_domains_normalized_hostname_dedup
+  ON awcms_mini_tenant_domains (normalized_hostname)
+  WHERE deleted_at IS NULL;
+
+-- At most one active primary domain per tenant.
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_tenant_domains_primary_dedup
+  ON awcms_mini_tenant_domains (tenant_id)
+  WHERE is_primary = true AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_mini_tenant_domains_tenant_idx
+  ON awcms_mini_tenant_domains (tenant_id);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_tenant_domains_tenant_status_idx
+  ON awcms_mini_tenant_domains (tenant_id, status)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_mini_tenant_domains_tenant_deleted_idx
+  ON awcms_mini_tenant_domains (tenant_id, deleted_at);
+
+ALTER TABLE awcms_mini_tenant_domains ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_tenant_domains FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_tenant_domains_tenant_isolation
+  ON awcms_mini_tenant_domains
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/sql/032_awcms_mini_tenant_domain_permissions.sql
+++ b/sql/032_awcms_mini_tenant_domain_permissions.sql
@@ -1,0 +1,19 @@
+-- Issue #557 (epic #555) — permission catalog seed for the new
+-- `awcms_mini_tenant_domains` table (migration 031). Exactly the six
+-- permissions from the issue's own §Seed permissions list. `module_key`
+-- 'tenant_domain' and `activity_code` 'domains' are new — not used by any
+-- other module's permission seed in this repo (checked against every
+-- existing `INSERT INTO awcms_mini_permissions` migration). No
+-- endpoints/roles are wired to these yet (that is Issue #562's admin API
+-- and whatever role/access-assignment work follows it); this migration
+-- only extends the global ABAC permission catalog, same shape as
+-- `sql/027_awcms_mini_blog_content_permissions.sql`.
+INSERT INTO awcms_mini_permissions (module_key, activity_code, action, description)
+VALUES
+  ('tenant_domain', 'domains', 'read', 'Read tenant domain/subdomain mappings'),
+  ('tenant_domain', 'domains', 'create', 'Add a tenant domain/subdomain mapping'),
+  ('tenant_domain', 'domains', 'update', 'Update a tenant domain/subdomain mapping'),
+  ('tenant_domain', 'domains', 'delete', 'Soft delete a tenant domain/subdomain mapping'),
+  ('tenant_domain', 'domains', 'verify', 'Verify ownership of a tenant domain/subdomain'),
+  ('tenant_domain', 'domains', 'set_primary', 'Set a tenant domain as the active primary domain')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -227,7 +227,9 @@ describe("database migration runner helpers", () => {
       "027_awcms_mini_blog_content_permissions.sql",
       "028_awcms_mini_blog_content_search_vector.sql",
       "029_awcms_mini_blog_content_presentation_schema.sql",
-      "030_awcms_mini_blog_content_presentation_permissions.sql"
+      "030_awcms_mini_blog_content_presentation_permissions.sql",
+      "031_awcms_mini_tenant_domain_schema.sql",
+      "032_awcms_mini_tenant_domain_permissions.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/tenant-domain-schema.integration.test.ts
+++ b/tests/integration/tenant-domain-schema.integration.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Integration tests for the tenant domain schema/RLS (Issue #557, epic
+ * #555) against a real PostgreSQL. Schema-only issue — no module
+ * descriptor (#558), resolver (#559), or API (#562) exist yet — this
+ * exercises migration 031/032's constraints and RLS enforcement directly
+ * via `withTenant`/raw admin SQL, the same pattern
+ * `blog-content-schema.integration.test.ts` (#537) and
+ * `module-management-schema.integration.test.ts` (#512) used.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+
+const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+async function seedTenants(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES
+      (${TENANT_A}, 'tenant-a', 'Tenant A', 'Tenant A Legal', 'active', 'en', 'light'),
+      (${TENANT_B}, 'tenant-b', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("tenant_domain schema — RLS isolation and constraints", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+  });
+
+  test("db:migrate is idempotent when run twice", async () => {
+    // applyMigrations() shells out to the real `scripts/db-migrate.ts`
+    // runner (same one `bun run db:migrate` invokes). beforeAll already ran
+    // it once; running it again here must not throw and must leave the
+    // schema/permission seed intact.
+    await expect(applyMigrations()).resolves.toBeUndefined();
+
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT activity_code, action FROM awcms_mini_permissions
+      WHERE module_key = 'tenant_domain'
+      ORDER BY activity_code, action
+    `) as { activity_code: string; action: string }[];
+
+    expect(rows.map((row) => `${row.activity_code}.${row.action}`)).toEqual([
+      "domains.create",
+      "domains.delete",
+      "domains.read",
+      "domains.set_primary",
+      "domains.update",
+      "domains.verify"
+    ]);
+  });
+
+  test("tenant_domain permission catalog is seeded with exactly the issue's six permissions", async () => {
+    const admin = getAdminSql();
+    const rows = (await admin`
+      SELECT activity_code, action FROM awcms_mini_permissions
+      WHERE module_key = 'tenant_domain'
+      ORDER BY activity_code, action
+    `) as { activity_code: string; action: string }[];
+
+    expect(rows.map((row) => `${row.activity_code}.${row.action}`)).toEqual([
+      "domains.create",
+      "domains.delete",
+      "domains.read",
+      "domains.set_primary",
+      "domains.update",
+      "domains.verify"
+    ]);
+  });
+
+  test("rejects an unknown status", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+
+    try {
+      await admin`
+        INSERT INTO awcms_mini_tenant_domains
+          (tenant_id, hostname, normalized_hostname, status)
+        VALUES (${TENANT_A}, 'example.com', 'example.com', 'bogus')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("rejects a normalized_hostname that does not match lower(trim(hostname))", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+
+    try {
+      await admin`
+        INSERT INTO awcms_mini_tenant_domains
+          (tenant_id, hostname, normalized_hostname)
+        VALUES (${TENANT_A}, 'Example.com', 'not-normalized.com')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("normalized_hostname is unique (case-insensitive) among active rows", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_tenant_domains
+        (tenant_id, hostname, normalized_hostname)
+      VALUES (${TENANT_A}, 'Example.com', 'example.com')
+    `;
+
+    let didThrow = false;
+    try {
+      // Same hostname, different casing/whitespace — normalizes to the same
+      // value, so this must collide on the tenant B side too.
+      await admin`
+        INSERT INTO awcms_mini_tenant_domains
+          (tenant_id, hostname, normalized_hostname)
+        VALUES (${TENANT_B}, ' EXAMPLE.com ', 'example.com')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("soft-deleting a domain frees its normalized_hostname for reuse", async () => {
+    const admin = getAdminSql();
+    const firstRows = await admin`
+      INSERT INTO awcms_mini_tenant_domains
+        (tenant_id, hostname, normalized_hostname)
+      VALUES (${TENANT_A}, 'example.com', 'example.com')
+      RETURNING id
+    `;
+    const firstId = (firstRows as { id: string }[])[0]!.id;
+
+    await admin`
+      UPDATE awcms_mini_tenant_domains
+      SET deleted_at = now(), delete_reason = 'moved off platform'
+      WHERE id = ${firstId}
+    `;
+
+    const secondRows = await admin`
+      INSERT INTO awcms_mini_tenant_domains
+        (tenant_id, hostname, normalized_hostname)
+      VALUES (${TENANT_B}, 'example.com', 'example.com')
+      RETURNING id
+    `;
+
+    expect(secondRows).toHaveLength(1);
+  });
+
+  test("only one active primary domain can exist per tenant", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_tenant_domains
+        (tenant_id, hostname, normalized_hostname, is_primary)
+      VALUES (${TENANT_A}, 'primary-one.com', 'primary-one.com', true)
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_tenant_domains
+          (tenant_id, hostname, normalized_hostname, is_primary)
+        VALUES (${TENANT_A}, 'primary-two.com', 'primary-two.com', true)
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+
+    // A second tenant can independently have its own primary domain.
+    const otherTenantRows = await admin`
+      INSERT INTO awcms_mini_tenant_domains
+        (tenant_id, hostname, normalized_hostname, is_primary)
+      VALUES (${TENANT_B}, 'b-primary.com', 'b-primary.com', true)
+      RETURNING id
+    `;
+    expect(otherTenantRows).toHaveLength(1);
+  });
+
+  test("a soft-deleted primary domain does not block a new primary for the same tenant", async () => {
+    const admin = getAdminSql();
+    const firstRows = await admin`
+      INSERT INTO awcms_mini_tenant_domains
+        (tenant_id, hostname, normalized_hostname, is_primary)
+      VALUES (${TENANT_A}, 'old-primary.com', 'old-primary.com', true)
+      RETURNING id
+    `;
+    const firstId = (firstRows as { id: string }[])[0]!.id;
+
+    await admin`
+      UPDATE awcms_mini_tenant_domains
+      SET deleted_at = now(), delete_reason = 'domain retired', is_primary = false
+      WHERE id = ${firstId}
+    `;
+
+    const secondRows = await admin`
+      INSERT INTO awcms_mini_tenant_domains
+        (tenant_id, hostname, normalized_hostname, is_primary)
+      VALUES (${TENANT_A}, 'new-primary.com', 'new-primary.com', true)
+      RETURNING id
+    `;
+
+    expect(secondRows).toHaveLength(1);
+  });
+
+  test("tenant A cannot see tenant B's domains (RLS isolation)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_tenant_domains
+        (tenant_id, hostname, normalized_hostname)
+      VALUES
+        (${TENANT_A}, 'a-domain.com', 'a-domain.com'),
+        (${TENANT_B}, 'b-domain.com', 'b-domain.com')
+    `;
+
+    const sql = getDatabaseClient();
+    const tenantARows = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT normalized_hostname FROM awcms_mini_tenant_domains`
+    );
+
+    expect(tenantARows).toHaveLength(1);
+    expect(
+      (tenantARows as { normalized_hostname: string }[])[0]?.normalized_hostname
+    ).toBe("a-domain.com");
+  });
+
+  test("querying domains without a tenant GUC set returns no rows (fail-closed)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_tenant_domains
+        (tenant_id, hostname, normalized_hostname)
+      VALUES (${TENANT_A}, 'a-domain.com', 'a-domain.com')
+    `;
+
+    const sql = getDatabaseClient();
+    const rows =
+      await sql`SELECT normalized_hostname FROM awcms_mini_tenant_domains`;
+
+    expect(rows).toHaveLength(0);
+  });
+
+  test("no DNS provider secret column exists on the table", async () => {
+    const admin = getAdminSql();
+    const columns = (await admin`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'awcms_mini_tenant_domains'
+    `) as { column_name: string }[];
+
+    const columnNames = columns.map((row) => row.column_name);
+
+    for (const forbidden of [
+      "provider_token",
+      "provider_secret",
+      "api_key",
+      "api_token",
+      "dns_provider_token",
+      "verification_token"
+    ]) {
+      expect(columnNames).not.toContain(forbidden);
+    }
+
+    // Only the hashed form is present, never a raw token column.
+    expect(columnNames).toContain("verification_token_hash");
+  });
+});


### PR DESCRIPTION
## Summary
- Second issue of epic #555 (online public tenant routing & tenant domain management), depends on #556 (config, merged). Schema-only — no module descriptor, API, resolver, or UI (those are #558/#559/#562/#563).
- Adds `sql/031_awcms_mini_tenant_domain_schema.sql` (`awcms_mini_tenant_domains`, tenant-scoped, `ENABLE`+`FORCE ROW LEVEL SECURITY`) and `sql/032_awcms_mini_tenant_domain_permissions.sql` (6-permission `tenant_domain.domains.*` seed), following the same two-file split `blog_content` used (026/027, 029/030).
- Key constraints: `normalized_hostname` unique case-insensitively among non-deleted rows (a dedicated stored column, CHECK-tied to `lower(btrim(hostname))`, not a functional index — matches the issue's explicit ask); at most one active primary domain per tenant; soft delete frees both the hostname and primary slot for reuse.
- No DNS provider secret is ever stored on this table — `verification_token_hash` is a hash (same construction as `password-reset-token.ts`), `verification_record_value` is only ever a public DNS record value.
- **Documents a real architectural finding** for Issue #559 to solve: `FORCE ROW LEVEL SECURITY` on this table (correctly required, not weakened) means the future host-based resolver's `hostname -> tenant_id` bootstrap lookup will need its own narrowly-scoped read path (e.g. a `SECURITY DEFINER` function), since it must run *before* any tenant context/GUC exists — the same problem ADR-0009 solves for `awcms_mini_tenants` by leaving that one table RLS-free, which isn't safe here (this table holds tenant-manageable verification data). Documented in both the migration comment and the skill.
- Updates `awcms-mini-tenant-domain-routing` skill's status table (#557 done) and adds a §Schema section for #558-#567 to reuse.

## Test plan
- [x] `bun run db:migrate` twice — idempotent (2nd run: 0 applied, 32 skipped)
- [x] `bun test tests/integration/tenant-domain-schema.integration.test.ts` — 11 pass
- [x] `bun run typecheck` / `bun run lint` / `bun run check:docs` — PASS
- [x] `bun test` against real PostgreSQL — 948 pass, 0 fail
- [x] `bun run build` — PASS
- [x] Reviewed by `awcms-mini-reviewer` — approved after empirical verification (raw `psql`: case-insensitive uniqueness conflict, primary-domain conflict, RLS cross-tenant isolation including a `WITH CHECK` write-path check, no-secret-column confirmation) and independent cross-check of the RLS bootstrap finding against migration 013's precedent.

## Security notes
No provider credentials stored anywhere on this table (env/secret-manager only, per epic #555's security notes). RLS `ENABLE`+`FORCE`d, verified to fail closed with no GUC set and to block both cross-tenant reads and writes. The RLS-bootstrap gap for the future public resolver is explicitly documented as a problem for #559 to solve narrowly — not worked around here by weakening this table's isolation.

## Next steps
Issue #558 (register `tenant_domain` module descriptor) is next per the epic's dependency order (`Depends on: #557`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)