### PR TITLE
feat(module-management): add tenant module presets for online, news, LAN, and minimal profiles (Issue #565)

### DIFF
--- a/.changeset/module-presets-issue-565.md
+++ b/.changeset/module-presets-issue-565.md
@@ -1,0 +1,41 @@
+---
+"awcms-mini": minor
+---
+
+Add reusable tenant module presets (Issue #565, epic #555): five named
+sets of modules (`online_website`, `news_portal`, `saas_online`, `pos_lan`,
+`minimal`) matching common deployment profiles, plus
+`applyModulePreset(tx, tenantId, actorTenantUserId, presetName)`
+(`src/modules/module-management/application/module-presets.ts`) — a plain
+callable service, no new API route or UI in this issue (that's #566/a
+future setup wizard step). Applying a preset both enables every listed
+module and disables every currently-enabled module that isn't listed and
+isn't protected, so a tenant actually reaches the target profile instead of
+only ever accumulating modules. "Protected" is computed generically
+(`domain/module-presets.ts`'s `resolveProtectedModuleKeys`) as every
+`isCore: true` module plus its full transitive dependency closure — in
+this registry, `module_management`'s own dependency closure
+(`tenant_admin`, `identity_access`, `profile_identity`). Every enable/disable
+still goes through the real `enableTenantModule`/`disableTenantModule`
+lifecycle validation (dependency graph, reverse-dependency protection,
+core-module protection) — never a direct `awcms_mini_tenant_modules` write.
+Idempotent: a module already in its target state is left untouched (no
+audit event); a module that can't be disabled because a still-enabled
+module transitively depends on it is skipped and reported, never
+force-disabled or silently dropped. One `tenant_module_enabled`/
+`tenant_module_disabled` audit event per module actually changed (never one
+aggregate "preset applied" event), tagged with `presetName`. Corrects the
+issue's own illustrative `workflow_approval` module key to the actually
+registered key, `workflow`. See
+`src/modules/module-management/domain/module-presets.ts`'s header comment
+for the full design rationale and
+`src/modules/module-management/README.md`'s "Tenant module presets"
+section.
+
+Post-review fix: the disable-planner's "stays enabled" base set previously
+only accounted for modules enabled before the plan ran, not modules the
+same plan is about to newly enable — so a disable candidate blocked only by
+a freshly-enabling dependent could slip through the pre-emptive skip check
+and surface as a spurious rejection from the real `disableTenantModule`
+call instead. Fixed by seeding that base set with the union of both, with
+a new regression test.

--- a/.claude/skills/awcms-mini-module-management/SKILL.md
+++ b/.claude/skills/awcms-mini-module-management/SKILL.md
@@ -62,6 +62,23 @@ Modul `isCore: true` (saat ini hanya `module_management` sendiri) tidak
 bisa dinonaktifkan — ini pencegah _admin lockout_ utama: kemampuan
 mengelola modul lain tidak pernah hilang.
 
+## Tenant module presets (Issue #565, epic #555)
+
+`domain/module-presets.ts` + `application/module-presets.ts`
+(`applyModulePreset`) — set state modul tenant sekaligus ke sebuah
+"profil" (`online_website`, `news_portal`, `saas_online`, `pos_lan`,
+`minimal`), 100% reuse `evaluateModuleEnable`/`evaluateModuleDisable`/
+`enableTenantModule`/`disableTenantModule` di atas — **tidak pernah**
+menulis `awcms_mini_tenant_modules` langsung. Preset menerapkan enable
+DAN disable (bukan cuma enable) — modul yang tidak ada di daftar preset
+dan bukan "protected" (`isCore` + closure transitif dependency-nya,
+dihitung dinamis lewat `resolveProtectedModuleKeys`) akan di-disable,
+leaves-first, skip (bukan force) untuk modul yang masih dibutuhkan modul
+lain yang tetap enabled. Idempotent (re-apply = plan kosong). **Baru
+service layer** — belum ada endpoint API/UI (scope Issue #566). Detail
+lengkap: `module-management/README.md` §Tenant module presets, skill
+`awcms-mini-tenant-domain-routing` §Tenant module presets (Issue #565).
+
 ## Settings — merge dangkal, bukan replace
 
 `PATCH .../settings` men-**merge dangkal** body ke `tenantOverride` yang

--- a/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
@@ -37,7 +37,7 @@ menjembatani beberapa modul sekaligus (config, `tenant_domain` module baru,
 | #562  | Tenant domain management API                                  | **Selesai** — lihat §API di bawah                                                |
 | #563  | Admin UI domain/subdomain                                     | **Selesai** — lihat §Admin UI di bawah                                           |
 | #564  | Tenant settings untuk rute `/news` vs legacy (`blog_content`) | **Selesai** — lihat §Tenant settings public route di bawah                       |
-| #565  | Tenant module presets (online/news/LAN/minimal)               | Belum                                                                            |
+| #565  | Tenant module presets (online/news/LAN/minimal)               | **Selesai** — lihat §Tenant module presets di bawah                              |
 | #566  | Tenant-module matrix admin UI                                 | Belum                                                                            |
 | #567  | Cloudflare DNS adapter (opsional)                             | Belum                                                                            |
 
@@ -602,6 +602,53 @@ test) dan 3 test paritas round-trip di
 lengkap kelima keputusan di atas: `blog-content/README.md` §Public route
 settings.
 
+### Tenant module presets (Issue #565, `module_management`)
+
+Domain+application service layer saja (`src/modules/module-management/domain/module-presets.ts` +
+`application/module-presets.ts`) — **belum ada endpoint API/UI** (itu
+scope #566's matrix UI dan/atau setup wizard yang belum ada). Lima preset
+(`online_website`, `news_portal`, `saas_online`, `pos_lan`, `minimal`),
+`applyModulePreset()` bisa dipanggil issue lanjutan mana pun yang butuh
+"set tenant module state ke profil X" — jangan re-derive dependency-graph
+logic-nya, itu sudah 100% reuse `evaluateModuleEnable`/
+`evaluateModuleDisable`/`enableTenantModule`/`disableTenantModule` yang
+ada sejak Issue #515.
+
+**Koreksi kunci key modul** yang wajib diikuti issue lanjutan manapun yang
+menyebut modul workflow: key registry sungguhan adalah `workflow`
+(`src/modules/workflow-approval/module.ts`), **bukan**
+`workflow_approval` — issue #565 sendiri salah menyebutnya di contoh
+JSON-nya. Grep `key: "` di `src/modules/*/module.ts` sebelum menulis key
+modul apa pun secara manual, jangan asumsikan nama direktori = key.
+
+**Preset menerapkan enable DAN disable** (bukan cuma enable) — modul yang
+sedang enabled, tidak ada di daftar preset, dan bukan "protected"
+(`isCore: true` ditambah closure transitif dependency-nya — dihitung
+dinamis lewat `resolveProtectedModuleKeys`, bukan hardcoded; hari ini
+resolve ke `{module_management, tenant_admin, identity_access,
+profile_identity}`) akan di-disable. Disable leaves-first, skip (bukan
+force) untuk modul yang masih dibutuhkan modul lain yang tetap enabled —
+termasuk modul yang plan yang SAMA baru saja mau enable (bug post-review:
+versi awal cuma menghitung status enabled SEBELUM plan, bukan union
+dengan modul yang baru mau di-enable plan itu sendiri — sudah diperbaiki,
+lihat komentar `planDisableOrder` di `domain/module-presets.ts`).
+Idempotent: re-apply preset yang sama menghasilkan plan kosong (tidak ada
+audit event baru). Setiap perubahan modul (bukan satu event "preset
+applied" agregat) tetap diaudit lewat `recordAuditEvent` pola sama
+`enable.ts`/`disable.ts`.
+
+`applyModulePreset` **tidak** melakukan ABAC check sendiri (sama seperti
+`enableTenantModule`/`disableTenantModule` yang dibungkusnya) — pemanggil
+masa depan (API #566 atau setup wizard) wajib `authorizeInTransaction`
+sendiri sebelum memanggilnya, guard permission yang sesuai (pola sama
+`ENABLE_GUARD`/`DISABLE_GUARD` di `enable.ts`/`disable.ts`).
+
+Test: `tests/unit/module-presets.test.ts` (18 test, pure domain logic
+lewat synthetic registry) dan
+`tests/integration/module-presets.integration.test.ts` (7 test, real
+Postgres). Detail lengkap tiga keputusan desain di atas:
+`module-management/README.md` §Tenant module presets.
+
 ## Aturan lintas-issue yang wajib diikuti
 
 1. **Backward compatibility non-negotiable**: setiap deployment offline/LAN existing yang tidak pernah set `PUBLIC_*` apa pun harus tetap `config:validate` PASS dan berperilaku persis seperti sebelum epic ini — jangan pernah membuat salah satu dari enam var config ini menjadi wajib secara default.
@@ -609,7 +656,7 @@ settings.
 3. **`/blog/{tenantCode}` (ADR-0009, skill `awcms-mini-blog-content`) TIDAK dihapus** — epic #555 secara eksplisit out-of-scope untuk "removing legacy `/blog/{tenantCode}` routes in the MVP". `/news` (#560) adalah rute **tambahan**, bukan pengganti. Issue #561 (selesai — `docs/adr/0010-public-host-tenant-routing.md`) mendokumentasikan `/blog/{tenantCode}` sebagai legacy, bukan menghapusnya.
 4. **Jangan trust `X-Forwarded-Host` tanpa proxy tepercaya** — ulangi dari epic #555 §Security notes. Berlaku juga untuk API domain #562 manapun yang membaca header host secara independen dari resolver #559.
 5. **Tenant existence tidak boleh bocor**: domain/tenant yang unknown, failed, suspended, atau inactive harus menghasilkan respons yang identik/tidak bisa dibedakan (pola sama seperti ADR-0009's 404 identik untuk `tenantCode` tak dikenal vs tenant tidak aktif) — resolver #559 sudah menegakkan ini (`resolvePublicTenantByHost`/`resolveDefaultPublicTenantFromEnv`/`resolveDefaultPublicTenantFromSetupState`/`resolvePublicTenantFromRequest` semua return `null` identik). Rute publik `/news` #560 **wajib** memetakan `null` resolver ini ke 404 generic yang sama, tidak menambah pesan/status yang membedakan kasus.
-6. **Module disabled tetap diblokir server-side** — kalau tenant module presets (#565) atau tenant-module matrix (#566) menonaktifkan sebuah modul, endpoint modul itu wajib tetap menolak di server (guard ABAC/tenant-module lifecycle yang sudah ada dari `module_management`), bukan hanya disembunyikan di UI.
+6. **Module disabled tetap diblokir server-side** — kalau tenant module presets (#565, selesai) atau tenant-module matrix (#566) menonaktifkan sebuah modul, endpoint modul itu wajib tetap menolak di server (guard ABAC/tenant-module lifecycle yang sudah ada dari `module_management`), bukan hanya disembunyikan di UI. Ditegakkan otomatis untuk #565 — `applyModulePreset` selalu lewat `disableTenantModule` yang sudah ada (tidak pernah menulis `awcms_mini_tenant_modules` langsung), jadi enforcement server-side yang sudah ada sejak Issue #515 tidak pernah dilewati.
 7. **Provider secret (mis. Cloudflare API token, #567) tidak pernah disimpan di module descriptor atau kolom DB biasa** — pakai environment variable seperti provider lain (Mailketing, R2), dan `configure`-only permission gate seperti pola `email`/`sync-storage` provider config.
 8. **Semua mutasi domain/module (create/update/delete domain mapping, enable/disable module preset) wajib diaudit** — pola `recordAuditEvent` yang sama dipakai modul lain, action literal sesuai konvensi modul (`tenant_domain.<resource>.<verb>` mengikuti pola `blog.<resource>.<verb>` dari blog_content). Resolver #559 sendiri **bukan** mutasi (read-only, anonymous) — tidak diaudit, sama seperti `resolvePublicTenantByCode` (ADR-0009) tidak diaudit.
 9. **Cloudflare DNS adapter (#567) adalah opsional/enhancement**, bukan hard dependency — epic #555 §Out of scope eksplisit menyebut "making Cloudflare DNS automation a hard dependency" di luar scope. Tenant domain mapping (#557/#562) harus tetap berfungsi tanpa Cloudflare sama sekali (manual DNS setup oleh operator).
@@ -617,14 +664,15 @@ settings.
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Isu #565-#567 (module presets, matrix UI admin, dan adapter Cloudflare
-DNS) **belum ada**. Sudah selesai: config (#556), schema
-`awcms_mini_tenant_domains` (#557), module descriptor `tenant_domain`
-(#558), resolver host-based (#559), rute publik `/news` (#560),
-dokumentasi legacy/ADR-0010 (#561), API tenant domain management (#562,
-§API di atas), admin UI (#563, §Admin UI di atas), dan tenant settings
-public route `blog_content` (#564, §Tenant settings public route di
-atas). Tabel `awcms_mini_tenant_domains` sekarang bisa
+Isu #566-#567 (matrix UI admin dan adapter Cloudflare DNS) **belum ada**.
+Sudah selesai: config (#556), schema `awcms_mini_tenant_domains` (#557),
+module descriptor `tenant_domain` (#558), resolver host-based (#559),
+rute publik `/news` (#560), dokumentasi legacy/ADR-0010 (#561), API
+tenant domain management (#562, §API di atas), admin UI (#563, §Admin UI
+di atas), tenant settings public route `blog_content` (#564, §Tenant
+settings public route di atas), dan tenant module presets (#565, §Tenant
+module presets di atas — **service layer saja, belum ada API/UI**, itu
+scope #566). Tabel `awcms_mini_tenant_domains` sekarang bisa
 ditulis lewat kode aplikasi (API #562 + admin UI #563) — bukan lagi
 schema-only. Operator yang benar-benar mengisi baris nyata lewat
 UI/API dan mengaktifkan `PUBLIC_TENANT_RESOLUTION_MODE=host_default`

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -324,6 +324,112 @@ also syncs the registry first (same reasoning as
   #516's `PATCH` endpoint already enforces applies here too, since this
   form calls that exact endpoint.
 
+## Tenant module presets — `domain/module-presets.ts` + `application/module-presets.ts` (Issue #565, epic #555)
+
+Reusable named sets of modules matching an intended deployment profile
+(`online_website`, `news_portal`, `saas_online`, `pos_lan`, `minimal`), so
+a new tenant can be initialized with module availability that matches its
+profile without an operator clicking through enable/disable one module at
+a time. Domain + application service layer only in this issue — no new API
+route or UI (`applyModulePreset(tx, tenantId, actorTenantUserId,
+presetName)` is a plain callable function, meant to be called by a future
+setup wizard step or tenant-admin flow, and by #566's tenant-module matrix
+UI).
+
+**Corrected module key**: the issue's own illustrative preset table used
+`workflow_approval`, but the actually registered module key (the directory
+is `workflow-approval`, the descriptor's `key` is `workflow`) is
+`workflow`. Every preset definition here uses the real key, verified
+against `listModules()` by `tests/unit/module-presets.test.ts`'s own
+cross-check test — a wrong key would otherwise silently no-op (the
+descriptor lookup returns nothing to act on) rather than fail loud.
+
+**A preset both enables AND disables.** Applying a preset enables every
+module it lists, and disables every currently-enabled module that isn't
+listed and isn't "protected" (below). Only-ever-enabling would make
+presets useless for reaching a coherent profile — a tenant that had
+`blog_content` enabled before applying `minimal` would stay non-minimal
+forever if presets never disabled anything. This makes preset application
+a best-effort "make tenant module state match this profile" operation.
+
+**"Protected" (core, for preset purposes) is computed, not hardcoded.**
+Only `module_management` sets `isCore: true` in this registry today —
+`tenant_admin`/`identity_access`/`profile_identity` don't, even though
+they're just as foundational; their protection today comes purely from the
+dependency graph's reverse-dependency check (nothing can disable
+`identity_access` while `module_management`, which depends on it
+transitively, remains enabled — and `module_management` itself can never
+be disabled). `resolveProtectedModuleKeys` makes this explicit: `isCore`
+keys unioned with the full transitive dependency closure of every `isCore`
+key. In this repo that evaluates to `{module_management, tenant_admin,
+identity_access, profile_identity}`. This is what lets `minimal` concretely
+mean "enable nothing beyond this protected set, disable everything else
+this tenant can safely give up" instead of an empty enable list that would
+leave every previously-enabled module untouched.
+
+**A preset-listed module's own missing dependency is never auto-enabled.**
+If a preset lists a module whose dependency isn't itself in the preset (or
+otherwise already enabled), this code does not invent resolution logic to
+silently add it — the real `evaluateModuleEnable` semantics
+(`MODULE_DEPENDENCY_MISSING`/`MODULE_DEPENDENCY_DISABLED`) are reused
+as-is, and that failure is a real, reportable per-module outcome. In
+practice this only matters cross-preset: e.g. `reporting` (listed by
+`online_website`/`news_portal`/`saas_online`/`pos_lan`) depends on
+`sync_storage` and `email`, neither of which every one of those presets
+lists explicitly — a fresh tenant has every module enabled by default so
+this never triggers on first apply, but if a _previous_ preset already
+disabled one of those dependencies, the disable-planning below (leaves-first,
+skip-not-force) actually prevents this from ever biting in practice: a
+still-enabled `reporting` blocks its own dependencies from being
+candidates for disabling in the first place (see next paragraph) — the
+`MODULE_DEPENDENCY_DISABLED` path exists as a defensive fallback for the
+general case, not because the five built-in presets are expected to hit it.
+
+**Disabling is leaves-first and skip-not-force.** A module is only
+disabled once nothing that stays enabled still depends on it (mirrors
+exactly what the real, sequential `disableTenantModule` calls see as each
+one lands). A module that can never become disableable — something that
+stays enabled (core/protected, or another preset-listed module) still
+depends on it — is reported in the result's `skipped` array with reason
+`reverse_dependency_active`, never force-disabled and never silently
+dropped. Concretely: applying `online_website` (lists `reporting` but not
+`sync_storage`) leaves `sync_storage` enabled and reports it `skipped`,
+because `reporting` — which stays enabled — depends on it.
+
+**Idempotency**: `enableTenantModule`/`disableTenantModule` return a
+`MODULE_ALREADY_ENABLED`/`MODULE_ALREADY_DISABLED` rejection when a module
+is already in the target state — the domain plan (`computeModulePresetPlan`)
+already excludes such modules from `toEnable`/`toDisable` in the first
+place (nothing to attempt), so a clean re-application of the same preset
+produces an empty plan and writes zero audit events. Any other rejection
+code the real lifecycle validation returns (`MODULE_DEPENDENCY_MISSING`,
+`MODULE_DEPENDENCY_DISABLED`, `CORE_MODULE_CANNOT_BE_DISABLED`,
+`MODULE_REVERSE_DEPENDENCY_ACTIVE`) is surfaced as a genuine `rejected`
+entry in the result's `changes` array — never silently swallowed.
+
+**Audit**: one `tenant_module_enabled`/`tenant_module_disabled` event per
+module actually changed (same action/resourceType as the manual
+enable/disable endpoints), each tagged with `attributes.presetName` — never
+one aggregate "preset applied" event, so an operator/auditor can see the
+exact per-module state transitions a preset produced.
+
+**Security**: never writes `awcms_mini_tenant_modules` directly — every
+change goes through the real `enableTenantModule`/`disableTenantModule`.
+Never touches `awcms_mini_roles`/`awcms_mini_role_permissions`/
+`awcms_mini_access_assignments` — a preset changes module _availability_
+only, never grants permissions (permission seeding is `bun run
+modules:sync`'s job, already called internally by `enableTenantModule`).
+`applyModulePreset` itself performs no auth/ABAC check — same division of
+responsibility as `enableTenantModule`/`disableTenantModule` — the caller
+(a future API route/setup wizard step) is responsible for
+`authorizeInTransaction` before calling it.
+
+Covered by `tests/unit/module-presets.test.ts` (pure domain planning
+against both a synthetic registry and the real one) and
+`tests/integration/module-presets.integration.test.ts` (real Postgres:
+real row states, real audit events, idempotent re-application, and
+switching between two different presets).
+
 ## Out of scope (epic #510)
 
 Marketplace, runtime plugin upload, running arbitrary jobs from the UI,

--- a/src/modules/module-management/application/module-presets.ts
+++ b/src/modules/module-management/application/module-presets.ts
@@ -1,0 +1,215 @@
+/**
+ * Tenant module preset application service (Issue #565, epic #555). Plain
+ * callable function — no HTTP route in this issue (that's a later
+ * issue/the setup wizard's job). Reads current tenant module state, asks
+ * `domain/module-presets.ts`'s pure `computeModulePresetPlan` what to
+ * enable/disable, then executes that plan exclusively through the existing
+ * `enableTenantModule`/`disableTenantModule` lifecycle primitives — never
+ * writes `awcms_mini_tenant_modules` directly, never re-implements
+ * dependency-graph validation.
+ *
+ * Idempotency: a second call with the same preset and no state change in
+ * between must be a clean no-op success, not a pile of rejections. This is
+ * handled by treating the underlying `MODULE_ALREADY_ENABLED`/
+ * `MODULE_ALREADY_DISABLED` rejections as an already-satisfied precondition
+ * (`outcome: "already_satisfied"` per-module, no audit event written since
+ * nothing actually changed) rather than surfacing them as errors. Any other
+ * rejection code (`MODULE_DEPENDENCY_MISSING`, `MODULE_DEPENDENCY_DISABLED`,
+ * `CORE_MODULE_CANNOT_BE_DISABLED`, `MODULE_REVERSE_DEPENDENCY_ACTIVE`,
+ * etc.) is a genuine, reportable outcome — never silently swallowed.
+ */
+import { listModules } from "../..";
+import { recordAuditEvent } from "../../logging/application/audit-log";
+import {
+  computeModulePresetPlan,
+  findModulePreset
+} from "../domain/module-presets";
+import {
+  disableTenantModule,
+  enableTenantModule,
+  fetchTenantModuleEntries
+} from "./tenant-module-lifecycle";
+
+export type ModulePresetModuleChange = {
+  moduleKey: string;
+  action: "enabled" | "disabled";
+  /**
+   * `applied` — the module's state actually changed this call.
+   * `already_satisfied` — the module was already in the target state
+   * (idempotent re-application, or another preset already got it there);
+   * no audit event was written for this entry since nothing changed.
+   * `rejected` — the real lifecycle validation refused the change; `code`/
+   * `message` carry the real reason (e.g. `MODULE_DEPENDENCY_DISABLED`).
+   */
+  outcome: "applied" | "already_satisfied" | "rejected";
+  code?: string;
+  message?: string;
+};
+
+export type ModulePresetSkippedModule = {
+  moduleKey: string;
+  action: "disabled";
+  reason: "reverse_dependency_active";
+  message: string;
+};
+
+export type ApplyModulePresetResult =
+  | {
+      outcome: "applied";
+      presetName: string;
+      /** Every module the plan attempted to enable/disable, one entry each, in the order attempted. */
+      changes: ModulePresetModuleChange[];
+      /**
+       * Modules deliberately left enabled because something that stays
+       * enabled still depends on them — planned by the domain layer, never
+       * even attempted against `disableTenantModule` (see
+       * `domain/module-presets.ts`'s `skippedDisable`).
+       */
+      skipped: ModulePresetSkippedModule[];
+      /** Preset-listed module keys that don't resolve to any registered descriptor — never attempted. */
+      unknownModuleKeys: string[];
+    }
+  | {
+      outcome: "rejected";
+      code: "MODULE_PRESET_NOT_FOUND";
+      message: string;
+    };
+
+/**
+ * Applies a named module preset for `tenantId`. Callable from any
+ * server-side context that already has a transaction and an authenticated
+ * actor (future setup wizard step, future tenant-admin "apply preset"
+ * action) — this function itself does no auth/ABAC check, same division of
+ * responsibility as `enableTenantModule`/`disableTenantModule` (the caller,
+ * e.g. an API route, is responsible for `authorizeInTransaction` before
+ * calling this).
+ */
+export async function applyModulePreset(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  presetName: string,
+  correlationId?: string | null
+): Promise<ApplyModulePresetResult> {
+  const preset = findModulePreset(presetName);
+
+  if (!preset) {
+    return {
+      outcome: "rejected",
+      code: "MODULE_PRESET_NOT_FOUND",
+      message: `Unknown module preset "${presetName}".`
+    };
+  }
+
+  const allDescriptors = listModules();
+  const entries = await fetchTenantModuleEntries(tx, tenantId);
+  const currentState = entries.map((entry) => ({
+    moduleKey: entry.moduleKey,
+    tenantEnabled: entry.tenantEnabled
+  }));
+
+  const plan = computeModulePresetPlan({
+    preset,
+    allDescriptors,
+    currentState
+  });
+
+  const changes: ModulePresetModuleChange[] = [];
+
+  for (const moduleKey of plan.toEnable) {
+    const result = await enableTenantModule(
+      tx,
+      tenantId,
+      moduleKey,
+      actorTenantUserId
+    );
+
+    if (result.outcome === "applied") {
+      await recordAuditEvent(tx, {
+        tenantId,
+        actorTenantUserId,
+        moduleKey: "module_management",
+        action: "tenant_module_enabled",
+        resourceType: "tenant_module",
+        resourceId: moduleKey,
+        severity: "info",
+        message: `Module enabled for tenant via preset "${preset.name}": ${moduleKey}.`,
+        attributes: { presetName: preset.name },
+        correlationId: correlationId ?? undefined
+      });
+      changes.push({ moduleKey, action: "enabled", outcome: "applied" });
+    } else if (result.validation.code === "MODULE_ALREADY_ENABLED") {
+      changes.push({
+        moduleKey,
+        action: "enabled",
+        outcome: "already_satisfied"
+      });
+    } else {
+      changes.push({
+        moduleKey,
+        action: "enabled",
+        outcome: "rejected",
+        code: result.validation.code,
+        message: result.validation.message
+      });
+    }
+  }
+
+  for (const moduleKey of plan.toDisable) {
+    const reason = `Module preset "${preset.name}" applied.`;
+    const result = await disableTenantModule(
+      tx,
+      tenantId,
+      moduleKey,
+      actorTenantUserId,
+      reason
+    );
+
+    if (result.outcome === "applied") {
+      await recordAuditEvent(tx, {
+        tenantId,
+        actorTenantUserId,
+        moduleKey: "module_management",
+        action: "tenant_module_disabled",
+        resourceType: "tenant_module",
+        resourceId: moduleKey,
+        severity: "warning",
+        message: `Module disabled for tenant via preset "${preset.name}": ${moduleKey}.`,
+        attributes: { presetName: preset.name, reason },
+        correlationId: correlationId ?? undefined
+      });
+      changes.push({ moduleKey, action: "disabled", outcome: "applied" });
+    } else if (result.validation.code === "MODULE_ALREADY_DISABLED") {
+      changes.push({
+        moduleKey,
+        action: "disabled",
+        outcome: "already_satisfied"
+      });
+    } else {
+      changes.push({
+        moduleKey,
+        action: "disabled",
+        outcome: "rejected",
+        code: result.validation.code,
+        message: result.validation.message
+      });
+    }
+  }
+
+  const skipped: ModulePresetSkippedModule[] = plan.skippedDisable.map(
+    (entry) => ({
+      moduleKey: entry.moduleKey,
+      action: "disabled",
+      reason: entry.reason,
+      message: `Module "${entry.moduleKey}" still required by an active dependent; not disabled by preset "${preset.name}".`
+    })
+  );
+
+  return {
+    outcome: "applied",
+    presetName: preset.name,
+    changes,
+    skipped,
+    unknownModuleKeys: [...plan.unknownModuleKeys]
+  };
+}

--- a/src/modules/module-management/domain/module-presets.ts
+++ b/src/modules/module-management/domain/module-presets.ts
@@ -1,0 +1,385 @@
+/**
+ * Pure tenant module preset definitions + decision logic (Issue #565, epic
+ * #555). No I/O here — the application layer
+ * (`application/module-presets.ts`) resolves the current tenant module
+ * state from `listModules()` + `awcms_mini_tenant_modules`, hands it to
+ * `computeModulePresetPlan`, then executes the plan through the existing
+ * `enableTenantModule`/`disableTenantModule` lifecycle primitives (never
+ * duplicated here — see `domain/tenant-module-lifecycle.ts`'s own header
+ * comment for the same "domain = pure, application = I/O" split).
+ *
+ * ## Design decision 1 — a preset both enables AND disables
+ *
+ * Applying a preset enables every module the preset lists, and disables
+ * every currently-enabled module that (a) is not in the preset's list and
+ * (b) is not "protected" (see below). Only-ever-enabling would make presets
+ * useless as a way to reach a coherent profile: a tenant that previously
+ * had `blog_content` enabled and then applies `minimal` would stay non-minimal
+ * forever if presets never disabled anything. A preset apply is therefore a
+ * best-effort "make tenant module state match this profile" operation, not
+ * a pure additive grant.
+ *
+ * ## Design decision 2 — what "protected" (core, for preset purposes) means
+ *
+ * Only `module_management` sets `isCore: true` in this registry today (see
+ * `src/modules/module-management/module.ts`). No other foundational module
+ * (`tenant_admin`, `identity_access`, `profile_identity`) sets it — their
+ * "core-ness" today is enforced *indirectly*, purely through the
+ * dependency graph's reverse-dependency check
+ * (`evaluateModuleDisable`'s `MODULE_REVERSE_DEPENDENCY_ACTIVE`): nothing
+ * can disable `identity_access` while `module_management` (which depends on
+ * it, transitively) remains enabled, and `module_management` itself can
+ * never be disabled (`isCore: true`).
+ *
+ * `resolveProtectedModuleKeys` makes that *indirect* protection *explicit*
+ * for preset-planning purposes: it is `isCore` keys unioned with the full
+ * transitive dependency closure of every `isCore` key. A preset never
+ * attempts to disable anything in this set — not because we duplicate the
+ * reverse-dependency check (we don't — `enableTenantModule`/
+ * `disableTenantModule` still run their own real validation against the
+ * live DB state), but because attempting to disable them would always be
+ * rejected anyway (`CORE_MODULE_CANNOT_BE_DISABLED` for `module_management`
+ * itself, `MODULE_REVERSE_DEPENDENCY_ACTIVE` for its dependencies as long as
+ * `module_management` stays enabled — which it always does, since nothing
+ * can disable it). Computing this set lets the `minimal` preset concretely
+ * mean "enable nothing beyond this protected set, disable everything else
+ * this tenant can safely give up" instead of an empty enable list that
+ * would silently leave every previously-enabled module untouched.
+ *
+ * In this repo's current registry, `resolveProtectedModuleKeys` evaluates
+ * to `{module_management, tenant_admin, identity_access, profile_identity}`
+ * — the closure of `module_management`'s own `dependencies` array plus
+ * itself.
+ *
+ * ## Design decision 3 — dependencies not listed in a preset are NOT auto-added
+ *
+ * If a preset lists a module whose dependency isn't itself in the preset
+ * (and isn't otherwise already enabled), this code does **not** invent new
+ * resolution logic to silently add it. The existing
+ * `evaluateModuleEnable` semantics (`MODULE_DEPENDENCY_MISSING`/
+ * `MODULE_DEPENDENCY_DISABLED`) are reused as-is: the module simply fails
+ * to enable and that failure is surfaced as a real, reportable outcome by
+ * the application layer — never swallowed, never silently worked around.
+ * (In practice, for the five presets defined below this only matters when
+ * a *previous* preset application disabled a module — e.g. `sync_storage`
+ * — that a *later* preset's listed module — e.g. `reporting` — depends on
+ * without listing it explicitly; a fresh tenant has every module enabled
+ * by default, so this never triggers on first apply.)
+ */
+import type { ModuleDescriptor } from "../../_shared/module-contract";
+import type { ModuleTenantState } from "./tenant-module-lifecycle";
+
+export type ModulePresetName =
+  "online_website" | "news_portal" | "saas_online" | "pos_lan" | "minimal";
+
+export type ModulePresetDefinition = {
+  name: ModulePresetName;
+  label: string;
+  description: string;
+  /**
+   * Module keys this preset wants enabled, beyond whatever
+   * `resolveProtectedModuleKeys` already protects/keeps enabled. `minimal`
+   * is deliberately empty — "core modules only" per the issue's own
+   * phrase.
+   */
+  enabledModuleKeys: readonly string[];
+};
+
+export const MODULE_PRESETS: readonly ModulePresetDefinition[] = [
+  {
+    name: "online_website",
+    label: "Online website",
+    description:
+      "Public website with custom domain, content, transactional email, and reporting.",
+    enabledModuleKeys: ["tenant_domain", "blog_content", "email", "reporting"]
+  },
+  {
+    name: "news_portal",
+    label: "News portal",
+    description:
+      "Online website plus editorial approval workflow for published content.",
+    enabledModuleKeys: [
+      "tenant_domain",
+      "blog_content",
+      "email",
+      "reporting",
+      "workflow"
+    ]
+  },
+  {
+    name: "saas_online",
+    label: "SaaS (online)",
+    description:
+      "Multi-tenant SaaS profile: custom domain, email, reporting, approval workflow — no public content module.",
+    enabledModuleKeys: ["tenant_domain", "email", "reporting", "workflow"]
+  },
+  {
+    name: "pos_lan",
+    label: "POS (LAN-first)",
+    description:
+      "Offline-capable point-of-sale profile: sync storage, reporting, approval workflow — no public-facing domain/content/email.",
+    enabledModuleKeys: ["sync_storage", "reporting", "workflow"]
+  },
+  {
+    name: "minimal",
+    label: "Minimal",
+    description:
+      "Core platform modules only — every non-core module a tenant hasn't explicitly kept is disabled.",
+    enabledModuleKeys: []
+  }
+];
+
+export function findModulePreset(name: string): ModulePresetDefinition | null {
+  return MODULE_PRESETS.find((preset) => preset.name === name) ?? null;
+}
+
+/**
+ * `isCore` keys unioned with the full transitive dependency closure of
+ * every `isCore` key — see design decision 2 above. Generic over whatever
+ * `allDescriptors` currently contains, never hardcoded to today's specific
+ * module keys.
+ */
+export function resolveProtectedModuleKeys(
+  allDescriptors: readonly ModuleDescriptor[]
+): Set<string> {
+  const descriptorByKey = new Map(allDescriptors.map((d) => [d.key, d]));
+  const protectedKeys = new Set<string>();
+
+  function includeWithDependencies(key: string): void {
+    if (protectedKeys.has(key)) {
+      return;
+    }
+    protectedKeys.add(key);
+
+    const descriptor = descriptorByKey.get(key);
+    for (const dep of descriptor?.dependencies ?? []) {
+      includeWithDependencies(dep);
+    }
+  }
+
+  for (const descriptor of allDescriptors) {
+    if (descriptor.isCore) {
+      includeWithDependencies(descriptor.key);
+    }
+  }
+
+  return protectedKeys;
+}
+
+function buildDependentsIndex(
+  allDescriptors: readonly ModuleDescriptor[]
+): Map<string, string[]> {
+  const dependents = new Map<string, string[]>();
+
+  for (const descriptor of allDescriptors) {
+    for (const dep of descriptor.dependencies) {
+      const list = dependents.get(dep) ?? [];
+      list.push(descriptor.key);
+      dependents.set(dep, list);
+    }
+  }
+
+  return dependents;
+}
+
+/**
+ * Orders `candidates` (module keys to enable) so each module's own
+ * dependencies come before it, given `alreadyEnabled` as a satisfied base
+ * set. Any candidate whose dependency can never be satisfied within this
+ * plan (missing from the registry entirely, or disabled and not itself a
+ * candidate) is still appended at the end — best-effort — so the real
+ * `enableTenantModule` call surfaces the exact rejection reason
+ * (`MODULE_DEPENDENCY_MISSING`/`MODULE_DEPENDENCY_DISABLED`) rather than
+ * this planner silently dropping it.
+ */
+function planEnableOrder(
+  candidates: ReadonlySet<string>,
+  allDescriptors: readonly ModuleDescriptor[],
+  alreadyEnabled: ReadonlySet<string>
+): string[] {
+  const descriptorByKey = new Map(allDescriptors.map((d) => [d.key, d]));
+  const remaining = new Set(candidates);
+  const ordered: string[] = [];
+  const satisfied = new Set(alreadyEnabled);
+
+  let changed = true;
+  while (remaining.size > 0 && changed) {
+    changed = false;
+
+    for (const key of remaining) {
+      const deps = descriptorByKey.get(key)?.dependencies ?? [];
+      const ready = deps.every((dep) => satisfied.has(dep));
+
+      if (ready) {
+        ordered.push(key);
+        satisfied.add(key);
+        remaining.delete(key);
+        changed = true;
+      }
+    }
+  }
+
+  // Best-effort: anything left has an unresolved dependency within this
+  // plan. Append it anyway so `enableTenantModule` reports the real reason.
+  return [...ordered, ...remaining];
+}
+
+export type ModulePresetDisableSkip = {
+  moduleKey: string;
+  reason: "reverse_dependency_active";
+};
+
+export type ModulePresetDisablePlan = {
+  ordered: string[];
+  skipped: ModulePresetDisableSkip[];
+};
+
+/**
+ * Orders `candidates` (module keys to disable) leaves-first, so a module is
+ * only disabled once nothing that remains enabled still depends on it —
+ * mirroring exactly what the real, sequential `disableTenantModule` calls
+ * will see as each one lands. A candidate that can never become
+ * disableable (a module that stays enabled — core/protected or another
+ * preset-listed module — depends on it) is reported in `skipped`, never
+ * silently dropped and never force-disabled. Modules that stay enabled
+ * (i.e. not in `candidates`) are never removed from `stillEnabled` below,
+ * so they naturally keep blocking anything that depends on them without
+ * needing to be passed in separately.
+ *
+ * `stillEnabledBase` must include BOTH modules already enabled before this
+ * plan runs AND modules this same plan is about to newly enable
+ * (`wantEnabled` at the call site) — a disable candidate that only a
+ * freshly-enabling module depends on must still be skipped, not scheduled
+ * for disable (post-review fix: the caller previously passed only the
+ * pre-plan enabled set, so a module blocked exclusively by a module in the
+ * same plan's `toEnable` slipped through as a disable candidate and only
+ * got caught later as a spurious rejection from the real
+ * `disableTenantModule` call, instead of a pre-emptive `skipped` entry).
+ */
+function planDisableOrder(
+  candidates: ReadonlySet<string>,
+  allDescriptors: readonly ModuleDescriptor[],
+  stillEnabledBase: ReadonlySet<string>
+): ModulePresetDisablePlan {
+  const dependentsOf = buildDependentsIndex(allDescriptors);
+  const remaining = new Set(candidates);
+  const ordered: string[] = [];
+  // Modules considered "still enabled" as the plan progresses — starts as
+  // stillEnabledBase, shrinks as we decide to disable one.
+  const stillEnabled = new Set(stillEnabledBase);
+
+  let changed = true;
+  while (remaining.size > 0 && changed) {
+    changed = false;
+
+    for (const key of remaining) {
+      const dependents = dependentsOf.get(key) ?? [];
+      const blocked = dependents.some((dependentKey) =>
+        stillEnabled.has(dependentKey)
+      );
+
+      if (!blocked) {
+        ordered.push(key);
+        stillEnabled.delete(key);
+        remaining.delete(key);
+        changed = true;
+      }
+    }
+  }
+
+  const skipped: ModulePresetDisableSkip[] = [...remaining].map((key) => ({
+    moduleKey: key,
+    reason: "reverse_dependency_active"
+  }));
+
+  return { ordered, skipped };
+}
+
+export type ModulePresetPlanInput = {
+  preset: ModulePresetDefinition;
+  allDescriptors: readonly ModuleDescriptor[];
+  currentState: readonly ModuleTenantState[];
+};
+
+export type ModulePresetPlan = {
+  presetName: ModulePresetName;
+  /** Module keys to enable, in dependency-safe order. */
+  toEnable: readonly string[];
+  /** Module keys to disable, in dependency-safe (leaves-first) order. */
+  toDisable: readonly string[];
+  /**
+   * Currently-enabled, non-preset-listed modules that were deliberately
+   * left enabled because something else that stays enabled still depends
+   * on them.
+   */
+  skippedDisable: readonly ModulePresetDisableSkip[];
+  /** Keys never considered for disabling at all (core or its dependency closure). */
+  protectedModuleKeys: readonly string[];
+  /** Preset-listed keys that don't resolve to any registered descriptor. */
+  unknownModuleKeys: readonly string[];
+};
+
+/**
+ * Pure decision function: given a preset, the live module registry, and the
+ * tenant's current per-module enabled state, decides which modules to
+ * enable and which to disable. Performs no I/O and calls neither
+ * `evaluateModuleEnable` nor `evaluateModuleDisable` itself — the
+ * application layer still runs the real `enableTenantModule`/
+ * `disableTenantModule` for every planned change, so this plan is a
+ * best-effort *intent*, not a guarantee (a planned enable/disable can still
+ * be rejected by the real lifecycle validation, which the application layer
+ * surfaces rather than this function pre-empting).
+ */
+export function computeModulePresetPlan(
+  input: ModulePresetPlanInput
+): ModulePresetPlan {
+  const { preset, allDescriptors, currentState } = input;
+  const descriptorByKey = new Map(allDescriptors.map((d) => [d.key, d]));
+  const currentlyEnabled = new Set(
+    currentState.filter((s) => s.tenantEnabled).map((s) => s.moduleKey)
+  );
+  const protectedKeys = resolveProtectedModuleKeys(allDescriptors);
+
+  const unknownModuleKeys = preset.enabledModuleKeys.filter(
+    (key) => !descriptorByKey.has(key)
+  );
+  const wantEnabled = new Set(
+    preset.enabledModuleKeys.filter((key) => descriptorByKey.has(key))
+  );
+
+  const enableCandidates = new Set(
+    [...wantEnabled].filter((key) => !currentlyEnabled.has(key))
+  );
+  const toEnable = planEnableOrder(
+    enableCandidates,
+    allDescriptors,
+    currentlyEnabled
+  );
+
+  const disableCandidates = new Set(
+    [...currentlyEnabled].filter(
+      (key) => !protectedKeys.has(key) && !wantEnabled.has(key)
+    )
+  );
+  // Seed with currentlyEnabled UNION wantEnabled, not just currentlyEnabled:
+  // a module this same plan is about to newly enable (wantEnabled) must
+  // still count as "will stay enabled" for the blocking check below, or a
+  // disable candidate that only that newly-enabling module depends on gets
+  // scheduled for disable instead of skipped — the real disableTenantModule
+  // call would still catch it (MODULE_REVERSE_DEPENDENCY_ACTIVE), but as a
+  // spurious rejection instead of the pre-emptive skip this plan promises.
+  const disablePlan = planDisableOrder(
+    disableCandidates,
+    allDescriptors,
+    new Set([...currentlyEnabled, ...wantEnabled])
+  );
+
+  return {
+    presetName: preset.name,
+    toEnable,
+    toDisable: disablePlan.ordered,
+    skippedDisable: disablePlan.skipped,
+    protectedModuleKeys: [...protectedKeys],
+    unknownModuleKeys
+  };
+}

--- a/tests/integration/module-presets.integration.test.ts
+++ b/tests/integration/module-presets.integration.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Integration tests for the tenant module preset application service
+ * (Issue #565, epic #555) against a real PostgreSQL: real
+ * `awcms_mini_tenant_modules` row states and real
+ * `awcms_mini_audit_events` rows after applying a preset, re-applying it
+ * (idempotency), and switching from one preset to a different one (proving
+ * the previous preset's non-listed, non-core modules actually get
+ * disabled — design decision documented in
+ * `src/modules/module-management/domain/module-presets.ts`).
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import { applyModulePreset } from "../../src/modules/module-management/application/module-presets";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string; tenantUserId: string };
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const loginIdentifier = `${tenantCode}-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  const admin = getAdminSql();
+  const tenantUserRows = (await admin`
+    SELECT tu.id FROM awcms_mini_tenant_users tu
+    JOIN awcms_mini_identities i ON i.id = tu.identity_id
+    WHERE tu.tenant_id = ${setup.body.data.tenantId} AND i.login_identifier = ${loginIdentifier}
+  `) as { id: string }[];
+
+  return {
+    tenantId: setup.body.data.tenantId,
+    token: login.body.data.token,
+    tenantUserId: tenantUserRows[0]!.id
+  };
+}
+
+async function fetchTenantModuleState(
+  tenantId: string
+): Promise<Map<string, boolean>> {
+  const admin = getAdminSql();
+  const rows = (await admin`
+    SELECT module_key, enabled FROM awcms_mini_tenant_modules
+    WHERE tenant_id = ${tenantId}
+  `) as { module_key: string; enabled: boolean }[];
+
+  return new Map(rows.map((row) => [row.module_key, row.enabled]));
+}
+
+async function fetchAuditActions(
+  tenantId: string
+): Promise<{ action: string; resource_id: string; attributes: unknown }[]> {
+  const admin = getAdminSql();
+  return (await admin`
+    SELECT action, resource_id, attributes
+    FROM awcms_mini_audit_events
+    WHERE tenant_id = ${tenantId}
+      AND action IN ('tenant_module_enabled', 'tenant_module_disabled')
+    ORDER BY created_at ASC
+  `) as { action: string; resource_id: string; attributes: unknown }[];
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("tenant module preset application service", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("applying online_website enables its listed modules (all default-enabled already, so no changes), disables the safely-disableable non-listed modules, and skips one blocked by a transitive dependency", async () => {
+    const owner = await bootstrap();
+    const sql = getDatabaseClient();
+
+    const result = await withTenant(sql, owner.tenantId, (tx) =>
+      applyModulePreset(
+        tx,
+        owner.tenantId,
+        owner.tenantUserId,
+        "online_website"
+      )
+    );
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome !== "applied") throw new Error("unreachable");
+
+    // Every module is enabled by default for a fresh tenant, so
+    // online_website's own listed modules are already in the target state
+    // — the domain plan never even includes them as enable candidates
+    // (nothing to attempt, nothing to report), so they simply don't
+    // appear in `changes` at all.
+    const changeByKey = new Map(result.changes.map((c) => [c.moduleKey, c]));
+    for (const key of ["tenant_domain", "blog_content", "email", "reporting"]) {
+      expect(changeByKey.has(key)).toBe(false);
+    }
+    // logging/workflow/form_drafts aren't listed and nothing depends on
+    // them, so they're safely disabled to actually produce the profile.
+    for (const key of ["logging", "workflow", "form_drafts"]) {
+      expect(changeByKey.get(key)?.outcome).toBe("applied");
+      expect(changeByKey.get(key)?.action).toBe("disabled");
+    }
+    // sync_storage is also not listed, but `reporting` (which IS listed,
+    // so stays enabled) depends on it — so it must be skipped, not
+    // force-disabled, per the reverse-dependency protection design.
+    expect(changeByKey.has("sync_storage")).toBe(false);
+    expect(result.skipped).toContainEqual({
+      moduleKey: "sync_storage",
+      action: "disabled",
+      reason: "reverse_dependency_active",
+      message: expect.stringContaining("sync_storage")
+    });
+
+    const state = await fetchTenantModuleState(owner.tenantId);
+    expect(state.get("tenant_domain")).not.toBe(false);
+    expect(state.get("sync_storage")).not.toBe(false);
+    expect(state.get("logging")).toBe(false);
+    expect(state.get("workflow")).toBe(false);
+    expect(state.get("form_drafts")).toBe(false);
+
+    const auditRows = await fetchAuditActions(owner.tenantId);
+    const disabledResourceIds = auditRows
+      .filter((r) => r.action === "tenant_module_disabled")
+      .map((r) => r.resource_id)
+      .sort();
+    expect(disabledResourceIds).toEqual(
+      ["form_drafts", "logging", "workflow"].sort()
+    );
+    // No audit event for modules that were already in the target state.
+    expect(auditRows.some((r) => r.action === "tenant_module_enabled")).toBe(
+      false
+    );
+  });
+
+  test("re-applying the same preset is idempotent: second call plans and changes nothing, writes no new audit events", async () => {
+    const owner = await bootstrap();
+    const sql = getDatabaseClient();
+
+    await withTenant(sql, owner.tenantId, (tx) =>
+      applyModulePreset(
+        tx,
+        owner.tenantId,
+        owner.tenantUserId,
+        "online_website"
+      )
+    );
+    const firstAuditCount = (await fetchAuditActions(owner.tenantId)).length;
+    expect(firstAuditCount).toBeGreaterThan(0);
+
+    const second = await withTenant(sql, owner.tenantId, (tx) =>
+      applyModulePreset(
+        tx,
+        owner.tenantId,
+        owner.tenantUserId,
+        "online_website"
+      )
+    );
+
+    expect(second.outcome).toBe("applied");
+    if (second.outcome !== "applied") throw new Error("unreachable");
+    expect(second.changes.every((c) => c.outcome === "already_satisfied")).toBe(
+      true
+    );
+    expect(second.changes.some((c) => c.outcome === "rejected")).toBe(false);
+
+    const secondAuditCount = (await fetchAuditActions(owner.tenantId)).length;
+    expect(secondAuditCount).toBe(firstAuditCount);
+  });
+
+  test("applying minimal disables every non-core module, protecting module_management/tenant_admin/identity_access/profile_identity", async () => {
+    const owner = await bootstrap();
+    const sql = getDatabaseClient();
+
+    const result = await withTenant(sql, owner.tenantId, (tx) =>
+      applyModulePreset(tx, owner.tenantId, owner.tenantUserId, "minimal")
+    );
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome !== "applied") throw new Error("unreachable");
+
+    // module_management is CORE_MODULE_CANNOT_BE_DISABLED-protected and
+    // never even attempted (excluded from the plan entirely, per
+    // resolveProtectedModuleKeys).
+    expect(
+      result.changes.some((c) => c.moduleKey === "module_management")
+    ).toBe(false);
+    expect(result.changes.some((c) => c.moduleKey === "tenant_admin")).toBe(
+      false
+    );
+    expect(result.changes.some((c) => c.moduleKey === "identity_access")).toBe(
+      false
+    );
+    expect(result.changes.some((c) => c.moduleKey === "profile_identity")).toBe(
+      false
+    );
+
+    const state = await fetchTenantModuleState(owner.tenantId);
+    // Protected modules have no row at all (never touched) or remain enabled.
+    expect(state.get("module_management")).not.toBe(false);
+    expect(state.get("tenant_admin")).not.toBe(false);
+    expect(state.get("identity_access")).not.toBe(false);
+    expect(state.get("profile_identity")).not.toBe(false);
+
+    // Everything else disabled.
+    for (const key of [
+      "blog_content",
+      "email",
+      "reporting",
+      "sync_storage",
+      "tenant_domain",
+      "workflow",
+      "form_drafts"
+    ]) {
+      expect(state.get(key)).toBe(false);
+    }
+  });
+
+  test("switching from pos_lan to saas_online: pos_lan's own non-listed, non-blocked modules actually get disabled, and modules a still-kept module transitively needs (email under pos_lan, sync_storage under saas_online) are skipped rather than force-disabled", async () => {
+    const owner = await bootstrap();
+    const sql = getDatabaseClient();
+
+    const posLan = await withTenant(sql, owner.tenantId, (tx) =>
+      applyModulePreset(tx, owner.tenantId, owner.tenantUserId, "pos_lan")
+    );
+    expect(posLan.outcome).toBe("applied");
+    if (posLan.outcome !== "applied") throw new Error("unreachable");
+
+    // pos_lan lists sync_storage/reporting/workflow — reporting is what's
+    // actually driving this: it depends on both sync_storage AND email, so
+    // `email` (not listed by pos_lan at all) is transitively still
+    // required and must be skipped, not disabled.
+    expect(posLan.skipped).toContainEqual({
+      moduleKey: "email",
+      action: "disabled",
+      reason: "reverse_dependency_active",
+      message: expect.stringContaining("email")
+    });
+    // tenant_domain/blog_content are genuinely unrelated to anything kept
+    // enabled, so they ARE safely disabled.
+    const posLanChangeByKey = new Map(
+      posLan.changes.map((c) => [c.moduleKey, c])
+    );
+    expect(posLanChangeByKey.get("tenant_domain")?.action).toBe("disabled");
+    expect(posLanChangeByKey.get("blog_content")?.action).toBe("disabled");
+
+    const stateAfterPosLan = await fetchTenantModuleState(owner.tenantId);
+    expect(stateAfterPosLan.get("sync_storage")).not.toBe(false);
+    expect(stateAfterPosLan.get("reporting")).not.toBe(false);
+    expect(stateAfterPosLan.get("workflow")).not.toBe(false);
+    expect(stateAfterPosLan.get("email")).not.toBe(false);
+    expect(stateAfterPosLan.get("tenant_domain")).toBe(false);
+    expect(stateAfterPosLan.get("blog_content")).toBe(false);
+
+    const saas = await withTenant(sql, owner.tenantId, (tx) =>
+      applyModulePreset(tx, owner.tenantId, owner.tenantUserId, "saas_online")
+    );
+    expect(saas.outcome).toBe("applied");
+    if (saas.outcome !== "applied") throw new Error("unreachable");
+
+    // saas_online lists tenant_domain — it was disabled by pos_lan, so it
+    // actually gets (re-)enabled now.
+    const changeByKey = new Map(saas.changes.map((c) => [c.moduleKey, c]));
+    expect(changeByKey.get("tenant_domain")?.outcome).toBe("applied");
+    expect(changeByKey.get("tenant_domain")?.action).toBe("enabled");
+    // email/reporting/workflow were already enabled and stay listed (or,
+    // for email, transitively required) by saas_online — untouched.
+    expect(changeByKey.has("email")).toBe(false);
+    expect(changeByKey.has("reporting")).toBe(false);
+    expect(changeByKey.has("workflow")).toBe(false);
+
+    // sync_storage is NOT listed by saas_online, so it's a disable
+    // candidate — but reporting (kept enabled) still depends on it, so it
+    // must be skipped, not disabled and not force-attempted.
+    expect(saas.changes.some((c) => c.moduleKey === "sync_storage")).toBe(
+      false
+    );
+    expect(saas.skipped).toContainEqual({
+      moduleKey: "sync_storage",
+      action: "disabled",
+      reason: "reverse_dependency_active",
+      message: expect.stringContaining("sync_storage")
+    });
+
+    const finalState = await fetchTenantModuleState(owner.tenantId);
+    expect(finalState.get("sync_storage")).not.toBe(false);
+    expect(finalState.get("tenant_domain")).toBe(true);
+    expect(finalState.get("email")).not.toBe(false);
+  });
+
+  test("audit events carry the preset name and are written per-module, not one aggregate event", async () => {
+    const owner = await bootstrap();
+    const sql = getDatabaseClient();
+
+    await withTenant(sql, owner.tenantId, (tx) =>
+      applyModulePreset(tx, owner.tenantId, owner.tenantUserId, "minimal")
+    );
+
+    const auditRows = await fetchAuditActions(owner.tenantId);
+    expect(auditRows.length).toBeGreaterThan(1);
+    expect(auditRows.every((r) => r.action === "tenant_module_disabled")).toBe(
+      true
+    );
+    for (const row of auditRows) {
+      expect((row.attributes as { presetName?: string }).presetName).toBe(
+        "minimal"
+      );
+    }
+  });
+
+  test("unknown preset name is rejected without touching any module state", async () => {
+    const owner = await bootstrap();
+    const sql = getDatabaseClient();
+
+    const result = await withTenant(sql, owner.tenantId, (tx) =>
+      applyModulePreset(
+        tx,
+        owner.tenantId,
+        owner.tenantUserId,
+        "does_not_exist"
+      )
+    );
+
+    expect(result).toEqual({
+      outcome: "rejected",
+      code: "MODULE_PRESET_NOT_FOUND",
+      message: expect.stringContaining("does_not_exist")
+    });
+
+    const auditRows = await fetchAuditActions(owner.tenantId);
+    expect(auditRows).toEqual([]);
+  });
+
+  test("RLS: applying a preset for tenant A never writes tenant_modules rows for tenant B", async () => {
+    const ownerA = await bootstrap("tenant-a", "Tenant A");
+    const admin = getAdminSql();
+    const tenantBId = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    await admin`
+      INSERT INTO awcms_mini_tenants
+        (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+      VALUES (${tenantBId}, 'tenant-b', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+    `;
+
+    const sql = getDatabaseClient();
+    await withTenant(sql, ownerA.tenantId, (tx) =>
+      applyModulePreset(tx, ownerA.tenantId, ownerA.tenantUserId, "minimal")
+    );
+
+    const rows = (await admin`
+      SELECT count(*)::int AS count FROM awcms_mini_tenant_modules
+      WHERE tenant_id = ${tenantBId}
+    `) as { count: number }[];
+    expect(rows[0]?.count).toBe(0);
+  });
+});

--- a/tests/unit/module-presets.test.ts
+++ b/tests/unit/module-presets.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeModulePresetPlan,
+  findModulePreset,
+  MODULE_PRESETS,
+  resolveProtectedModuleKeys,
+  type ModulePresetDefinition
+} from "../../src/modules/module-management/domain/module-presets";
+import type { ModuleDescriptor } from "../../src/modules/_shared/module-contract";
+import type { ModuleTenantState } from "../../src/modules/module-management/domain/tenant-module-lifecycle";
+
+function descriptor(
+  overrides: Partial<ModuleDescriptor> = {}
+): ModuleDescriptor {
+  return {
+    key: "a",
+    name: "A",
+    version: "1.0.0",
+    status: "active",
+    description: "Module A.",
+    dependencies: [],
+    ...overrides
+  };
+}
+
+function state(moduleKey: string, tenantEnabled: boolean): ModuleTenantState {
+  return { moduleKey, tenantEnabled };
+}
+
+function preset(
+  overrides: Partial<ModulePresetDefinition> = {}
+): ModulePresetDefinition {
+  return {
+    name: "minimal",
+    label: "Test preset",
+    description: "Test preset.",
+    enabledModuleKeys: [],
+    ...overrides
+  };
+}
+
+// A small synthetic registry mirroring the real shape closely enough to
+// exercise every branch: `core` is isCore, `foundation` is core's own
+// dependency (protected transitively), `leaf_a`/`leaf_b` are independent
+// optional modules, `dependent` depends on `leaf_a` (an optional module,
+// not core) so enabling it without `leaf_a` already enabled must fail
+// rather than silently auto-enabling `leaf_a`.
+const CORE: ModuleDescriptor = descriptor({
+  key: "core",
+  isCore: true,
+  dependencies: ["foundation"]
+});
+const FOUNDATION: ModuleDescriptor = descriptor({
+  key: "foundation",
+  dependencies: []
+});
+const LEAF_A: ModuleDescriptor = descriptor({
+  key: "leaf_a",
+  dependencies: ["foundation"]
+});
+const LEAF_B: ModuleDescriptor = descriptor({
+  key: "leaf_b",
+  dependencies: ["foundation"]
+});
+const DEPENDENT: ModuleDescriptor = descriptor({
+  key: "dependent",
+  dependencies: ["leaf_a"]
+});
+
+const REGISTRY: readonly ModuleDescriptor[] = [
+  CORE,
+  FOUNDATION,
+  LEAF_A,
+  LEAF_B,
+  DEPENDENT
+];
+
+describe("MODULE_PRESETS / findModulePreset", () => {
+  test("every defined preset resolves to real registered module keys (this repo's actual registry)", async () => {
+    // Cross-check against the real, live module registry — catches the
+    // exact class of bug the issue itself warned about (a preset
+    // referencing a module key, like the issue's own illustrative
+    // `workflow_approval`, that doesn't actually resolve via
+    // `listModules()`).
+    const { listModules } = await import("../../src/modules/index");
+    const realDescriptors = listModules();
+    const realKeys = new Set(realDescriptors.map((d) => d.key));
+
+    for (const p of MODULE_PRESETS) {
+      for (const key of p.enabledModuleKeys) {
+        expect(realKeys.has(key)).toBe(true);
+      }
+    }
+  });
+
+  test("findModulePreset resolves a known preset name", () => {
+    expect(findModulePreset("online_website")?.name).toBe("online_website");
+  });
+
+  test("findModulePreset returns null for an unknown preset name", () => {
+    expect(findModulePreset("does_not_exist")).toBeNull();
+  });
+
+  test("minimal preset's own enabledModuleKeys list is empty (core-only by construction)", () => {
+    expect(findModulePreset("minimal")?.enabledModuleKeys).toEqual([]);
+  });
+});
+
+describe("resolveProtectedModuleKeys", () => {
+  test("includes isCore keys and their full transitive dependency closure", () => {
+    const result = resolveProtectedModuleKeys(REGISTRY);
+
+    expect(result).toEqual(new Set(["core", "foundation"]));
+  });
+
+  test("does not include non-core, non-depended-upon modules", () => {
+    const result = resolveProtectedModuleKeys(REGISTRY);
+
+    expect(result.has("leaf_a")).toBe(false);
+    expect(result.has("leaf_b")).toBe(false);
+    expect(result.has("dependent")).toBe(false);
+  });
+
+  test("real registry's protected set is exactly module_management's own dependency closure", async () => {
+    const { listModules } = await import("../../src/modules/index");
+    const result = resolveProtectedModuleKeys(listModules());
+
+    expect(result).toEqual(
+      new Set([
+        "module_management",
+        "tenant_admin",
+        "identity_access",
+        "profile_identity"
+      ])
+    );
+  });
+});
+
+describe("computeModulePresetPlan — normal application", () => {
+  test("plans to enable every listed module not already enabled, dependencies-first", () => {
+    const plan = computeModulePresetPlan({
+      preset: preset({ enabledModuleKeys: ["leaf_a", "dependent"] }),
+      allDescriptors: REGISTRY,
+      currentState: [
+        state("core", true),
+        state("foundation", true),
+        state("leaf_a", false),
+        state("leaf_b", true),
+        state("dependent", false)
+      ]
+    });
+
+    expect(plan.toEnable).toEqual(["leaf_a", "dependent"]);
+  });
+
+  test("plans to disable currently-enabled, non-protected, non-listed modules", () => {
+    const plan = computeModulePresetPlan({
+      preset: preset({ enabledModuleKeys: ["leaf_a"] }),
+      allDescriptors: REGISTRY,
+      currentState: [
+        state("core", true),
+        state("foundation", true),
+        state("leaf_a", false),
+        state("leaf_b", true),
+        state("dependent", false)
+      ]
+    });
+
+    expect(plan.toEnable).toEqual(["leaf_a"]);
+    expect(plan.toDisable).toEqual(["leaf_b"]);
+  });
+
+  test("never plans to disable core or its dependency closure, even when not listed by the preset", () => {
+    const plan = computeModulePresetPlan({
+      preset: preset({ enabledModuleKeys: [] }),
+      allDescriptors: REGISTRY,
+      currentState: [
+        state("core", true),
+        state("foundation", true),
+        state("leaf_a", true),
+        state("leaf_b", true),
+        state("dependent", false)
+      ]
+    });
+
+    expect(plan.toDisable).not.toContain("core");
+    expect(plan.toDisable).not.toContain("foundation");
+    expect([...plan.protectedModuleKeys].sort()).toEqual([
+      "core",
+      "foundation"
+    ]);
+  });
+});
+
+describe("computeModulePresetPlan — idempotent re-application", () => {
+  test("second application against a state that already matches the preset plans no changes", () => {
+    const currentState: ModuleTenantState[] = [
+      state("core", true),
+      state("foundation", true),
+      state("leaf_a", true),
+      state("leaf_b", false),
+      state("dependent", false)
+    ];
+
+    const plan = computeModulePresetPlan({
+      preset: preset({ enabledModuleKeys: ["leaf_a"] }),
+      allDescriptors: REGISTRY,
+      currentState
+    });
+
+    expect(plan.toEnable).toEqual([]);
+    expect(plan.toDisable).toEqual([]);
+  });
+});
+
+describe("computeModulePresetPlan — a listed module's dependency that isn't itself in the preset", () => {
+  test("is included in toEnable as-is without auto-adding the missing dependency (no invented resolution logic)", () => {
+    // `dependent` needs `leaf_a`, but the preset only lists `dependent`.
+    // `leaf_a` is currently disabled for this tenant (e.g. a previous
+    // preset application disabled it). The plan must still include
+    // `dependent` in toEnable (best-effort) — it is the application
+    // layer's job (via the real `enableTenantModule`/
+    // `evaluateModuleEnable`) to surface the resulting
+    // `MODULE_DEPENDENCY_DISABLED` rejection, not this pure planner's job
+    // to silently add `leaf_a` to the plan.
+    const plan = computeModulePresetPlan({
+      preset: preset({ enabledModuleKeys: ["dependent"] }),
+      allDescriptors: REGISTRY,
+      currentState: [
+        state("core", true),
+        state("foundation", true),
+        state("leaf_a", false),
+        state("leaf_b", true),
+        state("dependent", false)
+      ]
+    });
+
+    expect(plan.toEnable).toEqual(["dependent"]);
+    expect(plan.toEnable).not.toContain("leaf_a");
+  });
+
+  test("when the dependency IS in the preset list, it is ordered before its dependent", () => {
+    const plan = computeModulePresetPlan({
+      preset: preset({ enabledModuleKeys: ["dependent", "leaf_a"] }),
+      allDescriptors: REGISTRY,
+      currentState: [
+        state("core", true),
+        state("foundation", true),
+        state("leaf_a", false),
+        state("leaf_b", true),
+        state("dependent", false)
+      ]
+    });
+
+    expect(plan.toEnable).toEqual(["leaf_a", "dependent"]);
+  });
+});
+
+describe("computeModulePresetPlan — disabling a module another still-enabled module depends on", () => {
+  test("skips (does not plan to disable) a module a preset-kept module still depends on, and reports it in skippedDisable", () => {
+    // `dependent` stays enabled by this preset (listed), and `dependent`
+    // depends on `leaf_a`. `leaf_a` itself is NOT listed by this preset,
+    // so it would otherwise be a disable candidate — but it must be
+    // skipped, not force-disabled, since `dependent` still needs it.
+    const plan = computeModulePresetPlan({
+      preset: preset({ enabledModuleKeys: ["dependent"] }),
+      allDescriptors: REGISTRY,
+      currentState: [
+        state("core", true),
+        state("foundation", true),
+        state("leaf_a", true),
+        state("leaf_b", false),
+        state("dependent", true)
+      ]
+    });
+
+    expect(plan.toDisable).not.toContain("leaf_a");
+    expect(plan.skippedDisable).toEqual([
+      { moduleKey: "leaf_a", reason: "reverse_dependency_active" }
+    ]);
+  });
+
+  test("disables in leaves-first order so a real dependent gets disabled before its own dependency", () => {
+    // Switching a preset from one that wants `dependent` + `leaf_a` to one
+    // that wants neither: `dependent` has no dependents itself, so it must
+    // be ordered before `leaf_a` (which `dependent` depends on).
+    const plan = computeModulePresetPlan({
+      preset: preset({ enabledModuleKeys: [] }),
+      allDescriptors: REGISTRY,
+      currentState: [
+        state("core", true),
+        state("foundation", true),
+        state("leaf_a", true),
+        state("leaf_b", false),
+        state("dependent", true)
+      ]
+    });
+
+    expect(plan.toDisable.indexOf("dependent")).toBeLessThan(
+      plan.toDisable.indexOf("leaf_a")
+    );
+    expect(plan.skippedDisable).toEqual([]);
+  });
+
+  test("skips a disable candidate that only a module THIS SAME PLAN is about to newly enable depends on (post-review regression)", () => {
+    // `dependent` starts DISABLED and is listed by this preset (so it's a
+    // toEnable candidate, not already-enabled). `leaf_a` starts ENABLED and
+    // is NOT listed (so it would otherwise be a disable candidate). Since
+    // this plan is about to enable `dependent`, which depends on `leaf_a`,
+    // `leaf_a` must be skipped — not scheduled for disable — even though
+    // nothing CURRENTLY enabled depends on it yet. Before the post-review
+    // fix, the disable-planner only seeded its "stays enabled" set from
+    // pre-plan state, so this case incorrectly scheduled leaf_a for
+    // disable; the real disableTenantModule call would still have caught
+    // it, but as a spurious MODULE_REVERSE_DEPENDENCY_ACTIVE rejection
+    // instead of this pre-emptive skip.
+    const plan = computeModulePresetPlan({
+      preset: preset({ enabledModuleKeys: ["dependent"] }),
+      allDescriptors: REGISTRY,
+      currentState: [
+        state("core", true),
+        state("foundation", true),
+        state("leaf_a", true),
+        state("leaf_b", false),
+        state("dependent", false)
+      ]
+    });
+
+    expect(plan.toEnable).toContain("dependent");
+    expect(plan.toDisable).not.toContain("leaf_a");
+    expect(plan.skippedDisable).toEqual([
+      { moduleKey: "leaf_a", reason: "reverse_dependency_active" }
+    ]);
+  });
+});
+
+describe("computeModulePresetPlan — unknown module keys", () => {
+  test("a preset-listed key that isn't a registered descriptor is reported, never silently enabled", () => {
+    const plan = computeModulePresetPlan({
+      preset: preset({ enabledModuleKeys: ["leaf_a", "workflow_approval"] }),
+      allDescriptors: REGISTRY,
+      currentState: [
+        state("core", true),
+        state("foundation", true),
+        state("leaf_a", false),
+        state("leaf_b", true),
+        state("dependent", false)
+      ]
+    });
+
+    expect(plan.unknownModuleKeys).toEqual(["workflow_approval"]);
+    expect(plan.toEnable).not.toContain("workflow_approval");
+  });
+});
+
+describe("computeModulePresetPlan — switching between presets end-to-end (synthetic registry)", () => {
+  test("applying a broader preset then a narrower one enables the broad set then disables what the narrow one drops", () => {
+    const broad = preset({
+      enabledModuleKeys: ["leaf_a", "leaf_b", "dependent"]
+    });
+    const narrow = preset({ enabledModuleKeys: ["leaf_a"] });
+
+    const initialState: ModuleTenantState[] = [
+      state("core", true),
+      state("foundation", true),
+      state("leaf_a", false),
+      state("leaf_b", false),
+      state("dependent", false)
+    ];
+
+    const broadPlan = computeModulePresetPlan({
+      preset: broad,
+      allDescriptors: REGISTRY,
+      currentState: initialState
+    });
+    expect([...broadPlan.toEnable].sort()).toEqual([
+      "dependent",
+      "leaf_a",
+      "leaf_b"
+    ]);
+    expect(broadPlan.toDisable).toEqual([]);
+
+    // Simulate the state after broadPlan's enables landed.
+    const afterBroad: ModuleTenantState[] = [
+      state("core", true),
+      state("foundation", true),
+      state("leaf_a", true),
+      state("leaf_b", true),
+      state("dependent", true)
+    ];
+
+    const narrowPlan = computeModulePresetPlan({
+      preset: narrow,
+      allDescriptors: REGISTRY,
+      currentState: afterBroad
+    });
+    expect(narrowPlan.toEnable).toEqual([]);
+    // `dependent` must be disabled before `leaf_a` would even be a
+    // candidate to disable — but `leaf_a` is kept by the narrow preset, so
+    // only `leaf_b` and `dependent` are disable candidates.
+    expect([...narrowPlan.toDisable].sort()).toEqual(["dependent", "leaf_b"]);
+    expect(narrowPlan.toDisable.indexOf("dependent")).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Tenth issue of epic #555. Adds `applyModulePreset()`, a domain+application service (no new API route or UI in this issue — that's #566/a future setup wizard step) offering five named module-set profiles: `online_website`, `news_portal`, `saas_online`, `pos_lan`, `minimal`.

## Key design decisions
- **Enable + disable, not enable-only**: applying a preset enables every listed module and disables every currently-enabled module that isn't listed and isn't "protected" — otherwise `minimal` would never actually become minimal on a tenant that previously had extra modules enabled. The issue's own acceptance criteria ("presets cannot disable core modules") presupposes this.
- **"Protected" is computed, not hardcoded**: every `isCore: true` module's key unioned with its full transitive dependency closure (`resolveProtectedModuleKeys`). In this registry that's `{module_management, tenant_admin, identity_access, profile_identity}` — this is what makes `minimal`'s empty module list concretely mean something.
- **Zero bypass of existing lifecycle validation**: every state change routes through the real `enableTenantModule`/`disableTenantModule` (dependency graph, reverse-dependency protection, core-module protection) — never a direct `awcms_mini_tenant_modules` write.
- **Idempotent**: a module already in its target state is excluded from the plan entirely (no audit event on re-apply). A module that can't be disabled because a still-enabled module depends on it is skipped and reported, never force-disabled or silently dropped.
- **Corrects a factual error in the issue itself**: its example JSON lists a module key `workflow_approval`, which doesn't exist in this registry — the real key is `workflow` (verified via `grep key: src/modules/*/module.ts`).

## Review chain
- `awcms-mini-coder`: implemented the service layer with detailed reasoning for both design decisions. Initial gate green (1108 tests against real Postgres).
- `awcms-mini-reviewer`: **Request changes → fixed in this PR.** Found a real bug in the disable-planner: it only seeded its "stays enabled" blocking-check set from modules enabled *before* the plan ran, not modules the *same plan* is about to newly enable. Reproduced directly against the real registry (a module disabled, its dependency's dependent module about to be freshly enabled by the same plan) — the disable candidate should have been pre-emptively skipped but instead got scheduled for disable, only caught later as a spurious rejection from the real `disableTenantModule` call (so final DB state was still correct — this was a caller-visible-result bug, not a data-integrity bug, but it broke the documented "never an unexpected rejection" contract a future caller like #566 would rely on). **Fixed**: seeded the disable-planner's base set with the union of pre-plan-enabled and about-to-be-enabled modules, with a new regression test reproducing the exact scenario the reviewer found. Re-reviewed the fix myself and re-ran the full gate.
- No separate `awcms-mini-security-auditor` pass: this issue adds no new API route, UI, or external attack surface — it's an internal callable service reusing already-audited lifecycle primitives, with no auth/ABAC surface of its own (by design, matching how `enableTenantModule`/`disableTenantModule` themselves don't self-authorize either). The reviewer's own checklist covered the security-relevant checks (no direct table writes, no permission/role escalation, audit coverage). A lightweight security pass is recommended once #566 wires this into a real, authenticated API route.

## Test plan
- [x] `bun test tests/unit/module-presets.test.ts` — 18 pass (17 original + 1 post-review regression test)
- [x] `bun test tests/integration/module-presets.integration.test.ts` — 7 pass
- [x] Full `bun test` against real PostgreSQL — 1109 pass, 0 fail
- [x] `bun run lint` / `bun run typecheck` / `bun run check:docs` / `bun run api:spec:check` / `bun run build` — all PASS (api:spec:check confirms true no-op, no OpenAPI/AsyncAPI/SQL diff)

## Security notes
No direct `awcms_mini_tenant_modules` writes anywhere in the new code. No `awcms_mini_roles`/`awcms_mini_role_permissions`/`awcms_mini_access_assignments` touched — a preset changes module *availability* only. One `tenant_module_enabled`/`tenant_module_disabled` audit event per module actually changed (never a hidden aggregate event), tagged with the triggering preset name.

## Next steps
Issue #566 (tenant-module matrix admin UI) is next in epic #555, and will need its own ABAC guard when it wires `applyModulePreset` into a real endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)