### PR TITLE
feat(tenant-domain): register tenant domain management module descriptor (Issue #558)

### DIFF
--- a/.changeset/tenant-domain-module-descriptor-issue-558.md
+++ b/.changeset/tenant-domain-module-descriptor-issue-558.md
@@ -1,0 +1,19 @@
+---
+"awcms-mini": minor
+---
+
+Register `tenant_domain` as a first-class AWCMS-Mini module (Issue #558,
+epic #555): `src/modules/tenant-domain/module.ts` declares `type:
+"system"`, `dependencies: ["tenant_admin", "identity_access"]`,
+`api.basePath: "/api/v1/tenant/domains"`, `navigation.path:
+"/admin/tenant/domains"`, the six `tenant_domain.domains.*` permissions
+seeded by `sql/032_awcms_mini_tenant_domain_permissions.sql`
+(`read`/`create`/`update`/`delete`/`verify`/`set_primary`), and
+`settings.defaults: { defaultVerificationMethod: "manual" }` (manual DNS
+mode only — no automatic provider default). Registered in
+`src/modules/index.ts`'s `listModules()` so `bun run modules:sync` picks
+it up and Module Management's permission sync/status report has a
+descriptor to compare the migration 032 seed against. Descriptor
+metadata only — no API implementation, admin UI, host-based resolver, or
+Cloudflare DNS adapter in this issue (those are #559/#562/#563/#567).
+Covered by `tests/modules/tenant-domain-module.test.ts`.

--- a/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
@@ -26,20 +26,20 @@ menjembatani beberapa modul sekaligus (config, `tenant_domain` module baru,
 
 ## Status per issue (jangan bangun ulang yang sudah ada)
 
-| Issue | Scope                                                         | Status                               |
-| ----- | ------------------------------------------------------------- | ------------------------------------ |
-| #556  | Online public mode config (`PUBLIC_*` env vars)               | **Selesai** — lihat §Config di bawah |
-| #557  | Tenant domain/subdomain mapping schema                        | **Selesai** — lihat §Schema di bawah |
-| #558  | Register module descriptor `tenant_domain`                    | Belum                                |
-| #559  | Public host tenant resolver (dengan fallback)                 | Belum                                |
-| #560  | Rute publik `/news` untuk `blog_content`                      | Belum                                |
-| #561  | Dokumentasi legacy `/blog/{tenantCode}`                       | Belum                                |
-| #562  | Tenant domain management API                                  | Belum                                |
-| #563  | Admin UI domain/subdomain                                     | Belum                                |
-| #564  | Tenant settings untuk rute `/news` vs legacy (`blog_content`) | Belum                                |
-| #565  | Tenant module presets (online/news/LAN/minimal)               | Belum                                |
-| #566  | Tenant-module matrix admin UI                                 | Belum                                |
-| #567  | Cloudflare DNS adapter (opsional)                             | Belum                                |
+| Issue | Scope                                                         | Status                                          |
+| ----- | ------------------------------------------------------------- | ----------------------------------------------- |
+| #556  | Online public mode config (`PUBLIC_*` env vars)               | **Selesai** — lihat §Config di bawah            |
+| #557  | Tenant domain/subdomain mapping schema                        | **Selesai** — lihat §Schema di bawah            |
+| #558  | Register module descriptor `tenant_domain`                    | **Selesai** — lihat §Module descriptor di bawah |
+| #559  | Public host tenant resolver (dengan fallback)                 | Belum                                           |
+| #560  | Rute publik `/news` untuk `blog_content`                      | Belum                                           |
+| #561  | Dokumentasi legacy `/blog/{tenantCode}`                       | Belum                                           |
+| #562  | Tenant domain management API                                  | Belum                                           |
+| #563  | Admin UI domain/subdomain                                     | Belum                                           |
+| #564  | Tenant settings untuk rute `/news` vs legacy (`blog_content`) | Belum                                           |
+| #565  | Tenant module presets (online/news/LAN/minimal)               | Belum                                           |
+| #566  | Tenant-module matrix admin UI                                 | Belum                                           |
+| #567  | Cloudflare DNS adapter (opsional)                             | Belum                                           |
 
 ## Yang sudah ada — pakai ulang, jangan re-derive
 
@@ -125,6 +125,48 @@ status, is_primary)`, atau role baca least-privilege terpisah) untuk
   soft-delete-frees-hostname, RLS isolation, fail-closed tanpa GUC, tidak
   ada kolom secret provider).
 
