### PR TITLE
feat(tenant): resolve public tenant by host with safe fallback (Issue #559)

### DIFF
--- a/.changeset/public-host-tenant-resolver-issue-559.md
+++ b/.changeset/public-host-tenant-resolver-issue-559.md
@@ -1,0 +1,60 @@
+---
+"awcms-mini": minor
+---
+
+Add the public host tenant resolver (Issue #559, epic #555):
+`src/lib/tenant/public-host-tenant-resolver.ts` resolves the public tenant
+for anonymous requests from `Host`/domain/subdomain, then falls back
+safely to `PUBLIC_DEFAULT_TENANT_ID` -> `PUBLIC_DEFAULT_TENANT_CODE` ->
+`awcms_mini_setup_state.tenant_id` -> generic `null` (404). Host-based
+lookup only runs when `PUBLIC_TENANT_RESOLUTION_MODE=host_default`; the
+env/setup fallback chain always runs regardless of mode, so existing
+offline/LAN deployments that never set `PUBLIC_*` never touch the new
+lookup path at all. `X-Forwarded-Host` is read only when
+`PUBLIC_TRUST_PROXY=true` is explicitly passed by the caller. Every
+failure case (unknown host, non-`active` domain status, soft-deleted
+domain, inactive tenant) returns an identical `null` — no distinguishable
+signal.
+
+Adds `sql/033_awcms_mini_tenant_domain_lookup_function.sql`, a narrowly
+scoped `SECURITY DEFINER` function
+(`awcms_mini_resolve_tenant_domain_lookup`) that closes the RLS bootstrap
+gap flagged in migration 031: it is the single sanctioned read path for
+`hostname -> tenant` before any tenant context exists. It joins the
+already-RLS-free `awcms_mini_tenants` row into the same call (no new
+privilege exposure — those columns are unconditionally public already)
+so `resolvePublicTenantByHost` completes in exactly one DB round trip for
+every outcome, closing a timing side-channel an earlier version had
+between "unmapped host" and "mapped but inactive tenant". `EXECUTE` is
+`REVOKE`d from `PUBLIC` and granted only to `awcms_mini_app`. `FORCE ROW
+LEVEL SECURITY` remains on `awcms_mini_tenant_domains` — direct queries
+against the table from the app role still return zero rows without a
+tenant GUC, proven alongside the function's bypass behavior and its
+single-round-trip property in
+`tests/integration/public-tenant-resolution.integration.test.ts`.
+
+`X-Forwarded-Host` handling also hardens against a misconfigured/spoofed
+multi-value header: if it ever contains more than one comma-separated
+value (never expected for this repo's documented single-trusted-proxy
+topology), the resolver does not guess which entry is trustworthy — it
+logs the anomaly and falls back to the plain `Host` header, exactly as if
+`PUBLIC_TRUST_PROXY` were `false` for that request. The requirement that a
+trusted proxy must fully overwrite (never append to) `X-Forwarded-Host` is
+now documented as binding in
+`docs/awcms-mini/18_configuration_env_reference.md`,
+`docs/awcms-mini/deployment-profiles.md`, and the
+`awcms-mini-tenant-domain-routing` skill.
+
+A general "Using `SECURITY DEFINER`" checklist (owner-is-superuser
+verification, static/parameterized body, minimal returned columns,
+explicit `EXECUTE` grant, `search_path` pinning, empirical verification,
+timing-side-channel awareness) is added to
+`docs/adr/0003-postgresql-rls-multi-tenant.md` and the
+`awcms-mini-new-migration` skill, referencing migration 033 as the
+canonical example, so future `SECURITY DEFINER` functions in this repo
+don't have to rediscover these rules from scratch.
+
+Library only — not yet consumed by any route/endpoint (that is Issue
+#560's `/news` routes). Covered by
+`tests/unit/public-host-tenant-resolver.test.ts` and
+`tests/integration/public-tenant-resolution.integration.test.ts`.

--- a/.claude/skills/awcms-mini-new-migration/SKILL.md
+++ b/.claude/skills/awcms-mini-new-migration/SKILL.md
@@ -68,6 +68,36 @@ CREATE POLICY awcms_mini_<name>_tenant_isolation ON awcms_mini_<name>
 COMMIT;
 ```
 
+## Menggunakan `SECURITY DEFINER` (bootstrap read sebelum tenant context ada)
+
+Kadang sebuah query harus jalan **sebelum** tenant context ada sama sekali
+(mis. resolusi publik `hostname`/`tenantCode` -> `tenant_id`), padahal
+tabelnya `FORCE ROW LEVEL SECURITY`. Jangan lepas `FORCE ROW LEVEL
+SECURITY` untuk mengakalinya — buat fungsi `SECURITY DEFINER` yang sempit.
+Checklist wajib (detail lengkap + alasan tiap butir:
+`docs/adr/0003-postgresql-rls-multi-tenant.md` §Checklist; contoh kanonik:
+`sql/033_awcms_mini_tenant_domain_lookup_function.sql`, Issue #559):
+
+1. Konfirmasi role pemilik migration benar-benar superuser (`SELECT
+rolsuper FROM pg_roles`) — keamanan mekanisme ini datang dari situ, bukan
+   dari RLS/`FORCE`.
+2. Body fungsi SQL statis/tetap, parameter selalu argumen fungsi
+   diparameterkan — tidak ada dynamic SQL/string concatenation.
+3. Minimalkan kolom yang di-return — tidak ada kolom sensitif kecuali
+   benar-benar dibutuhkan.
+4. `REVOKE ALL ... FROM PUBLIC` lalu `GRANT EXECUTE` eksplisit ke role
+   spesifik (mis. `awcms_mini_app`) — ini **tidak** otomatis tercakup
+   `ALTER DEFAULT PRIVILEGES` migration 013 (itu hanya tabel/sequence).
+5. `SET search_path = public, pg_temp` di definisi fungsi.
+6. `STABLE`/`IMMUTABLE` untuk fungsi read-only, bukan `VOLATILE` default.
+7. Verifikasi empiris terhadap DB yang berjalan (bukan asumsi dari
+   dokumentasi PostgreSQL semata) sebelum melaporkan mekanisme ini aman.
+8. Kalau ada query kedua yang kondisional setelah fungsi ini (mis. "kalau
+   baris ditemukan, query lagi ke tabel lain"), pertimbangkan apakah beda
+   jumlah round-trip antar outcome jadi timing side-channel — gabungkan
+   jadi satu query via `JOIN` kalau tabel kedua sudah RLS-free/publicly
+   readable.
+
 ## Append-only & immutable
 
 - Posted sales document & stock movement: **append-only**, tidak di-update/delete. Koreksi lewat reversal/return/adjustment.

--- a/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
@@ -31,7 +31,7 @@ menjembatani beberapa modul sekaligus (config, `tenant_domain` module baru,
 | #556  | Online public mode config (`PUBLIC_*` env vars)               | **Selesai** — lihat §Config di bawah            |
 | #557  | Tenant domain/subdomain mapping schema                        | **Selesai** — lihat §Schema di bawah            |
 | #558  | Register module descriptor `tenant_domain`                    | **Selesai** — lihat §Module descriptor di bawah |
-| #559  | Public host tenant resolver (dengan fallback)                 | Belum                                           |
+| #559  | Public host tenant resolver (dengan fallback)                 | **Selesai** — lihat §Resolver di bawah          |
 | #560  | Rute publik `/news` untuk `blog_content`                      | Belum                                           |
 | #561  | Dokumentasi legacy `/blog/{tenantCode}`                       | Belum                                           |
 | #562  | Tenant domain management API                                  | Belum                                           |
@@ -103,19 +103,12 @@ tenant. **Schema saja**, belum ada module descriptor (#558), resolver
   (`deleted_at`/`deleted_by`/`delete_reason`) membebaskan
   `normalized_hostname` untuk dipakai ulang.
 - RLS: `ENABLE` + `FORCE` + policy `tenant_isolation` standar (sama pola
-  semua tabel tenant-scoped lain) — **tapi ini menciptakan bootstrap gap
-  yang wajib diselesaikan #559**: query hostname→tenant_id butuh
-  dijalankan SEBELUM tenant context ada, sementara FORCE RLS + fail-closed
-  GUC (migration 013) membuat query tanpa `withTenant` selalu 0 baris.
-  `awcms_mini_tenants` (migration 013) sengaja RLS-free untuk masalah
-  bootstrap yang sama persis (lookup `tenantCode → tenant_id`, ADR-0009),
-  tapi `tenant_domains` TIDAK BOLEH ikut jadi RLS-free (kolom
-  `verification_token_hash` dkk. tenant-manageable). Resolusi yang
-  didokumentasikan di migration 031's komentar untuk #559: buat jalur baca
-  khusus (mis. fungsi `SECURITY DEFINER` yang cuma return `(tenant_id,
-status, is_primary)`, atau role baca least-privilege terpisah) untuk
-  satu query bootstrap ini — jangan lepas `FORCE ROW LEVEL SECURITY` dari
-  tabel ini untuk mengakalinya.
+  semua tabel tenant-scoped lain) — ini menciptakan bootstrap gap
+  (query hostname→tenant_id butuh dijalankan SEBELUM tenant context ada,
+  sementara FORCE RLS + fail-closed GUC dari migration 013 membuat query
+  tanpa `withTenant` selalu 0 baris), yang **sudah diselesaikan Issue #559**
+  lewat fungsi `SECURITY DEFINER` — lihat §Resolver di bawah untuk mekanisme
+  lengkap. `FORCE ROW LEVEL SECURITY` **tidak** dilepas dari tabel ini.
 - Permission seed: `module_key` `tenant_domain`, `activity_code` `domains`
   — `read`/`create`/`update`/`delete`/`verify`/`set_primary` (persis
   §Seed permissions issue #557). Belum ada role/access assignment yang
@@ -167,31 +160,175 @@ path: "/admin/tenant/domains", requiredPermission:
   issue yang benar-benar butuh (#559/#562/#563). Hanya `module.ts` +
   `README.md`.
 
+### Resolver (Issue #559, `src/lib/tenant/public-host-tenant-resolver.ts`)
+
+**Library saja** — belum dikonsumsi endpoint/route apa pun (itu #560). Lima
+fungsi: `normalizePublicHost`, `resolvePublicTenantByHost`,
+`resolveDefaultPublicTenantFromEnv`, `resolveDefaultPublicTenantFromSetupState`,
+`resolvePublicTenantFromRequest` (orkestrator).
+
+**Urutan resolusi**: (1) host/domain mapping — HANYA jalan kalau
+`config.mode === "host_default"` — → (2) `PUBLIC_DEFAULT_TENANT_ID` → (3)
+`PUBLIC_DEFAULT_TENANT_CODE` (2-3 satu fungsi,
+`resolveDefaultPublicTenantFromEnv`, coba ID dulu lalu CODE) → (4)
+`awcms_mini_setup_state.tenant_id` → (5) `null` (404 generic). **Langkah
+2-4 SELALU jalan, terlepas dari mode** — itu "safe fallback" di judul
+issue; hanya langkah 1 (host lookup) yang digerbangi mode. Konsekuensi
+keamanan yang disengaja: deployment yang tidak pernah set
+`PUBLIC_TENANT_RESOLUTION_MODE=host_default` (termasuk semua deployment
+offline/LAN existing yang tidak set `PUBLIC_*` sama sekali) TIDAK PERNAH
+menyentuh fungsi bootstrap `awcms_mini_tenant_domains` — permukaan lebih
+kecil, bukan cuma code path lebih pendek.
+
+**Fungsi `SECURITY DEFINER` bootstrap** — `sql/033_awcms_mini_tenant_domain_lookup_function.sql`
+(pakai checklist umum `SECURITY DEFINER` di
+`docs/adr/0003-postgresql-rls-multi-tenant.md` §Checklist untuk fungsi baru
+lain di masa depan):
+
+```sql
+CREATE OR REPLACE FUNCTION awcms_mini_resolve_tenant_domain_lookup(p_normalized_hostname text)
+RETURNS TABLE (
+  tenant_id uuid, domain_status text, is_primary boolean, route_mode text,
+  tenant_status text, tenant_code text, tenant_name text, default_locale text
+)
+LANGUAGE sql SECURITY DEFINER STABLE
+SET search_path = public, pg_temp
+AS $function$
+  SELECT d.tenant_id, d.status AS domain_status, d.is_primary, d.route_mode,
+         t.status AS tenant_status, t.tenant_code, t.tenant_name, t.default_locale
+  FROM awcms_mini_tenant_domains AS d
+  JOIN awcms_mini_tenants AS t ON t.id = d.tenant_id
+  WHERE d.normalized_hostname = p_normalized_hostname AND d.deleted_at IS NULL;
+$function$;
+
+REVOKE ALL ON FUNCTION awcms_mini_resolve_tenant_domain_lookup(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION awcms_mini_resolve_tenant_domain_lookup(text) TO awcms_mini_app;
+```
+
+**Post-review fix (timing side-channel, Medium finding):** the first
+version of this function returned only `(tenant_id, status, is_primary,
+route_mode)`, and `resolvePublicTenantByHost()` issued a SECOND,
+conditional query against `awcms_mini_tenants` only when the domain row
+was found `active` — an unknown/unmapped host returned after exactly one
+round trip, a host mapped to an active domain but an inactive tenant
+always cost two. That is an observable timing side-channel distinguishing
+"no such mapping" from "mapping exists, tenant just isn't active" purely
+by response latency. Fixed by joining `awcms_mini_tenants` into this same
+function (safe — that table is already RLS-free/publicly `SELECT`-able,
+so the join exposes nothing not already unconditionally public; it only
+removes a round trip) so `resolvePublicTenantByHost()` now issues **exactly
+one query for every outcome**, proven by
+`tests/integration/public-tenant-resolution.integration.test.ts`'s
+round-trip-counting test (wraps the same `sql` client in a `Proxy` and
+asserts the call count is 1 for an unmapped host, a mapped-but-inactive-
+tenant host, and a fully active host alike).
+
+Kenapa ini aman — **diverifikasi empiris** (bukan diasumsikan dari
+dokumentasi PostgreSQL) terhadap DB yang jalan sebelum migration ini
+ditulis, lihat percobaan di riwayat implementasi Issue #559:
+
+- Migration jalan sebagai role pemilik schema (`POSTGRES_USER`,
+  `awcms-mini` di `docker-compose.yml`), dan role itu adalah **Postgres
+  SUPERUSER sungguhan** (`SELECT rolsuper FROM pg_roles` → `true`).
+  Superuser bypass RLS **unconditional**, terlepas dari `FORCE ROW LEVEL
+SECURITY` — `FORCE` hanya menghapus exemption RLS milik _table owner_
+  ketika owner itu BUKAN superuser; tidak berefek pada owner yang memang
+  superuser. Jadi fungsi `SECURITY DEFINER` yang dimiliki role ini bypass
+  RLS dengan cara yang sama seperti DDL/DML migration lain di schema ini
+  — bukan mekanisme RLS-vs-FORCE yang berbeda.
+- Karena keamanan TIDAK datang dari RLS/FORCE di level fungsi ini, dua hal
+  lain yang justru jadi pagar sebenarnya: (1) badan fungsi adalah SQL
+  statis tetap (bukan dynamic SQL), hanya me-return 4 kolom non-sensitif
+  (`tenant_id`/`status`/`is_primary`/`route_mode`) untuk satu
+  `normalized_hostname` yang diparameterkan + `deleted_at IS NULL` — tidak
+  mungkin dipakai membaca `verification_token_hash`/
+  `verification_record_value`/`hostname` mentah/tabel lain; (2) `EXECUTE`
+  di-revoke dari `PUBLIC` lalu di-grant eksplisit hanya ke `awcms_mini_app`
+  — tidak ada role non-superuser lain yang bisa memanggil fungsi ini, dan
+  `awcms_mini_app` sendiri tetap tidak bisa `SELECT` langsung dari
+  `awcms_mini_tenant_domains` tanpa `withTenant(...)` (dibuktikan di
+  integration test).
+- `SET search_path = public, pg_temp` mengunci resolusi nama di dalam
+  fungsi (defense-in-depth standar untuk `SECURITY DEFINER`, terlepas dari
+  fakta ownernya sudah superuser).
+- Diverifikasi di
+  `tests/integration/public-tenant-resolution.integration.test.ts`: fungsi
+  ini resolve rows lewat `awcms_mini_app` TANPA `app.current_tenant_id`
+  GUC di-set; `SELECT` langsung ke tabel dari koneksi yang sama (tanpa
+  fungsi) tetap 0 baris; kolom yang dikembalikan fungsi tidak pernah
+  memuat `verification_token_hash`/`hostname`/`verification_record_value`.
+
+`resolvePublicTenantByHost()` sendiri masih menambah filter
+`domain_status === 'active' && tenant_status === 'active'` di sisi
+TypeScript (fungsi SQL sengaja tidak memfilter status — hanya
+`deleted_at IS NULL` — supaya keputusan "kombinasi status mana yang boleh
+resolve traffic publik" tetap satu tempat, di kode aplikasi yang lebih
+mudah diaudit/diubah daripada re-migrate SQL). Fungsi ini juga
+me-revalidasi _shape_ `normalizedHost` sendiri (`isValidHostnameShape`,
+Low finding — fungsi ini exported dan didokumentasikan bisa dipanggil
+langsung oleh #560, jadi tidak boleh hanya mengandalkan "caller sudah
+normalize duluan") sebelum query apa pun dijalankan — dibuktikan di
+`tests/unit/public-host-tenant-resolver.test.ts` dengan `sql` palsu yang
+throw kalau dipanggil sama sekali.
+
+Semua kegagalan — host tidak dikenal, domain non-`active`, domain
+soft-deleted, tenant inactive — return `null` yang identik, dalam **satu**
+round-trip DB (lihat perbaikan timing side-channel di atas); satu-satunya
+yang boleh throw adalah `normalizePublicHost()` dipanggil dengan string
+kosong (pelanggaran kontrak pemanggil, bukan hasil resolusi runtime).
+`resolvePublicTenantFromRequest()` tidak pernah memanggil
+`normalizePublicHost` dengan string kosong — request tanpa `Host` header
+cukup melewati langkah 1 seluruhnya.
+
+`X-Forwarded-Host` hanya dibaca kalau `config.trustProxy === true`
+(caller yang menentukan, bukan modul ini yang membaca `PUBLIC_TRUST_PROXY`
+langsung dari `process.env` — pemanggil bertanggung jawab membangun
+`config` dari env; lihat `resolveDefaultPublicTenantFromEnv`'s parameter
+`env` untuk satu-satunya fungsi di modul ini yang punya default
+`process.env` bawaan). **Aturan operasional mengikat (Medium finding,
+post-review):** deployment yang set `PUBLIC_TRUST_PROXY=true` WAJIB
+berada di belakang satu trusted edge proxy yang langsung bersebelahan
+(directly-adjacent) dan yang MENIMPA (overwrite) `X-Forwarded-Host` secara
+penuh di setiap request — tidak pernah append/forward nilai dari client.
+Topologi yang didokumentasikan repo ini tidak pernah menghasilkan lebih
+dari satu nilai `X-Forwarded-Host` secara sah. Kalau header tetap berisi
+lebih dari satu nilai comma-separated saat runtime, `extractHostHeader()`
+TIDAK menebak mana yang trustworthy (leftmost = persis yang bisa
+di-pre-seed penuh oleh attacker kalau proxy-nya append, bukan overwrite) —
+ia log anomali (`public_host_resolver.x_forwarded_host_multi_value`) dan
+fallback ke `Host` biasa, persis seperti `trustProxy: false`. Perilaku ini
+diuji di `tests/unit/public-host-tenant-resolver.test.ts`.
+
+Test: `tests/unit/public-host-tenant-resolver.test.ts` (murni,
+`normalizePublicHost` + percabangan `resolvePublicTenantFromRequest` lewat
+mocked `deps`, tanpa DB) dan
+`tests/integration/public-tenant-resolution.integration.test.ts` (Postgres
+nyata — setiap acceptance criterion issue #559, termasuk bukti RLS/bypass
+di atas).
+
 ## Aturan lintas-issue yang wajib diikuti
 
 1. **Backward compatibility non-negotiable**: setiap deployment offline/LAN existing yang tidak pernah set `PUBLIC_*` apa pun harus tetap `config:validate` PASS dan berperilaku persis seperti sebelum epic ini — jangan pernah membuat salah satu dari enam var config ini menjadi wajib secara default.
-2. **`PUBLIC_TRUST_PROXY=false` harus tetap default aman** di setiap lapisan baru (resolver #559, dst.) — jangan baca `X-Forwarded-Host`/`X-Forwarded-Proto` kecuali `PUBLIC_TRUST_PROXY=true` eksplisit diset.
+2. **`PUBLIC_TRUST_PROXY=false` harus tetap default aman** di setiap lapisan baru — jangan baca `X-Forwarded-Host`/`X-Forwarded-Proto` kecuali `PUBLIC_TRUST_PROXY=true` eksplisit diset. Resolver #559 sudah menegakkan ini (`resolvePublicTenantFromRequest`'s `config.trustProxy`, default `false`); API domain #562 manapun yang membaca header host langsung (bukan lewat resolver ini) wajib pola yang sama.
 3. **`/blog/{tenantCode}` (ADR-0009, skill `awcms-mini-blog-content`) TIDAK dihapus** — epic #555 secara eksplisit out-of-scope untuk "removing legacy `/blog/{tenantCode}` routes in the MVP". `/news` (#560) adalah rute **tambahan**, bukan pengganti. Issue #561 mendokumentasikan `/blog/{tenantCode}` sebagai legacy, bukan menghapusnya.
-4. **Jangan trust `X-Forwarded-Host` tanpa proxy tepercaya** — ulangi dari epic #555 §Security notes, berlaku untuk resolver #559 dan API domain #562 manapun yang membaca header host.
-5. **Tenant existence tidak boleh bocor**: domain/tenant yang unknown, failed, suspended, atau inactive harus menghasilkan respons yang identik/tidak bisa dibedakan (pola sama seperti ADR-0009's 404 identik untuk `tenantCode` tak dikenal vs tenant tidak aktif) — berlaku untuk resolver #559 dan rute publik `/news` #560.
+4. **Jangan trust `X-Forwarded-Host` tanpa proxy tepercaya** — ulangi dari epic #555 §Security notes. Berlaku juga untuk API domain #562 manapun yang membaca header host secara independen dari resolver #559.
+5. **Tenant existence tidak boleh bocor**: domain/tenant yang unknown, failed, suspended, atau inactive harus menghasilkan respons yang identik/tidak bisa dibedakan (pola sama seperti ADR-0009's 404 identik untuk `tenantCode` tak dikenal vs tenant tidak aktif) — resolver #559 sudah menegakkan ini (`resolvePublicTenantByHost`/`resolveDefaultPublicTenantFromEnv`/`resolveDefaultPublicTenantFromSetupState`/`resolvePublicTenantFromRequest` semua return `null` identik). Rute publik `/news` #560 **wajib** memetakan `null` resolver ini ke 404 generic yang sama, tidak menambah pesan/status yang membedakan kasus.
 6. **Module disabled tetap diblokir server-side** — kalau tenant module presets (#565) atau tenant-module matrix (#566) menonaktifkan sebuah modul, endpoint modul itu wajib tetap menolak di server (guard ABAC/tenant-module lifecycle yang sudah ada dari `module_management`), bukan hanya disembunyikan di UI.
 7. **Provider secret (mis. Cloudflare API token, #567) tidak pernah disimpan di module descriptor atau kolom DB biasa** — pakai environment variable seperti provider lain (Mailketing, R2), dan `configure`-only permission gate seperti pola `email`/`sync-storage` provider config.
-8. **Semua mutasi domain/module (create/update/delete domain mapping, enable/disable module preset) wajib diaudit** — pola `recordAuditEvent` yang sama dipakai modul lain, action literal sesuai konvensi modul (`tenant_domain.<resource>.<verb>` mengikuti pola `blog.<resource>.<verb>` dari blog_content).
+8. **Semua mutasi domain/module (create/update/delete domain mapping, enable/disable module preset) wajib diaudit** — pola `recordAuditEvent` yang sama dipakai modul lain, action literal sesuai konvensi modul (`tenant_domain.<resource>.<verb>` mengikuti pola `blog.<resource>.<verb>` dari blog_content). Resolver #559 sendiri **bukan** mutasi (read-only, anonymous) — tidak diaudit, sama seperti `resolvePublicTenantByCode` (ADR-0009) tidak diaudit.
 9. **Cloudflare DNS adapter (#567) adalah opsional/enhancement**, bukan hard dependency — epic #555 §Out of scope eksplisit menyebut "making Cloudflare DNS automation a hard dependency" di luar scope. Tenant domain mapping (#557/#562) harus tetap berfungsi tanpa Cloudflare sama sekali (manual DNS setup oleh operator).
+10. **#560's `/news` routes harus reuse `resolvePublicTenantFromRequest()` (Issue #559) langsung** — jangan re-derive hostname→tenant lookup logic lain. `config.mode` untuk panggilan itu dibangun dari `PUBLIC_TENANT_RESOLUTION_MODE`/`PUBLIC_TRUST_PROXY` di `process.env` (resolver sendiri tidak membaca `process.env` untuk keduanya — sengaja, untuk testability; lihat §Resolver). `#562`'s admin API (mutasi domain, tenant-scoped, authenticated) **TIDAK** boleh reuse resolver #559 (yang anonymous/pre-tenant-context) — API #562 memakai `withTenant(...)` biasa seperti endpoint tenant-scoped lain, RLS `awcms_mini_tenant_domains` yang menjaga isolasinya, bukan fungsi `SECURITY DEFINER` (fungsi itu murni untuk bootstrap publik tanpa tenant context).
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Isu #559-#567 (resolver host-based, rute publik `/news`, dokumentasi
-legacy, API tenant domain, admin UI domain, tenant settings rute
-`/news`/legacy di `blog_content`, module presets, matrix UI admin, dan
-adapter Cloudflare DNS) **belum ada** — hanya lapisan config (#556),
-schema `awcms_mini_tenant_domains` (#557), dan module descriptor
-`tenant_domain` (#558) yang selesai. Jangan asumsikan resolver host-based
-sudah bisa dipakai; env var `PUBLIC_PLATFORM_ROOT_DOMAIN`/`PUBLIC_TRUST_PROXY`
-baru **divalidasi dan didokumentasikan**, belum **dikonsumsi** oleh kode
-resolver apa pun. Tabel `awcms_mini_tenant_domains` baru berisi schema +
-constraint + RLS + permission catalog seed — belum ada baris yang pernah
-ditulis lewat kode aplikasi (menunggu #562's API), dan belum ada resolver
-yang membacanya (menunggu #559, yang juga harus menyelesaikan RLS
-bootstrap gap yang didokumentasikan di §Schema di atas dan di migration
-031's komentar sebelum bisa query tabel ini tanpa tenant context).
+Isu #560-#567 (rute publik `/news`, dokumentasi legacy, API tenant domain,
+admin UI domain, tenant settings rute `/news`/legacy di `blog_content`,
+module presets, matrix UI admin, dan adapter Cloudflare DNS) **belum ada**
+— hanya lapisan config (#556), schema `awcms_mini_tenant_domains` (#557),
+module descriptor `tenant_domain` (#558), dan resolver host-based (#559)
+yang selesai. Resolver #559 adalah **library murni** — belum dikonsumsi
+endpoint/route apa pun (menunggu #560). Tabel `awcms_mini_tenant_domains`
+masih berisi schema + constraint + RLS + permission catalog seed + fungsi
+lookup `SECURITY DEFINER` saja — belum ada baris yang pernah ditulis lewat
+kode aplikasi (menunggu #562's API); resolver #559 hanya bisa MEMBACA baris
+yang di-seed manual/via test, bukan menulisnya.

--- a/docs/adr/0003-postgresql-rls-multi-tenant.md
+++ b/docs/adr/0003-postgresql-rls-multi-tenant.md
@@ -22,3 +22,53 @@ Kami memutuskan memakai **PostgreSQL** dengan **Row Level Security (RLS)** pada 
 
 - **Isolasi hanya di aplikasi** — ditolak: satu bug = kebocoran data lintas-tenant.
 - **Database per tenant** — ditolak: biaya operasional dan migrasi tinggi untuk skala base.
+
+## Checklist: menggunakan `SECURITY DEFINER` (bootstrap read sebelum tenant context ada)
+
+RLS + `FORCE` (di atas) menutup akses tenant-scoped biasa, tapi beberapa
+query harus dijalankan **sebelum** tenant context ada sama sekali (mis.
+resolusi publik `hostname`/`tenantCode` -> `tenant_id`). Contoh kanonik:
+`sql/033_awcms_mini_tenant_domain_lookup_function.sql`'s
+`awcms_mini_resolve_tenant_domain_lookup` (Issue #559, epic #555) — baca
+komentar lengkap di file itu untuk penjelasan penuh, termasuk verifikasi
+empiris terhadap DB yang berjalan (bukan diasumsikan dari dokumentasi
+PostgreSQL semata). Setiap fungsi `SECURITY DEFINER` baru di repo ini wajib
+memenuhi checklist berikut sebelum dianggap aman:
+
+1. **Konfirmasi role pemilik benar-benar superuser (atau owner tabel yang
+   dituju)** — `SELECT rolsuper FROM pg_roles WHERE rolname = '<role>'`.
+   Migration di repo ini berjalan sebagai `POSTGRES_USER` (`awcms-mini`),
+   yang memang superuser sungguhan — keamanan mekanisme ini TIDAK datang
+   dari interaksi RLS/`FORCE`, melainkan dari dua pagar di bawah.
+2. **Body fungsi wajib SQL statis/tetap** — tidak ada dynamic SQL/string
+   concatenation dari parameter. Parameter selalu lewat argumen fungsi yang
+   diparameterkan (`p_<nama> text`, dst.), tidak pernah diselipkan ke query
+   string secara manual.
+3. **Minimalkan kolom yang di-return** — hanya kolom yang benar-benar
+   dibutuhkan pemanggil; jangan pernah kolom sensitif (token/secret hash,
+   PII, dll.) kecuali pemanggil memang butuh dan sudah diaudit sengaja.
+4. **`REVOKE ALL ... FROM PUBLIC` lalu `GRANT EXECUTE` eksplisit** ke role
+   spesifik (mis. `awcms_mini_app`) — PostgreSQL men-grant `EXECUTE` ke
+   `PUBLIC` secara default saat `CREATE FUNCTION`; ini **tidak** otomatis
+   ikut tercakup oleh `ALTER DEFAULT PRIVILEGES` migration 013 (klausa itu
+   hanya berlaku untuk tabel/sequence, bukan function/routine).
+5. **`SET search_path = public, pg_temp`** (atau schema spesifik yang
+   relevan) di definisi fungsi — mengunci resolusi nama supaya tidak bisa
+   dialihkan lewat `search_path` yang dikontrol caller (defense in depth
+   standar untuk `SECURITY DEFINER`, tetap dilakukan walau owner sudah
+   superuser).
+6. **`STABLE`/`IMMUTABLE`, bukan default `VOLATILE`**, untuk fungsi
+   read-only — mencerminkan perilaku `SELECT` biasa ke query planner.
+7. **Verifikasi empiris, bukan asumsi** — sebelum menganggap mekanisme ini
+   aman, buktikan langsung terhadap DB yang berjalan: (a) fungsi resolve
+   rows lewat role least-privilege TANPA `app.current_tenant_id` GUC
+   di-set; (b) `SELECT` langsung ke tabel yang sama dari role/session yang
+   sama (tanpa fungsi) tetap 0 baris; (c) kolom yang di-return persis
+   sesuai yang didokumentasikan, tidak lebih. `tests/integration/public-tenant-resolution.integration.test.ts`
+   adalah contoh test yang membuktikan ketiganya.
+8. **Hindari timing side-channel** — kalau fungsi ini dipanggil lalu diikuti
+   query kedua yang kondisional (mis. "kalau baris pertama ditemukan, query
+   lagi ke tabel lain"), pertimbangkan apakah beda jumlah round-trip antar
+   outcome bisa dieksploitasi sebagai side-channel (lihat riwayat perbaikan
+   di komentar migration 033 — gabungkan jadi satu query via `JOIN` kalau
+   tabel kedua sudah RLS-free/publicly readable, seperti `awcms_mini_tenants`).

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -167,9 +167,26 @@ tepercaya (mis. `deploy/nginx/awcms-mini.conf.example` dengan TLS
 termination) yang benar-benar memvalidasi/mengisi ulang header
 `X-Forwarded-Host` dari klien luar — jangan pernah mempercayai header ini
 langsung dari klien tanpa proxy tepercaya di depan, karena resolver
-host-based yang akan dibangun di Issue #559 memakainya untuk menentukan
-tenant, dan spoofing header bisa mengarahkan request ke tenant yang salah
-tanpa membocorkan keberadaan tenant lain (lihat epic #555 §Security notes).
+host-based Issue #559 (`src/lib/tenant/public-host-tenant-resolver.ts`)
+memakainya untuk menentukan tenant, dan spoofing header bisa mengarahkan
+request ke tenant yang salah tanpa membocorkan keberadaan tenant lain
+(lihat epic #555 §Security notes).
+
+**Persyaratan operasional mengikat**: proxy tepercaya di depan **wajib**
+satu hop yang langsung bersebelahan (directly-adjacent) dan **wajib
+menimpa (overwrite)** header `X-Forwarded-Host` secara penuh di setiap
+request — tidak pernah append/forward nilai yang datang dari klien.
+Topologi yang didukung repo ini tidak pernah menghasilkan lebih dari satu
+nilai `X-Forwarded-Host` yang sah. Resolver Issue #559 secara sengaja
+**tidak** menebak-nebak mana yang tepercaya kalau header itu ternyata
+berisi beberapa nilai comma-separated saat runtime (tidak ada konfigurasi
+"N trusted hop" di repo ini untuk menghitung dari kanan) — kalau itu
+terjadi, resolver mencatatnya sebagai anomali dan fallback ke header
+`Host` biasa, persis seperti `PUBLIC_TRUST_PROXY=false` untuk request itu.
+Proxy yang salah konfigurasi (append, bukan overwrite) tetap dianggap
+tidak tepercaya oleh aplikasi meski operator sudah set `PUBLIC_TRUST_PROXY=true` —
+perbaiki konfigurasi proxy-nya, jangan andalkan aplikasi menebak nilai
+mana yang benar.
 
 ### Provider CRM (opsional) — contoh domain retail/POS
 

--- a/docs/awcms-mini/deployment-profiles.md
+++ b/docs/awcms-mini/deployment-profiles.md
@@ -62,8 +62,16 @@ host-based menyusul di issue #557-#567.
   set `true` pada topologi offline/LAN yang melewati nginx sepenuhnya
   (baris "offline/LAN" di atas: "nginx dapat dilewati sepenuhnya") — tanpa
   proxy tepercaya di depan, header `X-Forwarded-Host` bisa dipalsukan
-  klien mana pun, dan resolver host-based yang akan dibangun di Issue
-  #559 akan memakainya untuk menentukan tenant.
+  klien mana pun, dan resolver host-based Issue #559
+  (`src/lib/tenant/public-host-tenant-resolver.ts`) memakainya untuk
+  menentukan tenant. **Wajib**: nginx (atau proxy tepercaya apa pun di
+  posisi ini) harus dikonfigurasi untuk **menimpa (overwrite)**
+  `X-Forwarded-Host` sepenuhnya, bukan meneruskan/append nilai dari klien
+  — kalau nginx-nya salah konfigurasi (append), resolver mendeteksi lebih
+  dari satu nilai comma-separated pada header dan sengaja fallback ke
+  `Host` biasa (tidak menebak nilai kiri/kanan mana yang tepercaya),
+  dicatat sebagai anomali di log; ini bukan pengganti memperbaiki
+  konfigurasi proxy yang salah.
 
 ## Cara menjalankan tiap profil
 

--- a/sql/033_awcms_mini_tenant_domain_lookup_function.sql
+++ b/sql/033_awcms_mini_tenant_domain_lookup_function.sql
@@ -1,0 +1,126 @@
+-- Issue #559 (epic #555, online public tenant routing) — closes the RLS
+-- bootstrap gap flagged in `sql/031_awcms_mini_tenant_domain_schema.sql`'s
+-- header comment (lines ~77-95): the public host resolver must discover
+-- `tenant_id` from a hostname in `awcms_mini_tenant_domains` BEFORE any
+-- tenant context (`app.current_tenant_id` GUC) exists, but that table is
+-- intentionally `FORCE ROW LEVEL SECURITY` (it holds tenant-manageable
+-- fields like `verification_token_hash`), so a plain `SELECT` from the
+-- least-privilege `awcms_mini_app` role always returns zero rows without
+-- `withTenant(...)`. This migration adds one narrowly-scoped `SECURITY
+-- DEFINER` function as the single sanctioned bootstrap read path, exactly
+-- as migration 031 recommended. `FORCE ROW LEVEL SECURITY` is NOT removed
+-- from the table by this migration.
+--
+-- How/why this is safe (verified empirically against the running
+-- migration-owner role before writing this file, not assumed from memory):
+--   - Migrations execute as the schema-owning role (`POSTGRES_USER`,
+--     `awcms-mini` in `docker-compose.yml`), which is created by the
+--     official postgres image as an actual Postgres SUPERUSER
+--     (`SELECT rolsuper FROM pg_roles WHERE rolname = 'awcms-mini'` ->
+--     true). Superusers bypass row security unconditionally, regardless of
+--     `FORCE ROW LEVEL SECURITY` (`FORCE` only removes the *table owner's*
+--     default RLS exemption when the owner is a non-superuser role; it has
+--     no effect on an actually-superuser owner). So a `SECURITY DEFINER`
+--     function owned by this role executes with the same unconditional RLS
+--     bypass as any other statement run by the definer, exactly like the
+--     migration's own DDL/DML already does against every FORCE-RLS table
+--     in this schema.
+--   - Because the *role* running this function's body already has an
+--     unconditional bypass, the safety of this mechanism does not come
+--     from RLS/FORCE at all — it comes entirely from two narrower
+--     guarantees this migration provides instead:
+--       1. The function body is fixed, static SQL (no dynamic SQL / string
+--          concatenation) that returns exactly eight non-sensitive columns
+--          (see RETURNS TABLE below) for rows matching one parameterized
+--          `normalized_hostname` argument and `deleted_at IS NULL`. It can
+--          never be used to read `verification_token_hash`,
+--          `verification_record_value`, `hostname` (raw/unnormalized), or
+--          any other column/table.
+--       2. `EXECUTE` on the function is revoked from `PUBLIC` and granted
+--          only to `awcms_mini_app` — no other non-superuser role can even
+--          invoke this bypass. `awcms_mini_app` still cannot query
+--          `awcms_mini_tenant_domains` directly without `withTenant(...)`;
+--          it can only go through this one fixed lookup shape.
+--   - `SET search_path = public, pg_temp` pins name resolution inside the
+--     function body so it cannot be redirected by a caller-controlled
+--     `search_path` (standard `SECURITY DEFINER` hardening, defense in
+--     depth alongside the schema already restricting `CREATE` on `public`
+--     to non-superuser roles by default since PostgreSQL 15).
+--   - `STABLE` (not `VOLATILE`): the function only reads, matching a plain
+--     read-only `SELECT` in cost/planning behavior.
+--
+-- Security-review follow-up (PR review for Issue #559, fixed in the same
+-- change before merge): the first version of this function returned only
+-- `(tenant_id, status, is_primary, route_mode)`, and the TypeScript
+-- resolver (`resolvePublicTenantByHost`) issued a SECOND query against
+-- `awcms_mini_tenants` to confirm the tenant itself was `active`. That
+-- created an observable timing side-channel: an unknown/unmapped hostname
+-- returned after exactly one round trip, while a hostname mapped to an
+-- active domain (even one whose tenant was inactive) always cost a second
+-- round trip before returning the same `null` — different latency for the
+-- same public response, distinguishing "no such mapping" from "mapping
+-- exists, tenant just isn't active" purely by timing. Fixed by joining
+-- `awcms_mini_tenants` into this same function and returning the tenant's
+-- own status/code/name/locale alongside the domain row, so
+-- `resolvePublicTenantByHost` needs exactly one query for every outcome
+-- (unknown host, inactive domain, inactive tenant, or a full resolution).
+-- This join does not widen the SECURITY DEFINER bypass in any way:
+-- `awcms_mini_tenants` is already RLS-free by design (ADR-0003/migration
+-- 013) and freely `SELECT`-able by `awcms_mini_app` with zero bypass
+-- needed — `resolvePublicTenantByCode` already reads the exact same
+-- columns directly, unprivileged. Joining it here only removes a round
+-- trip; it exposes nothing that was not already unconditionally public.
+--
+-- Consumer: `src/lib/tenant/public-host-tenant-resolver.ts`'s
+-- `resolvePublicTenantByHost()` (Issue #559). It still applies
+-- `domain_status = 'active' AND tenant_status = 'active'` itself (this
+-- function intentionally returns non-active, non-deleted domain rows too,
+-- e.g. `pending_verification`/`suspended`/`failed`, and whatever the
+-- joined tenant's status is, so the resolver layer — not this SQL layer —
+-- decides and documents which combination resolves public traffic; today
+-- only `active` + `active`, per the issue's acceptance criteria).
+
+CREATE OR REPLACE FUNCTION awcms_mini_resolve_tenant_domain_lookup(
+  p_normalized_hostname text
+)
+RETURNS TABLE (
+  tenant_id uuid,
+  domain_status text,
+  is_primary boolean,
+  route_mode text,
+  tenant_status text,
+  tenant_code text,
+  tenant_name text,
+  default_locale text
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public, pg_temp
+AS $function$
+  SELECT
+    d.tenant_id,
+    d.status AS domain_status,
+    d.is_primary,
+    d.route_mode,
+    t.status AS tenant_status,
+    t.tenant_code,
+    t.tenant_name,
+    t.default_locale
+  FROM awcms_mini_tenant_domains AS d
+  JOIN awcms_mini_tenants AS t ON t.id = d.tenant_id
+  WHERE d.normalized_hostname = p_normalized_hostname
+    AND d.deleted_at IS NULL;
+$function$;
+
+COMMENT ON FUNCTION awcms_mini_resolve_tenant_domain_lookup(text) IS
+  'Issue #559: narrow SECURITY DEFINER bootstrap read for hostname -> tenant lookup before tenant context exists. Joins the (already RLS-free) awcms_mini_tenants row in the same call so the TypeScript resolver needs exactly one round trip regardless of outcome (avoids a timing side-channel between "unmapped host" and "mapped but inactive tenant"). Returns only tenant_id/domain_status/is_primary/route_mode/tenant_status/tenant_code/tenant_name/default_locale for non-deleted domain rows matching a normalized hostname. Never returns verification_token_hash, verification_record_value, or raw hostname. EXECUTE restricted to awcms_mini_app.';
+
+-- Function EXECUTE privilege is a separate grant mechanism from the table
+-- GRANTs migration 013's `ALTER DEFAULT PRIVILEGES` already covers (that
+-- clause only applies to tables/sequences, not functions/routines) — this
+-- explicit grant is required, it is not automatic. PostgreSQL grants
+-- EXECUTE to PUBLIC by default on function creation; revoke that first so
+-- only the least-privilege app role can call this bypass.
+REVOKE ALL ON FUNCTION awcms_mini_resolve_tenant_domain_lookup(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION awcms_mini_resolve_tenant_domain_lookup(text) TO awcms_mini_app;

--- a/src/lib/tenant/public-host-tenant-resolver.ts
+++ b/src/lib/tenant/public-host-tenant-resolver.ts
@@ -1,0 +1,459 @@
+import { assertUuid } from "../database/tenant-context";
+import { log } from "../logging/logger";
+import {
+  resolvePublicTenantByCode,
+  type PublicTenantResolution
+} from "./public-tenant-resolver";
+
+/**
+ * Public host-based tenant resolution — Issue #559 (epic #555, online
+ * public tenant routing). Resolves the tenant for anonymous public routes
+ * (future `/news`, Issue #560) from the request `Host`/domain/subdomain
+ * first, then falls back safely to the same env/setup defaults offline/LAN
+ * deployments already rely on for `/blog/{tenantCode}` (ADR-0009). This
+ * module never touches tenant content — only `awcms_mini_tenant_domains`
+ * (via the `SECURITY DEFINER` bootstrap function, migration 033),
+ * `awcms_mini_tenants` (RLS-free by design, ADR-0003/migration 013), and
+ * `awcms_mini_setup_state` (RLS-free singleton, migration 006).
+ *
+ * Every exported function here returns `null` for *any* non-resolving
+ * case — unknown host, unmapped domain, non-`active` domain status
+ * (`pending_verification`/`suspended`/`failed`), soft-deleted domain, or
+ * an inactive tenant. Callers must treat `null` as a single generic "no
+ * tenant" outcome (404), exactly like `resolvePublicTenantByCode` (ADR-0009)
+ * — never branch on *why* resolution failed. The only function that ever
+ * throws is `normalizePublicHost()`, and only for a genuinely-empty input
+ * (a caller contract violation, not a runtime resolution outcome); a
+ * non-empty but malformed host still returns `null`, never throws.
+ */
+
+export type { PublicTenantResolution };
+
+type TenantDomainLookupRow = {
+  tenant_id: string;
+  domain_status: string;
+  is_primary: boolean;
+  route_mode: string;
+  tenant_status: string;
+  tenant_code: string;
+  tenant_name: string;
+  default_locale: string;
+};
+
+type TenantRow = {
+  id: string;
+  tenant_code: string;
+  tenant_name: string;
+  status: string;
+  default_locale: string;
+};
+
+type SetupStateRow = {
+  tenant_id: string | null;
+};
+
+/** The four modes documented for `PUBLIC_TENANT_RESOLUTION_MODE` (Issue #556). */
+export type PublicTenantResolutionMode =
+  "host_default" | "env_default" | "setup_default" | "tenant_code_legacy";
+
+export type PublicHostResolverConfig = {
+  /**
+   * `PUBLIC_TENANT_RESOLUTION_MODE` (Issue #556). Only `"host_default"`
+   * enables step 1 (host/domain lookup) below — every other value,
+   * including `undefined` (not set at all, today's offline/LAN default)
+   * and any unrecognized string, skips straight to the env/setup fallback
+   * chain (steps 2-4). This keeps the `awcms_mini_tenant_domains` bootstrap
+   * function entirely unreached by deployments that never opted into
+   * online/host-based routing — smaller attack surface, not just smaller
+   * code path, for the common offline/LAN case.
+   *
+   * The env/setup fallback chain (steps 2-4) always runs regardless of
+   * mode — that is the "safe fallback" the issue title names, and matches
+   * the acceptance criterion that an unset/other mode still tries
+   * `PUBLIC_DEFAULT_TENANT_ID` -> `PUBLIC_DEFAULT_TENANT_CODE` ->
+   * `awcms_mini_setup_state.tenant_id` before giving up.
+   */
+  mode?: string;
+  /**
+   * `PUBLIC_TRUST_PROXY` (Issue #556), default `false`. Only when `true`
+   * is `X-Forwarded-Host` read at all; otherwise the plain `Host` header is
+   * always used, matching the epic's binding security note ("never trust
+   * X-Forwarded-Host without a trusted proxy in front").
+   */
+  trustProxy?: boolean;
+};
+
+export type PublicHostResolverDeps = {
+  resolvePublicTenantByHost: typeof resolvePublicTenantByHost;
+  resolveDefaultPublicTenantFromEnv: typeof resolveDefaultPublicTenantFromEnv;
+  resolveDefaultPublicTenantFromSetupState: typeof resolveDefaultPublicTenantFromSetupState;
+};
+
+const MAX_HOST_LENGTH = 253; // RFC 1035 total hostname length limit.
+const MAX_LABEL_LENGTH = 63; // RFC 1035 per-label length limit.
+const HOST_LABEL_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+/**
+ * Shared DNS-hostname shape check (length + per-label charset), used by
+ * `normalizePublicHost()` (after it strips the port) and, as defense in
+ * depth, directly inside `resolvePublicTenantByHost()` — that function is
+ * exported and documented as directly callable (Issue #560 and beyond), so
+ * it must not rely solely on "the caller already normalized this" as its
+ * only guard. Does not strip a port or lowercase — the input is expected to
+ * already be normalized; this only re-validates shape.
+ */
+function isValidHostnameShape(value: string): boolean {
+  if (
+    value.length === 0 ||
+    value.length > MAX_HOST_LENGTH ||
+    value.startsWith(".") ||
+    value.endsWith(".") ||
+    value.includes("..") ||
+    value.includes("_") ||
+    /\s/.test(value)
+  ) {
+    return false;
+  }
+
+  return value
+    .split(".")
+    .every(
+      (label) =>
+        label.length > 0 &&
+        label.length <= MAX_LABEL_LENGTH &&
+        HOST_LABEL_PATTERN.test(label)
+    );
+}
+
+/**
+ * Normalizes an untrusted `Host`/`X-Forwarded-Host` value for use as a
+ * lookup key: strips a trailing `:<port>`, lowercases, trims, and validates
+ * DNS hostname shape. Returns `null` for anything that doesn't look like a
+ * plausible hostname (defense in depth — the DB lookup this feeds is
+ * already parameterized, this is an additional reject-early gate against
+ * obviously-malformed/oversized/injected input before it ever reaches a
+ * query). IPv6 literals (`[::1]`) are rejected: tenant domain mappings are
+ * always by hostname, never by IP literal.
+ *
+ * Throws only when `rawHost` itself is empty/not a string — that is a
+ * caller contract violation (e.g. calling this directly with `""`), not a
+ * runtime resolution outcome, so it is intentionally distinguishable from
+ * every other "not a valid/known host" case, which returns `null`.
+ * `resolvePublicTenantFromRequest()` never calls this with an empty string
+ * — a request with no `Host` header just skips step 1 entirely.
+ */
+export function normalizePublicHost(rawHost: string): string | null {
+  if (typeof rawHost !== "string" || rawHost.trim().length === 0) {
+    throw new Error("normalizePublicHost: rawHost must be a non-empty string.");
+  }
+
+  const trimmed = rawHost.trim().toLowerCase();
+
+  if (/\s/.test(trimmed)) {
+    return null;
+  }
+
+  if (trimmed.startsWith("[")) {
+    // IPv6 literal, e.g. "[::1]:4321" — not a supported tenant domain shape.
+    return null;
+  }
+
+  const colonIndex = trimmed.lastIndexOf(":");
+  const hostOnly = colonIndex === -1 ? trimmed : trimmed.slice(0, colonIndex);
+
+  return isValidHostnameShape(hostOnly) ? hostOnly : null;
+}
+
+/**
+ * Fetches an `active` tenant by id from `awcms_mini_tenants` — RLS-free by
+ * design (ADR-0003/migration 013, same as `resolvePublicTenantByCode`'s
+ * own table access), so this runs directly on the app-role connection,
+ * before any `withTenant(...)` transaction. Not exported: every exported
+ * resolution step in this file needs "look up a tenant by id and confirm
+ * it's active", so it is centralized here rather than duplicated per step.
+ */
+async function fetchActivePublicTenantById(
+  sql: Bun.SQL,
+  tenantId: string
+): Promise<PublicTenantResolution | null> {
+  const rows = (await sql`
+    SELECT id, tenant_code, tenant_name, status, default_locale
+    FROM awcms_mini_tenants
+    WHERE id = ${tenantId}
+  `) as TenantRow[];
+
+  const tenant = rows[0];
+
+  if (!tenant || tenant.status !== "active") {
+    return null;
+  }
+
+  return {
+    tenantId: tenant.id,
+    tenantCode: tenant.tenant_code,
+    tenantName: tenant.tenant_name,
+    defaultLocale: tenant.default_locale
+  };
+}
+
+/**
+ * Step 1 of the resolution order: hostname -> tenant, via the narrow
+ * `SECURITY DEFINER` bootstrap function `awcms_mini_resolve_tenant_domain_lookup`
+ * (migration 033). `normalizedHost` must already be normalized by
+ * `normalizePublicHost()` — this function re-validates hostname *shape* as
+ * defense in depth (it is exported and directly callable, e.g. by Issue
+ * #560, not only reachable through `normalizePublicHost()`), but does not
+ * re-strip a port or re-lowercase; callers must still normalize first.
+ *
+ * Exactly one query runs for every outcome (unknown host, non-`active`
+ * domain, or non-`active` tenant) — the SQL function joins
+ * `awcms_mini_tenants` in the same call and returns the tenant's own
+ * status/code/name/locale alongside the domain row, specifically so this
+ * function never needs a second, conditional round trip. An earlier
+ * version issued a second query only when a domain row was found active,
+ * which was a timing side-channel distinguishing "no such mapping" from
+ * "mapping exists, tenant just isn't active" by response latency alone
+ * (fixed in the same change, see migration 033's own comment for the full
+ * writeup).
+ *
+ * Only `domain_status === 'active' AND tenant_status === 'active'`
+ * resolves; every other combination — `pending_verification`/`suspended`/
+ * `failed` domain, soft-deleted domain (already excluded by the SQL
+ * function itself), or a non-`active` tenant — falls through to `null`
+ * identically. `is_primary` and `route_mode` are read but not part of the
+ * return value: they are not needed for base resolution (`route_mode` is
+ * Issue #560's concern), and keeping the public resolver's read surface
+ * minimal is a binding security note on this issue.
+ */
+export async function resolvePublicTenantByHost(
+  sql: Bun.SQL,
+  normalizedHost: string
+): Promise<PublicTenantResolution | null> {
+  if (
+    typeof normalizedHost !== "string" ||
+    !isValidHostnameShape(normalizedHost)
+  ) {
+    return null;
+  }
+
+  const rows = (await sql`
+    SELECT
+      tenant_id, domain_status, is_primary, route_mode,
+      tenant_status, tenant_code, tenant_name, default_locale
+    FROM awcms_mini_resolve_tenant_domain_lookup(${normalizedHost})
+  `) as TenantDomainLookupRow[];
+
+  const row = rows[0];
+
+  if (
+    !row ||
+    row.domain_status !== "active" ||
+    row.tenant_status !== "active"
+  ) {
+    return null;
+  }
+
+  return {
+    tenantId: row.tenant_id,
+    tenantCode: row.tenant_code,
+    tenantName: row.tenant_name,
+    defaultLocale: row.default_locale
+  };
+}
+
+/**
+ * Steps 2-3 of the resolution order: `PUBLIC_DEFAULT_TENANT_ID` first, then
+ * `PUBLIC_DEFAULT_TENANT_CODE` (exact order from the issue). A malformed
+ * `PUBLIC_DEFAULT_TENANT_ID` (not a UUID) is treated as "this step did not
+ * resolve" and falls through to the CODE check, rather than throwing —
+ * config validation (Issue #556's `checkPublicRoutingConfig`) is the place
+ * that should catch operator misconfiguration; this runtime path never
+ * surfaces a parse error to a public caller.
+ */
+export async function resolveDefaultPublicTenantFromEnv(
+  sql: Bun.SQL,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<PublicTenantResolution | null> {
+  const tenantId = env.PUBLIC_DEFAULT_TENANT_ID?.trim();
+
+  if (tenantId) {
+    try {
+      assertUuid(tenantId);
+      const resolved = await fetchActivePublicTenantById(sql, tenantId);
+
+      if (resolved) {
+        return resolved;
+      }
+    } catch {
+      // Malformed PUBLIC_DEFAULT_TENANT_ID — fall through to the CODE
+      // check below, never throw out of a public resolution path.
+    }
+  }
+
+  const tenantCode = env.PUBLIC_DEFAULT_TENANT_CODE?.trim();
+
+  if (tenantCode) {
+    return resolvePublicTenantByCode(sql, tenantCode);
+  }
+
+  return null;
+}
+
+/**
+ * Step 4 of the resolution order: `awcms_mini_setup_state.tenant_id` — the
+ * tenant chosen during the setup wizard. `awcms_mini_setup_state` is a
+ * RLS-free singleton table (migration 006), same "shared by design"
+ * category as `awcms_mini_tenants` (migration 013's comment), so this also
+ * runs directly on the app-role connection with no tenant context needed.
+ */
+export async function resolveDefaultPublicTenantFromSetupState(
+  sql: Bun.SQL
+): Promise<PublicTenantResolution | null> {
+  const rows = (await sql`
+    SELECT tenant_id
+    FROM awcms_mini_setup_state
+    WHERE id = true
+  `) as SetupStateRow[];
+
+  const tenantId = rows[0]?.tenant_id;
+
+  if (!tenantId) {
+    return null;
+  }
+
+  return fetchActivePublicTenantById(sql, tenantId);
+}
+
+const defaultDeps: PublicHostResolverDeps = {
+  resolvePublicTenantByHost,
+  resolveDefaultPublicTenantFromEnv,
+  resolveDefaultPublicTenantFromSetupState
+};
+
+/**
+ * Extracts the host to resolve from a `Request`. Reads the plain `Host`
+ * header by default; only reads `X-Forwarded-Host` when `trustProxy` is
+ * `true` (Issue #556's `PUBLIC_TRUST_PROXY`, default `false`) — an
+ * untrusted client can set `X-Forwarded-Host` to anything, so it must never
+ * be read unless a trusted reverse proxy in front is guaranteed to
+ * sanitize/overwrite it.
+ *
+ * **Binding operational requirement** (documented in
+ * `.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md` and
+ * `docs/awcms-mini/18_configuration_env_reference.md` — repeated here so
+ * the code and the docs cannot silently drift): a deployment that sets
+ * `PUBLIC_TRUST_PROXY=true` MUST run behind a single, directly-adjacent
+ * trusted edge proxy that fully OVERWRITES `X-Forwarded-Host` on every
+ * request, never appends to (or forwards) a client-supplied value. This
+ * repo's documented topology never legitimately produces more than one
+ * `X-Forwarded-Host` value. If the header nonetheless contains more than
+ * one comma-separated value at runtime, that is treated as a sign of a
+ * misconfigured proxy chain (e.g. one that appends instead of overwrites,
+ * which would let a client pre-seed an entry an attacker fully controls)
+ * or a spoofing attempt — this function does NOT guess which of several
+ * values is trustworthy (there is no "rightmost N trusted hops" config in
+ * this codebase to anchor that logic on). It logs the anomaly and falls
+ * back to the plain `Host` header instead, exactly as if `trustProxy` were
+ * `false` for this one request.
+ */
+function extractHostHeader(
+  request: Request,
+  trustProxy: boolean
+): string | null {
+  if (trustProxy) {
+    const forwarded = request.headers.get("x-forwarded-host");
+
+    if (forwarded && forwarded.trim().length > 0) {
+      const parts = forwarded
+        .split(",")
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0);
+
+      if (parts.length === 1) {
+        return parts[0] as string;
+      }
+
+      if (parts.length > 1) {
+        log("warning", "public_host_resolver.x_forwarded_host_multi_value", {
+          valueCount: parts.length,
+          // Not a secret, but capped defensively — this is an anomaly
+          // report, not a place to let an attacker-sized header balloon
+          // log storage.
+          firstValuePreview: parts[0]?.slice(0, 100)
+        });
+      }
+    }
+  }
+
+  return request.headers.get("host");
+}
+
+/**
+ * Orchestrates the full resolution order for a public request:
+ *
+ * 1. Host/domain mapping (`resolvePublicTenantByHost`) — only attempted
+ *    when `config.mode === "host_default"`.
+ * 2. `PUBLIC_DEFAULT_TENANT_ID`
+ * 3. `PUBLIC_DEFAULT_TENANT_CODE`
+ *    (2-3 are both handled inside `resolveDefaultPublicTenantFromEnv`)
+ * 4. `awcms_mini_setup_state.tenant_id`
+ * 5. `null` (caller responds with a generic 404)
+ *
+ * Steps 2-4 always run, regardless of `config.mode` — they are the "safe
+ * fallback" this issue's title promises, so an offline/LAN deployment that
+ * never sets `PUBLIC_TENANT_RESOLUTION_MODE` still gets a usable default
+ * tenant for routes that don't carry an explicit `tenantCode` (future
+ * `/news`, Issue #560), exactly like today's `tenant_code_legacy` default.
+ *
+ * `requestOrHost` accepts either a `Request` (host header extracted per
+ * `config.trustProxy`) or an already-known host string (bypasses header
+ * extraction entirely — used by callers that resolved the host some other
+ * way, and by tests). `deps` allows the three DB-touching steps to be
+ * swapped for test doubles without a database (see
+ * `tests/unit/public-host-tenant-resolver.test.ts`); production callers
+ * should omit it and use the real implementations.
+ */
+export async function resolvePublicTenantFromRequest(
+  sql: Bun.SQL,
+  requestOrHost: Request | string,
+  config: PublicHostResolverConfig = {},
+  deps: PublicHostResolverDeps = defaultDeps
+): Promise<PublicTenantResolution | null> {
+  const trustProxy = config.trustProxy ?? false;
+
+  if (config.mode === "host_default") {
+    const rawHost =
+      typeof requestOrHost === "string"
+        ? requestOrHost
+        : extractHostHeader(requestOrHost, trustProxy);
+
+    if (rawHost && rawHost.trim().length > 0) {
+      const normalizedHost = normalizePublicHost(rawHost);
+
+      if (normalizedHost) {
+        const byHost = await deps.resolvePublicTenantByHost(
+          sql,
+          normalizedHost
+        );
+
+        if (byHost) {
+          return byHost;
+        }
+      }
+    }
+  }
+
+  const byEnv = await deps.resolveDefaultPublicTenantFromEnv(sql);
+
+  if (byEnv) {
+    return byEnv;
+  }
+
+  const bySetupState = await deps.resolveDefaultPublicTenantFromSetupState(sql);
+
+  if (bySetupState) {
+    return bySetupState;
+  }
+
+  return null;
+}

--- a/src/modules/tenant-domain/README.md
+++ b/src/modules/tenant-domain/README.md
@@ -50,19 +50,20 @@ belongs to exactly one tenant); `awcms_mini_tenant_domains_primary_dedup`
 for reuse.
 
 RLS: `ENABLE` + `FORCE` with the standard `tenant_isolation` policy — same
-as every other tenant-scoped table. This creates a documented bootstrap
-gap for the future host-based resolver (#559): resolving `hostname ->
-tenant_id` has to happen _before_ a tenant context exists, but FORCE RLS
-plus the fail-closed GUC default (migration 013) means an
-un-tenant-scoped query returns zero rows. `awcms_mini_tenants` solves the
-equivalent bootstrap problem for `tenantCode -> tenant_id` lookups by
-being deliberately RLS-free (migration 013); `tenant_domains` cannot use
-that same trick because it holds tenant-manageable fields
-(`verification_token_hash` etc.). Migration 031's own comments spell out
-the resolution #559 is expected to build (e.g. a narrowly-scoped
-`SECURITY DEFINER` function or a dedicated least-privilege read role for
-that one lookup) — `FORCE ROW LEVEL SECURITY` must not be dropped from
-this table to work around it.
+as every other tenant-scoped table. This created a documented bootstrap
+gap for the host-based resolver (#559): resolving `hostname -> tenant_id`
+has to happen _before_ a tenant context exists, but FORCE RLS plus the
+fail-closed GUC default (migration 013) means an un-tenant-scoped query
+returns zero rows. `awcms_mini_tenants` solves the equivalent bootstrap
+problem for `tenantCode -> tenant_id` lookups by being deliberately
+RLS-free (migration 013); `tenant_domains` cannot use that same trick
+because it holds tenant-manageable fields (`verification_token_hash`
+etc.). Issue #559 closed this gap with a narrowly-scoped `SECURITY
+DEFINER` function, `awcms_mini_resolve_tenant_domain_lookup` (migration
+`033_awcms_mini_tenant_domain_lookup_function.sql`) — see
+`.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md` §Resolver for
+the full mechanism/security writeup. `FORCE ROW LEVEL SECURITY` was **not**
+dropped from this table to build it.
 
 ## Permission seed (migration `032_awcms_mini_tenant_domain_permissions.sql`, Issue #557)
 
@@ -122,11 +123,36 @@ ever will be, a runtime secret/token/credential — a hard rule from
 `module-contract.ts`'s header comment, checked by
 `tests/modules/tenant-domain-module.test.ts`.
 
+## Resolver (`src/lib/tenant/public-host-tenant-resolver.ts`, Issue #559)
+
+Public host-based tenant resolution with offline/LAN-safe fallback.
+**Library only** — not yet consumed by any route/endpoint (that is #560's
+`/news` routes). Five functions: `normalizePublicHost` (strip port,
+lowercase, validate DNS hostname shape — throws only on an empty input,
+never on a merely-malformed one), `resolvePublicTenantByHost` (queries
+`awcms_mini_resolve_tenant_domain_lookup`, the migration-033 `SECURITY
+DEFINER` bootstrap function, then confirms the tenant itself is `active`),
+`resolveDefaultPublicTenantFromEnv` (`PUBLIC_DEFAULT_TENANT_ID` then
+`PUBLIC_DEFAULT_TENANT_CODE`), `resolveDefaultPublicTenantFromSetupState`
+(`awcms_mini_setup_state.tenant_id`, also RLS-free by design), and the
+orchestrator `resolvePublicTenantFromRequest`. Resolution order: host
+lookup (only when `PUBLIC_TENANT_RESOLUTION_MODE=host_default`) -> env ID
+-> env CODE -> setup state -> `null`. The env/setup fallback chain always
+runs regardless of mode — every non-`host_default` mode (including unset,
+today's offline/LAN default) skips straight to it, so the
+`awcms_mini_tenant_domains` bootstrap function is never even reached by a
+deployment that hasn't opted into online routing. Every failure path —
+unknown host, non-`active` domain status, soft-deleted domain, inactive
+tenant — returns the same `null`, never a distinguishable error. Full
+mechanism/security writeup (including why the `SECURITY DEFINER` function
+is safe, verified empirically, not assumed) is in
+`.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md` §Resolver.
+Tests: `tests/unit/public-host-tenant-resolver.test.ts` (pure, mocked
+deps) and `tests/integration/public-tenant-resolution.integration.test.ts`
+(real Postgres, including RLS/bypass proof).
+
 ## Not yet available
 
-- Public host-based tenant resolver with offline/LAN fallback (Issue
-  #559) — including the RLS bootstrap-gap resolution described in
-  §Tables.
 - Tenant domain management API, `/api/v1/tenant/domains` (Issue #562).
 - Admin UI, `/admin/tenant/domains` (Issue #563).
 - `/news` public routes for `blog_content` (Issue #560) and the tenant

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -235,7 +235,8 @@ describe("database migration runner helpers", () => {
       "029_awcms_mini_blog_content_presentation_schema.sql",
       "030_awcms_mini_blog_content_presentation_permissions.sql",
       "031_awcms_mini_tenant_domain_schema.sql",
-      "032_awcms_mini_tenant_domain_permissions.sql"
+      "032_awcms_mini_tenant_domain_permissions.sql",
+      "033_awcms_mini_tenant_domain_lookup_function.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/public-tenant-resolution.integration.test.ts
+++ b/tests/integration/public-tenant-resolution.integration.test.ts
@@ -1,0 +1,526 @@
+/**
+ * Integration tests for the public host tenant resolver (Issue #559, epic
+ * #555) against a real PostgreSQL. Exercises every acceptance criterion in
+ * the issue end-to-end, including the RLS/SECURITY DEFINER bootstrap
+ * mechanism (migration 033) — proving it is a deliberate, narrow bypass,
+ * not an accidental RLS leak (same pattern
+ * `tenant-domain-schema.integration.test.ts` used for the schema itself).
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  getTestSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import {
+  normalizePublicHost,
+  resolveDefaultPublicTenantFromEnv,
+  resolveDefaultPublicTenantFromSetupState,
+  resolvePublicTenantByHost,
+  resolvePublicTenantFromRequest
+} from "../../src/lib/tenant/public-host-tenant-resolver";
+
+const TENANT_ACTIVE = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const TENANT_INACTIVE = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+async function seedTenants(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES
+      (${TENANT_ACTIVE}, 'tenant-active', 'Tenant Active', 'Tenant Active Legal', 'active', 'en', 'light'),
+      (${TENANT_INACTIVE}, 'tenant-inactive', 'Tenant Inactive', 'Tenant Inactive Legal', 'suspended', 'en', 'light')
+  `;
+}
+
+async function insertDomain(
+  tenantId: string,
+  hostname: string,
+  overrides: Partial<{
+    status: string;
+    domainType: string;
+    isPrimary: boolean;
+    deleted: boolean;
+  }> = {}
+): Promise<void> {
+  const admin = getAdminSql();
+  const normalized = hostname.toLowerCase().trim();
+  await admin`
+    INSERT INTO awcms_mini_tenant_domains
+      (tenant_id, hostname, normalized_hostname, domain_type, status, is_primary, deleted_at, deleted_by, delete_reason)
+    VALUES (
+      ${tenantId},
+      ${hostname},
+      ${normalized},
+      ${overrides.domainType ?? "custom_domain"},
+      ${overrides.status ?? "active"},
+      ${overrides.isPrimary ?? false},
+      ${overrides.deleted ? new Date() : null},
+      ${overrides.deleted ? TENANT_ACTIVE : null},
+      ${overrides.deleted ? "test cleanup" : null}
+    )
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("public host tenant resolver — end-to-end (Issue #559)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+  });
+
+  // ---------------------------------------------------------------------
+  // Acceptance: custom domain and subdomain resolve identically.
+  // ---------------------------------------------------------------------
+
+  test("a custom domain resolves to the active tenant mapped to that host", async () => {
+    await insertDomain(TENANT_ACTIVE, "domain.com", {
+      domainType: "custom_domain"
+    });
+
+    const sql = getTestSql();
+    const result = await resolvePublicTenantByHost(sql, "domain.com");
+
+    expect(result).not.toBeNull();
+    expect(result?.tenantId).toBe(TENANT_ACTIVE);
+    expect(result?.tenantCode).toBe("tenant-active");
+  });
+
+  test("a platform subdomain resolves the same way as a custom domain (no special-casing)", async () => {
+    await insertDomain(TENANT_ACTIVE, "subdomain.platform.com", {
+      domainType: "subdomain"
+    });
+
+    const sql = getTestSql();
+    const result = await resolvePublicTenantByHost(
+      sql,
+      "subdomain.platform.com"
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.tenantId).toBe(TENANT_ACTIVE);
+  });
+
+  // ---------------------------------------------------------------------
+  // Acceptance: hostnames with ports normalize correctly before lookup.
+  // ---------------------------------------------------------------------
+
+  test("a hostname with a port is normalized (port stripped) before resolution", async () => {
+    await insertDomain(TENANT_ACTIVE, "example.com");
+
+    const sql = getTestSql();
+    const normalized = normalizePublicHost("example.com:4321");
+    expect(normalized).toBe("example.com");
+
+    const result = await resolvePublicTenantByHost(sql, normalized as string);
+    expect(result?.tenantId).toBe(TENANT_ACTIVE);
+  });
+
+  test("resolvePublicTenantFromRequest end-to-end with a ported Host header", async () => {
+    await insertDomain(TENANT_ACTIVE, "example.com");
+
+    const sql = getTestSql();
+    const request = new Request("http://ignored.test/", {
+      headers: { host: "example.com:4321" }
+    });
+
+    const result = await resolvePublicTenantFromRequest(sql, request, {
+      mode: "host_default"
+    });
+
+    expect(result?.tenantId).toBe(TENANT_ACTIVE);
+  });
+
+  // ---------------------------------------------------------------------
+  // Acceptance: non-active domain statuses never resolve tenant traffic.
+  // ---------------------------------------------------------------------
+
+  for (const status of ["pending_verification", "suspended", "failed"]) {
+    test(`a domain with status "${status}" does not resolve tenant traffic`, async () => {
+      await insertDomain(TENANT_ACTIVE, "not-active.com", { status });
+
+      const sql = getTestSql();
+      const result = await resolvePublicTenantByHost(sql, "not-active.com");
+
+      expect(result).toBeNull();
+    });
+  }
+
+  test("a soft-deleted domain does not resolve tenant traffic", async () => {
+    await insertDomain(TENANT_ACTIVE, "deleted-domain.com", { deleted: true });
+
+    const sql = getTestSql();
+    const result = await resolvePublicTenantByHost(sql, "deleted-domain.com");
+
+    expect(result).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------
+  // Acceptance: inactive tenant behind an active domain -> generic null,
+  // identical to an unknown host (no distinguishable signal).
+  // ---------------------------------------------------------------------
+
+  test("an active domain mapped to an inactive tenant resolves to null (generic 404)", async () => {
+    await insertDomain(TENANT_INACTIVE, "inactive-tenant.com");
+
+    const sql = getTestSql();
+    const resultForInactiveTenant = await resolvePublicTenantByHost(
+      sql,
+      "inactive-tenant.com"
+    );
+    const resultForUnknownHost = await resolvePublicTenantByHost(
+      sql,
+      "totally-unknown-host.com"
+    );
+
+    expect(resultForInactiveTenant).toBeNull();
+    expect(resultForUnknownHost).toBeNull();
+    // Both failure modes are indistinguishable `null` — no differing shape,
+    // no thrown error, no extra field revealing which case it was.
+    expect(resultForInactiveTenant).toEqual(resultForUnknownHost);
+  });
+
+  // ---------------------------------------------------------------------
+  // Acceptance: unknown host only falls back when mode allows it; the
+  // env/setup fallback chain (steps 2-4) always runs regardless of mode.
+  // ---------------------------------------------------------------------
+
+  test("mode=host_default: unknown host falls through to PUBLIC_DEFAULT_TENANT_ID", async () => {
+    const sql = getTestSql();
+    const request = new Request("http://ignored.test/", {
+      headers: { host: "unmapped-host.com" }
+    });
+
+    const result = await resolvePublicTenantFromRequest(
+      sql,
+      request,
+      { mode: "host_default" },
+      undefined
+    );
+
+    // No PUBLIC_DEFAULT_TENANT_ID/CODE/setup_state configured yet -> null.
+    expect(result).toBeNull();
+
+    // Now prove the fallback chain actually works when env default IS set:
+    // resolveDefaultPublicTenantFromEnv is called with an explicit env
+    // object below (steps 2-3), independent from resolvePublicTenantFromRequest's
+    // internal default of `process.env` (that composition is covered by the
+    // unit test suite's mocked-deps tests).
+    const envResult = await resolveDefaultPublicTenantFromEnv(sql, {
+      PUBLIC_DEFAULT_TENANT_ID: TENANT_ACTIVE
+    } as NodeJS.ProcessEnv);
+
+    expect(envResult?.tenantId).toBe(TENANT_ACTIVE);
+  });
+
+  test("mode unset (offline/LAN default): host step never runs, but env/setup fallback still does", async () => {
+    await insertDomain(TENANT_ACTIVE, "would-have-matched.com");
+
+    const sql = getTestSql();
+    const request = new Request("http://ignored.test/", {
+      headers: { host: "would-have-matched.com" }
+    });
+
+    // No mode configured at all -> host lookup step is skipped entirely,
+    // even though a matching active domain row exists.
+    const result = await resolvePublicTenantFromRequest(sql, request, {});
+
+    expect(result).toBeNull();
+  });
+
+  test("if truly no step resolves a tenant, the result is a generic null (404)", async () => {
+    const sql = getTestSql();
+    const request = new Request("http://ignored.test/", {
+      headers: { host: "nothing-matches-anywhere.com" }
+    });
+
+    const result = await resolvePublicTenantFromRequest(sql, request, {
+      mode: "host_default"
+    });
+
+    expect(result).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------
+  // Acceptance: resolveDefaultPublicTenantFromEnv tries ID, then CODE.
+  // ---------------------------------------------------------------------
+
+  test("resolveDefaultPublicTenantFromEnv: PUBLIC_DEFAULT_TENANT_ID takes priority over CODE", async () => {
+    const sql = getTestSql();
+
+    const result = await resolveDefaultPublicTenantFromEnv(sql, {
+      PUBLIC_DEFAULT_TENANT_ID: TENANT_ACTIVE,
+      PUBLIC_DEFAULT_TENANT_CODE: "tenant-inactive"
+    } as NodeJS.ProcessEnv);
+
+    expect(result?.tenantId).toBe(TENANT_ACTIVE);
+  });
+
+  test("resolveDefaultPublicTenantFromEnv: falls back to CODE when ID is unset", async () => {
+    const sql = getTestSql();
+
+    const result = await resolveDefaultPublicTenantFromEnv(sql, {
+      PUBLIC_DEFAULT_TENANT_CODE: "tenant-active"
+    } as NodeJS.ProcessEnv);
+
+    expect(result?.tenantId).toBe(TENANT_ACTIVE);
+  });
+
+  test("resolveDefaultPublicTenantFromEnv: falls back to CODE when ID points at an inactive tenant", async () => {
+    const sql = getTestSql();
+
+    const result = await resolveDefaultPublicTenantFromEnv(sql, {
+      PUBLIC_DEFAULT_TENANT_ID: TENANT_INACTIVE,
+      PUBLIC_DEFAULT_TENANT_CODE: "tenant-active"
+    } as NodeJS.ProcessEnv);
+
+    expect(result?.tenantId).toBe(TENANT_ACTIVE);
+  });
+
+  test("resolveDefaultPublicTenantFromEnv: an inactive tenant behind PUBLIC_DEFAULT_TENANT_CODE resolves to null", async () => {
+    const sql = getTestSql();
+
+    const result = await resolveDefaultPublicTenantFromEnv(sql, {
+      PUBLIC_DEFAULT_TENANT_CODE: "tenant-inactive"
+    } as NodeJS.ProcessEnv);
+
+    expect(result).toBeNull();
+  });
+
+  test("resolveDefaultPublicTenantFromEnv: malformed PUBLIC_DEFAULT_TENANT_ID never throws, falls through to CODE", async () => {
+    const sql = getTestSql();
+
+    const result = await resolveDefaultPublicTenantFromEnv(sql, {
+      PUBLIC_DEFAULT_TENANT_ID: "not-a-uuid",
+      PUBLIC_DEFAULT_TENANT_CODE: "tenant-active"
+    } as NodeJS.ProcessEnv);
+
+    expect(result?.tenantId).toBe(TENANT_ACTIVE);
+  });
+
+  // ---------------------------------------------------------------------
+  // Acceptance: resolveDefaultPublicTenantFromSetupState reads
+  // awcms_mini_setup_state.tenant_id.
+  // ---------------------------------------------------------------------
+
+  test("resolveDefaultPublicTenantFromSetupState resolves the tenant recorded during setup", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_setup_state (id, tenant_id)
+      VALUES (true, ${TENANT_ACTIVE})
+      ON CONFLICT (id) DO UPDATE SET tenant_id = EXCLUDED.tenant_id
+    `;
+
+    const sql = getTestSql();
+    const result = await resolveDefaultPublicTenantFromSetupState(sql);
+
+    expect(result?.tenantId).toBe(TENANT_ACTIVE);
+  });
+
+  test("resolveDefaultPublicTenantFromSetupState returns null when no setup_state row/tenant is recorded", async () => {
+    const sql = getTestSql();
+    const result = await resolveDefaultPublicTenantFromSetupState(sql);
+
+    expect(result).toBeNull();
+  });
+
+  test("resolveDefaultPublicTenantFromSetupState returns null when the recorded tenant is inactive", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_setup_state (id, tenant_id)
+      VALUES (true, ${TENANT_INACTIVE})
+      ON CONFLICT (id) DO UPDATE SET tenant_id = EXCLUDED.tenant_id
+    `;
+
+    const sql = getTestSql();
+    const result = await resolveDefaultPublicTenantFromSetupState(sql);
+
+    expect(result).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------
+  // Acceptance: X-Forwarded-Host ignored unless PUBLIC_TRUST_PROXY=true.
+  // ---------------------------------------------------------------------
+
+  test("X-Forwarded-Host is ignored by default (trustProxy not set)", async () => {
+    await insertDomain(TENANT_ACTIVE, "real-host.com");
+    await insertDomain(TENANT_INACTIVE, "spoofed-host.com");
+
+    const sql = getTestSql();
+    const request = new Request("http://ignored.test/", {
+      headers: {
+        host: "real-host.com",
+        "x-forwarded-host": "spoofed-host.com"
+      }
+    });
+
+    const result = await resolvePublicTenantFromRequest(sql, request, {
+      mode: "host_default"
+    });
+
+    expect(result?.tenantId).toBe(TENANT_ACTIVE);
+  });
+
+  test("X-Forwarded-Host is honored only when trustProxy=true", async () => {
+    await insertDomain(TENANT_ACTIVE, "edge-proxy.internal");
+    await insertDomain(TENANT_INACTIVE, "public-facing.example.com");
+    // Give the forwarded-host tenant an active status too, to prove the
+    // header really is what drove resolution (not just "both are null").
+    await getAdminSql()`
+      UPDATE awcms_mini_tenants SET status = 'active' WHERE id = ${TENANT_INACTIVE}
+    `;
+
+    const sql = getTestSql();
+    const request = new Request("http://ignored.test/", {
+      headers: {
+        host: "edge-proxy.internal",
+        "x-forwarded-host": "public-facing.example.com"
+      }
+    });
+
+    const result = await resolvePublicTenantFromRequest(sql, request, {
+      mode: "host_default",
+      trustProxy: true
+    });
+
+    expect(result?.tenantId).toBe(TENANT_INACTIVE);
+  });
+
+  // ---------------------------------------------------------------------
+  // Acceptance / security note: the SECURITY DEFINER function is a
+  // deliberate, narrow bypass — not an accidental RLS leak. Proven by
+  // showing (a) the function works from the least-privilege app role with
+  // NO tenant GUC set, and (b) a direct SELECT on the underlying table from
+  // that same role/session still returns zero rows without the function.
+  // ---------------------------------------------------------------------
+
+  test("the SECURITY DEFINER lookup function resolves rows via awcms_mini_app with no app.current_tenant_id GUC set", async () => {
+    await insertDomain(TENANT_ACTIVE, "bootstrap-check.com");
+
+    const sql = getTestSql();
+
+    const guc = (await sql`
+      SELECT current_setting('app.current_tenant_id', true) AS tenant_guc
+    `) as { tenant_guc: string | null }[];
+    // The fail-closed default GUC (migration 013) — proves no withTenant(...)
+    // transaction/SET LOCAL happened in this session.
+    expect(guc[0]?.tenant_guc).toBe("00000000-0000-0000-0000-000000000000");
+
+    const rows = (await sql`
+      SELECT tenant_id, domain_status, tenant_status
+      FROM awcms_mini_resolve_tenant_domain_lookup('bootstrap-check.com')
+    `) as { tenant_id: string; domain_status: string; tenant_status: string }[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.tenant_id).toBe(TENANT_ACTIVE);
+    expect(rows[0]?.domain_status).toBe("active");
+    expect(rows[0]?.tenant_status).toBe("active");
+  });
+
+  test("a direct SELECT on awcms_mini_tenant_domains from the same app-role session (no function) still returns zero rows", async () => {
+    await insertDomain(TENANT_ACTIVE, "bootstrap-check-direct.com");
+
+    const sql = getTestSql();
+    const rows = await sql`
+      SELECT normalized_hostname FROM awcms_mini_tenant_domains
+      WHERE normalized_hostname = 'bootstrap-check-direct.com'
+    `;
+
+    // This is the exact fail-closed behavior migration 031 documented as
+    // "correct and required" — the SECURITY DEFINER function above is the
+    // one sanctioned exception, not a general RLS bypass for this role.
+    expect(rows).toHaveLength(0);
+  });
+
+  test("the lookup function never returns verification_token_hash or raw hostname columns", async () => {
+    await insertDomain(TENANT_ACTIVE, "narrow-surface-check.com");
+
+    const sql = getTestSql();
+    const rows = (await sql`
+      SELECT * FROM awcms_mini_resolve_tenant_domain_lookup('narrow-surface-check.com')
+    `) as Record<string, unknown>[];
+
+    expect(rows).toHaveLength(1);
+    const columns = Object.keys(rows[0] ?? {});
+    // The tenant_* columns (status/code/name/locale) were added to close a
+    // timing side-channel (see migration 033's comment): they let
+    // resolvePublicTenantByHost finish in exactly one round trip instead of
+    // a conditional second query, and they expose nothing that wasn't
+    // already unconditionally public on the RLS-free awcms_mini_tenants
+    // table (ADR-0003/migration 013).
+    expect(columns.sort()).toEqual(
+      [
+        "tenant_id",
+        "domain_status",
+        "is_primary",
+        "route_mode",
+        "tenant_status",
+        "tenant_code",
+        "tenant_name",
+        "default_locale"
+      ].sort()
+    );
+    expect(columns).not.toContain("verification_token_hash");
+    expect(columns).not.toContain("hostname");
+    expect(columns).not.toContain("verification_record_value");
+  });
+
+  // ---------------------------------------------------------------------
+  // Security fix (post-review): resolvePublicTenantByHost must complete in
+  // exactly one DB round trip for every outcome, so an unknown host and a
+  // host mapped to an active domain but an inactive tenant are not
+  // distinguishable by response latency. Proven directly by counting query
+  // invocations via a wrapping proxy around the same underlying sql client.
+  // ---------------------------------------------------------------------
+
+  test("resolvePublicTenantByHost issues exactly one query whether the host is unknown, mapped-but-inactive-tenant, or fully active", async () => {
+    await insertDomain(TENANT_ACTIVE, "single-query-active.com");
+    await insertDomain(TENANT_INACTIVE, "single-query-inactive-tenant.com");
+
+    const baseSql = getTestSql();
+    let callCount = 0;
+    const countingSql = new Proxy(baseSql, {
+      apply(target, thisArg, args) {
+        callCount += 1;
+        return Reflect.apply(
+          target as unknown as (...a: unknown[]) => unknown,
+          thisArg,
+          args
+        );
+      }
+    }) as unknown as Bun.SQL;
+
+    callCount = 0;
+    await resolvePublicTenantByHost(countingSql, "totally-unmapped-host.com");
+    const unmappedCallCount = callCount;
+
+    callCount = 0;
+    await resolvePublicTenantByHost(
+      countingSql,
+      "single-query-inactive-tenant.com"
+    );
+    const inactiveTenantCallCount = callCount;
+
+    callCount = 0;
+    await resolvePublicTenantByHost(countingSql, "single-query-active.com");
+    const activeCallCount = callCount;
+
+    expect(unmappedCallCount).toBe(1);
+    expect(inactiveTenantCallCount).toBe(1);
+    expect(activeCallCount).toBe(1);
+  });
+});

--- a/tests/unit/public-host-tenant-resolver.test.ts
+++ b/tests/unit/public-host-tenant-resolver.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Pure unit tests for `src/lib/tenant/public-host-tenant-resolver.ts`
+ * (Issue #559, epic #555) — no database. `normalizePublicHost()` is tested
+ * directly; `resolvePublicTenantFromRequest()`'s branching (mode gating,
+ * fallback order, trustProxy header selection) is tested with mocked
+ * `deps` so no DB-touching function actually runs. Real DB behavior
+ * (RLS/SECURITY DEFINER bypass, status filtering, tenant activation) is
+ * covered separately by
+ * `tests/integration/public-tenant-resolution.integration.test.ts`.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  normalizePublicHost,
+  resolvePublicTenantByHost,
+  resolvePublicTenantFromRequest,
+  type PublicHostResolverDeps,
+  type PublicTenantResolution
+} from "../../src/lib/tenant/public-host-tenant-resolver";
+
+const FAKE_SQL = {} as unknown as Bun.SQL;
+
+const SAMPLE_TENANT: PublicTenantResolution = {
+  tenantId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  tenantCode: "sample-tenant",
+  tenantName: "Sample Tenant",
+  defaultLocale: "en"
+};
+
+function makeDeps(overrides: Partial<PublicHostResolverDeps> = {}) {
+  const resolvePublicTenantByHost = mock(
+    async (): Promise<PublicTenantResolution | null> => null
+  );
+  const resolveDefaultPublicTenantFromEnv = mock(
+    async (): Promise<PublicTenantResolution | null> => null
+  );
+  const resolveDefaultPublicTenantFromSetupState = mock(
+    async (): Promise<PublicTenantResolution | null> => null
+  );
+
+  return {
+    resolvePublicTenantByHost,
+    resolveDefaultPublicTenantFromEnv,
+    resolveDefaultPublicTenantFromSetupState,
+    ...overrides
+  } as PublicHostResolverDeps;
+}
+
+describe("normalizePublicHost", () => {
+  test("lowercases and trims a plain hostname", () => {
+    expect(normalizePublicHost("  Example.COM  ")).toBe("example.com");
+  });
+
+  test("strips a trailing port", () => {
+    expect(normalizePublicHost("example.com:4321")).toBe("example.com");
+  });
+
+  test("resolves a subdomain the same way as a custom domain", () => {
+    expect(normalizePublicHost("Blog.Platform.com:8080")).toBe(
+      "blog.platform.com"
+    );
+  });
+
+  test("throws on an empty string (caller contract violation)", () => {
+    expect(() => normalizePublicHost("")).toThrow();
+  });
+
+  test("throws on a whitespace-only string", () => {
+    expect(() => normalizePublicHost("   ")).toThrow();
+  });
+
+  for (const invalid of [
+    "exa mple.com",
+    "example..com",
+    ".example.com",
+    "example.com.",
+    "example_.com",
+    "-example.com",
+    "example-.com",
+    "[::1]:4321",
+    "a".repeat(300),
+    "a".repeat(70) + ".com"
+  ]) {
+    test(`rejects invalid host format (returns null, does not throw): ${JSON.stringify(invalid)}`, () => {
+      expect(normalizePublicHost(invalid)).toBeNull();
+    });
+  }
+
+  test("accepts a bare single-label host (e.g. localhost)", () => {
+    expect(normalizePublicHost("localhost:4321")).toBe("localhost");
+  });
+});
+
+describe("resolvePublicTenantFromRequest — mode gating and fallback order", () => {
+  test("mode=host_default: resolves via host lookup, never touches env/setup fallback", async () => {
+    const deps = makeDeps({
+      resolvePublicTenantByHost: mock(async () => SAMPLE_TENANT)
+    });
+
+    const request = new Request("http://ignored.test/", {
+      headers: { host: "tenant-one.example.com" }
+    });
+
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      request,
+      { mode: "host_default" },
+      deps
+    );
+
+    expect(result).toEqual(SAMPLE_TENANT);
+    expect(deps.resolvePublicTenantByHost).toHaveBeenCalledTimes(1);
+    expect(
+      (deps.resolvePublicTenantByHost as ReturnType<typeof mock>).mock.calls[0]
+    ).toEqual([FAKE_SQL, "tenant-one.example.com"]);
+    expect(deps.resolveDefaultPublicTenantFromEnv).not.toHaveBeenCalled();
+    expect(
+      deps.resolveDefaultPublicTenantFromSetupState
+    ).not.toHaveBeenCalled();
+  });
+
+  test("mode=host_default but host does not resolve: falls through to env default", async () => {
+    const deps = makeDeps({
+      resolveDefaultPublicTenantFromEnv: mock(async () => SAMPLE_TENANT)
+    });
+
+    const request = new Request("http://ignored.test/", {
+      headers: { host: "unknown-host.example.com" }
+    });
+
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      request,
+      { mode: "host_default" },
+      deps
+    );
+
+    expect(result).toEqual(SAMPLE_TENANT);
+    expect(deps.resolvePublicTenantByHost).toHaveBeenCalledTimes(1);
+    expect(deps.resolveDefaultPublicTenantFromEnv).toHaveBeenCalledTimes(1);
+    expect(
+      deps.resolveDefaultPublicTenantFromSetupState
+    ).not.toHaveBeenCalled();
+  });
+
+  test("mode=host_default, host+env both fail: falls through to setup state", async () => {
+    const deps = makeDeps({
+      resolveDefaultPublicTenantFromSetupState: mock(async () => SAMPLE_TENANT)
+    });
+
+    const request = new Request("http://ignored.test/", {
+      headers: { host: "unknown-host.example.com" }
+    });
+
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      request,
+      { mode: "host_default" },
+      deps
+    );
+
+    expect(result).toEqual(SAMPLE_TENANT);
+    expect(deps.resolveDefaultPublicTenantFromEnv).toHaveBeenCalledTimes(1);
+    expect(deps.resolveDefaultPublicTenantFromSetupState).toHaveBeenCalledTimes(
+      1
+    );
+  });
+
+  test("every step fails: returns null (generic 404), never throws", async () => {
+    const deps = makeDeps();
+
+    const request = new Request("http://ignored.test/", {
+      headers: { host: "unknown-host.example.com" }
+    });
+
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      request,
+      { mode: "host_default" },
+      deps
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("mode unset: host lookup step is never attempted, only env/setup fallback runs", async () => {
+    const deps = makeDeps({
+      resolveDefaultPublicTenantFromEnv: mock(async () => SAMPLE_TENANT)
+    });
+
+    const request = new Request("http://ignored.test/", {
+      headers: { host: "tenant-one.example.com" }
+    });
+
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      request,
+      {},
+      deps
+    );
+
+    expect(result).toEqual(SAMPLE_TENANT);
+    expect(deps.resolvePublicTenantByHost).not.toHaveBeenCalled();
+  });
+
+  for (const otherMode of [
+    "env_default",
+    "setup_default",
+    "tenant_code_legacy"
+  ]) {
+    test(`mode=${otherMode}: host lookup step is never attempted (only host_default enables it)`, async () => {
+      const deps = makeDeps({
+        resolveDefaultPublicTenantFromSetupState: mock(
+          async () => SAMPLE_TENANT
+        )
+      });
+
+      const request = new Request("http://ignored.test/", {
+        headers: { host: "tenant-one.example.com" }
+      });
+
+      const result = await resolvePublicTenantFromRequest(
+        FAKE_SQL,
+        request,
+        { mode: otherMode },
+        deps
+      );
+
+      expect(result).toEqual(SAMPLE_TENANT);
+      expect(deps.resolvePublicTenantByHost).not.toHaveBeenCalled();
+    });
+  }
+
+  test("trustProxy=false (default): X-Forwarded-Host is ignored, plain Host header used", async () => {
+    const deps = makeDeps({
+      resolvePublicTenantByHost: mock(async () => SAMPLE_TENANT)
+    });
+
+    const request = new Request("http://ignored.test/", {
+      headers: {
+        host: "real-host.example.com",
+        "x-forwarded-host": "attacker-controlled.example.com"
+      }
+    });
+
+    await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      request,
+      { mode: "host_default" },
+      deps
+    );
+
+    expect(
+      (deps.resolvePublicTenantByHost as ReturnType<typeof mock>).mock.calls[0]
+    ).toEqual([FAKE_SQL, "real-host.example.com"]);
+  });
+
+  test("trustProxy=true: a single-value X-Forwarded-Host is used when present", async () => {
+    const deps = makeDeps({
+      resolvePublicTenantByHost: mock(async () => SAMPLE_TENANT)
+    });
+
+    const request = new Request("http://ignored.test/", {
+      headers: {
+        host: "edge-proxy.internal",
+        "x-forwarded-host": "public-facing.example.com"
+      }
+    });
+
+    await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      request,
+      { mode: "host_default", trustProxy: true },
+      deps
+    );
+
+    expect(
+      (deps.resolvePublicTenantByHost as ReturnType<typeof mock>).mock.calls[0]
+    ).toEqual([FAKE_SQL, "public-facing.example.com"]);
+  });
+
+  test("trustProxy=true: a multi-value X-Forwarded-Host (unexpected for this repo's single-trusted-proxy topology) falls back to the plain Host header, not the leftmost/client-controllable entry", async () => {
+    const deps = makeDeps({
+      resolvePublicTenantByHost: mock(async () => SAMPLE_TENANT)
+    });
+
+    const request = new Request("http://ignored.test/", {
+      headers: {
+        host: "real-edge-proxy.internal",
+        // A well-behaved single overwriting proxy never produces more than
+        // one value — this simulates either a spoofing attempt (client
+        // pre-seeded the header) or a misconfigured proxy chain that
+        // appends instead of overwriting. Either way, the leftmost value
+        // ("attacker-controlled.example.com") must NOT be trusted.
+        "x-forwarded-host":
+          "attacker-controlled.example.com, real-edge-proxy.internal"
+      }
+    });
+
+    await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      request,
+      { mode: "host_default", trustProxy: true },
+      deps
+    );
+
+    expect(
+      (deps.resolvePublicTenantByHost as ReturnType<typeof mock>).mock.calls[0]
+    ).toEqual([FAKE_SQL, "real-edge-proxy.internal"]);
+  });
+
+  test("accepts a raw host string instead of a Request", async () => {
+    const deps = makeDeps({
+      resolvePublicTenantByHost: mock(async () => SAMPLE_TENANT)
+    });
+
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      "direct-host.example.com:9999",
+      { mode: "host_default" },
+      deps
+    );
+
+    expect(result).toEqual(SAMPLE_TENANT);
+    expect(
+      (deps.resolvePublicTenantByHost as ReturnType<typeof mock>).mock.calls[0]
+    ).toEqual([FAKE_SQL, "direct-host.example.com"]);
+  });
+
+  test("a malformed host from the request never throws — falls through to the fallback chain", async () => {
+    const deps = makeDeps({
+      resolveDefaultPublicTenantFromEnv: mock(async () => SAMPLE_TENANT)
+    });
+
+    const request = new Request("http://ignored.test/", {
+      headers: { host: "exa mple.com" }
+    });
+
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      request,
+      { mode: "host_default" },
+      deps
+    );
+
+    expect(result).toEqual(SAMPLE_TENANT);
+    expect(deps.resolvePublicTenantByHost).not.toHaveBeenCalled();
+  });
+
+  test("no Host header at all: does not throw, skips straight to fallback chain", async () => {
+    const deps = makeDeps({
+      resolveDefaultPublicTenantFromSetupState: mock(async () => SAMPLE_TENANT)
+    });
+
+    const request = new Request("http://ignored.test/");
+
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      request,
+      { mode: "host_default" },
+      deps
+    );
+
+    expect(result).toEqual(SAMPLE_TENANT);
+    expect(deps.resolvePublicTenantByHost).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolvePublicTenantByHost — defense-in-depth shape validation", () => {
+  // `resolvePublicTenantByHost` is exported and documented as directly
+  // callable (e.g. by Issue #560), not only reachable through
+  // `normalizePublicHost()` first. These prove it re-validates hostname
+  // shape itself and short-circuits BEFORE ever touching `sql` — the fake
+  // `sql` below throws if invoked at all, so a passing test is direct
+  // proof no query was attempted for a malformed/oversized value.
+  function throwingSql(): Bun.SQL {
+    return (() => {
+      throw new Error(
+        "sql must not be called — resolvePublicTenantByHost should reject this input before querying."
+      );
+    }) as unknown as Bun.SQL;
+  }
+
+  test("rejects an oversized host (>253 chars) without querying the database", async () => {
+    const result = await resolvePublicTenantByHost(
+      throwingSql(),
+      "a".repeat(300)
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects a host containing whitespace without querying the database", async () => {
+    const result = await resolvePublicTenantByHost(
+      throwingSql(),
+      "not a valid host"
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects an empty string without querying the database", async () => {
+    const result = await resolvePublicTenantByHost(throwingSql(), "");
+
+    expect(result).toBeNull();
+  });
+
+  test("rejects a host with an invalid label (leading hyphen) without querying the database", async () => {
+    const result = await resolvePublicTenantByHost(
+      throwingSql(),
+      "-bad-label.example.com"
+    );
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Fourth issue of epic #555, depends on #556+#557 (both merged). Adds `src/lib/tenant/public-host-tenant-resolver.ts` — **library-only**, not yet consumed by any route (that's #560).
- 5 functions, exact resolution order from the issue: host/domain mapping → `PUBLIC_DEFAULT_TENANT_ID` → `PUBLIC_DEFAULT_TENANT_CODE` → `awcms_mini_setup_state.tenant_id` → generic `null`/404.
- **Closes the RLS bootstrap gap flagged in #557's migration 031**: `sql/033` adds a narrowly-scoped `SECURITY DEFINER` function (`awcms_mini_resolve_tenant_domain_lookup`) as the sanctioned bootstrap read path for `awcms_mini_tenant_domains`, which stays `FORCE` RLS'd. Verified empirically (not assumed) that the migration-owner role is an actual Postgres superuser — that's *why* the bypass is safe and intentional rather than an accidental owner/FORCE interaction. `EXECUTE` is revoked from `PUBLIC`, granted only to `awcms_mini_app`; the function body is fixed/parameterized; it returns only non-sensitive columns (never `verification_token_hash`/`verification_record_value`/raw hostname).

## Review chain (this is the epic's highest-risk mechanism so far)
- `awcms-mini-reviewer`: approved, every acceptance criterion verified empirically against real Postgres.
- `awcms-mini-security-auditor`: **PASS**, but found two Medium findings, both fixed in this same PR before merge:
  - **Timing side-channel**: an earlier version needed a second DB round trip only when a domain resolved to an inactive tenant, letting a caller distinguish "unmapped host" from "mapped, tenant inactive" by latency alone. Fixed by joining `awcms_mini_tenants` into the same `SECURITY DEFINER` call so every outcome costs exactly one round trip (safe — that table is already RLS-free/publicly readable by design).
  - **`X-Forwarded-Host` multi-value handling**: trusting the leftmost entry assumed a specific trusted-proxy header-append convention this repo doesn't actually configure/guarantee. Now treated as a misconfiguration/spoofing signal (falls back to plain `Host`, logs a warning) instead of guessing which value is trustworthy.
  - Plus two Low findings, also fixed: added a generic "Using `SECURITY DEFINER`" checklist to `docs/adr/0003-postgresql-rls-multi-tenant.md` and the `awcms-mini-new-migration` skill (this is the repo's first such function), and hardened `resolvePublicTenantByHost` to re-validate its own "already normalized" precondition rather than trusting callers.

## Test plan
- [x] `bun run db:migrate` twice — idempotent
- [x] `bun test tests/unit/public-host-tenant-resolver.test.ts` — 34 pass
- [x] `bun test tests/integration/public-tenant-resolution.integration.test.ts` — 26 pass (includes a round-trip-counting test proving the timing fix, and a test proving `FORCE RLS` on the underlying table is still fully intact)
- [x] `bun run typecheck` / `bun run lint` / `bun run check:docs` / `bun run api:spec:check` — PASS
- [x] `bun test` against real PostgreSQL — 1017 pass, 0 fail
- [x] `bun run build` — PASS
- [x] Independently re-verified: `EXECUTE` grants (only `awcms-mini` owner + `awcms_mini_app`, no `PUBLIC`), and that direct `SELECT` on `awcms_mini_tenant_domains` as `awcms_mini_app` with no tenant GUC still returns 0 rows (FORCE RLS untouched)

## Security notes
No secret/token flows through this resolver anywhere (grepped + tested). Never queries tenant content before resolution completes. Every failure case (unknown host, non-active domain, non-active tenant) returns an identical `null` — no distinguishable signal, payload or timing, after this PR's fixes. `X-Forwarded-Host` only read when `PUBLIC_TRUST_PROXY=true`, with the leftmost-value trust assumption removed per the auditor's finding.

## Known non-blocking product ambiguity (flagged for #560 to resolve explicitly)
Whether `PUBLIC_TENANT_RESOLUTION_MODE=tenant_code_legacy` should make this resolver always return `null` (since that mode's whole point is "no default-tenant guessing, require explicit `tenantCode`") vs. the current behavior where it still runs the env/setup fallback chain like `env_default`/`setup_default` do. Zero live impact today (no route consumes this yet) — both reviewers flagged this as a #560-scoping decision, not a defect here.

## Next steps
Issue #560 (`/news` public routes for `blog_content`) is next — it must resolve the `tenant_code_legacy` ambiguity above when wiring this resolver into an actual route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)