### PR TITLE
feat(module-management): add tenant-module matrix management screen (Issue #566)

### DIFF
--- a/.changeset/tenant-module-matrix-admin-ui-issue-566.md
+++ b/.changeset/tenant-module-matrix-admin-ui-issue-566.md
@@ -1,0 +1,49 @@
+---
+"awcms-mini": minor
+---
+
+Add the tenant-module matrix admin UI (Issue #566, epic #555, depends on
+#565): `src/pages/admin/modules/tenants.astro`, at the path already used
+by the issue (`/admin/modules/tenants`), gated on **both**
+`module_management.modules.read` and `module_management.tenant_modules.read`.
+
+**Single-tenant scope, not cross-tenant** (decided with the maintainer,
+documented in full in the page's own docblock and
+`module-management/README.md`): this repo's identity model is strictly
+1:1 tenant-scoped, so this screen shows module x relevant-attribute for
+the admin's own tenant only — there is no tenant selector/filter anywhere
+on this page.
+
+What the matrix adds beyond the existing `/admin/modules` list +
+`/admin/modules/{moduleKey}` detail pages: dependency and
+reverse-dependency warnings surfaced for every module at once (100%
+reuse of `evaluateModuleEnable`/`evaluateModuleDisable`, no re-derived
+graph logic — new `application/module-matrix.ts`'s `fetchModuleMatrix`),
+bulk core/protected visualization (`isCore` plus Issue #565's
+`resolveProtectedModuleKeys`, with the disable control hidden for both),
+and a client-side "only show modules with a warning" filter. Settings
+editing and the audit-event list are not duplicated — this screen links
+to the existing detail page for both. Applying a module preset
+(`applyModulePreset`, #565) was considered but left out of this issue —
+doing so cleanly needs a new guarded/audited API endpoint, a separable
+unit of work — and is noted as a follow-up.
+
+SSR reads (`fetchModuleMatrix`) are a direct, read-only DB call inside
+`withTenant`. Every mutation (enable/disable) goes through the real
+`/api/v1/tenant/modules/{moduleKey}/enable|disable` endpoints (Issue
+#515) via client-side `fetch` — no privileged SSR shortcut, same binding
+split `admin/tenant/domains.astro` (#563) established. Neither endpoint
+requires an `Idempotency-Key`; disable prompts for a reason via
+`window.prompt`, matching `admin/modules/[moduleKey].astro`'s existing
+enable/disable buttons exactly.
+
+New i18n catalog entries under `admin.modules.matrix_*` plus
+`admin.layout.nav_module_matrix` (en + id) — the module descriptor's
+`navigation` array gained a second entry for this page. New test:
+`tests/integration/module-tenant-matrix.integration.test.ts` — covers
+`fetchModuleMatrix`'s health-inclusion toggle, both warning directions
+(using the same registry scenarios
+`module-tenant-lifecycle.integration.test.ts` already established), core
+protection, real enable/disable mutations with audit-event assertions,
+and a 403 for a caller without `module_management.tenant_modules`
+permissions.

--- a/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
@@ -38,7 +38,7 @@ menjembatani beberapa modul sekaligus (config, `tenant_domain` module baru,
 | #563  | Admin UI domain/subdomain                                     | **Selesai** — lihat §Admin UI di bawah                                           |
 | #564  | Tenant settings untuk rute `/news` vs legacy (`blog_content`) | **Selesai** — lihat §Tenant settings public route di bawah                       |
 | #565  | Tenant module presets (online/news/LAN/minimal)               | **Selesai** — lihat §Tenant module presets di bawah                              |
-| #566  | Tenant-module matrix admin UI                                 | Belum                                                                            |
+| #566  | Tenant-module matrix admin UI                                 | **Selesai** — lihat §Tenant-module matrix admin UI di bawah                      |
 | #567  | Cloudflare DNS adapter (opsional)                             | Belum                                                                            |
 
 ## Yang sudah ada — pakai ulang, jangan re-derive
@@ -649,6 +649,62 @@ lewat synthetic registry) dan
 Postgres). Detail lengkap tiga keputusan desain di atas:
 `module-management/README.md` §Tenant module presets.
 
+### Tenant-module matrix admin UI (Issue #566, `module_management`)
+
+`/admin/modules/tenants` (`src/pages/admin/modules/tenants.astro` +
+`application/module-matrix.ts`'s `fetchModuleMatrix`) — layar admin yang
+menampilkan module x atribut relevan **untuk satu tenant**, di atas data
+yang sama yang sudah dibaca #521's list/detail (`fetchModuleCatalog`,
+`fetchTenantModuleEntries`, `fetchModuleHealthReport`) plus #565's
+`resolveProtectedModuleKeys`, dan `evaluateModuleEnable`/
+`evaluateModuleDisable` (#515) untuk dua peringatan baru
+(`dependencyWarning`/`reverseDependencyWarning`) — bukan graph baru.
+
+**Keputusan scope mengikat (single-tenant, BUKAN cross-tenant)**: kata-kata
+issue sendiri ("filter by tenant", "managing module availability across
+tenants") terbaca seperti matrix lintas-tenant sungguhan — tapi model
+identity repo ini strictly 1:1 tenant-scoped (`identity-access/README.md`,
+`TenantSwitcher.astro` adalah stub yang sengaja permanen-disabled). Sudah
+diputuskan bersama maintainer: layar ini scoped ke tenant admin sendiri
+(`context.tenantId`), sama seperti semua layar admin lain di app ini —
+**tidak ada** filter/selector tenant di mana pun di halaman ini. Alasan
+lengkap: docblock `tenants.astro` sendiri. Issue lanjutan manapun **jangan**
+"perbaiki" ini dengan menambah dropdown tenant satu-opsi palsu atau
+membangun filtering lintas-tenant sungguhan — itu butuh konsep
+identity/session platform-operator baru yang sama sekali di luar scope
+repo ini hari ini.
+
+**Nilai "matrix" konkret** (karena tidak ada sumbu tenant kedua untuk
+dijadikan grid sungguhan): (1) peringatan dependency/reverse-dependency
+untuk SEMUA modul sekaligus (100% reuse `evaluateModuleEnable`/
+`evaluateModuleDisable`, tidak pernah walk graph baru — `dependencyWarning`
+hanya dihitung untuk modul yang SEDANG disabled, `reverseDependencyWarning`
+hanya untuk modul yang SEDANG enabled, karena memanggil `evaluateModuleEnable`
+pada modul yang sudah enabled hanya akan short-circuit ke
+`MODULE_ALREADY_ENABLED` sebelum sempat mengecek dependency — bukan
+pertanyaan yang didesain untuk state itu); (2) visualisasi core/protected
+bulk (`isCore` + `isProtected` per baris, tombol disable disembunyikan untuk
+keduanya — protected non-core pun, karena disable-nya pasti ditolak server
+lewat `MODULE_REVERSE_DEPENDENCY_ACTIVE`); (3) filter client-side "hanya
+tampilkan modul dengan peringatan". Settings editing dan audit-event list
+**tidak** diduplikasi — tetap link ke `/admin/modules/{moduleKey}` yang
+sudah punya keduanya.
+
+**Preset (#565's `applyModulePreset`) SENGAJA TIDAK diwire ke layar ini** —
+butuh endpoint API + OpenAPI + guard + test baru, unit kerja tersendiri yang
+cukup besar; dicatat sebagai follow-up terpisah, bukan dipaksakan masuk
+issue ini.
+
+**Binding split sama seperti #563**: SSR baca langsung (`withTenant` +
+`fetchModuleMatrix`), setiap mutasi (enable/disable) lewat
+`/api/v1/tenant/modules/{moduleKey}/enable|disable` (#515) yang sudah ada —
+tidak ada shortcut SSR privileged. Kedua endpoint itu **tidak** butuh
+`Idempotency-Key` (dicek langsung dari `enable.ts`/`disable.ts`), jadi tidak
+dikirim di sini — beda dari `verify`/`set-primary` #563 yang butuh.
+
+Test: `tests/integration/module-tenant-matrix.integration.test.ts`. Detail
+lengkap: `module-management/README.md` §Tenant-module matrix admin UI.
+
 ## Aturan lintas-issue yang wajib diikuti
 
 1. **Backward compatibility non-negotiable**: setiap deployment offline/LAN existing yang tidak pernah set `PUBLIC_*` apa pun harus tetap `config:validate` PASS dan berperilaku persis seperti sebelum epic ini — jangan pernah membuat salah satu dari enam var config ini menjadi wajib secara default.
@@ -664,21 +720,22 @@ Postgres). Detail lengkap tiga keputusan desain di atas:
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Isu #566-#567 (matrix UI admin dan adapter Cloudflare DNS) **belum ada**.
-Sudah selesai: config (#556), schema `awcms_mini_tenant_domains` (#557),
-module descriptor `tenant_domain` (#558), resolver host-based (#559),
-rute publik `/news` (#560), dokumentasi legacy/ADR-0010 (#561), API
-tenant domain management (#562, §API di atas), admin UI (#563, §Admin UI
-di atas), tenant settings public route `blog_content` (#564, §Tenant
-settings public route di atas), dan tenant module presets (#565, §Tenant
-module presets di atas — **service layer saja, belum ada API/UI**, itu
-scope #566). Tabel `awcms_mini_tenant_domains` sekarang bisa
-ditulis lewat kode aplikasi (API #562 + admin UI #563) — bukan lagi
-schema-only. Operator yang benar-benar mengisi baris nyata lewat
-UI/API dan mengaktifkan `PUBLIC_TENANT_RESOLUTION_MODE=host_default`
-membuat resolver #559 langkah 1 (host/domain mapping asli) benar-benar
-reachable di production untuk pertama kalinya — lihat konsekuensi
-keamanan di ADR-0010 §Konsekuensi sebelum mengaktifkan mode itu.
+Isu #567 (adapter Cloudflare DNS) **belum ada**. Sudah selesai: config
+(#556), schema `awcms_mini_tenant_domains` (#557), module descriptor
+`tenant_domain` (#558), resolver host-based (#559), rute publik `/news`
+(#560), dokumentasi legacy/ADR-0010 (#561), API tenant domain management
+(#562, §API di atas), admin UI (#563, §Admin UI di atas), tenant settings
+public route `blog_content` (#564, §Tenant settings public route di atas),
+tenant module presets (#565, §Tenant module presets di atas — service layer
+saja), dan tenant-module matrix admin UI (#566, §Tenant-module matrix admin
+UI di atas — single-tenant scope, lihat keputusan mengikat di bagian itu).
+Tabel `awcms_mini_tenant_domains` sekarang bisa ditulis lewat kode aplikasi
+(API #562 + admin UI #563) — bukan lagi schema-only. Operator yang
+benar-benar mengisi baris nyata lewat UI/API dan mengaktifkan
+`PUBLIC_TENANT_RESOLUTION_MODE=host_default` membuat resolver #559 langkah 1
+(host/domain mapping asli) benar-benar reachable di production untuk
+pertama kalinya — lihat konsekuensi keamanan di ADR-0010 §Konsekuensi
+sebelum mengaktifkan mode itu.
 
 **Follow-up keamanan wajib diselesaikan sebelum `PUBLIC_TENANT_RESOLUTION_MODE=host_default` diaktifkan di production** (ditemukan `awcms-mini-security-auditor` saat audit #560, verdict PASS tapi non-blocking karena `host_default` belum bisa resolve apa pun secara nyata hari ini — lihat alasan di atas):
 

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -150,6 +150,10 @@ msgstr "Tenant Domains"
 msgid "admin.layout.nav_modules"
 msgstr "Modules"
 
+#. Issue #566, epic #555 — tenant-module matrix admin screen
+msgid "admin.layout.nav_module_matrix"
+msgstr "Module Matrix"
+
 msgid "admin.layout.breadcrumb_aria_label"
 msgstr "Breadcrumb"
 
@@ -723,6 +727,33 @@ msgstr "Time"
 
 msgid "admin.modules.no_audit_events"
 msgstr "No recent activity for this module."
+
+#. admin.modules.matrix_* — Issue #566, epic #555 (tenant-module matrix,
+#. single-tenant scope — see src/pages/admin/modules/tenants.astro's own
+#. docblock for the binding scope decision)
+msgid "admin.modules.matrix_title"
+msgstr "Module x Tenant Matrix"
+
+msgid "admin.modules.matrix_intro"
+msgstr "This view shows every module for your current tenant only — it is not a cross-tenant view. Use it to spot dependency issues, protected modules, and health problems across all modules at a glance."
+
+msgid "admin.modules.matrix_filter_warning_label"
+msgstr "Only show modules with a warning"
+
+msgid "admin.modules.tenant_status_column"
+msgstr "Tenant Status"
+
+msgid "admin.modules.warnings_column"
+msgstr "Warnings"
+
+msgid "admin.modules.protected_label"
+msgstr "Protected"
+
+msgid "admin.modules.matrix_dependency_warning_prefix"
+msgstr "Dependency issue:"
+
+msgid "admin.modules.matrix_reverse_dependency_warning_prefix"
+msgstr "Would block disabling:"
 
 #. admin.examples.wizard — Issue #483, non-domain fixture page
 msgid "admin.examples.wizard.nav_title"

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -150,6 +150,10 @@ msgstr "Domain Tenant"
 msgid "admin.layout.nav_modules"
 msgstr "Modul"
 
+#. Issue #566, epic #555 — layar admin matriks tenant-modul
+msgid "admin.layout.nav_module_matrix"
+msgstr "Matriks Modul"
+
 msgid "admin.layout.breadcrumb_aria_label"
 msgstr "Breadcrumb"
 
@@ -723,6 +727,33 @@ msgstr "Waktu"
 
 msgid "admin.modules.no_audit_events"
 msgstr "Belum ada aktivitas terbaru untuk modul ini."
+
+#. admin.modules.matrix_* — Issue #566, epic #555 (matriks tenant-modul,
+#. scope single-tenant — lihat docblock src/pages/admin/modules/tenants.astro
+#. untuk keputusan scope mengikat)
+msgid "admin.modules.matrix_title"
+msgstr "Matriks Modul x Tenant"
+
+msgid "admin.modules.matrix_intro"
+msgstr "Tampilan ini menampilkan semua modul hanya untuk tenant Anda saat ini — ini bukan tampilan lintas-tenant. Gunakan untuk melihat masalah dependensi, modul terproteksi, dan masalah kesehatan di semua modul sekaligus."
+
+msgid "admin.modules.matrix_filter_warning_label"
+msgstr "Hanya tampilkan modul dengan peringatan"
+
+msgid "admin.modules.tenant_status_column"
+msgstr "Status Tenant"
+
+msgid "admin.modules.warnings_column"
+msgstr "Peringatan"
+
+msgid "admin.modules.protected_label"
+msgstr "Terproteksi"
+
+msgid "admin.modules.matrix_dependency_warning_prefix"
+msgstr "Masalah dependensi:"
+
+msgid "admin.modules.matrix_reverse_dependency_warning_prefix"
+msgstr "Akan menghalangi penonaktifan:"
 
 #. admin.examples.wizard — Issue #483, fixture non-domain
 msgid "admin.examples.wizard.nav_title"

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -430,6 +430,96 @@ against both a synthetic registry and the real one) and
 real row states, real audit events, idempotent re-application, and
 switching between two different presets).
 
+## Tenant-module matrix admin UI — `application/module-matrix.ts` (Issue #566, epic #555)
+
+`/admin/modules/tenants` — a denser, module x relevant-attribute view for
+**one tenant** on top of the same registry/lifecycle data #521's list/detail
+pages already read, not a rebuild of either.
+
+**Binding scope decision (single-tenant, not cross-tenant)**: the issue's
+own wording ("filter by tenant", "managing module availability across
+tenants") reads like a genuine multi-tenant matrix, but this repo's identity
+model is strictly 1:1 tenant-scoped — `identity-access/README.md` documents
+no cross-tenant linking anywhere in the schema, and
+`src/components/TenantSwitcher.astro` is a permanently-disabled stub for
+exactly this reason. Decided with the maintainer: this screen is scoped to
+the admin's own tenant (`context.tenantId`), matching every other admin
+screen in this app — there is no tenant selector/filter anywhere on this
+page. Full reasoning: `src/pages/admin/modules/tenants.astro`'s own
+docblock.
+
+**What "matrix" concretely adds over #521's list+detail**, since there is no
+second (tenant) axis to build a real grid against:
+
+1. **Dependency/reverse-dependency warnings for every module at once**
+   (`fetchModuleMatrix`'s `dependencyWarning`/`reverseDependencyWarning`) —
+   100% reuse of `evaluateModuleEnable`/`evaluateModuleDisable` (#515), never
+   a re-derived graph walk. `dependencyWarning` is only ever computed for a
+   currently-**disabled** module (would enabling it succeed right now?,
+   filtered to the dependency/version rejection codes); `reverseDependencyWarning`
+   is only ever computed for a currently-**enabled** module (would disabling
+   it right now be blocked because something still depends on it?, filtered
+   to `MODULE_REVERSE_DEPENDENCY_ACTIVE`). Calling `evaluateModuleEnable` on
+   an already-enabled module would only ever short-circuit to
+   `MODULE_ALREADY_ENABLED` before reaching the dependency loop — asking it a
+   question it isn't designed to answer for that state — so this
+   deliberately does not attempt that direction; a currently-enabled
+   module's dependencies are guaranteed satisfied by construction anyway
+   (`disableTenantModule` already refuses to disable a dependency while an
+   active dependent remains enabled).
+2. **Core/protected visualization** — `isCore` and `isProtected`
+   (`resolveProtectedModuleKeys`, #565) are both flagged per row, so an
+   admin can bulk-see which modules are freely toggleable vs. structurally
+   protected instead of discovering it one rejected click at a time on the
+   detail page. The disable control is hidden for both — not just literal
+   `isCore` — because a protected-but-non-core module's disable is always
+   rejected server-side anyway (`MODULE_REVERSE_DEPENDENCY_ACTIVE`), so
+   offering a guaranteed-to-fail button would be misleading (the issue only
+   strictly requires blocking literal core modules; this goes slightly
+   further as a UX nicety, never a security boundary — the endpoint enforces
+   both ways regardless).
+3. **A single "only show modules with a warning" client-side filter**, pure
+   `data-*` show/hide like #521's own type/status filters — no equivalent on
+   either existing page.
+
+**Explicitly reused, not duplicated**: settings editing and the audit-event
+list both already exist on `/admin/modules/{moduleKey}` — this screen only
+links there (`admin.modules.view_detail_link`, same label #521's own list
+page uses), it does not re-render either.
+
+**Preset application (#565's `applyModulePreset`) is NOT wired into this
+screen.** It was considered — this is the first plausible UI caller — but
+doing so cleanly needs a new guarded/audited API endpoint (+ OpenAPI update,
+its own ABAC guard, its own tests), which is large enough to be its own
+atomic unit of work. Noted as a natural follow-up issue rather than
+force-fit here.
+
+**Binding split**: SSR reads are a direct, read-only `withTenant` call
+(`fetchModuleMatrix`), same pattern as `admin/modules.astro`. Every mutation
+(enable/disable) goes through the real `/api/v1/tenant/modules/{moduleKey}/enable|disable`
+endpoints (#515) via client-side `fetch` — no privileged SSR shortcut,
+same binding split `admin/tenant/domains.astro` (#563) established for this
+epic. Neither endpoint requires an `Idempotency-Key` (confirmed by reading
+both route files), so none is sent. Disable prompts for a reason via
+`window.prompt` (same pattern as `admin/modules/[moduleKey].astro`'s
+enable/disable buttons) — the real endpoint rejects an empty reason with
+`400 VALIDATION_ERROR` regardless of what the UI does.
+
+Gated on **both** `module_management.modules.read` AND
+`module_management.tenant_modules.read` (the matrix intrinsically shows
+tenant enablement, unlike the plain catalog list) — `module_management.health.read`
+additionally gates the health column exactly like `admin/modules.astro`.
+
+Covered by `tests/integration/module-tenant-matrix.integration.test.ts`
+(real Postgres: `fetchModuleMatrix`'s health-inclusion toggle, both warning
+directions using the same registry scenarios
+`module-tenant-lifecycle.integration.test.ts` already established, core
+protection, and the real enable/disable endpoints including a 403 for a
+caller without permission). Client-side-only behavior (filters, the
+StateNotice empty/error branches) has no browser/SSR render harness in this
+repo (see `blog-content-admin-ui.integration.test.ts`'s own docblock) —
+smoke-tested manually against a real dev server instead.
+
 ## Out of scope (epic #510)
 
 Marketplace, runtime plugin upload, running arbitrary jobs from the UI,

--- a/src/modules/module-management/application/module-matrix.ts
+++ b/src/modules/module-management/application/module-matrix.ts
@@ -1,0 +1,232 @@
+/**
+ * Tenant-module matrix read service (Issue #566, epic #555) — the SSR data
+ * layer for `/admin/modules/tenants`. Single-tenant scope: this is module x
+ * relevant-attribute for the ONE tenant already in the caller's
+ * `context.tenantId`, never a genuine cross-tenant view — see that page's
+ * own docblock for the full scope decision (this repo's identity model is
+ * strictly 1:1 tenant-scoped, `identity-access/README.md`).
+ *
+ * 100% reuse, zero re-derivation of dependency-graph logic:
+ *   - `fetchModuleCatalog` (#514) for static/registry fields.
+ *   - `fetchTenantModuleEntries` (#515) for this tenant's enabled state.
+ *   - `fetchModuleHealthReport` (#520) for the health pill, same as
+ *     `admin/modules.astro`.
+ *   - `resolveProtectedModuleKeys` (#565) for the core/protected flag.
+ *   - `evaluateModuleEnable`/`evaluateModuleDisable` (#515's own pure domain
+ *     functions) for the two per-row warnings below — called with each
+ *     module's REAL current state, never a synthetic/forced one, so this
+ *     stays an honest re-application of the exact same validation the real
+ *     enable/disable endpoints run, not a parallel reimplementation.
+ *
+ * ## Why only two warning directions, not four
+ *
+ * `dependencyWarning` is only ever computed for a currently-DISABLED module
+ * — "would enabling this module succeed right now?", filtered to the
+ * dependency/version-related rejection codes (`MODULE_DEPENDENCY_MISSING`,
+ * `MODULE_DEPENDENCY_DISABLED`, `MODULE_DEPENDENCY_CYCLE`,
+ * `MODULE_VERSION_INCOMPATIBLE`) — never `MODULE_ALREADY_ENABLED` (not a
+ * problem) or `MODULE_NOT_FOUND` (surfaced separately via `status`).
+ *
+ * `reverseDependencyWarning` is only ever computed for a currently-ENABLED
+ * module — "would disabling this module right now be blocked because
+ * something still depends on it?", filtered to
+ * `MODULE_REVERSE_DEPENDENCY_ACTIVE`.
+ *
+ * A currently-enabled module's dependencies are guaranteed satisfied by
+ * construction: `disableTenantModule` already refuses to disable a
+ * dependency while an active dependent remains enabled
+ * (`MODULE_REVERSE_DEPENDENCY_ACTIVE`), so "enabled module with a disabled
+ * dependency" cannot arise through this app's own guarded lifecycle. Calling
+ * `evaluateModuleEnable` on an already-enabled module would only ever
+ * short-circuit to `MODULE_ALREADY_ENABLED` before it even reaches the
+ * dependency loop — that would be asking the function a question it isn't
+ * designed to answer for that state, not a genuine dependency check. This
+ * function never works around that short-circuit by forging a fake tenant
+ * state; it only ever asks each function the question it is actually
+ * designed to answer, for the module's real current state.
+ */
+import packageJson from "../../../../package.json";
+import { listModules } from "../..";
+import { fetchModuleCatalog, type ModuleCatalogEntry } from "./module-catalog";
+import {
+  fetchTenantModuleEntries,
+  type TenantModuleListEntry
+} from "./tenant-module-lifecycle";
+import { fetchModuleHealthReport } from "./health-registry";
+import { resolveProtectedModuleKeys } from "../domain/module-presets";
+import {
+  evaluateModuleDisable,
+  evaluateModuleEnable,
+  type ModuleLifecycleErrorCode,
+  type ModuleTenantState
+} from "../domain/tenant-module-lifecycle";
+
+const CURRENT_APP_VERSION = packageJson.version;
+
+const DEPENDENCY_WARNING_CODES: ReadonlySet<ModuleLifecycleErrorCode> = new Set(
+  [
+    "MODULE_DEPENDENCY_MISSING",
+    "MODULE_DEPENDENCY_DISABLED",
+    "MODULE_DEPENDENCY_CYCLE",
+    "MODULE_VERSION_INCOMPATIBLE"
+  ]
+);
+
+export type ModuleMatrixWarning = {
+  code: ModuleLifecycleErrorCode;
+  message: string;
+};
+
+export type ModuleMatrixRow = {
+  moduleKey: string;
+  name: string;
+  version: string;
+  type: ModuleCatalogEntry["type"];
+  status: string;
+  isCore: boolean;
+  /** `isCore` unioned with the transitive dependency closure of every core module (`resolveProtectedModuleKeys`, #565) — a disable attempt on any of these is guaranteed to be rejected server-side, so the UI never even offers the control. */
+  isProtected: boolean;
+  tenantEnabled: boolean;
+  disableReason: string | null;
+  dependencies: string[];
+  /** `null` unless `options.includeHealth` was `true`. */
+  healthStatus: string | null;
+  /** Only ever set for a currently-disabled module. */
+  dependencyWarning: ModuleMatrixWarning | null;
+  /** Only ever set for a currently-enabled module. */
+  reverseDependencyWarning: ModuleMatrixWarning | null;
+};
+
+export type ModuleMatrixOptions = {
+  /** Pass `false` when the caller lacks `module_management.health.read` — mirrors `admin/modules.astro`'s own permission-gated health fetch. */
+  includeHealth: boolean;
+  correlationId?: string | null;
+};
+
+function toTenantState(entry: TenantModuleListEntry): ModuleTenantState {
+  return { moduleKey: entry.moduleKey, tenantEnabled: entry.tenantEnabled };
+}
+
+export async function fetchModuleMatrix(
+  tx: Bun.SQL,
+  tenantId: string,
+  options: ModuleMatrixOptions
+): Promise<ModuleMatrixRow[]> {
+  const [catalog, tenantEntries] = await Promise.all([
+    fetchModuleCatalog(tx),
+    fetchTenantModuleEntries(tx, tenantId)
+  ]);
+
+  const allDescriptors = listModules();
+  const descriptorByKey = new Map(allDescriptors.map((d) => [d.key, d]));
+  const tenantStateByKey = new Map(
+    tenantEntries.map((entry) => [entry.moduleKey, toTenantState(entry)])
+  );
+  const tenantEntryByKey = new Map(
+    tenantEntries.map((entry) => [entry.moduleKey, entry])
+  );
+  const protectedKeys = resolveProtectedModuleKeys(allDescriptors);
+
+  function resolveTenantState(moduleKey: string): ModuleTenantState {
+    return (
+      tenantStateByKey.get(moduleKey) ?? { moduleKey, tenantEnabled: true }
+    );
+  }
+
+  return Promise.all(
+    catalog.map(async (entry) => {
+      const descriptor = descriptorByKey.get(entry.moduleKey) ?? null;
+      const tenantState = resolveTenantState(entry.moduleKey);
+      const tenantEntry = tenantEntryByKey.get(entry.moduleKey) ?? null;
+
+      let dependencyWarning: ModuleMatrixRow["dependencyWarning"] = null;
+      if (!tenantState.tenantEnabled && descriptor) {
+        const dependencyStates = descriptor.dependencies.map((depKey) => {
+          const depDescriptor = descriptorByKey.get(depKey) ?? null;
+          return depDescriptor
+            ? {
+                descriptor: depDescriptor,
+                tenantState: resolveTenantState(depKey)
+              }
+            : { descriptor: null, moduleKey: depKey };
+        });
+
+        const validation = evaluateModuleEnable({
+          target: descriptor,
+          targetTenantState: tenantState,
+          dependencyStates,
+          allDescriptors,
+          currentAppVersion: CURRENT_APP_VERSION
+        });
+
+        if (
+          !validation.valid &&
+          DEPENDENCY_WARNING_CODES.has(validation.code)
+        ) {
+          dependencyWarning = {
+            code: validation.code,
+            message: validation.message
+          };
+        }
+      }
+
+      let reverseDependencyWarning: ModuleMatrixRow["reverseDependencyWarning"] =
+        null;
+      if (tenantState.tenantEnabled && descriptor) {
+        const reverseDependencies = allDescriptors
+          .filter(
+            (d) =>
+              d.key !== entry.moduleKey &&
+              d.dependencies.includes(entry.moduleKey)
+          )
+          .map((d) => ({
+            descriptor: d,
+            tenantState: resolveTenantState(d.key)
+          }));
+
+        const validation = evaluateModuleDisable({
+          target: descriptor,
+          targetTenantState: tenantState,
+          reverseDependencies
+        });
+
+        if (
+          !validation.valid &&
+          validation.code === "MODULE_REVERSE_DEPENDENCY_ACTIVE"
+        ) {
+          reverseDependencyWarning = {
+            code: validation.code,
+            message: validation.message
+          };
+        }
+      }
+
+      const healthStatus = options.includeHealth
+        ? ((
+            await fetchModuleHealthReport(
+              tx,
+              tenantId,
+              entry.moduleKey,
+              options.correlationId ?? undefined
+            )
+          )?.status ?? null)
+        : null;
+
+      return {
+        moduleKey: entry.moduleKey,
+        name: entry.name,
+        version: entry.version,
+        type: entry.type,
+        status: entry.status,
+        isCore: entry.isCore,
+        isProtected: protectedKeys.has(entry.moduleKey),
+        tenantEnabled: tenantState.tenantEnabled,
+        disableReason: tenantEntry?.disableReason ?? null,
+        dependencies: entry.dependencies,
+        healthStatus,
+        dependencyWarning,
+        reverseDependencyWarning
+      };
+    })
+  );
+}

--- a/src/modules/module-management/module.ts
+++ b/src/modules/module-management/module.ts
@@ -20,6 +20,12 @@ export const moduleManagementModule = defineModule({
       path: "/admin/modules",
       order: 50,
       requiredPermission: "module_management.modules.read"
+    },
+    {
+      labelKey: "admin.layout.nav_module_matrix",
+      path: "/admin/modules/tenants",
+      order: 51,
+      requiredPermission: "module_management.tenant_modules.read"
     }
   ],
   permissions: [

--- a/src/pages/admin/modules/tenants.astro
+++ b/src/pages/admin/modules/tenants.astro
@@ -1,0 +1,672 @@
+---
+/**
+ * Tenant-module matrix admin screen (Issue #566, epic #555, depends on
+ * #565). Path is `/admin/modules/tenants` per the issue's own literal
+ * wording, gated by `module_management.modules.read` AND
+ * `module_management.tenant_modules.read` (both required — this is the
+ * catalog x tenant-enablement matrix, not a copy of `admin/modules.astro`).
+ *
+ * ## Binding scope decision — single-tenant, not cross-tenant (read this first)
+ *
+ * The issue's own wording ("filter by tenant", "managing module
+ * availability across tenants") reads like a genuine multi-tenant matrix.
+ * This repo's identity model is strictly 1:1 tenant-scoped —
+ * `awcms_mini_identities.tenant_id` has no cross-tenant linking anywhere in
+ * the schema (`identity-access/README.md` line ~74), and
+ * `src/components/TenantSwitcher.astro` is a permanently-disabled stub for
+ * exactly this reason ("switch tenant sungguhan tidak punya target untuk
+ * saat ini"). Every other `/admin/*` screen in this app
+ * (`admin/modules.astro`, `admin/blog/*`, `admin/tenant/domains.astro`)
+ * operates within exactly one tenant's `withTenant`/RLS-scoped session —
+ * none are cross-tenant.
+ *
+ * **Decided with the maintainer**: this screen is a single-tenant matrix,
+ * scoped to the admin's own tenant (`context.tenantId`), matching every
+ * other admin screen in this repo. There is NO tenant selector/filter
+ * anywhere on this page — the session is already scoped to one tenant, same
+ * as `admin/modules.astro` today. A future reader must not "fix" this by
+ * adding a fake single-option tenant dropdown or by trying to build real
+ * cross-tenant filtering — that would require an entirely new
+ * platform-operator identity/session concept that does not exist in this
+ * repo and is out of scope here.
+ *
+ * ## What "matrix" concretely means given the above
+ *
+ * With no second (tenant) axis, the matrix is: module x the
+ * attributes/actions relevant to THIS tenant, all visible at once — a
+ * denser, more consolidated view than `admin/modules.astro` (list) +
+ * `admin/modules/{moduleKey}.astro` (one module's detail) combined. Its
+ * genuine, non-duplicated value over those two existing pages:
+ *
+ *  1. **Dependency/reverse-dependency warnings surfaced for every module at
+ *     once** (`application/module-matrix.ts`'s `dependencyWarning`/
+ *     `reverseDependencyWarning`, 100% reuse of `evaluateModuleEnable`/
+ *     `evaluateModuleDisable`, #515) — the detail page can only ever show
+ *     one module's dependency list at a time; this page lets an admin spot
+ *     "module X can't be safely re-enabled" or "disabling module Y would
+ *     break Z" across the WHOLE registry in one glance, which neither
+ *     existing page offers.
+ *  2. **Core/protected visualization** — `isCore` (server-enforced,
+ *     `CORE_MODULE_CANNOT_BE_DISABLED`) and `isProtected`
+ *     (`resolveProtectedModuleKeys`, #565 — core's transitive dependency
+ *     closure) are both flagged per row, so an admin can bulk-see which
+ *     modules are freely toggleable vs. structurally protected, instead of
+ *     discovering it one rejected click at a time on the detail page.
+ *  3. **A single-action "only show modules with a warning" filter** (pure
+ *     client-side, same `data-*` pattern as `admin/modules.astro`'s
+ *     type/status filters) that has no equivalent anywhere else.
+ *
+ * Explicitly NOT rebuilt here (issue's own instruction — reuse, don't
+ * duplicate): settings editing and the audit-event list both already exist
+ * on `/admin/modules/{moduleKey}` — this page only links there via the
+ * existing "View" affordance, same label/target `admin/modules.astro`
+ * already uses. Preset application (`applyModulePreset`, #565) is NOT wired
+ * into this screen — doing so cleanly needs a new guarded/audited API
+ * endpoint (+ OpenAPI update), which is a large enough, separable unit of
+ * work that force-fitting it here would blow this issue's atomic scope;
+ * noted as a natural follow-up issue instead.
+ *
+ * ## Binding split (same as every other admin-mutation screen in this epic —
+ * see `admin/tenant/domains.astro`, Issue #563, for the precedent this
+ * follows exactly)
+ *
+ * SSR reads are a direct, read-only DB call (`fetchModuleMatrix` via
+ * `withTenant`) — same pattern as `admin/modules.astro`. **Every mutation**
+ * (enable/disable) goes through the real, already-guarded/audited
+ * `/api/v1/tenant/modules/{moduleKey}/enable|disable` endpoints (#515) via
+ * client-side `fetch` — this page has no privileged SSR shortcut. Neither
+ * endpoint requires an `Idempotency-Key` (confirmed by reading
+ * `enable.ts`/`disable.ts` — neither reads one), so none is sent here
+ * either, matching `admin/modules/[moduleKey].astro`'s own enable/disable
+ * buttons exactly (as opposed to `admin/tenant/domains.astro`'s
+ * verify/set-primary, which do require one).
+ *
+ * Disable requires a reason: the real API rejects an empty/missing `reason`
+ * with `400 VALIDATION_ERROR` (`disable.ts`), so this page uses the same
+ * `window.prompt` pattern as `admin/modules/[moduleKey].astro` — no
+ * additional `window.confirm`, matching that exact sibling precedent, not
+ * `admin/tenant/domains.astro`'s prompt+confirm pair (that page's delete is
+ * a different, destructive action class).
+ *
+ * A literal `isCore` module never renders a disable control (defense in
+ * depth — hiding it is a UX nicety, `CORE_MODULE_CANNOT_BE_DISABLED` is the
+ * real, authoritative enforcement). A transitively `isProtected`
+ * (non-core) module also has its disable control hidden here, even though
+ * the issue only strictly requires blocking literal core modules — a
+ * protected module's disable would always be rejected server-side anyway
+ * (`MODULE_REVERSE_DEPENDENCY_ACTIVE`, since something that can never be
+ * disabled still depends on it), so offering a guaranteed-to-fail button
+ * would be actively misleading.
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { fetchModuleMatrix } from "../../../modules/module-management/application/module-matrix";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/modules/tenants.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_READ_MODULES = context.permissions.has(
+  permissionKey("module_management", "modules", "read")
+);
+const CAN_READ_TENANT_MODULES = context.permissions.has(
+  permissionKey("module_management", "tenant_modules", "read")
+);
+const CAN_ENABLE = context.permissions.has(
+  permissionKey("module_management", "tenant_modules", "enable")
+);
+const CAN_DISABLE = context.permissions.has(
+  permissionKey("module_management", "tenant_modules", "disable")
+);
+const CAN_READ_HEALTH = context.permissions.has(
+  permissionKey("module_management", "health", "read")
+);
+
+const CAN_VIEW_MATRIX = CAN_READ_MODULES && CAN_READ_TENANT_MODULES;
+
+const clientStrings = {
+  enableSuccess: t("admin.modules.enable_success"),
+  disableSuccess: t("admin.modules.disable_success"),
+  disableReasonPrompt: t("admin.modules.disable_reason_prompt"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+let rows: Awaited<ReturnType<typeof fetchModuleMatrix>> = [];
+let loadError = false;
+
+if (CAN_VIEW_MATRIX) {
+  try {
+    rows = await withTenant(getDatabaseClient(), context.tenantId, (tx) =>
+      fetchModuleMatrix(tx, context.tenantId, {
+        includeHealth: CAN_READ_HEALTH,
+        correlationId: Astro.locals.correlationId
+      })
+    );
+  } catch (error) {
+    console.error(
+      "admin/modules/tenants.astro: failed to load module matrix",
+      error
+    );
+    loadError = true;
+  }
+}
+
+const types = [...new Set(rows.map((r) => r.type).filter(Boolean))];
+const statuses = [...new Set(rows.map((r) => r.status))];
+---
+
+<AdminLayout title={t("admin.modules.matrix_title")}>
+  {
+    !CAN_VIEW_MATRIX && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.modules.access_denied_title")}
+        body={t("admin.modules.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_VIEW_MATRIX && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_VIEW_MATRIX && !loadError && (
+      <div class="module-matrix">
+        <p class="matrix-intro">{t("admin.modules.matrix_intro")}</p>
+        <p>
+          <a href="/admin/modules">{t("admin.modules.back_to_list")}</a>
+        </p>
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        <form
+          class="matrix-filters"
+          aria-label={t("admin.modules.filters_aria_label")}
+        >
+          <label>
+            {t("admin.modules.filter_type_label")}
+            <select id="filter-type">
+              <option value="">{t("admin.modules.filter_all")}</option>
+              {types.map((type) => (
+                <option value={type ?? ""}>{type}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            {t("admin.modules.filter_status_label")}
+            <select id="filter-status">
+              <option value="">{t("admin.modules.filter_all")}</option>
+              {statuses.map((status) => (
+                <option value={status}>{status}</option>
+              ))}
+            </select>
+          </label>
+          <label class="checkbox-label">
+            <input type="checkbox" id="filter-warnings-only" />
+            {t("admin.modules.matrix_filter_warning_label")}
+          </label>
+        </form>
+
+        <div class="table-scroll">
+          <table class="matrix-table">
+            <thead>
+              <tr>
+                <th>{t("admin.modules.module_column")}</th>
+                <th>{t("admin.modules.type_column")}</th>
+                <th>{t("admin.modules.core_column")}</th>
+                <th>{t("admin.modules.tenant_status_column")}</th>
+                {CAN_READ_HEALTH && <th>{t("admin.modules.health_column")}</th>}
+                <th>{t("admin.modules.warnings_column")}</th>
+                <th>
+                  <span class="sr-only">
+                    {t("admin.modules.actions_column")}
+                  </span>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="matrix-tbody">
+              {rows.length === 0 && (
+                <tr>
+                  <td colspan={CAN_READ_HEALTH ? 7 : 6}>
+                    {t("admin.modules.no_modules")}
+                  </td>
+                </tr>
+              )}
+              {rows.map((row) => {
+                const hasWarning = Boolean(
+                  row.dependencyWarning || row.reverseDependencyWarning
+                );
+                const canOfferDisable =
+                  row.tenantEnabled &&
+                  CAN_DISABLE &&
+                  !row.isCore &&
+                  !row.isProtected;
+                const canOfferEnable = !row.tenantEnabled && CAN_ENABLE;
+
+                return (
+                  <tr
+                    data-type={row.type ?? ""}
+                    data-status={row.status}
+                    data-has-warning={hasWarning ? "true" : "false"}
+                  >
+                    <td>
+                      <strong>{row.name}</strong>
+                      <br />
+                      <code>{row.moduleKey}</code>
+                    </td>
+                    <td>{row.type ?? "-"}</td>
+                    <td>
+                      {row.isCore ? (
+                        <span class="status-pill" data-status="active">
+                          {t("common.yes")}
+                        </span>
+                      ) : row.isProtected ? (
+                        <span class="status-pill" data-status="protected">
+                          {t("admin.modules.protected_label")}
+                        </span>
+                      ) : (
+                        t("common.no")
+                      )}
+                    </td>
+                    <td>
+                      <span
+                        class="status-pill"
+                        data-status={row.tenantEnabled ? "active" : "inactive"}
+                      >
+                        {row.tenantEnabled
+                          ? t("admin.modules.enabled_label")
+                          : t("admin.modules.disabled_label")}
+                      </span>
+                      {row.disableReason && (
+                        <div class="field-hint">{row.disableReason}</div>
+                      )}
+                    </td>
+                    {CAN_READ_HEALTH && (
+                      <td>
+                        {row.healthStatus ? (
+                          <span
+                            class="health-pill"
+                            data-health={row.healthStatus}
+                          >
+                            {row.healthStatus}
+                          </span>
+                        ) : (
+                          "-"
+                        )}
+                      </td>
+                    )}
+                    <td>
+                      {row.dependencyWarning && (
+                        <p class="warning-text">
+                          {t("admin.modules.matrix_dependency_warning_prefix")}{" "}
+                          {row.dependencyWarning.message}
+                        </p>
+                      )}
+                      {row.reverseDependencyWarning && (
+                        <p class="warning-text">
+                          {t(
+                            "admin.modules.matrix_reverse_dependency_warning_prefix"
+                          )}{" "}
+                          {row.reverseDependencyWarning.message}
+                        </p>
+                      )}
+                      {!row.dependencyWarning &&
+                        !row.reverseDependencyWarning &&
+                        "-"}
+                    </td>
+                    <td class="actions-cell">
+                      {canOfferEnable && (
+                        <button
+                          type="button"
+                          class="enable-module-button"
+                          data-module-key={row.moduleKey}
+                        >
+                          {t("admin.modules.enable_button")}
+                        </button>
+                      )}
+                      {canOfferDisable && (
+                        <button
+                          type="button"
+                          class="disable-module-button"
+                          data-module-key={row.moduleKey}
+                        >
+                          {t("admin.modules.disable_button")}
+                        </button>
+                      )}
+                      <a href={`/admin/modules/${row.moduleKey}`}>
+                        {t("admin.modules.view_detail_link")}
+                      </a>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .module-matrix {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .matrix-intro {
+    color: var(--color-text-muted);
+    font-size: var(--fs-sm);
+    max-width: 68ch;
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .matrix-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-4);
+    align-items: end;
+  }
+
+  .matrix-filters label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .checkbox-label {
+    flex-direction: row !important;
+    align-items: center;
+    gap: var(--sp-2) !important;
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .matrix-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .matrix-table th,
+  .matrix-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    font-size: var(--fs-sm);
+    vertical-align: top;
+  }
+
+  .status-pill,
+  .health-pill {
+    display: inline-block;
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-full);
+    font-size: var(--fs-xs);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+  }
+
+  .status-pill[data-status="active"] {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .status-pill[data-status="inactive"] {
+    background: var(--color-danger-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-danger-strong);
+  }
+
+  .status-pill[data-status="protected"] {
+    background: var(--color-warning);
+    border-color: var(--color-warning);
+  }
+
+  .health-pill[data-health="healthy"] {
+    background: var(--color-success-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-success-strong);
+  }
+
+  .health-pill[data-health="degraded"] {
+    background: var(--color-warning);
+    border-color: var(--color-warning);
+  }
+
+  .health-pill[data-health="failed"] {
+    background: var(--color-danger-strong);
+    color: var(--color-primary-contrast);
+    border-color: var(--color-danger-strong);
+  }
+
+  .warning-text {
+    margin: 0 0 var(--sp-1);
+    color: var(--color-danger-strong);
+    font-size: var(--fs-xs);
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+    margin-top: var(--sp-1);
+  }
+
+  .actions-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--sp-1);
+    min-width: 140px;
+  }
+
+  .actions-cell button,
+  .actions-cell a {
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-2);
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+    color: var(--color-text);
+    text-decoration: none;
+    box-sizing: border-box;
+    width: 100%;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  input:focus-visible,
+  select:focus-visible,
+  button:focus-visible,
+  a:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface ModuleMatrixStrings {
+    enableSuccess: string;
+    disableSuccess: string;
+    disableReasonPrompt: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<ModuleMatrixStrings>();
+
+  function applyFilters(): void {
+    const typeValue =
+      (document.getElementById("filter-type") as HTMLSelectElement | null)
+        ?.value ?? "";
+    const statusValue =
+      (document.getElementById("filter-status") as HTMLSelectElement | null)
+        ?.value ?? "";
+    const warningsOnly =
+      (
+        document.getElementById(
+          "filter-warnings-only"
+        ) as HTMLInputElement | null
+      )?.checked ?? false;
+
+    document
+      .querySelectorAll<HTMLTableRowElement>("#matrix-tbody tr[data-type]")
+      .forEach((row) => {
+        const matchesType = !typeValue || row.dataset.type === typeValue;
+        const matchesStatus =
+          !statusValue || row.dataset.status === statusValue;
+        const matchesWarning =
+          !warningsOnly || row.dataset.hasWarning === "true";
+
+        row.hidden = !(matchesType && matchesStatus && matchesWarning);
+      });
+  }
+
+  document
+    .getElementById("filter-type")
+    ?.addEventListener("change", applyFilters);
+  document
+    .getElementById("filter-status")
+    ?.addEventListener("change", applyFilters);
+  document
+    .getElementById("filter-warnings-only")
+    ?.addEventListener("change", applyFilters);
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".enable-module-button")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const moduleKey = button.dataset.moduleKey;
+        if (!moduleKey) return;
+
+        const unlock = lockElement(button, strings.pleaseWait);
+        try {
+          const result = await submitJson(
+            `/api/v1/tenant/modules/${moduleKey}/enable`,
+            "POST",
+            {},
+            strings
+          );
+          showBanner(
+            "action-banner",
+            result.ok ? strings.enableSuccess : result.message,
+            result.ok ? "success" : "error"
+          );
+          if (result.ok) reloadAfterDelay();
+        } finally {
+          unlock();
+        }
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".disable-module-button")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const moduleKey = button.dataset.moduleKey;
+        if (!moduleKey) return;
+
+        const reason = window.prompt(strings.disableReasonPrompt);
+        if (!reason || reason.trim().length === 0) return;
+
+        const unlock = lockElement(button, strings.pleaseWait);
+        try {
+          const result = await submitJson(
+            `/api/v1/tenant/modules/${moduleKey}/disable`,
+            "POST",
+            { reason },
+            strings
+          );
+          showBanner(
+            "action-banner",
+            result.ok ? strings.disableSuccess : result.message,
+            result.ok ? "success" : "error"
+          );
+          if (result.ok) reloadAfterDelay();
+        } finally {
+          unlock();
+        }
+      });
+    });
+</script>

--- a/tests/integration/module-tenant-matrix.integration.test.ts
+++ b/tests/integration/module-tenant-matrix.integration.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Integration tests for the tenant-module matrix admin screen (Issue #566,
+ * epic #555) — `/admin/modules/tenants`. Single-tenant scope (see that
+ * page's own docblock and `module-management/README.md` §Tenant-module
+ * matrix admin UI for the full, maintainer-confirmed scope decision): this
+ * is NOT a cross-tenant view, so these tests never assert anything about a
+ * second tenant seeing another tenant's matrix — RLS isolation for
+ * `awcms_mini_tenant_modules` is already proven by
+ * `module-tenant-lifecycle.integration.test.ts`'s own RLS test and is not
+ * re-proven here.
+ *
+ * Follows this repo's established convention for admin-page integration
+ * tests (see `blog-content-admin-ui.integration.test.ts`'s own docblock):
+ * exercises the SSR data-loading function (`fetchModuleMatrix`) and the
+ * real, already-guarded/audited mutation endpoints
+ * (`/api/v1/tenant/modules/{moduleKey}/enable|disable`) directly. There is
+ * no browser/SSR render harness in this repo for `.astro` pages, so
+ * client-side-only behavior (type/status filters, the "only show warnings"
+ * checkbox, and the StateNotice empty/error branches — all pure Astro
+ * conditional rendering) is NOT covered here; it is smoke-tested manually
+ * against a real dev server per this repo's UI-change convention.
+ *
+ * Coverage map against the issue's testing checklist:
+ *   - "permission-gating (denied without module_management.modules.read)":
+ *     the page's own SSR permission check is the generic
+ *     `context.permissions.has(...)` pattern every admin page already uses
+ *     (not new logic to re-test); what IS new and load-bearing is that
+ *     hiding a button in this screen is never the only enforcement — proven
+ *     below by calling the real enable/disable endpoints as a caller
+ *     without `module_management.tenant_modules.*` permissions and
+ *     asserting `403`.
+ *   - "empty state": not applicable at this layer — `fetchModuleMatrix`
+ *     always returns one row per registered module in this app's fixed
+ *     registry (never legitimately empty); the page's own empty branch
+ *     (`rows.length === 0`) is dead code protecting against a
+ *     theoretical empty registry, not a state these tests can produce.
+ *   - "populated state with health/dependency data": covered by the
+ *     health-inclusion-toggle test and both warning-direction tests below.
+ *   - "enable/disable mutation through the real API with a real audit-event
+ *     assertion", "core-module-cannot-be-disabled enforcement": covered
+ *     directly.
+ *   - "preset application through this screen": NOT built in this issue
+ *     (see this screen's own docblock for why) — no test for it here.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { POST as enableModule } from "../../src/pages/api/v1/tenant/modules/[moduleKey]/enable";
+import { POST as disableModule } from "../../src/pages/api/v1/tenant/modules/[moduleKey]/disable";
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import { listModules } from "../../src/modules";
+import { fetchModuleMatrix } from "../../src/modules/module-management/application/module-matrix";
+import { syncModuleDescriptors } from "../../src/modules/module-management/application/descriptor-sync";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string; tenantUserId: string };
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const loginIdentifier = `${tenantCode}-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  const admin = getAdminSql();
+  const tenantUserRows = (await admin`
+    SELECT tu.id FROM awcms_mini_tenant_users tu
+    JOIN awcms_mini_identities i ON i.id = tu.identity_id
+    WHERE tu.tenant_id = ${setup.body.data.tenantId} AND i.login_identifier = ${loginIdentifier}
+  `) as { id: string }[];
+
+  return {
+    tenantId: setup.body.data.tenantId,
+    token: login.body.data.token,
+    tenantUserId: tenantUserRows[0]!.id
+  };
+}
+
+function authHeaders(owner: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": owner.tenantId,
+    authorization: `Bearer ${owner.token}`
+  };
+}
+
+/** Mirrors `module-catalog.integration.test.ts`'s own helper. */
+async function provisionNoPermissionUser(
+  tenantId: string
+): Promise<{ token: string }> {
+  const password = "integration-test-no-permission-password";
+  const admin = getAdminSql();
+  const passwordHash = await Bun.password.hash(password);
+
+  await admin.begin(async (tx) => {
+    await tx.unsafe(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+    const profile = (await tx`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', 'No Permission') RETURNING id
+    `) as { id: string }[];
+    const identity = (await tx`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profile[0]!.id}, 'no-permission@example.com', ${passwordHash})
+      RETURNING id
+    `) as { id: string }[];
+    await tx`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${tenantId}, ${identity[0]!.id})
+    `;
+  });
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier: "no-permission@example.com", password },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { token: login.body.data.token };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite(
+  "tenant-module matrix admin screen (fetchModuleMatrix + real API)",
+  () => {
+    beforeAll(async () => {
+      await applyMigrations();
+      await provisionAppRole();
+    });
+
+    beforeEach(async () => {
+      await resetDatabase();
+    });
+
+    test("fetchModuleMatrix returns one row per registered module, health only computed when requested", async () => {
+      const owner = await bootstrap();
+      const sql = getDatabaseClient();
+
+      const withoutHealth = await withTenant(sql, owner.tenantId, (tx) =>
+        fetchModuleMatrix(tx, owner.tenantId, { includeHealth: false })
+      );
+      expect(withoutHealth.length).toBe(listModules().length);
+      expect(withoutHealth.every((row) => row.healthStatus === null)).toBe(
+        true
+      );
+
+      const withHealth = await withTenant(sql, owner.tenantId, (tx) =>
+        fetchModuleMatrix(tx, owner.tenantId, { includeHealth: true })
+      );
+      expect(
+        withHealth.every((row) => typeof row.healthStatus === "string")
+      ).toBe(true);
+    });
+
+    test("default tenant state: every module enabled, core/protected flags match resolveProtectedModuleKeys", async () => {
+      const owner = await bootstrap();
+      const sql = getDatabaseClient();
+
+      const rows = await withTenant(sql, owner.tenantId, (tx) =>
+        fetchModuleMatrix(tx, owner.tenantId, { includeHealth: false })
+      );
+      expect(rows.every((row) => row.tenantEnabled)).toBe(true);
+      expect(rows.every((row) => row.dependencyWarning === null)).toBe(true);
+
+      const byKey = new Map(rows.map((row) => [row.moduleKey, row]));
+      expect(byKey.get("module_management")?.isCore).toBe(true);
+      expect(byKey.get("module_management")?.isProtected).toBe(true);
+      for (const key of [
+        "tenant_admin",
+        "identity_access",
+        "profile_identity"
+      ]) {
+        expect(byKey.get(key)?.isCore).toBe(false);
+        expect(byKey.get(key)?.isProtected).toBe(true);
+      }
+      expect(byKey.get("blog_content")?.isProtected).toBe(false);
+    });
+
+    test("email shows a reverseDependencyWarning because reporting still depends on it, matching the real 409 disabling email would hit", async () => {
+      const owner = await bootstrap();
+      const sql = getDatabaseClient();
+
+      const rows = await withTenant(sql, owner.tenantId, (tx) =>
+        fetchModuleMatrix(tx, owner.tenantId, { includeHealth: false })
+      );
+      const email = rows.find((row) => row.moduleKey === "email");
+      expect(email?.reverseDependencyWarning?.code).toBe(
+        "MODULE_REVERSE_DEPENDENCY_ACTIVE"
+      );
+      expect(email?.reverseDependencyWarning?.message).toContain("reporting");
+      expect(email?.dependencyWarning).toBeNull();
+
+      const disableResult = await invoke(disableModule, {
+        method: "POST",
+        path: "/api/v1/tenant/modules/email/disable",
+        headers: authHeaders(owner),
+        params: { moduleKey: "email" },
+        body: { reason: "Trying to disable a relied-upon module." }
+      });
+      expect(disableResult.status).toBe(409);
+    });
+
+    test("form_drafts shows a dependencyWarning once identity_access is force-disabled, matching the real 409 re-enabling form_drafts would hit", async () => {
+      const owner = await bootstrap();
+      const admin = getAdminSql();
+
+      // Same forced-state setup as
+      // `module-tenant-lifecycle.integration.test.ts`'s own
+      // MODULE_DEPENDENCY_DISABLED test — direct DB rows, bypassing the
+      // endpoints on purpose (the real disable flow would never reach this
+      // state on its own, since identity_access has active reverse
+      // dependents).
+      await syncModuleDescriptors(admin);
+      await admin`
+      INSERT INTO awcms_mini_tenant_modules (tenant_id, module_key, enabled, disabled_at)
+      VALUES (${owner.tenantId}, 'identity_access', false, now())
+    `;
+      await admin`
+      INSERT INTO awcms_mini_tenant_modules (tenant_id, module_key, enabled, disabled_at)
+      VALUES (${owner.tenantId}, 'form_drafts', false, now())
+    `;
+
+      const sql = getDatabaseClient();
+      const rows = await withTenant(sql, owner.tenantId, (tx) =>
+        fetchModuleMatrix(tx, owner.tenantId, { includeHealth: false })
+      );
+      const formDrafts = rows.find((row) => row.moduleKey === "form_drafts");
+      expect(formDrafts?.tenantEnabled).toBe(false);
+      expect(formDrafts?.dependencyWarning?.code).toBe(
+        "MODULE_DEPENDENCY_DISABLED"
+      );
+      expect(formDrafts?.reverseDependencyWarning).toBeNull();
+
+      const enableResult = await invoke(enableModule, {
+        method: "POST",
+        path: "/api/v1/tenant/modules/form_drafts/enable",
+        headers: authHeaders(owner),
+        params: { moduleKey: "form_drafts" }
+      });
+      expect(enableResult.status).toBe(409);
+    });
+
+    test("module_management is core: the matrix flags it, and the real disable endpoint this screen calls enforces it server-side", async () => {
+      const owner = await bootstrap();
+      const sql = getDatabaseClient();
+
+      const rows = await withTenant(sql, owner.tenantId, (tx) =>
+        fetchModuleMatrix(tx, owner.tenantId, { includeHealth: false })
+      );
+      expect(
+        rows.find((r) => r.moduleKey === "module_management")?.isCore
+      ).toBe(true);
+
+      const result = await invoke(disableModule, {
+        method: "POST",
+        path: "/api/v1/tenant/modules/module_management/disable",
+        headers: authHeaders(owner),
+        params: { moduleKey: "module_management" },
+        body: { reason: "Trying to disable module management itself." }
+      });
+      expect(result.status).toBe(409);
+    });
+
+    test("disabling then re-enabling a module through the real API this screen's buttons call writes real audit events", async () => {
+      const owner = await bootstrap();
+
+      const disableResult = await invoke(disableModule, {
+        method: "POST",
+        path: "/api/v1/tenant/modules/form_drafts/disable",
+        headers: authHeaders(owner),
+        params: { moduleKey: "form_drafts" },
+        body: { reason: "Matrix screen test." }
+      });
+      expect(disableResult.status).toBe(200);
+
+      const enableResult = await invoke(enableModule, {
+        method: "POST",
+        path: "/api/v1/tenant/modules/form_drafts/enable",
+        headers: authHeaders(owner),
+        params: { moduleKey: "form_drafts" }
+      });
+      expect(enableResult.status).toBe(200);
+
+      const admin = getAdminSql();
+      const auditRows = (await admin`
+      SELECT action, resource_id FROM awcms_mini_audit_events
+      WHERE tenant_id = ${owner.tenantId} AND resource_id = 'form_drafts'
+      ORDER BY created_at ASC
+    `) as { action: string; resource_id: string }[];
+      expect(auditRows.map((r) => r.action)).toEqual([
+        "tenant_module_disabled",
+        "tenant_module_enabled"
+      ]);
+    });
+
+    test("disable via the API requires a non-empty reason (same contract this screen's window.prompt() flow relies on)", async () => {
+      const owner = await bootstrap();
+
+      const result = await invoke(disableModule, {
+        method: "POST",
+        path: "/api/v1/tenant/modules/form_drafts/disable",
+        headers: authHeaders(owner),
+        params: { moduleKey: "form_drafts" },
+        body: {}
+      });
+      expect(result.status).toBe(400);
+    });
+
+    test("a caller without module_management.tenant_modules permissions is denied by the real endpoints this screen's buttons call — hiding the button is never the only enforcement", async () => {
+      const owner = await bootstrap();
+      const noPermission = await provisionNoPermissionUser(owner.tenantId);
+      const headers = {
+        "content-type": "application/json",
+        "x-awcms-mini-tenant-id": owner.tenantId,
+        authorization: `Bearer ${noPermission.token}`
+      };
+
+      const disableResult = await invoke(disableModule, {
+        method: "POST",
+        path: "/api/v1/tenant/modules/form_drafts/disable",
+        headers,
+        params: { moduleKey: "form_drafts" },
+        body: { reason: "Should be denied." }
+      });
+      expect(disableResult.status).toBe(403);
+
+      const enableResult = await invoke(enableModule, {
+        method: "POST",
+        path: "/api/v1/tenant/modules/form_drafts/enable",
+        headers,
+        params: { moduleKey: "form_drafts" }
+      });
+      expect(enableResult.status).toBe(403);
+    });
+  }
+);


### PR DESCRIPTION
## Summary
- Eleventh issue of epic #555. Adds `/admin/modules/tenants`, a matrix-style admin screen showing every module's enable state, health, and dependency-conflict status for the admin's own tenant.

## Scope decision made with the maintainer before implementation
Issue #566's literal wording ("filter by tenant," "managing module availability across tenants") implies a genuinely cross-tenant view. I found this repo's identity model is **strictly 1:1 tenant-scoped** — `awcms_mini_identities.tenant_id` has zero cross-tenant linking anywhere (explicitly documented: `identity-access/README.md`, and `TenantSwitcher.astro` is a permanently-disabled stub for exactly this reason — "switch tenant sungguhan tidak punya target untuk saat ini"). I raised this with the maintainer before writing any code; they confirmed building this as a **single-tenant** matrix (no tenant selector/filter), matching every other admin screen in this repo, rather than inventing a new platform-operator identity/session concept that would be a much larger, unplanned architecture change.

## What the matrix adds
Beyond the existing `/admin/modules` list and `/admin/modules/{moduleKey}` detail pages:
- **Dependency/reverse-dependency warnings for every module at once** — 100% reuse of `evaluateModuleEnable`/`evaluateModuleDisable` (Issue #515), no re-derived graph logic.
- **Bulk core/protected visualization** — `isCore` plus Issue #565's `resolveProtectedModuleKeys`, with the disable control hidden for both.
- **A client-side "only show modules with a warning" filter.**

Settings editing and the audit-event list are not duplicated — the screen links to the existing detail page for both. Applying a module preset (Issue #565's `applyModulePreset`) was considered but deliberately left out — wiring it in cleanly needs a new guarded/audited API endpoint, a separable follow-up.

## Review chain
- `awcms-mini-coder`: implemented the screen, then independently performed a full live dev-server smoke test (real login session, real mutation cycle, DB state re-verified) before reporting done.
- I independently re-verified in a browser session against a real dev server + Postgres: page renders, module data matches DB state, and the 4 protected modules (`module_management`, `tenant_admin`, `identity_access`, `profile_identity`) correctly have no disable button while the other 8 do.
- `awcms-mini-reviewer`: **Approve**. Verified every claim in the implementation report against actual code and live test runs — the matrix value-add claims, the no-privileged-SSR-shortcut split, the disable-reason contract match, the pre-existing permission (no new migration needed), and i18n completeness across both locales.
- `awcms-mini-security-auditor`: **PASS**, no Critical/High/Medium findings. Confirmed via `git diff` that the underlying `enable.ts`/`disable.ts` endpoints are completely unchanged by this PR (zero new server-side attack surface), core-module-disable-blocking holds even via a direct API call bypassing the UI entirely (real 409, tested), and no cross-tenant data leakage is possible in `fetchModuleMatrix`. One trivial Low finding (an existing, non-regressed UI pattern already present on the sibling detail page) — not a blocker.

## Test plan
- [x] `bun test tests/integration/module-tenant-matrix.integration.test.ts` — 8 pass
- [x] Full `bun test` against real PostgreSQL — 1117 pass, 0 fail
- [x] `bun run lint` / `bun run typecheck` / `bun run check:docs` / `bun run api:spec:check` / `bun run build` — all PASS (api:spec:check confirms true no-op — no new API surface, only existing endpoints reused)
- [x] Manual browser verification against real dev server + Postgres (see above)

## Security notes
No new API endpoints, no new SQL, no new permission checks beyond what Issue #515 already gates. SSR reads are read-only; every mutation goes through the real, unchanged, already-audited enable/disable endpoints — UI-hidden controls are a convenience only, never the actual enforcement boundary.

## Next steps
Issue #567 (optional Cloudflare DNS adapter) is the last issue in epic #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)