+### Module descriptor (Issue #558, `src/modules/tenant-domain/module.ts`)
+
+Modul `tenant_domain` terdaftar di `src/modules/index.ts`'s `listModules()`
+(12 modul total sekarang). **Hanya descriptor** — tidak ada API/UI/resolver
+di sini, itu semua issue lanjutan.
+
+- `key: "tenant_domain"`, `type: "system"` (bukan `"domain"`/`"integration"`)
+  — modul ini mengelola routing infrastructure yang dipakai bersama SEMUA
+  tenant (resolusi hostname→tenant), bukan fitur bisnis tenant-facing, dan
+  bukan didefinisikan oleh integrasi provider eksternal (Cloudflare adapter
+  #567 opsional/enhancement, bukan sifat inti modul). Alasan sama seperti
+  `module_management`'s `type: "system"`.
+- `dependencies: ["tenant_admin", "identity_access"]`. `isCore` **tidak**
+  di-set (beda dari `module_management`) — tidak ada yang wajib memakai
+  modul ini; tenant yang cuma pakai `/blog/{tenantCode}` legacy tidak
+  pernah butuh domain mapping.
+- `api: { basePath: "/api/v1/tenant/domains", openApiPath:
+"openapi/awcms-mini-public-api.openapi.yaml" }` dan `navigation: [{
+path: "/admin/tenant/domains", requiredPermission:
+"tenant_domain.domains.read", ... }]` **dideklarasikan sekarang**
+  meski API (#562)/UI (#563) belum ada — permintaan eksplisit issue
+  #558's descriptor requirements. Konsekuensi: Module Management's
+  `openApiDocumentedSignal` (readiness check) akan melaporkan `fail`
+  untuk `tenant_domain` sampai #562 menambah path OpenAPI nyata di bawah
+  basePath itu — ini diharapkan, bukan regresi. Nav entry hanya muncul di
+  sidebar untuk pemegang `tenant_domain.domains.read` (belum ada role yang
+  punya izin ini sampai ada assignment eksplisit).
+- `permissions`: 6 entry `tenant_domain.domains.*` (`read`/`create`/
+  `update`/`delete`/`verify`/`set_primary`), match persis dengan seed
+  migration 032 (`activityCode`/`action`/`description` identik) — divalidasi
+  `tests/modules/tenant-domain-module.test.ts`.
+- `settings: { schemaVersion: 1, defaults: { defaultVerificationMethod:
+"manual" } }` — satu-satunya preferensi non-secret yang dideklarasikan;
+  **bukan** default ke `dns_txt`/`dns_cname`/provider otomatis apa pun.
+  Tidak ada field `jobs`/`health` (belum ada command/health-check nyata
+  untuk didokumentasikan, konsisten dengan konvensi
+  `module_management/README.md`).
+- Tidak ada folder `domain/`/`application/` yang dibuat untuk modul ini di
+  Issue #558 — belum ada logic apa pun untuk ditempatkan di sana sampai
+  issue yang benar-benar butuh (#559/#562/#563). Hanya `module.ts` +
+  `README.md`.
+
 ## Aturan lintas-issue yang wajib diikuti
 
 1. **Backward compatibility non-negotiable**: setiap deployment offline/LAN existing yang tidak pernah set `PUBLIC_*` apa pun harus tetap `config:validate` PASS dan berperilaku persis seperti sebelum epic ini — jangan pernah membuat salah satu dari enam var config ini menjadi wajib secara default.
@@ -139,14 +181,14 @@ status, is_primary)`, atau role baca least-privilege terpisah) untuk
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Semua isu #558-#567 (module descriptor `tenant_domain`, resolver
-host-based, rute publik `/news`, dokumentasi legacy, API tenant domain,
-admin UI domain, tenant settings rute `/news`/legacy di `blog_content`,
-module presets, matrix UI admin, dan adapter Cloudflare DNS) **belum ada**
-— hanya lapisan config (#556) dan schema `awcms_mini_tenant_domains`
-(#557) yang selesai. Jangan asumsikan resolver host-based sudah bisa
-dipakai; env var `PUBLIC_PLATFORM_ROOT_DOMAIN`/`PUBLIC_TRUST_PROXY` baru
-**divalidasi dan didokumentasikan**, belum **dikonsumsi** oleh kode
+Isu #559-#567 (resolver host-based, rute publik `/news`, dokumentasi
+legacy, API tenant domain, admin UI domain, tenant settings rute
+`/news`/legacy di `blog_content`, module presets, matrix UI admin, dan
+adapter Cloudflare DNS) **belum ada** — hanya lapisan config (#556),
+schema `awcms_mini_tenant_domains` (#557), dan module descriptor
+`tenant_domain` (#558) yang selesai. Jangan asumsikan resolver host-based
+sudah bisa dipakai; env var `PUBLIC_PLATFORM_ROOT_DOMAIN`/`PUBLIC_TRUST_PROXY`
+baru **divalidasi dan didokumentasikan**, belum **dikonsumsi** oleh kode
 resolver apa pun. Tabel `awcms_mini_tenant_domains` baru berisi schema +
 constraint + RLS + permission catalog seed — belum ada baris yang pernah
 ditulis lewat kode aplikasi (menunggu #562's API), dan belum ada resolver

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -9,6 +9,7 @@ import { profileIdentityModule } from "./profile-identity/module";
 import { reportingModule } from "./reporting/module";
 import { syncStorageModule } from "./sync-storage/module";
 import { tenantAdminModule } from "./tenant-admin/module";
+import { tenantDomainModule } from "./tenant-domain/module";
 import { workflowApprovalModule } from "./workflow-approval/module";
 
 export const modules: ModuleDescriptor[] = [
@@ -22,7 +23,8 @@ export const modules: ModuleDescriptor[] = [
   formDraftsModule,
   emailModule,
   moduleManagementModule,
-  blogContentModule
+  blogContentModule,
+  tenantDomainModule
 ];
 
 export function getModuleByKey(

--- a/src/modules/tenant-domain/README.md
+++ b/src/modules/tenant-domain/README.md
@@ -1,0 +1,144 @@
+# Tenant Domain
+
+Epic #555 (online public tenant routing, `/news` routes, and tenant domain
+management). This module (`key: tenant_domain`) owns hostname/subdomain ->
+tenant mapping so public routes can resolve a tenant without a `tenantCode`
+in the path. See `.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md`
+for the full cross-issue context (config, schema, and everything still
+outstanding across the epic).
+
+## Scope per issue
+
+Issue #556: `PUBLIC_*` env config (`scripts/validate-env.ts`'s
+`checkPublicRoutingConfig`) — resolution mode, default tenant, platform
+root domain, canonical base path, trust-proxy flag. Lives outside this
+module (config, not a module descriptor).
+
+Issue #557: the `awcms_mini_tenant_domains` schema (see §Tables) and its
+permission catalog seed (see §Permission seed).
+
+Issue #558 (this module — `module.ts`): registers `tenant_domain` in the
+trusted code module catalog (`src/modules/index.ts`) so it syncs into
+`awcms_mini_modules` via `bun run modules:sync`, and declares the six
+permissions from migration 032 so Module Management's permission
+sync/status report has something to compare the database seed against.
+**No API, no admin UI, no resolver, no DNS adapter** — see §Not yet
+available below.
+
+## Tables (migration `031_awcms_mini_tenant_domain_schema.sql`, Issue #557)
+
+`awcms_mini_tenant_domains` — one row per hostname/subdomain mapped to a
+tenant. Key columns: `hostname` (raw) + `normalized_hostname` (lowercase +
+trimmed, kept in sync by a CHECK constraint); `domain_type`
+(`subdomain | custom_domain`); `route_mode` (`canonical` -> future `/news`
+routes, Issue #560 | `legacy_blog` -> existing `/blog/{tenantCode}` routes,
+ADR-0009 — column exists, not consumed by any resolver yet); `status`
+(`pending_verification | active | suspended | failed`; soft delete via
+`deleted_at` is a separate, fifth "does not resolve traffic" state);
+`verification_method` (`dns_txt | dns_cname | file | manual`, nullable);
+`verification_token_hash` (sha256 hex, `sha256:`-prefixed, same
+construction as `lib/auth/password-reset-token.ts`'s `hashResetToken` —
+raw token never persisted); `verification_record_name` /
+`verification_record_value` (public DNS record values the tenant
+publishes, never a secret); `is_primary` + `redirect_to_primary`.
+
+Constraints: `awcms_mini_tenant_domains_normalized_hostname_dedup`
+(globally unique across tenants, `WHERE deleted_at IS NULL` — one hostname
+belongs to exactly one tenant); `awcms_mini_tenant_domains_primary_dedup`
+(at most one active primary domain per tenant). Standard soft delete
+(`deleted_at`/`deleted_by`/`delete_reason`) frees a `normalized_hostname`
+for reuse.
+
+RLS: `ENABLE` + `FORCE` with the standard `tenant_isolation` policy — same
+as every other tenant-scoped table. This creates a documented bootstrap
+gap for the future host-based resolver (#559): resolving `hostname ->
+tenant_id` has to happen _before_ a tenant context exists, but FORCE RLS
+plus the fail-closed GUC default (migration 013) means an
+un-tenant-scoped query returns zero rows. `awcms_mini_tenants` solves the
+equivalent bootstrap problem for `tenantCode -> tenant_id` lookups by
+being deliberately RLS-free (migration 013); `tenant_domains` cannot use
+that same trick because it holds tenant-manageable fields
+(`verification_token_hash` etc.). Migration 031's own comments spell out
+the resolution #559 is expected to build (e.g. a narrowly-scoped
+`SECURITY DEFINER` function or a dedicated least-privilege read role for
+that one lookup) — `FORCE ROW LEVEL SECURITY` must not be dropped from
+this table to work around it.
+
+## Permission seed (migration `032_awcms_mini_tenant_domain_permissions.sql`, Issue #557)
+
+Six permissions, `module_key = 'tenant_domain'`, `activity_code =
+'domains'`: `read`, `create`, `update`, `delete`, `verify`, `set_primary`.
+`module.ts`'s `permissions` array mirrors these six entries
+(`activityCode`/`action`/`description`) exactly so Module Management's
+permission sync/status report (`fetchModulePermissionSyncReport`, used by
+the generic `admin/modules/[moduleKey].astro` detail page) shows no
+`missing`/`mismatched_description`/`orphaned` entries for this module. No
+role/access assignment uses these permissions yet — that depends on the
+admin UI (#563) or manual assignment via the existing Access & Users
+screens once the API (#562) exists to authorize against them.
+
+## `module.ts`'s own descriptor
+
+`type: "system"` — this module manages routing infrastructure shared by
+every tenant's public traffic (hostname -> tenant resolution), not a
+tenant-facing business feature (contrast `blog_content`, `type:
+"domain"`), and it is not defined by talking to an external provider
+(contrast `email`, `type` implicitly integration-shaped via its Mailketing
+adapter) — `tenant_domain` is fully functional with `verification_method:
+'manual'` and zero external providers; the optional Cloudflare DNS adapter
+(#567) is a later, optional enhancement, not this module's defining trait.
+Same reasoning `module_management` used for its own `type: "system"`.
+
+`dependencies: ["tenant_admin", "identity_access"]` per the issue.
+`isCore` is **not** set (unlike `module_management`) — nothing about this
+module is required for the platform to function; a tenant that only ever
+uses `/blog/{tenantCode}` legacy routing never needs a domain mapping at
+all.
+
+`api.basePath: "/api/v1/tenant/domains"` and `navigation.path:
+"/admin/tenant/domains"` are declared now even though neither the API
+(#562) nor the admin UI (#563) exist yet, per this issue's own explicit
+descriptor requirements. Two consequences worth knowing about until those
+issues land:
+
+- Module Management's readiness check (`openApiDocumentedSignal`,
+  `application/health-registry.ts`) will report this module's
+  `openapi_documented` signal as `fail` until #562 adds real
+  `/api/v1/tenant/domains` paths to the OpenAPI document — this is
+  expected, not a regression.
+- The navigation entry only ever appears in the admin sidebar for a
+  caller holding `tenant_domain.domains.read`, and (per §Permission seed)
+  no role has that permission yet. If an operator manually grants it via
+  Access & Users before #563 ships, the link will 404 — a known,
+  low-probability gap accepted for this issue rather than withholding the
+  descriptor requirement the issue asked for.
+
+`settings.defaults: { defaultVerificationMethod: "manual" }` — the only
+non-secret operational preference this module currently declares
+(`settings.schemaVersion: 1`). It intentionally does **not** default to
+`dns_txt`/`dns_cname`/any automated provider mode; those still require an
+operator/tenant to explicitly opt in per domain. No field here is, or
+ever will be, a runtime secret/token/credential — a hard rule from
+`module-contract.ts`'s header comment, checked by
+`tests/modules/tenant-domain-module.test.ts`.
+
+## Not yet available
+
+- Public host-based tenant resolver with offline/LAN fallback (Issue
+  #559) — including the RLS bootstrap-gap resolution described in
+  §Tables.
+- Tenant domain management API, `/api/v1/tenant/domains` (Issue #562).
+- Admin UI, `/admin/tenant/domains` (Issue #563).
+- `/news` public routes for `blog_content` (Issue #560) and the tenant
+  setting that chooses between `/news` and legacy `/blog/{tenantCode}`
+  (Issue #564).
+- Optional Cloudflare DNS adapter (Issue #567) — explicitly out of scope
+  for the whole epic as a hard dependency; manual DNS setup by the
+  operator must keep working without it.
+
+No `jobs` or `health` are declared on this module's descriptor yet — both
+fields exist on `ModuleDescriptor` but, consistent with
+`module_management`'s own README ("a descriptor should only claim a
+capability once the corresponding feature is real, not in advance"),
+there is no scheduled command or health check to describe until a later
+issue adds one.

--- a/src/modules/tenant-domain/module.ts
+++ b/src/modules/tenant-domain/module.ts
@@ -1,0 +1,94 @@
+import { defineModule } from "../_shared/module-contract";
+
+/**
+ * `tenant_domain` (Issue #558, epic #555 — online public tenant routing &
+ * tenant domain management). This issue registers the **module descriptor
+ * only** — no API (#562), no admin UI (#563), no host-based resolver
+ * (#559), no Cloudflare DNS adapter (#567). The descriptor exists now so
+ * the database-backed module registry (Module Management, epic #510) can
+ * track this module's lifecycle/permissions/settings from day one, the
+ * same "register the descriptor before the feature is fully built" order
+ * every other module in this repo has followed since Issue #511.
+ *
+ * `type: "system"` (not `"domain"` or `"integration"`): this module
+ * manages hostname/subdomain -> tenant mapping consumed by every public
+ * route (the resolver in #559, and eventually every `/news` request in
+ * #560) — it is routing/platform infrastructure that all tenants share the
+ * mechanism of, not a tenant-facing business feature (contrast
+ * `blog_content`, `type: "domain"`). It is also not `"integration"`:
+ * that type fits a module whose primary job is talking to an external
+ * provider (e.g. `email`'s Mailketing adapter) — `tenant_domain` works
+ * fully with `verification_method: 'manual'` and zero external providers;
+ * the optional Cloudflare DNS adapter (#567) is an enhancement bolted on
+ * later, not this module's defining trait. `"system"` matches
+ * `module_management`'s own reasoning: generic platform infrastructure
+ * that other modules/tenants depend on, not a domain feature.
+ */
+export const tenantDomainModule = defineModule({
+  key: "tenant_domain",
+  name: "Tenant Domain",
+  version: "0.1.0",
+  status: "active",
+  description:
+    "Tenant domain/subdomain mapping for online-primary public routing (epic #555). Issue #557 added the `awcms_mini_tenant_domains` schema (migration 031: hostname/normalized_hostname, domain_type subdomain|custom_domain, route_mode canonical|legacy_blog, status pending_verification|active|suspended|failed, verification_method dns_txt|dns_cname|file|manual, is_primary/redirect_to_primary, tenant-scoped RLS with FORCE) and its permission catalog seed (migration 032: tenant_domain.domains.{read,create,update,delete,verify,set_primary}). Issue #558 (this descriptor) registers the module in the trusted code catalog so it syncs into `awcms_mini_modules` and its six permissions sync/report cleanly against the migration 032 seed. Still to come: the public host-based tenant resolver with offline/LAN fallback (#559), the tenant domain management API (#562), the admin UI (#563), and an optional Cloudflare DNS adapter (#567) — none of those exist yet. This module never stores a DNS provider API token/credential; `verification_token_hash` (migration 031) is an internal bearer-token hash, and `verification_record_value` is the public DNS record value the tenant publishes, not a secret.",
+  dependencies: ["tenant_admin", "identity_access"],
+  type: "system",
+  api: {
+    openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
+    basePath: "/api/v1/tenant/domains"
+  },
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_tenant_domains",
+      path: "/admin/tenant/domains",
+      order: 60,
+      requiredPermission: "tenant_domain.domains.read"
+    }
+  ],
+  permissions: [
+    {
+      activityCode: "domains",
+      action: "read",
+      description: "Read tenant domain/subdomain mappings"
+    },
+    {
+      activityCode: "domains",
+      action: "create",
+      description: "Add a tenant domain/subdomain mapping"
+    },
+    {
+      activityCode: "domains",
+      action: "update",
+      description: "Update a tenant domain/subdomain mapping"
+    },
+    {
+      activityCode: "domains",
+      action: "delete",
+      description: "Soft delete a tenant domain/subdomain mapping"
+    },
+    {
+      activityCode: "domains",
+      action: "verify",
+      description: "Verify ownership of a tenant domain/subdomain"
+    },
+    {
+      activityCode: "domains",
+      action: "set_primary",
+      description: "Set a tenant domain as the active primary domain"
+    }
+  ],
+  settings: {
+    schemaVersion: 1,
+    // Non-secret operational preference only (module-contract.ts's header
+    // rule): the default domain verification mode is manual DNS
+    // attestation, never an automatic provider. This is not a default of
+    // "dns_txt"/"dns_cname" — those still require an operator/tenant to
+    // publish a DNS record themselves; "manual" means no automated check
+    // at all is assumed until a tenant/operator explicitly picks one of
+    // the other `verification_method` values (migration 031). The
+    // optional Cloudflare DNS adapter (#567) may later add its own
+    // provider-mode setting, but it will never default this value away
+    // from manual on its own.
+    defaults: { defaultVerificationMethod: "manual" }
+  }
+});

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -58,8 +58,8 @@ describe("soft delete helper", () => {
 });
 
 describe("module registry", () => {
-  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, email, module_management, and blog_content are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498, #511-#513, #537", () => {
-    expect(listModules()).toHaveLength(11);
+  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, email, module_management, blog_content, and tenant_domain are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498, #511-#513, #537, #558", () => {
+    expect(listModules()).toHaveLength(12);
     expect(getModuleByKey("tenant_admin")).toMatchObject({
       key: "tenant_admin",
       status: "active"
@@ -116,6 +116,12 @@ describe("module registry", () => {
       version: "0.7.0",
       status: "active",
       type: "domain",
+      dependencies: ["tenant_admin", "identity_access"]
+    });
+    expect(getModuleByKey("tenant_domain")).toMatchObject({
+      key: "tenant_domain",
+      status: "active",
+      type: "system",
       dependencies: ["tenant_admin", "identity_access"]
     });
     expect(getModuleByKey("unknown_module")).toBeUndefined();

--- a/tests/modules/tenant-domain-module.test.ts
+++ b/tests/modules/tenant-domain-module.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+
+import { getModuleByKey, listModules } from "../../src/modules";
+import { tenantDomainModule } from "../../src/modules/tenant-domain/module";
+
+// Issue #558 (epic #555) — the six permissions seeded by
+// sql/032_awcms_mini_tenant_domain_permissions.sql, verbatim. The
+// descriptor's `permissions` array must match this list exactly
+// (activityCode/action/description) or Module Management's permission
+// sync/status report will show `missing`/`mismatched_description` for
+// this module.
+const MIGRATION_032_PERMISSIONS = [
+  {
+    activityCode: "domains",
+    action: "read",
+    description: "Read tenant domain/subdomain mappings"
+  },
+  {
+    activityCode: "domains",
+    action: "create",
+    description: "Add a tenant domain/subdomain mapping"
+  },
+  {
+    activityCode: "domains",
+    action: "update",
+    description: "Update a tenant domain/subdomain mapping"
+  },
+  {
+    activityCode: "domains",
+    action: "delete",
+    description: "Soft delete a tenant domain/subdomain mapping"
+  },
+  {
+    activityCode: "domains",
+    action: "verify",
+    description: "Verify ownership of a tenant domain/subdomain"
+  },
+  {
+    activityCode: "domains",
+    action: "set_primary",
+    description: "Set a tenant domain as the active primary domain"
+  }
+];
+
+describe("tenant_domain module descriptor (Issue #558)", () => {
+  test("listModules() includes tenant_domain", () => {
+    expect(listModules().some((m) => m.key === "tenant_domain")).toBe(true);
+    expect(getModuleByKey("tenant_domain")).toBe(tenantDomainModule);
+  });
+
+  test("descriptor shape matches the issue's requirements", () => {
+    expect(tenantDomainModule.key).toBe("tenant_domain");
+    expect(tenantDomainModule.status).toBe("active");
+    // "system" (not "domain"/"integration") — routing infrastructure
+    // shared by every tenant, not a business feature and not defined by
+    // an external provider integration (see module.ts's own comment for
+    // the full reasoning).
+    expect(tenantDomainModule.type).toBe("system");
+    expect(tenantDomainModule.dependencies).toEqual([
+      "tenant_admin",
+      "identity_access"
+    ]);
+  });
+
+  test("api.basePath matches the issue's requirement", () => {
+    expect(tenantDomainModule.api?.basePath).toBe("/api/v1/tenant/domains");
+    expect(tenantDomainModule.api?.openApiPath).toBe(
+      "openapi/awcms-mini-public-api.openapi.yaml"
+    );
+  });
+
+  test("navigation.path matches the issue's requirement and is permission-gated", () => {
+    expect(tenantDomainModule.navigation).toHaveLength(1);
+    expect(tenantDomainModule.navigation?.[0]?.path).toBe(
+      "/admin/tenant/domains"
+    );
+    expect(tenantDomainModule.navigation?.[0]?.requiredPermission).toBe(
+      "tenant_domain.domains.read"
+    );
+  });
+
+  test("permissions array matches migration 032's seed exactly", () => {
+    expect(tenantDomainModule.permissions).toEqual(MIGRATION_032_PERMISSIONS);
+  });
+
+  test("permissions use the same module_key/activity_code the migration seeded", () => {
+    // permissionKey convention used across the codebase is
+    // `${moduleKey}.${activityCode}.${action}` — assert the descriptor's
+    // own key plus every permission entry reproduces exactly the six
+    // `tenant_domain.domains.*` keys the migration seeded.
+    const permissionKeys = (tenantDomainModule.permissions ?? []).map(
+      (p) => `${tenantDomainModule.key}.${p.activityCode}.${p.action}`
+    );
+
+    expect(permissionKeys).toEqual([
+      "tenant_domain.domains.read",
+      "tenant_domain.domains.create",
+      "tenant_domain.domains.update",
+      "tenant_domain.domains.delete",
+      "tenant_domain.domains.verify",
+      "tenant_domain.domains.set_primary"
+    ]);
+  });
+
+  test("settings.defaults only sets manual DNS verification mode, nothing provider-specific", () => {
+    expect(tenantDomainModule.settings?.defaults).toEqual({
+      defaultVerificationMethod: "manual"
+    });
+  });
+
+  test("settings.defaults never contains a secret-shaped key or value", () => {
+    const defaults = tenantDomainModule.settings?.defaults ?? {};
+    const serialized = JSON.stringify(defaults).toLowerCase();
+
+    for (const forbidden of [
+      "password",
+      "token",
+      "secret",
+      "credential",
+      "apikey",
+      "api_key"
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+
+    // The only allowed default value is the manual verification mode —
+    // never an automated provider mode (Cloudflare, #567, is opt-in only
+    // and out of scope for this issue).
+    expect(defaults).not.toHaveProperty("provider");
+    expect(defaults).not.toHaveProperty("cloudflareApiToken");
+  });
+
+  test("the module never declares jobs or health before those capabilities are real", () => {
+    // Consistent with module_management's own README convention: a
+    // descriptor should only claim jobs/health once the corresponding
+    // feature exists. Neither exists for tenant_domain as of Issue #558.
+    expect(tenantDomainModule.jobs).toBeUndefined();
+    expect(tenantDomainModule.health).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Third issue of epic #555 (online public tenant routing & tenant domain management), depends on #557 (schema, merged). Descriptor-only — no API, UI, or resolver logic (those are #559/#562/#563).
- Adds `src/modules/tenant-domain/module.ts` + `README.md`, registers in `src/modules/index.ts`.
- `type: "system"` — shared routing infrastructure used by all tenants (hostname→tenant mapping), not a tenant-facing business feature or a provider-integration module; same reasoning `module_management` uses for its own `type: "system"`.
- `settings.defaults: { defaultVerificationMethod: "manual" }` — the only non-secret operational preference declared, per the issue's explicit "prefer manual mode as default" instruction. No provider auto-default.
- The 6 declared permissions match `sql/032_awcms_mini_tenant_domain_permissions.sql`'s seed character-for-character (`activityCode`/`action`/`description`) — verified via a live `fetchModulePermissionSyncReport` call against real Postgres: all 6 report `synced`, zero missing/orphaned/mismatched.
- No `domain/`/`application/` folders created — nothing to put in them until a later issue adds real logic (consistent with "declare a capability only when it's real").
- Updates `awcms-mini-tenant-domain-routing` skill (#558 done) with a module descriptor section for #559-#567 to reuse.

## Test plan
- [x] `bun test tests/modules/tenant-domain-module.test.ts` — 9 pass
- [x] `bun run modules:sync` against real Postgres — synced cleanly, `tenant_domain` present in `awcms_mini_modules`
- [x] Permission sync report — all 6 permissions `synced`, no missing/orphaned/mismatched
- [x] `bun run typecheck` / `bun run lint` / `bun run check:docs` / `bun run api:spec:check` — PASS
- [x] `bun test` against real PostgreSQL — 957 pass, 0 fail
- [x] `bun run build` — PASS
- [x] Reviewed by `awcms-mini-reviewer` — approved, every acceptance criterion independently verified against a live DB (not just read)

## Security notes
No secret/token/credential anywhere in the descriptor (grepped + asserted by test). Module Management detail page displays this module generically with no hardcoded allowlist to update.

## Next steps
Issue #559 (public host tenant resolver, `Depends on: #556, #557` — both merged) is next; it also needs to resolve the RLS-bootstrap gap documented in #557's migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)