### PR TITLE
feat(tenant-domain): add admin UI for domain and subdomain management (Issue #563)

### DIFF
--- a/.changeset/tenant-domain-admin-ui-issue-563.md
+++ b/.changeset/tenant-domain-admin-ui-issue-563.md
@@ -1,0 +1,55 @@
+---
+"awcms-mini": minor
+---
+
+Add the tenant domain/subdomain admin UI (Issue #563, epic #555):
+`src/pages/admin/tenant/domains.astro`, at the path/permission already
+declared by the module descriptor (Issue #558) —
+`/admin/tenant/domains`, gated on `tenant_domain.domains.read`.
+
+List, add platform subdomain/custom domain, show/copy TXT/CNAME
+verification records, trigger manual-first verify, set primary domain,
+soft delete, and preview the public `/news` link for a domain that is
+both `active` and the tenant's primary. Status badges use the real DB
+enum (`pending_verification | active | suspended | failed`, migration
+031) rather than the issue's own shorthand list.
+
+SSR reads (`listTenantDomains`) are a direct, read-only DB call inside
+`withTenant` — the same convention `admin/blog/categories.astro` uses.
+**Every mutation** (create/update/verify/set-primary/delete) goes through
+the real `/api/v1/tenant/domains/**` endpoints (Issue #562) via
+client-side `fetch` — no privileged SSR shortcut. `verify`/`set-primary`
+send a fresh `Idempotency-Key` (`crypto.randomUUID()`) per click, matching
+`admin/blog/posts/[id].astro`'s lifecycle-action buttons; every mutating
+control is `lockElement`-guarded against double-submit. Hostname
+validation is duplicated client-side as a UX nicety only (mirrors
+`normalizePublicHost()`'s shape rules) — the API remains the enforcement
+boundary.
+
+Extends `src/lib/i18n/error-messages.ts`'s `ERROR_CODE_KEYS` with the
+tenant domain API's own `HOSTNAME_CONFLICT`, `INVALID_STATUS_TRANSITION`,
+and `CONCURRENT_UPDATE` codes so the admin UI never surfaces a raw
+server message for them. `src/modules/tenant-domain/domain/tenant-domain-validation.ts`
+now exports its enum vocabulary arrays (`TENANT_DOMAIN_TYPES` etc.) so the
+create/edit forms build their `<select>` options from the same source of
+truth the validator itself uses, instead of a second opinion.
+
+New i18n catalog entries under `admin.tenant_domain.*` and
+`admin.layout.nav_tenant_domains` (en + id). New test:
+`tests/integration/tenant-domain-admin.integration.test.ts` — the SSR
+read path's empty/populated/active-primary/tenant-isolation shapes, and
+that the three new error codes are ones the real API actually returns.
+
+Post-review fix: the edit form's status `<select>` was previously hidden
+entirely for an `active` domain, leaving no self-service way to suspend a
+live domain from this screen (the API already allowed `active ->
+suspended`/`failed` via `PATCH`, since Issue #562 never gated that
+transition on current status). The status field now always renders, with
+a "leave unchanged" default option (wiring up a catalog entry the first
+draft had added but never used) plus a hint explaining the consequence
+when the current status is `active`. Also removed a native HTML `pattern`
+attribute on the create form's hostname input that could block submission
+with the browser's untranslated tooltip before the app's own localized
+error banner (`looksLikeValidHostname()`) ever ran — the client-side
+check remains a UX nicety only; `normalizePublicHost()` via the API stays
+the enforcement boundary.

--- a/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
@@ -35,7 +35,7 @@ menjembatani beberapa modul sekaligus (config, `tenant_domain` module baru,
 | #560  | Rute publik `/news` untuk `blog_content`                      | **Selesai** — lihat §Rute publik `/news` di bawah                                |
 | #561  | Dokumentasi legacy `/blog/{tenantCode}`                       | **Selesai** — lihat ADR-0010, `blog-content/README.md`, `deployment-profiles.md` |
 | #562  | Tenant domain management API                                  | **Selesai** — lihat §API di bawah                                                |
-| #563  | Admin UI domain/subdomain                                     | Belum                                                                            |
+| #563  | Admin UI domain/subdomain                                     | **Selesai** — lihat §Admin UI di bawah                                           |
 | #564  | Tenant settings untuk rute `/news` vs legacy (`blog_content`) | Belum                                                                            |
 | #565  | Tenant module presets (online/news/LAN/minimal)               | Belum                                                                            |
 | #566  | Tenant-module matrix admin UI                                 | Belum                                                                            |
@@ -501,6 +501,29 @@ lengkap acceptance criterion) ada di
 `src/modules/tenant-domain/README.md` §Tenant domain management API. Test:
 `tests/integration/tenant-domain-api.integration.test.ts`.
 
+### Admin UI (Issue #563, `src/pages/admin/tenant/domains.astro`)
+
+Path/permission gate persis descriptor Issue #558:
+`/admin/tenant/domains`, `tenant_domain.domains.read`. **Binding split**
+yang wajib diikuti issue turunan manapun yang menambah aksi baru di
+halaman ini: SSR initial render boleh baca langsung lewat
+`listTenantDomains`/`withTenant` (read-only, sama pola
+`admin/blog/categories.astro`), tapi **setiap mutasi** (create/update/
+delete/verify/set-primary) **wajib** lewat `fetch` client-side ke
+`/api/v1/tenant/domains/**` (#562) — tidak ada shortcut SSR privileged
+untuk mutasi apa pun, itu acceptance criterion mengikat issue #563.
+`verify`/`set-primary` mengirim `Idempotency-Key` baru
+(`newIdempotencyKey()`) per klik, pola sama
+`admin/blog/posts/[id].astro`'s tombol lifecycle. Validasi hostname
+client-side (`looksLikeValidHostname()` di halaman ini) murni UX —
+`normalizePublicHost()` lewat API tetap satu-satunya enforcement.
+Badge status pakai enum DB asli (`pending_verification | active |
+suspended | failed`) — bukan daftar shorthand issue #563 sendiri yang
+menyebut "verified" sebagai status kelima (tidak ada di schema). Link
+preview `/news` hanya muncul untuk domain yang `active` **dan**
+`isPrimary` sekaligus. Test:
+`tests/integration/tenant-domain-admin.integration.test.ts`.
+
 ## Aturan lintas-issue yang wajib diikuti
 
 1. **Backward compatibility non-negotiable**: setiap deployment offline/LAN existing yang tidak pernah set `PUBLIC_*` apa pun harus tetap `config:validate` PASS dan berperilaku persis seperti sebelum epic ini — jangan pernah membuat salah satu dari enam var config ini menjadi wajib secara default.
@@ -516,21 +539,19 @@ lengkap acceptance criterion) ada di
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Isu #562-#567 (API tenant domain, admin UI domain, tenant settings rute
-`/news`/legacy di `blog_content`, module presets, matrix UI admin, dan
-adapter Cloudflare DNS) **belum ada** — lapisan config (#556), schema
-`awcms_mini_tenant_domains` (#557), module descriptor `tenant_domain`
-(#558), resolver host-based (#559), rute publik `/news` (#560), dan
-dokumentasi legacy/ADR-0010 (#561) sudah selesai (lihat §Rute publik
-`/news` dan aturan #3 di atas). Tabel
-`awcms_mini_tenant_domains` masih berisi schema + constraint + RLS +
-permission catalog seed + fungsi lookup `SECURITY DEFINER` saja — belum
-ada baris yang pernah ditulis lewat kode aplikasi (menunggu #562's API);
-resolver #559 hanya bisa MEMBACA baris yang di-seed manual/via test, bukan
-menulisnya — `/news` (#560) karena itu, sampai #562 ada, hanya bisa
-resolve tenant lewat fallback env/setup-state (langkah 2-4), tidak pernah
-lewat host/domain mapping asli (langkah 1) kecuali baris
-`awcms_mini_tenant_domains` di-seed manual.
+Isu #564-#567 (tenant settings rute `/news`/legacy di `blog_content`,
+module presets, matrix UI admin, dan adapter Cloudflare DNS) **belum
+ada**. Sudah selesai: config (#556), schema `awcms_mini_tenant_domains`
+(#557), module descriptor `tenant_domain` (#558), resolver host-based
+(#559), rute publik `/news` (#560), dokumentasi legacy/ADR-0010 (#561),
+API tenant domain management (#562, §API di atas), dan admin UI (#563,
+§Admin UI di atas). Tabel `awcms_mini_tenant_domains` sekarang bisa
+ditulis lewat kode aplikasi (API #562 + admin UI #563) — bukan lagi
+schema-only. Operator yang benar-benar mengisi baris nyata lewat
+UI/API dan mengaktifkan `PUBLIC_TENANT_RESOLUTION_MODE=host_default`
+membuat resolver #559 langkah 1 (host/domain mapping asli) benar-benar
+reachable di production untuk pertama kalinya — lihat konsekuensi
+keamanan di ADR-0010 §Konsekuensi sebelum mengaktifkan mode itu.
 
 **Follow-up keamanan wajib diselesaikan sebelum `PUBLIC_TENANT_RESOLUTION_MODE=host_default` diaktifkan di production** (ditemukan `awcms-mini-security-auditor` saat audit #560, verdict PASS tapi non-blocking karena `host_default` belum bisa resolve apa pun secara nyata hari ini — lihat alasan di atas):
 

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -113,6 +113,15 @@ msgstr "This cannot be permanently deleted while other records depend on it."
 msgid "error.purge_requires_soft_delete"
 msgstr "This must be archived before it can be permanently deleted."
 
+msgid "error.hostname_conflict"
+msgstr "This hostname is already mapped to a tenant."
+
+msgid "error.invalid_status_transition"
+msgstr "This action is not allowed for the current status."
+
+msgid "error.concurrent_update"
+msgstr "Another request already changed this. Please try again."
+
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"
 msgstr "No role"
@@ -134,6 +143,9 @@ msgstr "Sync"
 
 msgid "admin.layout.nav_settings"
 msgstr "Settings"
+
+msgid "admin.layout.nav_tenant_domains"
+msgstr "Tenant Domains"
 
 msgid "admin.layout.nav_modules"
 msgstr "Modules"
@@ -1685,4 +1697,185 @@ msgstr "Delete this advertisement?"
 
 msgid "admin.blog.ads.delete_success"
 msgstr "Advertisement deleted."
+
+#. admin.tenant_domain (Issue #563)
+msgid "admin.tenant_domain.title"
+msgstr "Tenant Domains"
+
+msgid "admin.tenant_domain.access_denied_title"
+msgstr "Access denied."
+
+msgid "admin.tenant_domain.access_denied_body"
+msgstr "Your account does not have permission to view tenant domains. Contact your tenant admin/owner to request access."
+
+msgid "admin.tenant_domain.no_domains"
+msgstr "No domains yet. Add a platform subdomain or a custom domain to get started."
+
+msgid "admin.tenant_domain.hostname_column"
+msgstr "Hostname"
+
+msgid "admin.tenant_domain.type_column"
+msgstr "Type"
+
+msgid "admin.tenant_domain.status_column"
+msgstr "Status"
+
+msgid "admin.tenant_domain.verification_column"
+msgstr "Verification"
+
+msgid "admin.tenant_domain.actions_column"
+msgstr "Actions"
+
+msgid "admin.tenant_domain.domain_type.subdomain"
+msgstr "Platform subdomain"
+
+msgid "admin.tenant_domain.domain_type.custom_domain"
+msgstr "Custom domain"
+
+msgid "admin.tenant_domain.route_mode.canonical"
+msgstr "Canonical (/news)"
+
+msgid "admin.tenant_domain.route_mode.legacy_blog"
+msgstr "Legacy (/blog/{tenantCode})"
+
+msgid "admin.tenant_domain.status.pending_verification"
+msgstr "Pending verification"
+
+msgid "admin.tenant_domain.status.active"
+msgstr "Active"
+
+msgid "admin.tenant_domain.status.suspended"
+msgstr "Suspended"
+
+msgid "admin.tenant_domain.status.failed"
+msgstr "Failed"
+
+msgid "admin.tenant_domain.primary_badge_label"
+msgstr "Primary domain"
+
+msgid "admin.tenant_domain.verification_method.dns_txt"
+msgstr "TXT record"
+
+msgid "admin.tenant_domain.verification_method.dns_cname"
+msgstr "CNAME record"
+
+msgid "admin.tenant_domain.verification_method.file"
+msgstr "File upload"
+
+msgid "admin.tenant_domain.verification_method.manual"
+msgstr "Manual (operator-attested)"
+
+msgid "admin.tenant_domain.verification_method_none"
+msgstr "No verification method set"
+
+msgid "admin.tenant_domain.no_record_configured"
+msgstr "No DNS record configured for this verification method yet."
+
+msgid "admin.tenant_domain.record_name_label"
+msgstr "Record name/host"
+
+msgid "admin.tenant_domain.record_value_label"
+msgstr "Record value"
+
+msgid "admin.tenant_domain.copy_button"
+msgstr "Copy"
+
+msgid "admin.tenant_domain.copy_success"
+msgstr "Copied to clipboard."
+
+msgid "admin.tenant_domain.copy_error"
+msgstr "Could not copy automatically — please copy it manually."
+
+msgid "admin.tenant_domain.preview_link"
+msgstr "Open public /news site"
+
+msgid "admin.tenant_domain.preview_hint"
+msgstr "Only resolves publicly if host-based public routing is enabled for this deployment."
+
+msgid "admin.tenant_domain.verify_button"
+msgstr "Verify"
+
+msgid "admin.tenant_domain.verify_confirm"
+msgstr "Verify this domain now? This marks it active based on your attestation that DNS/ownership is correct."
+
+msgid "admin.tenant_domain.verify_success"
+msgstr "Domain verified."
+
+msgid "admin.tenant_domain.set_primary_button"
+msgstr "Set as primary"
+
+msgid "admin.tenant_domain.set_primary_confirm"
+msgstr "Set this domain as the tenant's primary domain?"
+
+msgid "admin.tenant_domain.set_primary_success"
+msgstr "Primary domain updated."
+
+msgid "admin.tenant_domain.delete_button"
+msgstr "Delete"
+
+msgid "admin.tenant_domain.delete_reason_prompt"
+msgstr "Reason for deleting this domain mapping:"
+
+msgid "admin.tenant_domain.delete_confirm"
+msgstr "Delete this domain mapping? This cannot be undone from this screen."
+
+msgid "admin.tenant_domain.delete_success"
+msgstr "Domain mapping deleted."
+
+msgid "admin.tenant_domain.edit_summary"
+msgstr "Edit"
+
+msgid "admin.tenant_domain.save_button"
+msgstr "Save"
+
+msgid "admin.tenant_domain.update_success"
+msgstr "Domain mapping updated."
+
+msgid "admin.tenant_domain.field_status_no_change"
+msgstr "Leave unchanged"
+
+msgid "admin.tenant_domain.field_status_active_hint"
+msgstr "This domain is currently active. Choosing a status below (e.g. Suspended) will take it out of service — the change applies immediately when you save."
+
+msgid "admin.tenant_domain.field_verification_method_none_option"
+msgstr "Not set"
+
+msgid "admin.tenant_domain.create_summary"
+msgstr "Add a domain or subdomain"
+
+msgid "admin.tenant_domain.create_submit"
+msgstr "Add domain"
+
+msgid "admin.tenant_domain.create_success"
+msgstr "Domain mapping added."
+
+msgid "admin.tenant_domain.field_hostname"
+msgstr "Hostname"
+
+msgid "admin.tenant_domain.field_hostname_hint"
+msgstr "Enter the full hostname, e.g. shop.example.com — no scheme (https://), no port."
+
+msgid "admin.tenant_domain.field_domain_type"
+msgstr "Domain type"
+
+msgid "admin.tenant_domain.field_route_mode"
+msgstr "Route mode"
+
+msgid "admin.tenant_domain.field_verification_method"
+msgstr "Verification method"
+
+msgid "admin.tenant_domain.field_record_name"
+msgstr "Verification record name/host (optional)"
+
+msgid "admin.tenant_domain.field_record_value"
+msgstr "Verification record value (optional)"
+
+msgid "admin.tenant_domain.field_redirect_to_primary"
+msgstr "Redirect to primary domain"
+
+msgid "admin.tenant_domain.field_status"
+msgstr "Status"
+
+msgid "admin.tenant_domain.invalid_hostname"
+msgstr "Enter a valid hostname (no scheme, no port, e.g. shop.example.com)."
 

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -113,6 +113,15 @@ msgstr "Tidak dapat dihapus permanen selama masih direferensikan data lain."
 msgid "error.purge_requires_soft_delete"
 msgstr "Data ini harus diarsipkan dulu sebelum dapat dihapus permanen."
 
+msgid "error.hostname_conflict"
+msgstr "Hostname ini sudah dipetakan ke tenant lain."
+
+msgid "error.invalid_status_transition"
+msgstr "Aksi ini tidak diizinkan untuk status saat ini."
+
+msgid "error.concurrent_update"
+msgstr "Permintaan lain sudah mengubah data ini. Silakan coba lagi."
+
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"
 msgstr "Tanpa role"
@@ -134,6 +143,9 @@ msgstr "Sync"
 
 msgid "admin.layout.nav_settings"
 msgstr "Pengaturan"
+
+msgid "admin.layout.nav_tenant_domains"
+msgstr "Domain Tenant"
 
 msgid "admin.layout.nav_modules"
 msgstr "Modul"
@@ -1685,4 +1697,185 @@ msgstr "Hapus iklan ini?"
 
 msgid "admin.blog.ads.delete_success"
 msgstr "Iklan berhasil dihapus."
+
+#. admin.tenant_domain (Issue #563)
+msgid "admin.tenant_domain.title"
+msgstr "Domain Tenant"
+
+msgid "admin.tenant_domain.access_denied_title"
+msgstr "Akses ditolak."
+
+msgid "admin.tenant_domain.access_denied_body"
+msgstr "Akun Anda tidak memiliki izin untuk melihat domain tenant. Hubungi admin/pemilik tenant Anda untuk meminta akses."
+
+msgid "admin.tenant_domain.no_domains"
+msgstr "Belum ada domain. Tambahkan subdomain platform atau domain kustom untuk memulai."
+
+msgid "admin.tenant_domain.hostname_column"
+msgstr "Hostname"
+
+msgid "admin.tenant_domain.type_column"
+msgstr "Tipe"
+
+msgid "admin.tenant_domain.status_column"
+msgstr "Status"
+
+msgid "admin.tenant_domain.verification_column"
+msgstr "Verifikasi"
+
+msgid "admin.tenant_domain.actions_column"
+msgstr "Aksi"
+
+msgid "admin.tenant_domain.domain_type.subdomain"
+msgstr "Subdomain platform"
+
+msgid "admin.tenant_domain.domain_type.custom_domain"
+msgstr "Domain kustom"
+
+msgid "admin.tenant_domain.route_mode.canonical"
+msgstr "Canonical (/news)"
+
+msgid "admin.tenant_domain.route_mode.legacy_blog"
+msgstr "Legacy (/blog/{tenantCode})"
+
+msgid "admin.tenant_domain.status.pending_verification"
+msgstr "Menunggu verifikasi"
+
+msgid "admin.tenant_domain.status.active"
+msgstr "Aktif"
+
+msgid "admin.tenant_domain.status.suspended"
+msgstr "Ditangguhkan"
+
+msgid "admin.tenant_domain.status.failed"
+msgstr "Gagal"
+
+msgid "admin.tenant_domain.primary_badge_label"
+msgstr "Domain utama"
+
+msgid "admin.tenant_domain.verification_method.dns_txt"
+msgstr "Rekaman TXT"
+
+msgid "admin.tenant_domain.verification_method.dns_cname"
+msgstr "Rekaman CNAME"
+
+msgid "admin.tenant_domain.verification_method.file"
+msgstr "Unggah file"
+
+msgid "admin.tenant_domain.verification_method.manual"
+msgstr "Manual (atestasi operator)"
+
+msgid "admin.tenant_domain.verification_method_none"
+msgstr "Belum ada metode verifikasi"
+
+msgid "admin.tenant_domain.no_record_configured"
+msgstr "Belum ada rekaman DNS untuk metode verifikasi ini."
+
+msgid "admin.tenant_domain.record_name_label"
+msgstr "Nama/host rekaman"
+
+msgid "admin.tenant_domain.record_value_label"
+msgstr "Nilai rekaman"
+
+msgid "admin.tenant_domain.copy_button"
+msgstr "Salin"
+
+msgid "admin.tenant_domain.copy_success"
+msgstr "Berhasil disalin ke clipboard."
+
+msgid "admin.tenant_domain.copy_error"
+msgstr "Gagal menyalin otomatis — silakan salin secara manual."
+
+msgid "admin.tenant_domain.preview_link"
+msgstr "Buka situs publik /news"
+
+msgid "admin.tenant_domain.preview_hint"
+msgstr "Hanya bisa diakses publik jika routing publik berbasis host diaktifkan pada deployment ini."
+
+msgid "admin.tenant_domain.verify_button"
+msgstr "Verifikasi"
+
+msgid "admin.tenant_domain.verify_confirm"
+msgstr "Verifikasi domain ini sekarang? Ini akan menandainya aktif berdasarkan atestasi Anda bahwa DNS/kepemilikan sudah benar."
+
+msgid "admin.tenant_domain.verify_success"
+msgstr "Domain terverifikasi."
+
+msgid "admin.tenant_domain.set_primary_button"
+msgstr "Jadikan utama"
+
+msgid "admin.tenant_domain.set_primary_confirm"
+msgstr "Jadikan domain ini sebagai domain utama tenant?"
+
+msgid "admin.tenant_domain.set_primary_success"
+msgstr "Domain utama berhasil diperbarui."
+
+msgid "admin.tenant_domain.delete_button"
+msgstr "Hapus"
+
+msgid "admin.tenant_domain.delete_reason_prompt"
+msgstr "Alasan menghapus pemetaan domain ini:"
+
+msgid "admin.tenant_domain.delete_confirm"
+msgstr "Hapus pemetaan domain ini? Tindakan ini tidak dapat dibatalkan dari layar ini."
+
+msgid "admin.tenant_domain.delete_success"
+msgstr "Pemetaan domain berhasil dihapus."
+
+msgid "admin.tenant_domain.edit_summary"
+msgstr "Ubah"
+
+msgid "admin.tenant_domain.save_button"
+msgstr "Simpan"
+
+msgid "admin.tenant_domain.update_success"
+msgstr "Pemetaan domain berhasil diperbarui."
+
+msgid "admin.tenant_domain.field_status_no_change"
+msgstr "Biarkan tidak berubah"
+
+msgid "admin.tenant_domain.field_status_active_hint"
+msgstr "Domain ini sedang aktif. Memilih status di bawah (mis. Ditangguhkan) akan menonaktifkannya — perubahan berlaku langsung saat disimpan."
+
+msgid "admin.tenant_domain.field_verification_method_none_option"
+msgstr "Tidak diset"
+
+msgid "admin.tenant_domain.create_summary"
+msgstr "Tambah domain atau subdomain"
+
+msgid "admin.tenant_domain.create_submit"
+msgstr "Tambah domain"
+
+msgid "admin.tenant_domain.create_success"
+msgstr "Pemetaan domain berhasil ditambahkan."
+
+msgid "admin.tenant_domain.field_hostname"
+msgstr "Hostname"
+
+msgid "admin.tenant_domain.field_hostname_hint"
+msgstr "Masukkan hostname lengkap, mis. shop.example.com — tanpa skema (https://), tanpa port."
+
+msgid "admin.tenant_domain.field_domain_type"
+msgstr "Tipe domain"
+
+msgid "admin.tenant_domain.field_route_mode"
+msgstr "Mode rute"
+
+msgid "admin.tenant_domain.field_verification_method"
+msgstr "Metode verifikasi"
+
+msgid "admin.tenant_domain.field_record_name"
+msgstr "Nama/host rekaman verifikasi (opsional)"
+
+msgid "admin.tenant_domain.field_record_value"
+msgstr "Nilai rekaman verifikasi (opsional)"
+
+msgid "admin.tenant_domain.field_redirect_to_primary"
+msgstr "Alihkan ke domain utama"
+
+msgid "admin.tenant_domain.field_status"
+msgstr "Status"
+
+msgid "admin.tenant_domain.invalid_hostname"
+msgstr "Masukkan hostname yang valid (tanpa skema, tanpa port, mis. shop.example.com)."
 

--- a/src/lib/i18n/error-messages.ts
+++ b/src/lib/i18n/error-messages.ts
@@ -4,7 +4,9 @@ import type { Translator } from "./translate";
  * Maps the canonical error codes (doc 05 §Error code standard, plus the
  * lifecycle-specific codes some endpoints add — `AUTH_INVALID_CREDENTIALS`,
  * `RESOURCE_CONFLICT`, `PURGE_BLOCKED_BY_DEPENDENTS`,
- * `PURGE_REQUIRES_SOFT_DELETE`) to i18n catalog keys under the `error.`
+ * `PURGE_REQUIRES_SOFT_DELETE`, and — Issue #563 — the tenant domain
+ * management API's own `HOSTNAME_CONFLICT`/`INVALID_STATUS_TRANSITION`/
+ * `CONCURRENT_UPDATE`, Issue #562) to i18n catalog keys under the `error.`
  * namespace. Used both server-side (SSR error panels) and to build the
  * client-string JSON blob admin pages inline for their fetch-based action
  * banners (see `AdminLayout.astro`'s client i18n script pattern).
@@ -28,7 +30,10 @@ export const ERROR_CODE_KEYS: Record<string, string> = {
   PROVIDER_ERROR: "error.provider_error",
   INTERNAL_ERROR: "error.internal_error",
   PURGE_BLOCKED_BY_DEPENDENTS: "error.purge_blocked_by_dependents",
-  PURGE_REQUIRES_SOFT_DELETE: "error.purge_requires_soft_delete"
+  PURGE_REQUIRES_SOFT_DELETE: "error.purge_requires_soft_delete",
+  HOSTNAME_CONFLICT: "error.hostname_conflict",
+  INVALID_STATUS_TRANSITION: "error.invalid_status_transition",
+  CONCURRENT_UPDATE: "error.concurrent_update"
 };
 
 /**

--- a/src/modules/tenant-domain/domain/tenant-domain-validation.ts
+++ b/src/modules/tenant-domain/domain/tenant-domain-validation.ts
@@ -41,25 +41,28 @@ export type TenantDomainVerificationMethod =
 export type UpdatableTenantDomainStatus =
   "pending_verification" | "suspended" | "failed";
 
-const DOMAIN_TYPES: readonly TenantDomainType[] = [
+// Exported (Issue #563, admin UI): the create/edit forms on
+// `/admin/tenant/domains` build their `<select>` option lists from these
+// same arrays rather than re-declaring a second opinion of the enum
+// vocabulary — a value the UI can select is guaranteed to be a value this
+// validator accepts.
+export const TENANT_DOMAIN_TYPES: readonly TenantDomainType[] = [
   "subdomain",
   "custom_domain"
 ];
-const ROUTE_MODES: readonly TenantDomainRouteMode[] = [
+export const TENANT_DOMAIN_ROUTE_MODES: readonly TenantDomainRouteMode[] = [
   "canonical",
   "legacy_blog"
 ];
-const VERIFICATION_METHODS: readonly TenantDomainVerificationMethod[] = [
-  "dns_txt",
-  "dns_cname",
-  "file",
-  "manual"
-];
-const UPDATABLE_STATUSES: readonly UpdatableTenantDomainStatus[] = [
-  "pending_verification",
-  "suspended",
-  "failed"
-];
+export const TENANT_DOMAIN_VERIFICATION_METHODS: readonly TenantDomainVerificationMethod[] =
+  ["dns_txt", "dns_cname", "file", "manual"];
+export const TENANT_DOMAIN_UPDATABLE_STATUSES: readonly UpdatableTenantDomainStatus[] =
+  ["pending_verification", "suspended", "failed"];
+
+const DOMAIN_TYPES = TENANT_DOMAIN_TYPES;
+const ROUTE_MODES = TENANT_DOMAIN_ROUTE_MODES;
+const VERIFICATION_METHODS = TENANT_DOMAIN_VERIFICATION_METHODS;
+const UPDATABLE_STATUSES = TENANT_DOMAIN_UPDATABLE_STATUSES;
 
 // DNS TXT record values can legitimately run long (concatenated
 // multi-string records); this is a generous defense-in-depth cap, not a

--- a/src/modules/tenant-domain/module.ts
+++ b/src/modules/tenant-domain/module.ts
@@ -3,8 +3,8 @@ import { defineModule } from "../_shared/module-contract";
 /**
  * `tenant_domain` (Issue #558, epic #555 — online public tenant routing &
  * tenant domain management). This issue registers the **module descriptor
- * only** — the management API (#562) and host-based resolver (#559) have
- * since landed; no admin UI (#563) or Cloudflare DNS adapter (#567) yet.
+ * only** — the management API (#562), host-based resolver (#559), and
+ * admin UI (#563) have since landed; no Cloudflare DNS adapter (#567) yet.
  * The descriptor exists now so
  * the database-backed module registry (Module Management, epic #510) can
  * track this module's lifecycle/permissions/settings from day one, the
@@ -31,7 +31,7 @@ export const tenantDomainModule = defineModule({
   version: "0.1.0",
   status: "active",
   description:
-    "Tenant domain/subdomain mapping for online-primary public routing (epic #555). Issue #557 added the `awcms_mini_tenant_domains` schema (migration 031: hostname/normalized_hostname, domain_type subdomain|custom_domain, route_mode canonical|legacy_blog, status pending_verification|active|suspended|failed, verification_method dns_txt|dns_cname|file|manual, is_primary/redirect_to_primary, tenant-scoped RLS with FORCE) and its permission catalog seed (migration 032: tenant_domain.domains.{read,create,update,delete,verify,set_primary}). Issue #558 (this descriptor) registers the module in the trusted code catalog so it syncs into `awcms_mini_modules` and its six permissions sync/report cleanly against the migration 032 seed. The public host-based tenant resolver with offline/LAN fallback (#559) and the tenant domain management API (#562) have since landed. Still to come: the admin UI (#563) and an optional Cloudflare DNS adapter (#567). This module never stores a DNS provider API token/credential; `verification_token_hash` (migration 031) is an internal bearer-token hash, and `verification_record_value` is the public DNS record value the tenant publishes, not a secret.",
+    "Tenant domain/subdomain mapping for online-primary public routing (epic #555). Issue #557 added the `awcms_mini_tenant_domains` schema (migration 031: hostname/normalized_hostname, domain_type subdomain|custom_domain, route_mode canonical|legacy_blog, status pending_verification|active|suspended|failed, verification_method dns_txt|dns_cname|file|manual, is_primary/redirect_to_primary, tenant-scoped RLS with FORCE) and its permission catalog seed (migration 032: tenant_domain.domains.{read,create,update,delete,verify,set_primary}). Issue #558 (this descriptor) registers the module in the trusted code catalog so it syncs into `awcms_mini_modules` and its six permissions sync/report cleanly against the migration 032 seed. The public host-based tenant resolver with offline/LAN fallback (#559), the tenant domain management API (#562), and the admin UI (#563) have since landed. Still to come: an optional Cloudflare DNS adapter (#567). This module never stores a DNS provider API token/credential; `verification_token_hash` (migration 031) is an internal bearer-token hash, and `verification_record_value` is the public DNS record value the tenant publishes, not a secret.",
   dependencies: ["tenant_admin", "identity_access"],
   type: "system",
   api: {

--- a/src/pages/admin/tenant/domains.astro
+++ b/src/pages/admin/tenant/domains.astro
@@ -1,0 +1,1074 @@
+---
+/**
+ * Tenant domain/subdomain admin UI (Issue #563, epic #555) — built entirely
+ * on top of the tenant domain management API (`/api/v1/tenant/domains/**`,
+ * Issue #562). Path/permission match the descriptor declared by Issue #558
+ * (`src/modules/tenant-domain/module.ts`'s `navigation` entry):
+ * `/admin/tenant/domains`, gated on `tenant_domain.domains.read`.
+ *
+ * SSR read is a direct, read-only DB call (`listTenantDomains` via
+ * `withTenant`) — the same convention `admin/blog/categories.astro` and
+ * `admin/blog/posts/[id].astro` use for their own initial page render.
+ * **Every mutation** (create/update/verify/set-primary/delete) goes through
+ * the real, already-guarded/audited `/api/v1/tenant/domains/**` endpoints
+ * via client-side `fetch` (`submitJson`) — this page never writes to
+ * `awcms_mini_tenant_domains` directly. That split (SSR reads direct,
+ * mutations only through the API) is the same one
+ * `admin/blog/posts/[id].astro`'s own docblock documents, and is a binding
+ * acceptance criterion for this issue: no privileged SSR shortcut for any
+ * mutation.
+ *
+ * Verify/set-primary are the two "requires `Idempotency-Key`" actions here
+ * (Issue #562) — a fresh `crypto.randomUUID()` per user click
+ * (`newIdempotencyKey()`, `src/lib/ui/admin-form-client.ts`), same pattern
+ * `admin/blog/posts/[id].astro`'s publish/schedule/archive/restore/purge
+ * buttons already use. Create/update/delete are idempotent by construction
+ * at the API layer (same body -> same end state / soft delete is a no-op
+ * to repeat), so they need no `Idempotency-Key`, matching
+ * `blog/terms`/`blog/posts` create/update/delete. Every mutating button is
+ * still `lockElement`-guarded against a fast double-click regardless.
+ *
+ * Preview-the-public-site link only renders for a domain that is BOTH
+ * `active` AND `isPrimary` — the schema's own docs say `is_primary` is
+ * "where canonical URLs point" (migration 031), so the primary domain is
+ * the one meaningful public entry point to link to; a non-primary active
+ * domain still technically resolves (`resolvePublicTenantByHost` does not
+ * check `is_primary`), but linking every active row would be noisy/
+ * confusing for a non-technical admin picking "the" URL for this tenant.
+ *
+ * Status badges use the real DB enum (`pending_verification | active |
+ * suspended | failed`, migration 031/`tenant-domain-validation.ts`) — not
+ * the issue's own shorthand list ("pending, verified, active, failed,
+ * suspended"), which doesn't have a fifth "verified" status distinct from
+ * `active` in this schema.
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { listTenantDomains } from "../../../modules/tenant-domain/application/tenant-domain-directory";
+import {
+  TENANT_DOMAIN_ROUTE_MODES,
+  TENANT_DOMAIN_TYPES,
+  TENANT_DOMAIN_UPDATABLE_STATUSES,
+  TENANT_DOMAIN_VERIFICATION_METHODS
+} from "../../../modules/tenant-domain/domain/tenant-domain-validation";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+import { formatDateTime } from "../../../lib/i18n/format";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/tenant/domains.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const locale = Astro.locals.locale;
+const t = await createTranslator(locale);
+
+const CAN_READ = context.permissions.has(
+  permissionKey("tenant_domain", "domains", "read")
+);
+const CAN_CREATE = context.permissions.has(
+  permissionKey("tenant_domain", "domains", "create")
+);
+const CAN_UPDATE = context.permissions.has(
+  permissionKey("tenant_domain", "domains", "update")
+);
+const CAN_DELETE = context.permissions.has(
+  permissionKey("tenant_domain", "domains", "delete")
+);
+const CAN_VERIFY = context.permissions.has(
+  permissionKey("tenant_domain", "domains", "verify")
+);
+const CAN_SET_PRIMARY = context.permissions.has(
+  permissionKey("tenant_domain", "domains", "set_primary")
+);
+
+const clientStrings = {
+  createSuccess: t("admin.tenant_domain.create_success"),
+  updateSuccess: t("admin.tenant_domain.update_success"),
+  deleteSuccess: t("admin.tenant_domain.delete_success"),
+  verifySuccess: t("admin.tenant_domain.verify_success"),
+  setPrimarySuccess: t("admin.tenant_domain.set_primary_success"),
+  deleteReasonPrompt: t("admin.tenant_domain.delete_reason_prompt"),
+  deleteConfirm: t("admin.tenant_domain.delete_confirm"),
+  verifyConfirm: t("admin.tenant_domain.verify_confirm"),
+  setPrimaryConfirm: t("admin.tenant_domain.set_primary_confirm"),
+  invalidHostname: t("admin.tenant_domain.invalid_hostname"),
+  copySuccess: t("admin.tenant_domain.copy_success"),
+  copyError: t("admin.tenant_domain.copy_error"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+let domains: Awaited<ReturnType<typeof listTenantDomains>> = [];
+let loadError = false;
+
+if (CAN_READ) {
+  try {
+    // Read-only, direct DB call — see this file's own docblock for why this
+    // is not a "privileged SSR shortcut": no mutation ever happens through
+    // this path, only through `/api/v1/tenant/domains/**` client-side.
+    // `listTenantDomains` returns at most `TENANT_DOMAIN_LIST_LIMIT` (100)
+    // newest-first rows; this screen does not add cursor pagination on top
+    // (out of this issue's scope — a tenant with over 100 domain mappings
+    // is not an expected shape today).
+    domains = await withTenant(getDatabaseClient(), context.tenantId, (tx) =>
+      listTenantDomains(tx, context.tenantId)
+    );
+  } catch (error) {
+    console.error(
+      "admin/tenant/domains.astro: failed to load tenant domains",
+      error
+    );
+    loadError = true;
+  }
+}
+
+function canPreviewNewsLink(domain: {
+  status: string;
+  isPrimary: boolean;
+}): boolean {
+  return domain.status === "active" && domain.isPrimary;
+}
+
+function canVerify(domain: { status: string }): boolean {
+  return domain.status === "pending_verification" || domain.status === "failed";
+}
+
+function canSetPrimary(domain: {
+  status: string;
+  isPrimary: boolean;
+}): boolean {
+  return domain.status === "active" && !domain.isPrimary;
+}
+
+function hasVerificationRecord(domain: {
+  verificationMethod: string | null;
+}): boolean {
+  return (
+    domain.verificationMethod === "dns_txt" ||
+    domain.verificationMethod === "dns_cname"
+  );
+}
+---
+
+<AdminLayout title={t("admin.tenant_domain.title")}>
+  {
+    !CAN_READ && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.tenant_domain.access_denied_title")}
+        body={t("admin.tenant_domain.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ && !loadError && (
+      <div class="domain-manager">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        {domains.length === 0 ? (
+          <p class="empty-state">{t("admin.tenant_domain.no_domains")}</p>
+        ) : (
+          <div class="table-scroll">
+            <table class="domain-table">
+              <thead>
+                <tr>
+                  <th>{t("admin.tenant_domain.hostname_column")}</th>
+                  <th>{t("admin.tenant_domain.type_column")}</th>
+                  <th>{t("admin.tenant_domain.status_column")}</th>
+                  <th>{t("admin.tenant_domain.verification_column")}</th>
+                  <th>{t("admin.tenant_domain.actions_column")}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {domains.map((domain) => (
+                  <tr>
+                    <td>
+                      <code>{domain.hostname}</code>
+                      {domain.isPrimary && (
+                        <span
+                          class="primary-badge"
+                          title={t("admin.tenant_domain.primary_badge_label")}
+                        >
+                          <span aria-hidden="true">★</span>{" "}
+                          {t("admin.tenant_domain.primary_badge_label")}
+                        </span>
+                      )}
+                      <div class="field-hint">
+                        {formatDateTime(new Date(domain.createdAt), locale)}
+                      </div>
+                    </td>
+                    <td>
+                      {t(
+                        `admin.tenant_domain.domain_type.${domain.domainType}`
+                      )}
+                    </td>
+                    <td>
+                      <span class="status-pill" data-status={domain.status}>
+                        {t(`admin.tenant_domain.status.${domain.status}`)}
+                      </span>
+                    </td>
+                    <td>
+                      {domain.verificationMethod ? (
+                        <div class="verification-cell">
+                          <span class="field-hint">
+                            {t(
+                              `admin.tenant_domain.verification_method.${domain.verificationMethod}`
+                            )}
+                          </span>
+                          {hasVerificationRecord(domain) &&
+                          domain.verificationRecordName &&
+                          domain.verificationRecordValue ? (
+                            <dl class="record-list">
+                              <dt>
+                                {t("admin.tenant_domain.record_name_label")}
+                              </dt>
+                              <dd>
+                                <code>{domain.verificationRecordName}</code>
+                                <button
+                                  type="button"
+                                  class="copy-record-button"
+                                  data-copy-value={
+                                    domain.verificationRecordName
+                                  }
+                                >
+                                  {t("admin.tenant_domain.copy_button")}
+                                </button>
+                              </dd>
+                              <dt>
+                                {t("admin.tenant_domain.record_value_label")}
+                              </dt>
+                              <dd>
+                                <code>{domain.verificationRecordValue}</code>
+                                <button
+                                  type="button"
+                                  class="copy-record-button"
+                                  data-copy-value={
+                                    domain.verificationRecordValue
+                                  }
+                                >
+                                  {t("admin.tenant_domain.copy_button")}
+                                </button>
+                              </dd>
+                            </dl>
+                          ) : (
+                            hasVerificationRecord(domain) && (
+                              <p class="field-hint">
+                                {t("admin.tenant_domain.no_record_configured")}
+                              </p>
+                            )
+                          )}
+                        </div>
+                      ) : (
+                        <span class="field-hint">
+                          {t("admin.tenant_domain.verification_method_none")}
+                        </span>
+                      )}
+                    </td>
+                    <td class="actions-cell">
+                      {CAN_VERIFY && canVerify(domain) && (
+                        <button
+                          type="button"
+                          class="verify-domain-button"
+                          data-domain-id={domain.id}
+                        >
+                          {t("admin.tenant_domain.verify_button")}
+                        </button>
+                      )}
+                      {CAN_SET_PRIMARY && canSetPrimary(domain) && (
+                        <button
+                          type="button"
+                          class="set-primary-domain-button"
+                          data-domain-id={domain.id}
+                        >
+                          {t("admin.tenant_domain.set_primary_button")}
+                        </button>
+                      )}
+                      {canPreviewNewsLink(domain) && (
+                        <a
+                          class="preview-link"
+                          href={`https://${domain.normalizedHostname}/news`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title={t("admin.tenant_domain.preview_hint")}
+                        >
+                          {t("admin.tenant_domain.preview_link")}
+                        </a>
+                      )}
+                      {CAN_UPDATE && (
+                        <details class="edit-domain">
+                          <summary>
+                            {t("admin.tenant_domain.edit_summary")}
+                          </summary>
+                          <form
+                            class="edit-domain-form"
+                            data-domain-id={domain.id}
+                          >
+                            <label>
+                              {t("admin.tenant_domain.field_domain_type")}
+                              <select name="domainType">
+                                {TENANT_DOMAIN_TYPES.map((value) => (
+                                  <option
+                                    value={value}
+                                    selected={domain.domainType === value}
+                                  >
+                                    {t(
+                                      `admin.tenant_domain.domain_type.${value}`
+                                    )}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <label>
+                              {t("admin.tenant_domain.field_route_mode")}
+                              <select name="routeMode">
+                                {TENANT_DOMAIN_ROUTE_MODES.map((value) => (
+                                  <option
+                                    value={value}
+                                    selected={domain.routeMode === value}
+                                  >
+                                    {t(
+                                      `admin.tenant_domain.route_mode.${value}`
+                                    )}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
+                            <label>
+                              {t("admin.tenant_domain.field_status")}
+                              <select name="status">
+                                <option
+                                  value=""
+                                  selected={
+                                    !TENANT_DOMAIN_UPDATABLE_STATUSES.includes(
+                                      domain.status as (typeof TENANT_DOMAIN_UPDATABLE_STATUSES)[number]
+                                    )
+                                  }
+                                >
+                                  {t(
+                                    "admin.tenant_domain.field_status_no_change"
+                                  )}
+                                </option>
+                                {TENANT_DOMAIN_UPDATABLE_STATUSES.map(
+                                  (value) => (
+                                    <option
+                                      value={value}
+                                      selected={domain.status === value}
+                                    >
+                                      {t(`admin.tenant_domain.status.${value}`)}
+                                    </option>
+                                  )
+                                )}
+                              </select>
+                              {domain.status === "active" && (
+                                <span class="field-hint">
+                                  {t(
+                                    "admin.tenant_domain.field_status_active_hint"
+                                  )}
+                                </span>
+                              )}
+                            </label>
+                            <label>
+                              {t(
+                                "admin.tenant_domain.field_verification_method"
+                              )}
+                              <select name="verificationMethod">
+                                <option
+                                  value=""
+                                  selected={domain.verificationMethod === null}
+                                >
+                                  {t(
+                                    "admin.tenant_domain.field_verification_method_none_option"
+                                  )}
+                                </option>
+                                {TENANT_DOMAIN_VERIFICATION_METHODS.map(
+                                  (value) => (
+                                    <option
+                                      value={value}
+                                      selected={
+                                        domain.verificationMethod === value
+                                      }
+                                    >
+                                      {t(
+                                        `admin.tenant_domain.verification_method.${value}`
+                                      )}
+                                    </option>
+                                  )
+                                )}
+                              </select>
+                            </label>
+                            <label>
+                              {t("admin.tenant_domain.field_record_name")}
+                              <input
+                                type="text"
+                                name="verificationRecordName"
+                                maxlength="2000"
+                                value={domain.verificationRecordName ?? ""}
+                              />
+                            </label>
+                            <label>
+                              {t("admin.tenant_domain.field_record_value")}
+                              <input
+                                type="text"
+                                name="verificationRecordValue"
+                                maxlength="2000"
+                                value={domain.verificationRecordValue ?? ""}
+                              />
+                            </label>
+                            <label class="checkbox-label">
+                              <input
+                                type="checkbox"
+                                name="redirectToPrimary"
+                                checked={domain.redirectToPrimary}
+                              />
+                              {t(
+                                "admin.tenant_domain.field_redirect_to_primary"
+                              )}
+                            </label>
+                            <button type="submit">
+                              {t("admin.tenant_domain.save_button")}
+                            </button>
+                          </form>
+                        </details>
+                      )}
+                      {CAN_DELETE && (
+                        <button
+                          type="button"
+                          class="delete-domain-button"
+                          data-domain-id={domain.id}
+                        >
+                          {t("admin.tenant_domain.delete_button")}
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {CAN_CREATE && (
+          <details class="create-domain">
+            <summary>{t("admin.tenant_domain.create_summary")}</summary>
+            <form id="create-domain-form" class="create-domain-form">
+              <label>
+                {t("admin.tenant_domain.field_hostname")}
+                <input
+                  type="text"
+                  name="hostname"
+                  required
+                  maxlength="253"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <span class="field-hint">
+                  {t("admin.tenant_domain.field_hostname_hint")}
+                </span>
+              </label>
+              <label>
+                {t("admin.tenant_domain.field_domain_type")}
+                <select name="domainType">
+                  {TENANT_DOMAIN_TYPES.map((value) => (
+                    <option value={value}>
+                      {t(`admin.tenant_domain.domain_type.${value}`)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                {t("admin.tenant_domain.field_route_mode")}
+                <select name="routeMode">
+                  {TENANT_DOMAIN_ROUTE_MODES.map((value) => (
+                    <option value={value} selected={value === "canonical"}>
+                      {t(`admin.tenant_domain.route_mode.${value}`)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                {t("admin.tenant_domain.field_verification_method")}
+                <select name="verificationMethod">
+                  <option value="">
+                    {t(
+                      "admin.tenant_domain.field_verification_method_none_option"
+                    )}
+                  </option>
+                  {TENANT_DOMAIN_VERIFICATION_METHODS.map((value) => (
+                    <option value={value}>
+                      {t(`admin.tenant_domain.verification_method.${value}`)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                {t("admin.tenant_domain.field_record_name")}
+                <input
+                  type="text"
+                  name="verificationRecordName"
+                  maxlength="2000"
+                />
+              </label>
+              <label>
+                {t("admin.tenant_domain.field_record_value")}
+                <input
+                  type="text"
+                  name="verificationRecordValue"
+                  maxlength="2000"
+                />
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" name="redirectToPrimary" />
+                {t("admin.tenant_domain.field_redirect_to_primary")}
+              </label>
+              <button type="submit">
+                {t("admin.tenant_domain.create_submit")}
+              </button>
+            </form>
+          </details>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .domain-manager {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .empty-state {
+    color: var(--color-text-muted);
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .domain-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .domain-table th,
+  .domain-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+    margin: var(--sp-1) 0 0;
+  }
+
+  .primary-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sp-1);
+    margin-left: var(--sp-2);
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-full);
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    font-size: var(--fs-xs);
+    font-weight: 700;
+  }
+
+  .status-pill {
+    display: inline-block;
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-full);
+    font-size: var(--fs-xs);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+  }
+
+  .status-pill[data-status="active"] {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .status-pill[data-status="pending_verification"] {
+    background: var(--color-warning);
+    border-color: var(--color-warning);
+  }
+
+  .status-pill[data-status="suspended"],
+  .status-pill[data-status="failed"] {
+    background: var(--color-danger-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-danger-strong);
+  }
+
+  .verification-cell {
+    max-width: 320px;
+  }
+
+  .record-list {
+    margin: var(--sp-1) 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+  }
+
+  .record-list dt {
+    font-size: var(--fs-xs);
+    color: var(--color-text-muted);
+  }
+
+  .record-list dd {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--sp-2);
+    word-break: break-all;
+  }
+
+  .record-list code {
+    font-family: var(--font-mono);
+    font-size: var(--fs-xs);
+  }
+
+  .copy-record-button {
+    flex-shrink: 0;
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: 0 var(--sp-2);
+    min-height: 32px;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+  }
+
+  .actions-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--sp-1);
+    min-width: 160px;
+  }
+
+  .actions-cell button,
+  .actions-cell .preview-link {
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-2);
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+    color: var(--color-text);
+    text-decoration: none;
+    box-sizing: border-box;
+    width: 100%;
+  }
+
+  .delete-domain-button {
+    color: var(--color-danger-strong);
+    border-color: var(--color-danger-strong);
+  }
+
+  .preview-link {
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+  }
+
+  .edit-domain-form,
+  .create-domain-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+    margin-top: var(--sp-2);
+    max-width: 420px;
+  }
+
+  .edit-domain-form label,
+  .create-domain-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .checkbox-label {
+    flex-direction: row !important;
+    align-items: center;
+  }
+
+  .edit-domain-form input,
+  .edit-domain-form select,
+  .create-domain-form input,
+  .create-domain-form select {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .edit-domain-form button,
+  .create-domain-form button {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .create-domain {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .create-domain summary,
+  .edit-domain summary,
+  details summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  button:focus-visible,
+  a:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    newIdempotencyKey,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface DomainManagerStrings {
+    createSuccess: string;
+    updateSuccess: string;
+    deleteSuccess: string;
+    verifySuccess: string;
+    setPrimarySuccess: string;
+    deleteReasonPrompt: string;
+    deleteConfirm: string;
+    verifyConfirm: string;
+    setPrimaryConfirm: string;
+    invalidHostname: string;
+    copySuccess: string;
+    copyError: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<DomainManagerStrings>();
+
+  /**
+   * UX-nicety-only client-side hostname shape check — mirrors (does not
+   * replace) `normalizePublicHost()`'s shape rules (Issue #559): no
+   * whitespace, no port, no leading/trailing/doubled dots, no underscore,
+   * RFC-1035-ish per-label charset, overall length <= 253. The API
+   * (`validateCreateTenantDomainInput`, reusing `normalizePublicHost()`
+   * itself) remains the actual enforcement boundary — this only avoids a
+   * round trip for an obviously-invalid value.
+   */
+  function looksLikeValidHostname(value: string): boolean {
+    const trimmed = value.trim().toLowerCase();
+
+    if (
+      trimmed.length === 0 ||
+      trimmed.length > 253 ||
+      trimmed.includes(":") ||
+      trimmed.includes("..") ||
+      trimmed.startsWith(".") ||
+      trimmed.endsWith(".") ||
+      trimmed.includes("_") ||
+      /\s/.test(trimmed)
+    ) {
+      return false;
+    }
+
+    return trimmed
+      .split(".")
+      .every((label) => /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/.test(label));
+  }
+
+  function submitButtonOf(form: HTMLFormElement): HTMLButtonElement | null {
+    return form.querySelector('button[type="submit"]');
+  }
+
+  document
+    .getElementById("create-domain-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = submitButtonOf(form);
+      if (button?.disabled) return;
+
+      const formData = new FormData(form);
+      const hostname = String(formData.get("hostname") ?? "").trim();
+
+      if (!looksLikeValidHostname(hostname)) {
+        showBanner("action-banner", strings.invalidHostname, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const verificationMethod =
+          String(formData.get("verificationMethod") ?? "").trim() || null;
+        const verificationRecordName =
+          String(formData.get("verificationRecordName") ?? "").trim() || null;
+        const verificationRecordValue =
+          String(formData.get("verificationRecordValue") ?? "").trim() || null;
+
+        const result = await submitJson(
+          "/api/v1/tenant/domains",
+          "POST",
+          {
+            hostname,
+            domainType: formData.get("domainType"),
+            routeMode: formData.get("routeMode"),
+            verificationMethod,
+            verificationRecordName,
+            verificationRecordValue,
+            redirectToPrimary: formData.get("redirectToPrimary") === "on"
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.createSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document.querySelectorAll(".edit-domain-form").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const el = event.target as HTMLFormElement;
+      const button = submitButtonOf(el);
+      if (button?.disabled) return;
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+
+      try {
+        const domainId = el.dataset.domainId!;
+        const formData = new FormData(el);
+        // The status <select> always renders now (Issue #563 post-review
+        // fix), with a "no change" option (value="") — only send `status`
+        // when the admin actually picked a real value, so leaving it on
+        // "no change" never accidentally re-submits the current status as
+        // an explicit transition.
+        const statusValue = String(formData.get("status") ?? "");
+        const verificationMethod =
+          String(formData.get("verificationMethod") ?? "").trim() || null;
+        const verificationRecordName =
+          String(formData.get("verificationRecordName") ?? "").trim() || null;
+        const verificationRecordValue =
+          String(formData.get("verificationRecordValue") ?? "").trim() || null;
+
+        const body: Record<string, unknown> = {
+          domainType: formData.get("domainType"),
+          routeMode: formData.get("routeMode"),
+          verificationMethod,
+          verificationRecordName,
+          verificationRecordValue,
+          redirectToPrimary: formData.get("redirectToPrimary") === "on"
+        };
+        if (statusValue !== "") {
+          body.status = statusValue;
+        }
+
+        const result = await submitJson(
+          `/api/v1/tenant/domains/${domainId}`,
+          "PATCH",
+          body,
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.updateSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+  });
+
+  document.querySelectorAll(".verify-domain-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+      if (!window.confirm(strings.verifyConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const domainId = el.dataset.domainId!;
+        const result = await submitJson(
+          `/api/v1/tenant/domains/${domainId}/verify`,
+          "POST",
+          {},
+          strings,
+          { "Idempotency-Key": newIdempotencyKey() }
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.verifySuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+
+  document.querySelectorAll(".set-primary-domain-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+      if (!window.confirm(strings.setPrimaryConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const domainId = el.dataset.domainId!;
+        const result = await submitJson(
+          `/api/v1/tenant/domains/${domainId}/set-primary`,
+          "POST",
+          {},
+          strings,
+          { "Idempotency-Key": newIdempotencyKey() }
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.setPrimarySuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+
+  document.querySelectorAll(".delete-domain-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+
+      const reason = window.prompt(strings.deleteReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+      if (!window.confirm(strings.deleteConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const domainId = el.dataset.domainId!;
+        const result = await submitJson(
+          `/api/v1/tenant/domains/${domainId}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+
+  document.querySelectorAll(".copy-record-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      const value = el.dataset.copyValue ?? "";
+
+      try {
+        await navigator.clipboard.writeText(value);
+        showBanner("action-banner", strings.copySuccess, "success");
+      } catch {
+        showBanner("action-banner", strings.copyError, "error");
+      }
+    });
+  });
+</script>

--- a/tests/integration/tenant-domain-admin.integration.test.ts
+++ b/tests/integration/tenant-domain-admin.integration.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Integration tests for the tenant domain admin UI (Issue #563, epic #555,
+ * `src/pages/admin/tenant/domains.astro`) against a real PostgreSQL.
+ *
+ * This page is not rendered through a browser/SSR harness (this repo has no
+ * such harness for any `/admin/*` page — see
+ * `tests/integration/blog-content-admin-ui.integration.test.ts`, the closest
+ * precedent, which exercises the admin-UI-only *data* functions a page reads
+ * directly rather than rendering markup). Following that same convention,
+ * this file exercises the two things the page's own docblock says it
+ * depends on:
+ *
+ * 1. `listTenantDomains` (`tenant-domain-directory.ts`) — the exact
+ *    read-only, direct-DB-call function `domains.astro`'s frontmatter calls
+ *    via `withTenant` for its SSR data (see that file's own docblock: "SSR
+ *    read is a direct, read-only DB call ... the same convention
+ *    `admin/blog/categories.astro` ... use[s]"). Tested here for the shapes
+ *    the page's rendering logic branches on — empty state, a freshly
+ *    created (`pending_verification`, not primary) domain, and the
+ *    post-verify/set-primary shape (`status: "active"`, `isPrimary: true`)
+ *    that gates the primary badge and the public `/news` preview link
+ *    (`canPreviewNewsLink()` in the page's own frontmatter) — and for tenant
+ *    isolation on that exact read path, since the admin page never goes
+ *    through an extra ABAC/RLS layer beyond what `withTenant` already
+ *    enforces.
+ * 2. The real `/api/v1/tenant/domains/**` route handlers (Issue #562) for
+ *    the specific error codes the admin page's client-side error-message
+ *    catalog (`src/lib/i18n/error-messages.ts`'s `ERROR_CODE_KEYS`,
+ *    extended by this issue with `HOSTNAME_CONFLICT`/
+ *    `INVALID_STATUS_TRANSITION`/`CONCURRENT_UPDATE`) must be able to map
+ *    to a short, safe, human-readable message — proving those mappings are
+ *    not dead code for codes the API never actually returns.
+ *
+ * All mutation coverage for the API itself (CRUD, cross-tenant 404,
+ * duplicate-hostname 409, verify/set-primary idempotency + status gating,
+ * set-primary atomicity, no `verification_token_hash` leak) already lives in
+ * `tenant-domain-api.integration.test.ts` — this file does not repeat that
+ * exhaustively, only what is specific to the admin page's own contract.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { POST as createDomain } from "../../src/pages/api/v1/tenant/domains/index";
+import { POST as verifyDomain } from "../../src/pages/api/v1/tenant/domains/[id]/verify";
+import { POST as setPrimaryDomain } from "../../src/pages/api/v1/tenant/domains/[id]/set-primary";
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import { listTenantDomains } from "../../src/modules/tenant-domain/application/tenant-domain-directory";
+import { ERROR_CODE_KEYS } from "../../src/lib/i18n/error-messages";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string };
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: `${tenantCode}-${OWNER_LOGIN}`,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: {
+      loginIdentifier: `${tenantCode}-${OWNER_LOGIN}`,
+      password: OWNER_PASSWORD
+    },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId, token: login.body.data.token };
+}
+
+function authHeaders(b: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": b.tenantId,
+    authorization: `Bearer ${b.token}`
+  };
+}
+
+/**
+ * `POST /setup/initialize` is a once-per-database singleton lock — a second
+ * tenant with a real session is provisioned directly, same pattern
+ * `tenant-domain-api.integration.test.ts`'s own
+ * `provisionSecondTenantWithDomainReadAccess` uses.
+ */
+async function provisionSecondTenantWithDomainReadAccess(): Promise<Bootstrap> {
+  const tenantId = crypto.randomUUID();
+  const password = "integration-test-tenant-b-password";
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_mini_tenants (id, tenant_code, tenant_name)
+    VALUES (${tenantId}, 'tenant-b-raw', 'Tenant B Raw')
+  `;
+
+  const passwordHash = await Bun.password.hash(password);
+
+  await admin.begin(async (tx) => {
+    await tx.unsafe(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+    const profile = (await tx`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', 'Tenant B User') RETURNING id
+    `) as { id: string }[];
+    const identity = (await tx`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profile[0]!.id}, 'tenant-b-admin-domain-user@example.com', ${passwordHash})
+      RETURNING id
+    `) as { id: string }[];
+    const tenantUser = (await tx`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${tenantId}, ${identity[0]!.id}) RETURNING id
+    `) as { id: string }[];
+    const role = (await tx`
+      INSERT INTO awcms_mini_roles (tenant_id, role_code, role_name)
+      VALUES (${tenantId}, 'domain_reader', 'Domain Reader') RETURNING id
+    `) as { id: string }[];
+    const permission = (await tx`
+      SELECT id FROM awcms_mini_permissions
+      WHERE module_key = 'tenant_domain' AND activity_code = 'domains' AND action = 'read'
+    `) as { id: string }[];
+
+    await tx`
+      INSERT INTO awcms_mini_role_permissions (tenant_id, role_id, permission_id)
+      VALUES (${tenantId}, ${role[0]!.id}, ${permission[0]!.id})
+    `;
+    await tx`
+      INSERT INTO awcms_mini_access_assignments (tenant_id, tenant_user_id, role_id)
+      VALUES (${tenantId}, ${tenantUser[0]!.id}, ${role[0]!.id})
+    `;
+  });
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: {
+      loginIdentifier: "tenant-b-admin-domain-user@example.com",
+      password
+    },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId, token: login.body.data.token };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("tenant domain admin UI data source (Issue #563)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("listTenantDomains: empty for a fresh tenant (SSR empty state)", async () => {
+    const owner = await bootstrap();
+    const sql = getDatabaseClient();
+
+    const domains = await withTenant(sql, owner.tenantId, (tx) =>
+      listTenantDomains(tx, owner.tenantId)
+    );
+
+    expect(domains).toEqual([]);
+  });
+
+  test("listTenantDomains: freshly created domain is pending_verification, not primary (SSR default row state)", async () => {
+    const owner = await bootstrap();
+
+    const created = await invoke<{ data: { id: string } }>(createDomain, {
+      method: "POST",
+      path: "/api/v1/tenant/domains",
+      headers: authHeaders(owner),
+      body: { hostname: "shop.example.com", domainType: "custom_domain" }
+    });
+    expect(created.status).toBe(200);
+
+    const sql = getDatabaseClient();
+    const domains = await withTenant(sql, owner.tenantId, (tx) =>
+      listTenantDomains(tx, owner.tenantId)
+    );
+
+    expect(domains).toHaveLength(1);
+    expect(domains[0]!.status).toBe("pending_verification");
+    expect(domains[0]!.isPrimary).toBe(false);
+    expect(domains[0]!.normalizedHostname).toBe("shop.example.com");
+    // Never leaks a provider/internal secret field through the SSR read path
+    // the admin page uses (Issue #563 §Security notes).
+    expect(domains[0]!).not.toHaveProperty("verificationTokenHash");
+  });
+
+  test("listTenantDomains: after verify + set-primary, domain is active and primary — the shape the primary badge and /news preview link key off", async () => {
+    const owner = await bootstrap();
+
+    const created = await invoke<{ data: { id: string } }>(createDomain, {
+      method: "POST",
+      path: "/api/v1/tenant/domains",
+      headers: authHeaders(owner),
+      body: {
+        hostname: "shop.example.com",
+        domainType: "custom_domain",
+        verificationMethod: "manual"
+      }
+    });
+    expect(created.status).toBe(200);
+    const domainId = created.body.data.id;
+
+    const verified = await invoke(verifyDomain, {
+      method: "POST",
+      path: `/api/v1/tenant/domains/${domainId}/verify`,
+      params: { id: domainId },
+      headers: {
+        ...authHeaders(owner),
+        "idempotency-key": crypto.randomUUID()
+      },
+      body: {}
+    });
+    expect(verified.status).toBe(200);
+
+    const primary = await invoke(setPrimaryDomain, {
+      method: "POST",
+      path: `/api/v1/tenant/domains/${domainId}/set-primary`,
+      params: { id: domainId },
+      headers: {
+        ...authHeaders(owner),
+        "idempotency-key": crypto.randomUUID()
+      },
+      body: {}
+    });
+    expect(primary.status).toBe(200);
+
+    const sql = getDatabaseClient();
+    const domains = await withTenant(sql, owner.tenantId, (tx) =>
+      listTenantDomains(tx, owner.tenantId)
+    );
+
+    expect(domains).toHaveLength(1);
+    expect(domains[0]!.status).toBe("active");
+    expect(domains[0]!.isPrimary).toBe(true);
+  });
+
+  test("listTenantDomains: tenant isolation on the same direct-read path the admin page uses", async () => {
+    const tenantA = await bootstrap();
+    const tenantB = await provisionSecondTenantWithDomainReadAccess();
+
+    const created = await invoke(createDomain, {
+      method: "POST",
+      path: "/api/v1/tenant/domains",
+      headers: authHeaders(tenantA),
+      body: { hostname: "tenant-a-only.example.com" }
+    });
+    expect(created.status).toBe(200);
+
+    const sql = getDatabaseClient();
+
+    const forA = await withTenant(sql, tenantA.tenantId, (tx) =>
+      listTenantDomains(tx, tenantA.tenantId)
+    );
+    expect(forA).toHaveLength(1);
+    expect(forA[0]!.normalizedHostname).toBe("tenant-a-only.example.com");
+
+    const forB = await withTenant(sql, tenantB.tenantId, (tx) =>
+      listTenantDomains(tx, tenantB.tenantId)
+    );
+    expect(forB).toEqual([]);
+  });
+
+  test("VALIDATION_ERROR: verify without a verification_method configured is mapped by the admin UI's error catalog", async () => {
+    const owner = await bootstrap();
+
+    const created = await invoke<{ data: { id: string } }>(createDomain, {
+      method: "POST",
+      path: "/api/v1/tenant/domains",
+      headers: authHeaders(owner),
+      body: { hostname: "no-verification.example.com" }
+    });
+    expect(created.status).toBe(200);
+    const domainId = created.body.data.id;
+
+    const result = await invoke<{ error: { code: string } }>(verifyDomain, {
+      method: "POST",
+      path: `/api/v1/tenant/domains/${domainId}/verify`,
+      params: { id: domainId },
+      headers: {
+        ...authHeaders(owner),
+        "idempotency-key": crypto.randomUUID()
+      },
+      body: {}
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error.code).toBe("VALIDATION_ERROR");
+    expect(ERROR_CODE_KEYS[result.body.error.code]).toBeDefined();
+  });
+
+  test("HOSTNAME_CONFLICT: duplicate hostname is a code the admin UI's error catalog maps to a safe message", async () => {
+    const owner = await bootstrap();
+
+    const first = await invoke(createDomain, {
+      method: "POST",
+      path: "/api/v1/tenant/domains",
+      headers: authHeaders(owner),
+      body: { hostname: "dup.example.com" }
+    });
+    expect(first.status).toBe(200);
+
+    const second = await invoke<{ error: { code: string } }>(createDomain, {
+      method: "POST",
+      path: "/api/v1/tenant/domains",
+      headers: authHeaders(owner),
+      body: { hostname: "DUP.example.com" }
+    });
+
+    expect(second.status).toBe(409);
+    expect(second.body.error.code).toBe("HOSTNAME_CONFLICT");
+    expect(ERROR_CODE_KEYS[second.body.error.code]).toBe(
+      "error.hostname_conflict"
+    );
+  });
+
+  test("INVALID_STATUS_TRANSITION: set-primary on a non-active domain is a code the admin UI's error catalog maps to a safe message", async () => {
+    const owner = await bootstrap();
+
+    const created = await invoke<{ data: { id: string } }>(createDomain, {
+      method: "POST",
+      path: "/api/v1/tenant/domains",
+      headers: authHeaders(owner),
+      body: { hostname: "not-yet-active.example.com" }
+    });
+    expect(created.status).toBe(200);
+    const domainId = created.body.data.id;
+
+    const result = await invoke<{ error: { code: string } }>(setPrimaryDomain, {
+      method: "POST",
+      path: `/api/v1/tenant/domains/${domainId}/set-primary`,
+      params: { id: domainId },
+      headers: {
+        ...authHeaders(owner),
+        "idempotency-key": crypto.randomUUID()
+      },
+      body: {}
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error.code).toBe("INVALID_STATUS_TRANSITION");
+    expect(ERROR_CODE_KEYS[result.body.error.code]).toBe(
+      "error.invalid_status_transition"
+    );
+  });
+
+  test("CONCURRENT_UPDATE: set-primary race on a tenant with no existing primary is a code the admin UI's error catalog maps to a safe message", async () => {
+    const owner = await bootstrap();
+
+    const first = await invoke<{ data: { id: string } }>(createDomain, {
+      method: "POST",
+      path: "/api/v1/tenant/domains",
+      headers: authHeaders(owner),
+      body: {
+        hostname: "race-one.example.com",
+        verificationMethod: "manual"
+      }
+    });
+    const second = await invoke<{ data: { id: string } }>(createDomain, {
+      method: "POST",
+      path: "/api/v1/tenant/domains",
+      headers: authHeaders(owner),
+      body: {
+        hostname: "race-two.example.com",
+        verificationMethod: "manual"
+      }
+    });
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+
+    await invoke(verifyDomain, {
+      method: "POST",
+      path: `/api/v1/tenant/domains/${first.body.data.id}/verify`,
+      params: { id: first.body.data.id },
+      headers: {
+        ...authHeaders(owner),
+        "idempotency-key": crypto.randomUUID()
+      },
+      body: {}
+    });
+    await invoke(verifyDomain, {
+      method: "POST",
+      path: `/api/v1/tenant/domains/${second.body.data.id}/verify`,
+      params: { id: second.body.data.id },
+      headers: {
+        ...authHeaders(owner),
+        "idempotency-key": crypto.randomUUID()
+      },
+      body: {}
+    });
+
+    const [raceA, raceB] = await Promise.all([
+      invoke<{ error?: { code: string } }>(setPrimaryDomain, {
+        method: "POST",
+        path: `/api/v1/tenant/domains/${first.body.data.id}/set-primary`,
+        params: { id: first.body.data.id },
+        headers: {
+          ...authHeaders(owner),
+          "idempotency-key": crypto.randomUUID()
+        },
+        body: {}
+      }),
+      invoke<{ error?: { code: string } }>(setPrimaryDomain, {
+        method: "POST",
+        path: `/api/v1/tenant/domains/${second.body.data.id}/set-primary`,
+        params: { id: second.body.data.id },
+        headers: {
+          ...authHeaders(owner),
+          "idempotency-key": crypto.randomUUID()
+        },
+        body: {}
+      })
+    ]);
+
+    const statuses = [raceA.status, raceB.status].sort();
+    expect(statuses).toEqual([200, 409]);
+    const conflict = raceA.status === 409 ? raceA : raceB;
+    expect(conflict.body.error?.code).toBe("CONCURRENT_UPDATE");
+    expect(ERROR_CODE_KEYS[conflict.body.error!.code]).toBe(
+      "error.concurrent_update"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Eighth issue of epic #555. Adds `src/pages/admin/tenant/domains.astro`, an admin UI built entirely on top of the tenant domain management API (Issue #562, merged in PR #574).
- Features: list tenant domains, add platform subdomain, add custom domain, show/copy TXT/CNAME verification records, trigger manual-first verify, set primary domain, soft delete, status badges (real DB enum: `pending_verification | active | suspended | failed`), and a public `/news` preview link for domains that are both `active` and the tenant's primary.
- **Binding split enforced**: SSR initial render reads directly (`listTenantDomains` via `withTenant`, same convention as `admin/blog/categories.astro`), but **every mutation** goes through the real, already-audited `/api/v1/tenant/domains/**` endpoints via client-side `fetch` — no privileged SSR shortcut for any mutation, which was this issue's binding acceptance criterion.
- `verify`/`set-primary` send a fresh `Idempotency-Key` (`crypto.randomUUID()`) per click; every mutating control is `lockElement`-guarded against double-submit.

## Manual verification
I manually smoke-tested this end-to-end against a real running dev server + real Postgres (this repo has no browser/SSR test harness for admin pages, per the established convention documented in `tests/integration/blog-content-admin-ui.integration.test.ts`):
- Logged in as a real seeded admin, hit the empty state, created a domain via the real API, verified it, set it primary — confirmed the page correctly reflected each state (status pill, verification record fields, primary badge, `/news` preview link) at every step.
- Tested a cross-tenant attack by swapping the tenant cookie while keeping the same session token — got a `302` redirect to `/login` (fail-closed), not a data leak, confirming `resolveSsrContext` re-validates the session against the specific tenant in context rather than trusting the cookie blindly.

## Review chain
- `awcms-mini-coder`: implemented the UI. Full local gate green (1070 tests against real Postgres, lint/typecheck/check:docs/build).
- `awcms-mini-reviewer`: **Approve**. Verified every acceptance-criteria/security-note item by reading the actual code (SSR-read-only import list, idempotency key freshness, error-message mapping, i18n key completeness cross-checked against both `.po` catalogs, hostname-validation parity between client and server). One functional gap found and fixed in this PR: the edit form hid the `status` field entirely for `active` domains, leaving no self-service way to suspend a live domain even though the API always allowed that transition. Also flagged and fixed: an unused i18n catalog entry (now wired up as the "leave unchanged" default option) and a native HTML `pattern` attribute that could short-circuit past the app's localized hostname error banner.
- `awcms-mini-security-auditor`: **PASS**, no Critical/High/Medium findings. Confirmed no mutating function is ever imported into the page's SSR frontmatter (only `listTenantDomains`), no `verification_token_hash` exposure, XSS-safe rendering (Astro auto-escaping, the one `set:html` usage is server-controlled i18n strings only), CSRF-safe (same-origin `fetch`, no state-changing GET), and independent server-side validation of the soft-delete reason (not just trusting client-side skip logic). One pre-existing Low item (inherited unchanged from #562, already tracked as non-blocking in the skill) — not new to this PR.

## Test plan
- [x] `bun test tests/integration/tenant-domain-admin.integration.test.ts` — 8 pass
- [x] Full `bun test` against real PostgreSQL — 1070 pass, 0 fail
- [x] `bun run lint` / `bun run typecheck` / `bun run check:docs` / `bun run api:spec:check` / `bun run build` — all PASS
- [x] Manual end-to-end smoke test against real dev server + Postgres (see above)

## Security notes
No provider tokens/secrets ever rendered. Tenant isolation enforced by the validated SSR session (not client-controlled input) plus the already-audited API's RLS/ABAC. No privileged SSR mutation shortcut anywhere in this page.

## Next steps
Issue #564 (tenant settings for `/news` vs legacy route in `blog_content`) is next in epic #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)