### PR TITLE
feat(tenant-domain): add optional Cloudflare DNS adapter for managed platform subdomains (Issue #567)

### DIFF
--- a/.changeset/tenant-domain-cloudflare-dns-adapter-issue-567.md
+++ b/.changeset/tenant-domain-cloudflare-dns-adapter-issue-567.md
@@ -1,0 +1,51 @@
+---
+"awcms-mini": minor
+---
+
+Add an optional Cloudflare DNS adapter for the `tenant_domain` module
+(Issue #567, epic #555 — the epic's final issue). Manual domain management
+(`POST /api/v1/tenant/domains/{id}/verify`, Issue #562) remains the MVP
+default; this issue adds a provider boundary, not a hard dependency, and
+**no route calls it yet** — wiring it into `.../verify` or a "provision
+platform subdomain" flow is left for future work.
+
+Four new env vars, all optional/backward-compatible
+(`src/modules/tenant-domain/domain/tenant-domain-dns-config.ts`,
+`scripts/validate-env.ts`'s new `checkTenantDomainDnsConfig`):
+`TENANT_DOMAIN_DNS_PROVIDER` (`manual` default | `cloudflare`),
+`TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN`, `TENANT_DOMAIN_CLOUDFLARE_ZONE_ID`,
+and `TENANT_DOMAIN_CLOUDFLARE_API_TOKEN` — the last three required only
+when `TENANT_DOMAIN_DNS_PROVIDER=cloudflare`.
+`TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` is deliberately a separate variable
+from `PUBLIC_PLATFORM_ROOT_DOMAIN` (Issue #556) even though the two will
+often share a value — one gates the public host-based resolver (#559),
+the other scopes which hostnames this adapter is allowed to touch.
+
+New adapter, `src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter.ts`:
+a `TenantDomainDnsProvider` port with `createVerificationRecord` (creates a
+TXT/CNAME record, idempotent by construction — lists for an existing
+matching record before writing) and `checkVerificationStatus` (lists and
+compares against an expected value, normalizing CNAME case/trailing dot).
+Both calls are timeout-bounded (`withTimeout`, default 8s) and gated by a
+shared circuit breaker, mirroring
+`email/infrastructure/mailketing-provider.ts` and
+`sync-storage/infrastructure/object-storage-uploader.ts`; both are meant to
+run outside any DB transaction (ADR-0006).
+
+Security: the Cloudflare API token/zone id are read only from env — never
+persisted to `awcms_mini_tenant_domains` or `awcms_mini_module_settings`,
+never rendered in any response. `validateDnsRecordInput` (exported, pure)
+rejects any `recordName` outside `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` (or a
+subdomain of it) before any network call. Provider errors are redacted:
+only Cloudflare's numeric `errors[].code` values are surfaced (never
+`.message`), and a `redact()` pass strips the configured token/zone id out
+of any thrown-error text as defense in depth, before truncation.
+
+Test: `tests/unit/cloudflare-dns-adapter.test.ts` (pure validation cases,
+plus a local `Bun.serve` fake Cloudflare API covering success, idempotent
+re-create, provider error with redaction proof, timeout, circuit-breaker
+trip, and `resolveTenantDomainDnsProvider`'s missing/invalid-env behavior)
+and `tests/validate-env.test.ts`'s new `checkTenantDomainDnsConfig`
+`describe` block. Docs: `src/modules/tenant-domain/README.md` §Cloudflare
+DNS adapter, `docs/awcms-mini/18_configuration_env_reference.md` §Cloudflare
+DNS adapter, `.env.example`.

--- a/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
@@ -39,7 +39,7 @@ menjembatani beberapa modul sekaligus (config, `tenant_domain` module baru,
 | #564  | Tenant settings untuk rute `/news` vs legacy (`blog_content`) | **Selesai** — lihat §Tenant settings public route di bawah                       |
 | #565  | Tenant module presets (online/news/LAN/minimal)               | **Selesai** — lihat §Tenant module presets di bawah                              |
 | #566  | Tenant-module matrix admin UI                                 | **Selesai** — lihat §Tenant-module matrix admin UI di bawah                      |
-| #567  | Cloudflare DNS adapter (opsional)                             | Belum                                                                            |
+| #567  | Cloudflare DNS adapter (opsional)                             | **Selesai** — lihat §Cloudflare DNS adapter di bawah                             |
 
 ## Yang sudah ada — pakai ulang, jangan re-derive
 
@@ -705,6 +705,93 @@ dikirim di sini — beda dari `verify`/`set-primary` #563 yang butuh.
 Test: `tests/integration/module-tenant-matrix.integration.test.ts`. Detail
 lengkap: `module-management/README.md` §Tenant-module matrix admin UI.
 
+### Cloudflare DNS adapter (Issue #567, `tenant_domain`)
+
+Provider boundary saja — **belum ada rute apa pun** di repo ini yang
+memanggilnya (menyelesaikan `.../verify` dengan panggilan DNS nyata, atau
+"provision platform subdomain", tetap follow-up terbuka). Manual domain
+management (`POST /api/v1/tenant/domains/{id}/verify`, #562) tetap default
+MVP tanpa perubahan — tidak ada var baru yang wajib.
+
+**Env baru** (`domain/tenant-domain-dns-config.ts`,
+`scripts/validate-env.ts`'s `checkTenantDomainDnsConfig`), semuanya
+opsional/backward-compatible:
+
+- `TENANT_DOMAIN_DNS_PROVIDER` — `manual` (default) | `cloudflare`.
+- `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` — wajib bila `cloudflare`. **Var
+  terpisah** dari `PUBLIC_PLATFORM_ROOT_DOMAIN` (#556) meski keduanya
+  biasanya bernilai sama secara operasional: `PUBLIC_PLATFORM_ROOT_DOMAIN`
+  menggerbangi resolver host-based publik (#559, siapa yang boleh
+  di-_resolve_ jadi tenant); var ini menggerbangi hostname mana yang
+  boleh disentuh adapter Cloudflare (siapa yang boleh dibuatkan/dicek
+  record DNS-nya) — juga mencerminkan batasan nyata API Cloudflare (satu
+  zone id/token hanya bisa mengelola record di dalam zone-nya sendiri).
+  Jangan gabungkan kedua var ini di issue lanjutan mana pun.
+- `TENANT_DOMAIN_CLOUDFLARE_ZONE_ID` — wajib bila `cloudflare`.
+- `TENANT_DOMAIN_CLOUDFLARE_API_TOKEN` — wajib bila `cloudflare`, secret
+  sungguhan. Hanya dari env/secret manager — **tidak pernah** disimpan di
+  `awcms_mini_tenant_domains`/`awcms_mini_module_settings`/tabel lain, tidak
+  pernah dirender di admin UI mana pun (menegakkan §Aturan lintas-issue #7
+  di bawah).
+
+**Adapter** (`infrastructure/cloudflare-dns-adapter.ts`) — port
+`TenantDomainDnsProvider` dengan dua method, keduanya timeout-bounded
+(`withTimeout`, default 8 detik) dan digerbangi circuit breaker bersama
+(`getProviderCircuitBreaker("tenant-domain-cloudflare-dns")`), pola persis
+`email/infrastructure/mailketing-provider.ts` dan
+`sync-storage/infrastructure/object-storage-uploader.ts`. Keduanya dipanggil
+di luar transaksi DB mana pun (ADR-0006) — file ini tidak pernah membuka
+`sql.begin(...)`:
+
+- `createVerificationRecord({recordType, recordName, recordValue})` —
+  **idempotent by construction**: list dulu record yang match
+  type/name/content persis, return `{ok:true, alreadyExists:true}` tanpa
+  write kedua kalau sudah ada, bukan mengandalkan kode error duplicate
+  Cloudflare tertentu.
+- `checkVerificationStatus({recordType, recordName, expectedValue})` — list
+  record pada name/type itu, bandingkan content (CNAME dinormalisasi:
+  strip trailing dot + lowercase sebelum dibandingkan).
+
+**Validasi input mengikat** (`validateDnsRecordInput`, exported, pure):
+`recordName` wajib persis `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` atau
+subdomain-nya — ditolak SEBELUM panggilan network apa pun. Shape check
+`recordName` **sengaja bukan** reuse `normalizePublicHost()` (#559): nama
+record verifikasi DNS lazim berlabel underscore-prefix (mis.
+`_acme-challenge.example.com`, `_awcms-verify.tenant1.platform.example`)
+yang shape-check `Host` header (`normalizePublicHost`) menolaknya, padahal
+konvensi ini valid dan lazim untuk TXT record verifikasi — lihat
+`isValidDnsRecordNameShape` (fungsi baru, dedicated) di file adapter.
+`normalizePublicHost()` tetap dipakai ulang, tidak berubah, untuk
+memvalidasi _target_ CNAME (hostname sungguhan yang dituju, bukan label
+record).
+
+**Redaksi error mengikat**: error HTTP dari Cloudflare tidak pernah
+menyertakan `errors[].message` mentah — hanya kode numerik
+`errors[].code` yang disurfacekan (aman, tidak identifiable). Teks error
+apa pun yang di-throw (network failure, timeout) juga melewati `redact()`
+yang menghapus nilai `apiToken`/`zoneId` yang dikonfigurasi sebagai defense
+in depth (mis. error jaringan yang pesannya kebetulan menyertakan URL
+request, yang menyertakan zone id) sebelum dipotong ke 300 karakter. Tidak
+pernah stack trace.
+
+`resolveTenantDomainDnsProvider(env)` — resolver produksi (mirror
+`resolveEmailProvider`/`resolveObjectUploader`): membangun provider
+Cloudflare sungguhan kalau lengkap terkonfigurasi, atau stub aman yang
+selalu `{ok:false}` dengan pesan jelas (tidak pernah throw) untuk mode
+`manual`, provider tak dikenal, atau `cloudflare` yang kurang salah satu
+dari tiga var wajib. **Belum dipanggil dari mana pun** di issue ini — tidak
+ada route yang wire ke sini.
+
+Test: `tests/unit/cloudflare-dns-adapter.test.ts` (`validateDnsRecordInput`
+pure cases; lalu terhadap `Bun.serve` fake server lokal — sukses,
+idempotent re-create, provider error dengan bukti redaksi terhadap server
+yang sengaja meng-echo token/zone id di `errors[].message`, timeout,
+circuit breaker trip, dan `resolveTenantDomainDnsProvider`'s perilaku
+env hilang/tidak-dikenal/`cloudflare` tidak lengkap).
+`tests/validate-env.test.ts`'s `describe("checkTenantDomainDnsConfig", ...)`
+menguji aturan gating env di atas. Detail lengkap:
+`src/modules/tenant-domain/README.md` §Cloudflare DNS adapter.
+
 ## Aturan lintas-issue yang wajib diikuti
 
 1. **Backward compatibility non-negotiable**: setiap deployment offline/LAN existing yang tidak pernah set `PUBLIC_*` apa pun harus tetap `config:validate` PASS dan berperilaku persis seperti sebelum epic ini — jangan pernah membuat salah satu dari enam var config ini menjadi wajib secara default.
@@ -720,15 +807,19 @@ lengkap: `module-management/README.md` §Tenant-module matrix admin UI.
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Isu #567 (adapter Cloudflare DNS) **belum ada**. Sudah selesai: config
-(#556), schema `awcms_mini_tenant_domains` (#557), module descriptor
-`tenant_domain` (#558), resolver host-based (#559), rute publik `/news`
-(#560), dokumentasi legacy/ADR-0010 (#561), API tenant domain management
-(#562, §API di atas), admin UI (#563, §Admin UI di atas), tenant settings
-public route `blog_content` (#564, §Tenant settings public route di atas),
-tenant module presets (#565, §Tenant module presets di atas — service layer
-saja), dan tenant-module matrix admin UI (#566, §Tenant-module matrix admin
-UI di atas — single-tenant scope, lihat keputusan mengikat di bagian itu).
+**Epic #555 (#556-#567) sekarang 100% selesai** — semua 12 issue sudah
+merge: config (#556), schema `awcms_mini_tenant_domains` (#557), module
+descriptor `tenant_domain` (#558), resolver host-based (#559), rute publik
+`/news` (#560), dokumentasi legacy/ADR-0010 (#561), API tenant domain
+management (#562, §API di atas), admin UI (#563, §Admin UI di atas), tenant
+settings public route `blog_content` (#564, §Tenant settings public route di
+atas), tenant module presets (#565, §Tenant module presets di atas —
+service layer saja), tenant-module matrix admin UI (#566, §Tenant-module
+matrix admin UI di atas — single-tenant scope, lihat keputusan mengikat di
+bagian itu), dan adapter Cloudflare DNS opsional (#567, §Cloudflare DNS
+adapter di atas — provider boundary saja, **belum ada route yang
+memanggilnya**, lihat follow-up #4 di bawah).
+
 Tabel `awcms_mini_tenant_domains` sekarang bisa ditulis lewat kode aplikasi
 (API #562 + admin UI #563) — bukan lagi schema-only. Operator yang
 benar-benar mengisi baris nyata lewat UI/API dan mengaktifkan
@@ -736,6 +827,22 @@ benar-benar mengisi baris nyata lewat UI/API dan mengaktifkan
 (host/domain mapping asli) benar-benar reachable di production untuk
 pertama kalinya — lihat konsekuensi keamanan di ADR-0010 §Konsekuensi
 sebelum mengaktifkan mode itu.
+
+**Follow-up non-blocking untuk issue lanjutan mana pun yang menyentuh area
+ini** (bukan gate merge #567, dicatat di sini supaya tidak di-re-derive):
+
+4. `infrastructure/cloudflare-dns-adapter.ts` (#567) belum di-wire ke rute
+   apa pun — `POST /api/v1/tenant/domains/{id}/verify` (#562) tetap
+   manual-first murni (tidak ada panggilan DNS/HTTP keluar). Issue lanjutan
+   yang ingin menambah verifikasi Cloudflare otomatis harus: (a) memanggil
+   `resolveTenantDomainDnsProvider(env)`/`createCloudflareDnsProvider` di
+   luar transaksi DB `withTenant` mana pun (ADR-0006 — adapter ini sendiri
+   tidak pernah membuka transaksi, tapi endpoint pemanggilnya wajib tetap
+   menjaga aturan itu), (b) tetap treat hasil provider sebagai _input_ ke
+   `verifyTenantDomain` yang sudah ada, bukan menggantikannya, dan (c) tetap
+   audit `tenant_domain.domain.verified` seperti sekarang — jangan tambah
+   audit event kedua khusus "cloudflare check" kecuali ada kebutuhan produk
+   eksplisit.
 
 **Follow-up keamanan wajib diselesaikan sebelum `PUBLIC_TENANT_RESOLUTION_MODE=host_default` diaktifkan di production** (ditemukan `awcms-mini-security-auditor` saat audit #560, verdict PASS tapi non-blocking karena `host_default` belum bisa resolve apa pun secara nyata hari ini — lihat alasan di atas):
 

--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,20 @@ PUBLIC_TRUST_PROXY=false
 # Wajib diisi hanya bila PUBLIC_TENANT_RESOLUTION_MODE=host_default.
 # PUBLIC_PLATFORM_ROOT_DOMAIN=
 
+# Optional Cloudflare DNS adapter (Issue #567, epic #555, tenant_domain
+# module). Manual domain management (POST /api/v1/tenant/domains/{id}/verify,
+# Issue #562) tetap default MVP — TENANT_DOMAIN_DNS_PROVIDER tidak di-set
+# (atau "manual") tidak memerlukan var lain di bawah ini sama sekali, dan
+# tidak ada rute yang memanggil adapter ini hari ini (belum di-wire, lihat
+# src/modules/tenant-domain/README.md §Cloudflare DNS adapter). Set
+# "cloudflare" hanya bila operator benar-benar mengelola platform subdomain
+# lewat zona Cloudflare; tiga var lain WAJIB diisi saat itu. Jangan pernah
+# isi TENANT_DOMAIN_CLOUDFLARE_API_TOKEN dengan kredensial asli di file ini.
+# TENANT_DOMAIN_DNS_PROVIDER=manual
+# TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN=
+# TENANT_DOMAIN_CLOUDFLARE_ZONE_ID=
+# TENANT_DOMAIN_CLOUDFLARE_API_TOKEN=
+
 # Provider eksternal opsional (default off) — base tidak menetapkan provider
 # tertentu; aplikasi turunan menambah flag provider-nya sendiri di sini
 # (lihat contoh domain retail/POS di doc 18 §Provider CRM/AI analyst).

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -198,6 +198,47 @@ tidak tepercaya oleh aplikasi meski operator sudah set `PUBLIC_TRUST_PROXY=true`
 perbaiki konfigurasi proxy-nya, jangan andalkan aplikasi menebak nilai
 mana yang benar.
 
+### Cloudflare DNS adapter (opsional — Issue #567, epic #555, modul `tenant_domain`)
+
+Manual domain management (`POST /api/v1/tenant/domains/{id}/verify`, Issue
+#562) tetap default MVP. Var di bawah ini semuanya opsional/backward
+compatible — tidak di-set sama sekali (atau `TENANT_DOMAIN_DNS_PROVIDER=manual`)
+tetap lulus `config:validate` tanpa var lain wajib, dan **belum ada rute
+apa pun** di repo ini yang memanggil adapter tersebut (lihat
+`src/modules/tenant-domain/README.md` §Cloudflare DNS adapter untuk
+detail lengkap — issue ini hanya menambah provider boundary-nya, bukan
+wiring ke endpoint).
+
+| Var                                  | Wajib           | Default  | Sensitif | Fungsi                                                                            |
+| ------------------------------------ | --------------- | -------- | -------- | --------------------------------------------------------------------------------- |
+| `TENANT_DOMAIN_DNS_PROVIDER`         | –               | `manual` | –        | `manual` (default) atau `cloudflare` — nilai lain gagal validasi                  |
+| `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` | bila cloudflare | –        | –        | Root domain platform; adapter menolak record di luar domain ini atau subdomainnya |
+| `TENANT_DOMAIN_CLOUDFLARE_ZONE_ID`   | bila cloudflare | –        | –        | Zone id Cloudflare tempat record dibuat/diperiksa                                 |
+| `TENANT_DOMAIN_CLOUDFLARE_API_TOKEN` | bila cloudflare | –        | Ya       | Token API Cloudflare — hanya dari env/secret manager, tidak pernah disimpan di DB |
+
+Aturan validasi cross-field (`scripts/validate-env.ts`'s
+`checkTenantDomainDnsConfig`): `TENANT_DOMAIN_DNS_PROVIDER` tidak di-set atau
+`manual` → tidak ada var lain wajib. `cloudflare` → ketiga var lain
+(`TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN`/`TENANT_DOMAIN_CLOUDFLARE_ZONE_ID`/
+`TENANT_DOMAIN_CLOUDFLARE_API_TOKEN`) wajib diisi.
+`TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` sengaja **var terpisah** dari
+`PUBLIC_PLATFORM_ROOT_DOMAIN` (§Public routing di atas) meski keduanya
+biasanya bernilai sama secara operasional — var itu menggerbangi resolver
+host-based publik (Issue #559), var ini menggerbangi hostname mana yang
+boleh disentuh adapter Cloudflare (Issue #567), mencegah perubahan satu
+concern diam-diam mengubah concern lain.
+
+**Catatan keamanan mengikat**: `TENANT_DOMAIN_CLOUDFLARE_API_TOKEN` hanya
+pernah dibaca dari environment/secret manager — tidak pernah disimpan di
+`awcms_mini_tenant_domains`, `awcms_mini_module_settings`, atau tabel DB
+lain mana pun, dan tidak pernah dirender di admin UI mana pun. Error dari
+adapter (`src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter.ts`)
+di-redact: hanya kode error numerik Cloudflare yang disurfacekan (bukan
+teks `.message` mentah), token/zone id disaring dari teks error apa pun
+sebagai defense in depth, dan tidak pernah stack trace. Setiap panggilan
+provider timeout-bounded (default 8 detik) dan dijalankan di luar
+transaksi DB mana pun (ADR-0006).
+
 ### Provider CRM (opsional) — contoh domain retail/POS
 
 | Var                    | Wajib      | Default | Sensitif | Fungsi             |

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -79,6 +79,18 @@
  *         `PUBLIC_TRUST_PROXY=true` must only be used behind a trusted
  *         reverse proxy, since a future host-based resolver (#559) would
  *         otherwise trust a spoofable `X-Forwarded-Host` header.
+ *  6. Optional Cloudflare DNS adapter (Issue #567, epic #555): if
+ *     TENANT_DOMAIN_DNS_PROVIDER is set, it must be one of
+ *     `KNOWN_TENANT_DOMAIN_DNS_PROVIDERS`
+ *     (`../src/modules/tenant-domain/domain/tenant-domain-dns-config`) —
+ *     `manual` (default/MVP, no extra var required) or `cloudflare` (then
+ *     TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN, TENANT_DOMAIN_CLOUDFLARE_ZONE_ID,
+ *     and TENANT_DOMAIN_CLOUDFLARE_API_TOKEN must all be set). Left unset it
+ *     is *not* an error — manual domain management
+ *     (`POST /api/v1/tenant/domains/{id}/verify`, Issue #562) remains the
+ *     default and keeps working with none of these vars present. Mirrors
+ *     the EMAIL_PROVIDER conditional check above. See
+ *     `src/modules/tenant-domain/README.md` §Cloudflare DNS adapter.
  *
  * Never prints actual secret values — only which variable name is
  * missing/invalid (doc 18: "Var wajib hilang → gagal start dengan pesan
@@ -92,6 +104,11 @@ import {
   EMAIL_REQUIRED_WHEN_ENABLED,
   isKnownEmailProvider
 } from "../src/modules/email/domain/email-config";
+import {
+  isKnownTenantDomainDnsProvider,
+  KNOWN_TENANT_DOMAIN_DNS_PROVIDERS,
+  TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED
+} from "../src/modules/tenant-domain/domain/tenant-domain-dns-config";
 
 export type EnvCheckResult = {
   name: string;
@@ -399,6 +416,65 @@ export function checkPublicRoutingConfig(
   return results;
 }
 
+/**
+ * Optional Cloudflare DNS adapter (Issue #567, epic #555). Manual domain
+ * management stays the default: `TENANT_DOMAIN_DNS_PROVIDER` left unset (or
+ * explicitly `"manual"`) requires none of the Cloudflare vars below and
+ * `config:validate` passes exactly as it does today. Only
+ * `"cloudflare"` gates the three extra vars, mirroring `checkEmailConfig`'s
+ * `EMAIL_PROVIDER=mailketing` conditional above.
+ */
+export function checkTenantDomainDnsConfig(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult[] {
+  const results: EnvCheckResult[] = [];
+  const raw = env.TENANT_DOMAIN_DNS_PROVIDER;
+
+  if (!isSet(raw)) {
+    results.push({
+      name: "TENANT_DOMAIN_DNS_PROVIDER",
+      status: "pass",
+      detail:
+        "TENANT_DOMAIN_DNS_PROVIDER is not set — defaults to manual domain verification (Issue #562's POST .../verify); no Cloudflare credentials required."
+    });
+    return results;
+  }
+
+  const provider = (raw as string).trim();
+
+  if (!isKnownTenantDomainDnsProvider(provider)) {
+    results.push({
+      name: "TENANT_DOMAIN_DNS_PROVIDER",
+      status: "fail",
+      detail: `TENANT_DOMAIN_DNS_PROVIDER must be one of ${KNOWN_TENANT_DOMAIN_DNS_PROVIDERS.join(", ")}; got "${provider}".`
+    });
+    return results;
+  }
+
+  results.push({
+    name: "TENANT_DOMAIN_DNS_PROVIDER",
+    status: "pass",
+    detail: `TENANT_DOMAIN_DNS_PROVIDER is a known provider (${provider}).`
+  });
+
+  if (provider === "cloudflare") {
+    for (const name of TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED) {
+      if (isSet(env[name])) {
+        results.push({ name, status: "pass", detail: `${name} is set.` });
+        continue;
+      }
+
+      results.push({
+        name,
+        status: "fail",
+        detail: `TENANT_DOMAIN_DNS_PROVIDER=cloudflare but ${name} is missing or empty.`
+      });
+    }
+  }
+
+  return results;
+}
+
 export function runEnvValidation(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -407,7 +483,8 @@ export function runEnvValidation(
     checkSyncConfig(env),
     ...checkR2Config(env),
     ...checkEmailConfig(env),
-    ...checkPublicRoutingConfig(env)
+    ...checkPublicRoutingConfig(env),
+    ...checkTenantDomainDnsConfig(env)
   ];
 }
 

--- a/src/modules/tenant-domain/README.md
+++ b/src/modules/tenant-domain/README.md
@@ -280,14 +280,118 @@ hostname 409, soft-delete-only, verify idempotency + status gating,
 set-primary atomicity + idempotency, no `verification_token_hash` in any
 response).
 
+## Cloudflare DNS adapter (`infrastructure/cloudflare-dns-adapter.ts`, Issue #567)
+
+Optional enhancement, **not a hard dependency** — manual domain management
+(`POST /api/v1/tenant/domains/{id}/verify`, Issue #562) remains the MVP
+default and keeps working with zero Cloudflare configuration. Nothing in
+this repo calls this adapter yet: no route wires it into `.../verify` or a
+"provision platform subdomain" flow (that is left for a future issue). This
+issue only adds the provider boundary itself — config, adapter, and tests —
+so that future work has a ready-made, security-reviewed integration point
+instead of inventing one under time pressure.
+
+### Config (`domain/tenant-domain-dns-config.ts`, `scripts/validate-env.ts`'s `checkTenantDomainDnsConfig`)
+
+Four env vars, all optional/backward-compatible:
+
+- `TENANT_DOMAIN_DNS_PROVIDER` — `manual` (default) | `cloudflare`. Left
+  unset, `config:validate` passes exactly as before this issue.
+- `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` — required only when
+  `TENANT_DOMAIN_DNS_PROVIDER=cloudflare`. **Deliberately a separate
+  variable from `PUBLIC_PLATFORM_ROOT_DOMAIN`** (Issue #556) even though the
+  two will often hold the same value operationally:
+  `PUBLIC_PLATFORM_ROOT_DOMAIN` gates the public host-based _resolver_
+  (which subdomains are trusted to resolve a tenant, Issue #559); this one
+  scopes which hostnames the Cloudflare adapter is allowed to create/query
+  DNS records for. Conflating the two would let a change meant for one
+  concern silently change the other.
+- `TENANT_DOMAIN_CLOUDFLARE_ZONE_ID` — required only when selected. Not a
+  secret in the traditional sense, but still never rendered anywhere and
+  redacted out of any adapter error text as defense in depth (see below).
+- `TENANT_DOMAIN_CLOUDFLARE_API_TOKEN` — required only when selected. A
+  real secret, read from env/secret manager only — **never** stored in
+  `awcms_mini_tenant_domains`, `awcms_mini_module_settings`, or any other
+  DB table, and never returned in any API response or rendered in any admin
+  UI (binding rule, Issue #567 §Security notes; also epic #555's own §Aturan
+  lintas-issue #7).
+
+### Adapter (`infrastructure/cloudflare-dns-adapter.ts`)
+
+Port `TenantDomainDnsProvider` with two methods, both timeout-bounded
+(`withTimeout`, default 8s) and gated by a shared circuit breaker
+(`getProviderCircuitBreaker("tenant-domain-cloudflare-dns")`) — the same
+pattern `email/infrastructure/mailketing-provider.ts` and
+`sync-storage/infrastructure/object-storage-uploader.ts` already use, and
+meant to be called **outside** any DB transaction (ADR-0006):
+
+- `createVerificationRecord({ recordType: "TXT" | "CNAME", recordName, recordValue })`
+  — creates a DNS record on the configured zone. **Idempotent by
+  construction**: it first lists existing records with the same
+  type/name/content and returns `{ ok: true, alreadyExists: true }` without
+  a second write if a match already exists, rather than depending on a
+  specific Cloudflare duplicate-record error code.
+- `checkVerificationStatus({ recordType, recordName, expectedValue })` —
+  lists records at that name/type and reports whether one matches
+  `expectedValue` (`{ ok: true, verified: boolean }`). CNAME comparison
+  normalizes a trailing dot and case before matching.
+
+**Input validation (binding, "no arbitrary DNS record creation from
+user-controlled input")**: `validateDnsRecordInput()` (exported, pure)
+rejects any `recordName` that is not `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN`
+itself or a subdomain of it — before any network call is attempted. This
+mirrors a real Cloudflare API constraint (one zone id/token can only manage
+records within its own zone), not an arbitrary restriction. Record-name
+shape validation is a **dedicated** check
+(`isValidDnsRecordNameShape`), not a reuse of
+`lib/tenant/public-host-tenant-resolver.ts`'s `normalizePublicHost()` (Issue
+#559): DNS verification record names conventionally use an
+underscore-prefixed label (e.g. `_acme-challenge.example.com`,
+`_awcms-verify.tenant1.platform.example`) that a `Host`-header shape check
+rightly rejects but every DNS verification flow needs to allow.
+`normalizePublicHost()` is still reused, unchanged, for the CNAME _target
+value_ (a real "points-to" hostname, not a record label) — that one keeps
+the strict shape. `recordValue` is further bounded (no `\r`/`\n`, TXT
+content ≤ 2048 chars — Cloudflare's own limit).
+
+**Error redaction (binding, "no token, zone ID internals, or stack
+trace")**: a provider HTTP error never surfaces Cloudflare's own
+`errors[].message` text — only the numeric `errors[].code` values (safe,
+non-identifying) are included. Any thrown-error text (network failure,
+timeout) is also passed through `redact()`, which strips the configured
+`apiToken`/`zoneId` values out of it as defense in depth (e.g. a network
+error whose message happens to embed the request URL, which itself embeds
+the zone id) before truncation to 300 characters.
+
+`resolveTenantDomainDnsProvider(env)` is the production resolver (mirrors
+`email/infrastructure/email-provider-resolver.ts`'s `resolveEmailProvider`
+and `sync-storage/infrastructure/object-storage-uploader.ts`'s
+`resolveObjectUploader`): builds the real Cloudflare provider when fully
+configured, or a safe stub that returns a clear `{ ok: false }` result —
+never throws — for `manual` mode, an unknown provider value, or a
+`cloudflare` selection missing any of the three required vars. `bun run
+config:validate` is what should already have caught a misconfigured
+deployment at boot; this resolver is a second, defensive layer.
+
+Test: `tests/unit/cloudflare-dns-adapter.test.ts` — pure `validateDnsRecordInput`
+cases, and, against a local fake HTTP server (`Bun.serve`, same technique as
+`tests/object-storage-uploader.test.ts`): success (create + idempotent
+re-create), provider error (redaction proven against a server that
+deliberately echoes the token/zone id in its error `message`, which the
+adapter must never forward), timeout, circuit-breaker trip, and
+`resolveTenantDomainDnsProvider`'s missing/invalid/unknown-env behavior.
+`tests/validate-env.test.ts`'s `describe("checkTenantDomainDnsConfig", ...)`
+covers the env-gating rules above.
+
 ## Not yet available
 
-- Admin UI, `/admin/tenant/domains` (Issue #563).
-- The tenant setting that chooses between `/news` and legacy
-  `/blog/{tenantCode}` (Issue #564).
-- Optional Cloudflare DNS adapter (Issue #567) — explicitly out of scope
-  for the whole epic as a hard dependency; manual DNS setup by the
-  operator must keep working without it.
+- Admin UI, `/admin/tenant/domains` (Issue #563) is done, but it never
+  edits Cloudflare provider credentials — that stays env/secret-manager-only
+  by design (out of scope for the whole epic, Issue #567 §Out of scope).
+- Wiring `cloudflare-dns-adapter.ts` into
+  `POST /api/v1/tenant/domains/{id}/verify` or a "provision platform
+  subdomain" endpoint — Issue #567 added the provider boundary only, no
+  route calls it yet.
 
 No `jobs` or `health` are declared on this module's descriptor yet — both
 fields exist on `ModuleDescriptor` but, consistent with

--- a/src/modules/tenant-domain/domain/tenant-domain-dns-config.ts
+++ b/src/modules/tenant-domain/domain/tenant-domain-dns-config.ts
@@ -1,0 +1,54 @@
+/**
+ * Tenant domain DNS provider configuration (Issue #567, epic #555). Pure —
+ * no `process.env` reads here; `scripts/validate-env.ts` and the Cloudflare
+ * adapter's resolver (`../infrastructure/cloudflare-dns-adapter.ts`) both
+ * pass in whatever `env` they were given, the same split
+ * `email/domain/email-config.ts` already uses for its own provider
+ * selection.
+ *
+ * `"manual"` (default, MVP) means the operator publishes DNS records
+ * themselves and verifies via `POST /api/v1/tenant/domains/{id}/verify`
+ * (Issue #562) exactly as today — this module makes zero outbound DNS/HTTP
+ * calls in that mode, and none of the vars below are required. `"cloudflare"`
+ * is the one optional adapter that can create/check DNS records for
+ * platform-managed subdomains on a Cloudflare-managed zone. Choosing
+ * `cloudflare` never becomes a hard dependency (epic #555 §Out of scope;
+ * skill `awcms-mini-tenant-domain-routing` §Aturan lintas-issue #9) — manual
+ * DNS setup must keep working whether this var is left unset or explicitly
+ * set to `"manual"`.
+ */
+export const KNOWN_TENANT_DOMAIN_DNS_PROVIDERS = [
+  "manual",
+  "cloudflare"
+] as const;
+
+export type TenantDomainDnsProviderKind =
+  (typeof KNOWN_TENANT_DOMAIN_DNS_PROVIDERS)[number];
+
+export function isKnownTenantDomainDnsProvider(
+  value: string | undefined
+): value is TenantDomainDnsProviderKind {
+  return (KNOWN_TENANT_DOMAIN_DNS_PROVIDERS as readonly string[]).includes(
+    value ?? ""
+  );
+}
+
+/**
+ * Env var names required only when `TENANT_DOMAIN_DNS_PROVIDER=cloudflare`.
+ *
+ * `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` is deliberately a *separate* variable
+ * from `PUBLIC_PLATFORM_ROOT_DOMAIN` (Issue #556) even though the two will
+ * often hold the same value operationally: `PUBLIC_PLATFORM_ROOT_DOMAIN`
+ * gates the public host-based *resolver* (which subdomains are trusted to
+ * resolve a tenant, Issue #559); this one scopes which hostnames the
+ * Cloudflare adapter is allowed to create/query DNS records for (defense in
+ * depth — see `validateDnsRecordInput` in the adapter file, and note that
+ * this also reflects a real Cloudflare API constraint: a zone/token can only
+ * manage records within its own zone). Conflating the two would let a change
+ * meant for one concern silently change the other.
+ */
+export const TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED = [
+  "TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN",
+  "TENANT_DOMAIN_CLOUDFLARE_ZONE_ID",
+  "TENANT_DOMAIN_CLOUDFLARE_API_TOKEN"
+] as const;

--- a/src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter.ts
+++ b/src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter.ts
@@ -1,0 +1,554 @@
+/**
+ * Optional Cloudflare DNS adapter (Issue #567, epic #555). Manual domain
+ * management (Issue #562's `POST /api/v1/tenant/domains/{id}/verify`)
+ * remains the MVP default — this adapter is never called unless an operator
+ * explicitly sets `TENANT_DOMAIN_DNS_PROVIDER=cloudflare` (see
+ * `../domain/tenant-domain-dns-config.ts`). **No route in this repo calls it
+ * yet** — wiring it into `.../verify` or a "provision platform subdomain"
+ * flow is out of scope for this issue (see the module README's §Not yet
+ * available); this file exists so that future work can depend on the
+ * `TenantDomainDnsProvider` port without inventing the provider boundary,
+ * config split, or redaction/timeout/idempotency behavior at that point.
+ *
+ * Capabilities (Issue #567's own scope): create a TXT/CNAME DNS verification
+ * record, and check whether a DNS record has propagated to the value
+ * expected. Both calls are timeout-bounded (`withTimeout`) and gated by a
+ * shared circuit breaker
+ * (`getProviderCircuitBreaker("tenant-domain-cloudflare-dns")`) — the same
+ * pattern `email/infrastructure/mailketing-provider.ts` and
+ * `sync-storage/infrastructure/object-storage-uploader.ts` already use for
+ * outbound provider calls. Both methods are meant to be invoked OUTSIDE any
+ * DB transaction (ADR-0006, doc 16 §Transactional outbox) — this file never
+ * opens, or participates in, one.
+ *
+ * Security notes (binding, Issue #567 acceptance criteria):
+ * - `apiToken`/`zoneId` are read only from configuration
+ *   (`resolveTenantDomainDnsProvider(env)` below) — never persisted to
+ *   `awcms_mini_tenant_domains` or `awcms_mini_module_settings`, never
+ *   rendered in any response. `verification_record_value` (migration 031)
+ *   is the *public* DNS value a tenant is told to publish, never this
+ *   token.
+ * - Errors returned to callers are redacted: never the raw Cloudflare API
+ *   response `errors[].message` text (only the numeric `errors[].code`
+ *   values are surfaced — safe, non-identifying), never the configured
+ *   token or zone id, never a stack trace. `redact()` additionally strips
+ *   the configured secrets out of any thrown-error text as defense in depth
+ *   (e.g. a network error whose message happens to embed the request URL,
+ *   which itself embeds the zone id).
+ * - `createVerificationRecord`/`checkVerificationStatus` reject any
+ *   `recordName` that is not `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` itself or
+ *   a subdomain of it (`isWithinPlatformRootDomain`) — this adapter refuses
+ *   to create or query DNS records for an arbitrary caller-supplied
+ *   hostname outside the platform's own managed zone. This mirrors a real
+ *   Cloudflare API constraint (one zone id can only manage records within
+ *   its own zone) rather than adding an arbitrary restriction. Record-name
+ *   shape validation is a dedicated check, not a reuse of
+ *   `normalizePublicHost()` (Issue #559) — DNS verification record names
+ *   conventionally use an underscore-prefixed label (e.g.
+ *   `_acme-challenge.example.com`) that a `Host`-header shape check
+ *   rightly rejects but every DNS verification flow needs to allow; see
+ *   `isValidDnsRecordNameShape` below. `normalizePublicHost()` is still
+ *   reused for the CNAME *target value* (a real "points-to" hostname).
+ * - `createVerificationRecord` is idempotent: it first lists existing
+ *   records with the same type/name/content and returns
+ *   `{ ok: true, alreadyExists: true }` without a second write if a match is
+ *   already present, rather than depending on a specific Cloudflare
+ *   duplicate-record error code.
+ */
+import { getProviderCircuitBreaker } from "../../../lib/database/circuit-breaker";
+import { withTimeout } from "../../../lib/integration/timeout";
+import { normalizePublicHost } from "../../../lib/tenant/public-host-tenant-resolver";
+import {
+  isKnownTenantDomainDnsProvider,
+  TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED
+} from "../domain/tenant-domain-dns-config";
+
+const PROVIDER_KEY = "tenant-domain-cloudflare-dns";
+const DEFAULT_TIMEOUT_MS = 8_000;
+const MAX_ERROR_MESSAGE_LENGTH = 300;
+const DEFAULT_API_BASE_URL = "https://api.cloudflare.com/client/v4";
+const MAX_TXT_VALUE_LENGTH = 2048; // Cloudflare TXT record content limit.
+
+export type DnsRecordType = "TXT" | "CNAME";
+
+export type CreateVerificationRecordInput = {
+  recordType: DnsRecordType;
+  /** Fully-qualified DNS name, e.g. "_awcms-verify.tenant1.platform.example". Must equal or be a subdomain of the configured platform root domain. */
+  recordName: string;
+  /** TXT record content, or the CNAME target hostname. */
+  recordValue: string;
+};
+
+export type CreateVerificationRecordResult =
+  | { ok: true; providerRecordId?: string; alreadyExists: boolean }
+  | { ok: false; error: string; retryable: boolean };
+
+export type CheckVerificationStatusInput = {
+  recordType: DnsRecordType;
+  recordName: string;
+  expectedValue: string;
+};
+
+export type CheckVerificationStatusResult =
+  | { ok: true; verified: boolean }
+  | { ok: false; error: string; retryable: boolean };
+
+/**
+ * The port. A future issue that wires this into `.../verify` or a
+ * subdomain-provisioning endpoint should depend on this type, never on
+ * `createCloudflareDnsProvider` by name — mirrors
+ * `email/domain/email-provider-contract.ts`'s `EmailProvider` convention.
+ */
+export type TenantDomainDnsProvider = {
+  createVerificationRecord(
+    input: CreateVerificationRecordInput
+  ): Promise<CreateVerificationRecordResult>;
+  checkVerificationStatus(
+    input: CheckVerificationStatusInput
+  ): Promise<CheckVerificationStatusResult>;
+};
+
+export type CloudflareDnsProviderConfig = {
+  zoneId: string;
+  apiToken: string;
+  platformRootDomain: string;
+  /** Override for tests/dev only — a local fake HTTP server standing in for the Cloudflare API. Always supplied from configuration, never from request/user input (SSRF-safe, same convention as `mailketing-provider.ts`'s `baseUrl` override). */
+  baseUrl?: string;
+  timeoutMs?: number;
+};
+
+type CloudflareApiError = { code: number; message: string };
+
+type CloudflareApiResponse<T> = {
+  success: boolean;
+  errors?: CloudflareApiError[];
+  result?: T;
+};
+
+type CloudflareDnsRecord = {
+  id: string;
+  type: string;
+  name: string;
+  content: string;
+};
+
+function truncate(message: string): string {
+  return message.length > MAX_ERROR_MESSAGE_LENGTH
+    ? `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`
+    : message;
+}
+
+/**
+ * Strips the configured secret/identifier values out of `message` before it
+ * is ever returned to a caller or logged — defense in depth against a
+ * thrown error accidentally echoing part of the request (e.g. a `fetch()`
+ * network-error message that includes the target URL, which embeds the
+ * zone id).
+ */
+function redact(message: string, secrets: readonly string[]): string {
+  let sanitized = message;
+
+  for (const secret of secrets) {
+    if (secret) {
+      sanitized = sanitized.split(secret).join("[redacted]");
+    }
+  }
+
+  return sanitized;
+}
+
+/**
+ * Only the numeric Cloudflare `errors[].code` values are surfaced — never
+ * `.message`, which can echo request content this adapter does not fully
+ * control. Satisfies the "no internal detail leakage" acceptance criterion
+ * without needing to guess what a provider error message might contain.
+ */
+function summarizeApiErrors(errors: CloudflareApiError[] | undefined): string {
+  if (!errors || errors.length === 0) {
+    return "no error detail provided";
+  }
+
+  return `error code(s) ${errors.map((error) => error.code).join(", ")}`;
+}
+
+const MAX_RECORD_NAME_LENGTH = 253; // RFC 1035 total hostname length limit.
+const MAX_RECORD_NAME_LABEL_LENGTH = 63; // RFC 1035 per-label length limit.
+// Deliberately more permissive than `normalizePublicHost()`'s
+// `HOST_LABEL_PATTERN` (Issue #559): DNS verification record names
+// conventionally use an underscore-prefixed label (e.g.
+// "_acme-challenge.example.com", "_dmarc.example.com") that RFC 1035
+// technically disallows but every major DNS verification flow uses and
+// every public resolver accepts (RFC 2181 §11 relaxes the restriction). A
+// `Host` header, by contrast, is never legitimately underscore-prefixed —
+// which is why this file does not reuse `normalizePublicHost()` for
+// `recordName` shape, only for the CNAME *target value* below (a real
+// "points-to" hostname, not a record label).
+const RECORD_NAME_LABEL_PATTERN = /^[a-z0-9_]([a-z0-9_-]{0,61}[a-z0-9_])?$/;
+
+function isValidDnsRecordNameShape(value: string): boolean {
+  const trimmed = value.trim().toLowerCase();
+
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > MAX_RECORD_NAME_LENGTH ||
+    trimmed.startsWith(".") ||
+    trimmed.endsWith(".") ||
+    trimmed.includes("..") ||
+    /\s/.test(trimmed)
+  ) {
+    return false;
+  }
+
+  return trimmed
+    .split(".")
+    .every(
+      (label) =>
+        label.length > 0 &&
+        label.length <= MAX_RECORD_NAME_LABEL_LENGTH &&
+        RECORD_NAME_LABEL_PATTERN.test(label)
+    );
+}
+
+/**
+ * `recordName` must equal `platformRootDomain` or be a subdomain of it —
+ * refuses to let this adapter touch a hostname outside the platform's own
+ * managed zone, even though the configured Cloudflare zone/token may
+ * technically be able to. `platformRootDomain` comes from trusted operator
+ * configuration (`TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN`), not request input.
+ */
+function isWithinPlatformRootDomain(
+  recordName: string,
+  platformRootDomain: string
+): boolean {
+  const normalizedRoot = platformRootDomain.trim().toLowerCase();
+
+  if (
+    normalizedRoot.length === 0 ||
+    !isValidDnsRecordNameShape(normalizedRoot)
+  ) {
+    return false;
+  }
+
+  if (!isValidDnsRecordNameShape(recordName)) {
+    return false;
+  }
+
+  const normalizedName = recordName.trim().toLowerCase();
+
+  return (
+    normalizedName === normalizedRoot ||
+    normalizedName.endsWith(`.${normalizedRoot}`)
+  );
+}
+
+function isValidRecordValue(
+  recordType: DnsRecordType,
+  value: unknown
+): value is string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return false;
+  }
+
+  if (/[\r\n]/.test(value)) {
+    return false;
+  }
+
+  if (recordType === "TXT") {
+    return value.length <= MAX_TXT_VALUE_LENGTH;
+  }
+
+  // CNAME target must itself look like a plausible hostname.
+  try {
+    return normalizePublicHost(value) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates a DNS-record request before any network call is attempted —
+ * "Do not allow arbitrary DNS record creation from user-controlled input
+ * without validation" (Issue #567 §Security notes). Pure, exported for unit
+ * testing without a network double.
+ */
+export function validateDnsRecordInput(
+  input: { recordType: unknown; recordName: unknown; recordValue: unknown },
+  platformRootDomain: string
+): string | null {
+  if (input.recordType !== "TXT" && input.recordType !== "CNAME") {
+    return 'recordType must be "TXT" or "CNAME".';
+  }
+
+  if (
+    typeof input.recordName !== "string" ||
+    !isWithinPlatformRootDomain(input.recordName, platformRootDomain)
+  ) {
+    return "recordName must equal the platform root domain or be a subdomain of it.";
+  }
+
+  if (!isValidRecordValue(input.recordType, input.recordValue)) {
+    return "recordValue is not a valid value for the given recordType.";
+  }
+
+  return null;
+}
+
+function normalizeRecordValueForComparison(
+  recordType: DnsRecordType,
+  value: string
+): string {
+  const trimmed = value.trim();
+
+  if (recordType === "CNAME") {
+    return trimmed.replace(/\.$/, "").toLowerCase();
+  }
+
+  return trimmed;
+}
+
+export function createCloudflareDnsProvider(
+  config: CloudflareDnsProviderConfig
+): TenantDomainDnsProvider {
+  const baseUrl = config.baseUrl ?? DEFAULT_API_BASE_URL;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const breaker = getProviderCircuitBreaker(PROVIDER_KEY);
+  const secrets = [config.apiToken, config.zoneId];
+
+  async function callApi<T>(
+    path: string,
+    init: RequestInit,
+    label: string
+  ): Promise<{ status: number; body: CloudflareApiResponse<T> | undefined }> {
+    const response = await withTimeout(
+      fetch(`${baseUrl}/zones/${config.zoneId}${path}`, {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${config.apiToken}`,
+          "Content-Type": "application/json",
+          ...(init.headers ?? {})
+        }
+      }),
+      timeoutMs,
+      label
+    );
+
+    const rawBody = await response.text().catch(() => "");
+    let body: CloudflareApiResponse<T> | undefined;
+
+    try {
+      body = rawBody
+        ? (JSON.parse(rawBody) as CloudflareApiResponse<T>)
+        : undefined;
+    } catch {
+      body = undefined;
+    }
+
+    return { status: response.status, body };
+  }
+
+  async function listMatchingRecords(
+    recordType: DnsRecordType,
+    recordName: string
+  ): Promise<CloudflareDnsRecord[]> {
+    const query = new URLSearchParams({ type: recordType, name: recordName });
+    const { status, body } = await callApi<CloudflareDnsRecord[]>(
+      `/dns_records?${query.toString()}`,
+      { method: "GET" },
+      "cloudflare dns list records"
+    );
+
+    if (status < 200 || status >= 300 || !body?.success) {
+      throw new Error(
+        `Cloudflare DNS API list request failed (HTTP ${status}, ${summarizeApiErrors(body?.errors)}).`
+      );
+    }
+
+    return body.result ?? [];
+  }
+
+  return {
+    async createVerificationRecord(input) {
+      const attemptedAt = new Date();
+      const validationError = validateDnsRecordInput(
+        input,
+        config.platformRootDomain
+      );
+
+      if (validationError) {
+        return { ok: false, error: validationError, retryable: false };
+      }
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "Cloudflare DNS circuit breaker is open; skipping attempt.",
+          retryable: true
+        };
+      }
+
+      try {
+        const existing = await listMatchingRecords(
+          input.recordType,
+          input.recordName
+        );
+        const match = existing.find(
+          (record) => record.content === input.recordValue
+        );
+
+        if (match) {
+          breaker.recordSuccess(attemptedAt);
+          return { ok: true, providerRecordId: match.id, alreadyExists: true };
+        }
+
+        const { status, body } = await callApi<CloudflareDnsRecord>(
+          "/dns_records",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              type: input.recordType,
+              name: input.recordName,
+              content: input.recordValue,
+              ttl: 300,
+              proxied: false
+            })
+          },
+          "cloudflare dns create record"
+        );
+
+        if (status < 200 || status >= 300 || !body?.success) {
+          breaker.recordFailure(attemptedAt);
+          return {
+            ok: false,
+            error: truncate(
+              redact(
+                `Cloudflare DNS API create request failed (HTTP ${status}, ${summarizeApiErrors(body?.errors)}).`,
+                secrets
+              )
+            ),
+            retryable: status >= 500 || status === 0
+          };
+        }
+
+        breaker.recordSuccess(attemptedAt);
+        return {
+          ok: true,
+          providerRecordId: body.result?.id,
+          alreadyExists: false
+        };
+      } catch (error) {
+        breaker.recordFailure(attemptedAt);
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          ok: false,
+          error: truncate(redact(message, secrets)),
+          retryable: true
+        };
+      }
+    },
+
+    async checkVerificationStatus(input) {
+      const attemptedAt = new Date();
+      const validationError = validateDnsRecordInput(
+        { ...input, recordValue: input.expectedValue },
+        config.platformRootDomain
+      );
+
+      if (validationError) {
+        return { ok: false, error: validationError, retryable: false };
+      }
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "Cloudflare DNS circuit breaker is open; skipping attempt.",
+          retryable: true
+        };
+      }
+
+      try {
+        const records = await listMatchingRecords(
+          input.recordType,
+          input.recordName
+        );
+        const verified = records.some(
+          (record) =>
+            normalizeRecordValueForComparison(
+              input.recordType,
+              record.content
+            ) ===
+            normalizeRecordValueForComparison(
+              input.recordType,
+              input.expectedValue
+            )
+        );
+
+        breaker.recordSuccess(attemptedAt);
+        return { ok: true, verified };
+      } catch (error) {
+        breaker.recordFailure(attemptedAt);
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          ok: false,
+          error: truncate(redact(message, secrets)),
+          retryable: true
+        };
+      }
+    }
+  };
+}
+
+function createMisconfiguredProvider(reason: string): TenantDomainDnsProvider {
+  return {
+    async createVerificationRecord() {
+      return { ok: false, error: reason, retryable: false };
+    },
+    async checkVerificationStatus() {
+      return { ok: false, error: reason, retryable: false };
+    }
+  };
+}
+
+/**
+ * Production resolver (mirrors
+ * `email/infrastructure/email-provider-resolver.ts`'s `resolveEmailProvider`
+ * and `sync-storage/infrastructure/object-storage-uploader.ts`'s
+ * `resolveObjectUploader`): builds the configured provider from `env`,
+ * degrading to a clean misconfigured-result provider — never throwing —
+ * whenever `TENANT_DOMAIN_DNS_PROVIDER=cloudflare` is missing required
+ * config, or the var is unset/`"manual"`/unrecognized. `bun run
+ * config:validate` (`scripts/validate-env.ts`'s `checkTenantDomainDnsConfig`)
+ * is what should already have caught a misconfigured deployment at boot;
+ * this resolver is a second, defensive layer so a single misconfigured
+ * caller cannot crash on a missing var. **Not called from anywhere in this
+ * issue (#567)** — no route wires it in yet, see the module README's §Not
+ * yet available.
+ */
+export function resolveTenantDomainDnsProvider(
+  env: NodeJS.ProcessEnv = process.env
+): TenantDomainDnsProvider {
+  const provider = env.TENANT_DOMAIN_DNS_PROVIDER ?? "manual";
+
+  if (!isKnownTenantDomainDnsProvider(provider)) {
+    return createMisconfiguredProvider(
+      "TENANT_DOMAIN_DNS_PROVIDER is not a known provider."
+    );
+  }
+
+  if (provider === "manual") {
+    return createMisconfiguredProvider(
+      'TENANT_DOMAIN_DNS_PROVIDER is "manual" — no automated DNS provider is configured; use manual verification (POST /api/v1/tenant/domains/{id}/verify).'
+    );
+  }
+
+  const zoneId = env.TENANT_DOMAIN_CLOUDFLARE_ZONE_ID;
+  const apiToken = env.TENANT_DOMAIN_CLOUDFLARE_API_TOKEN;
+  const platformRootDomain = env.TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN;
+
+  if (!zoneId || !apiToken || !platformRootDomain) {
+    return createMisconfiguredProvider(
+      `Cloudflare DNS provider is not configured (requires ${TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED.join(", ")}).`
+    );
+  }
+
+  return createCloudflareDnsProvider({ zoneId, apiToken, platformRootDomain });
+}

--- a/src/modules/tenant-domain/module.ts
+++ b/src/modules/tenant-domain/module.ts
@@ -3,9 +3,10 @@ import { defineModule } from "../_shared/module-contract";
 /**
  * `tenant_domain` (Issue #558, epic #555 — online public tenant routing &
  * tenant domain management). This issue registers the **module descriptor
- * only** — the management API (#562), host-based resolver (#559), and
- * admin UI (#563) have since landed; no Cloudflare DNS adapter (#567) yet.
- * The descriptor exists now so
+ * only** — the management API (#562), host-based resolver (#559), admin UI
+ * (#563), and the optional Cloudflare DNS adapter (#567,
+ * `infrastructure/cloudflare-dns-adapter.ts`, not wired into any route yet)
+ * have since landed. The descriptor exists now so
  * the database-backed module registry (Module Management, epic #510) can
  * track this module's lifecycle/permissions/settings from day one, the
  * same "register the descriptor before the feature is fully built" order
@@ -13,15 +14,16 @@ import { defineModule } from "../_shared/module-contract";
  *
  * `type: "system"` (not `"domain"` or `"integration"`): this module
  * manages hostname/subdomain -> tenant mapping consumed by every public
- * route (the resolver in #559, and eventually every `/news` request in
- * #560) — it is routing/platform infrastructure that all tenants share the
- * mechanism of, not a tenant-facing business feature (contrast
- * `blog_content`, `type: "domain"`). It is also not `"integration"`:
- * that type fits a module whose primary job is talking to an external
- * provider (e.g. `email`'s Mailketing adapter) — `tenant_domain` works
- * fully with `verification_method: 'manual'` and zero external providers;
- * the optional Cloudflare DNS adapter (#567) is an enhancement bolted on
- * later, not this module's defining trait. `"system"` matches
+ * route (the resolver in #559, and every `/news` request since #560) — it
+ * is routing/platform infrastructure that all tenants share the mechanism
+ * of, not a tenant-facing business feature (contrast `blog_content`, `type:
+ * "domain"`). It is also not `"integration"`: that type fits a module
+ * whose primary job is talking to an external provider (e.g. `email`'s
+ * Mailketing adapter) — `tenant_domain` works fully with
+ * `verification_method: 'manual'` and zero external providers; the
+ * optional Cloudflare DNS adapter (#567,
+ * `infrastructure/cloudflare-dns-adapter.ts`) is an enhancement bolted on
+ * later (no route calls it yet), not this module's defining trait. `"system"` matches
  * `module_management`'s own reasoning: generic platform infrastructure
  * that other modules/tenants depend on, not a domain feature.
  */
@@ -31,7 +33,7 @@ export const tenantDomainModule = defineModule({
   version: "0.1.0",
   status: "active",
   description:
-    "Tenant domain/subdomain mapping for online-primary public routing (epic #555). Issue #557 added the `awcms_mini_tenant_domains` schema (migration 031: hostname/normalized_hostname, domain_type subdomain|custom_domain, route_mode canonical|legacy_blog, status pending_verification|active|suspended|failed, verification_method dns_txt|dns_cname|file|manual, is_primary/redirect_to_primary, tenant-scoped RLS with FORCE) and its permission catalog seed (migration 032: tenant_domain.domains.{read,create,update,delete,verify,set_primary}). Issue #558 (this descriptor) registers the module in the trusted code catalog so it syncs into `awcms_mini_modules` and its six permissions sync/report cleanly against the migration 032 seed. The public host-based tenant resolver with offline/LAN fallback (#559), the tenant domain management API (#562), and the admin UI (#563) have since landed. Still to come: an optional Cloudflare DNS adapter (#567). This module never stores a DNS provider API token/credential; `verification_token_hash` (migration 031) is an internal bearer-token hash, and `verification_record_value` is the public DNS record value the tenant publishes, not a secret.",
+    "Tenant domain/subdomain mapping for online-primary public routing (epic #555). Issue #557 added the `awcms_mini_tenant_domains` schema (migration 031: hostname/normalized_hostname, domain_type subdomain|custom_domain, route_mode canonical|legacy_blog, status pending_verification|active|suspended|failed, verification_method dns_txt|dns_cname|file|manual, is_primary/redirect_to_primary, tenant-scoped RLS with FORCE) and its permission catalog seed (migration 032: tenant_domain.domains.{read,create,update,delete,verify,set_primary}). Issue #558 (this descriptor) registers the module in the trusted code catalog so it syncs into `awcms_mini_modules` and its six permissions sync/report cleanly against the migration 032 seed. The public host-based tenant resolver with offline/LAN fallback (#559), the tenant domain management API (#562), the admin UI (#563), and the optional Cloudflare DNS adapter (#567) have since landed. This module never stores a DNS provider API token/credential in the database: `verification_token_hash` (migration 031) is an internal bearer-token hash, `verification_record_value` is the public DNS record value the tenant publishes (not a secret), and the Cloudflare adapter's own API token/zone id are read only from `TENANT_DOMAIN_CLOUDFLARE_*` env vars, never persisted here or in `awcms_mini_module_settings`.",
   dependencies: ["tenant_admin", "identity_access"],
   type: "system",
   api: {
@@ -87,9 +89,11 @@ export const tenantDomainModule = defineModule({
     // publish a DNS record themselves; "manual" means no automated check
     // at all is assumed until a tenant/operator explicitly picks one of
     // the other `verification_method` values (migration 031). The
-    // optional Cloudflare DNS adapter (#567) may later add its own
-    // provider-mode setting, but it will never default this value away
-    // from manual on its own.
+    // optional Cloudflare DNS adapter (#567,
+    // `infrastructure/cloudflare-dns-adapter.ts`) is selected purely via
+    // the `TENANT_DOMAIN_DNS_PROVIDER` env var (not this settings object,
+    // and not wired into any route yet) — it never defaults this value
+    // away from manual on its own.
     defaults: { defaultVerificationMethod: "manual" }
   }
 });

--- a/tests/unit/cloudflare-dns-adapter.test.ts
+++ b/tests/unit/cloudflare-dns-adapter.test.ts
@@ -1,0 +1,520 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resetProviderCircuitBreakersForTests } from "../../src/lib/database/circuit-breaker";
+import {
+  createCloudflareDnsProvider,
+  resolveTenantDomainDnsProvider,
+  validateDnsRecordInput
+} from "../../src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter";
+
+const ROOT_DOMAIN = "platform.example";
+
+describe("validateDnsRecordInput", () => {
+  test("accepts a TXT record at the platform root domain itself", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "TXT",
+          recordName: "platform.example",
+          recordValue: "awcms-verify=abc123"
+        },
+        ROOT_DOMAIN
+      )
+    ).toBeNull();
+  });
+
+  test("accepts a TXT record on a subdomain of the platform root domain", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "TXT",
+          recordName: "_awcms-verify.tenant1.platform.example",
+          recordValue: "awcms-verify=abc123"
+        },
+        ROOT_DOMAIN
+      )
+    ).toBeNull();
+  });
+
+  test("accepts a CNAME record whose value is a valid hostname", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "CNAME",
+          recordName: "tenant1.platform.example",
+          recordValue: "edge.awcms-mini.example"
+        },
+        ROOT_DOMAIN
+      )
+    ).toBeNull();
+  });
+
+  test("rejects an unknown recordType", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "A",
+          recordName: "tenant1.platform.example",
+          recordValue: "1.2.3.4"
+        },
+        ROOT_DOMAIN
+      )
+    ).toMatch(/recordType/);
+  });
+
+  test("rejects a recordName outside the platform root domain", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "TXT",
+          recordName: "evil.other-domain.example",
+          recordValue: "awcms-verify=abc123"
+        },
+        ROOT_DOMAIN
+      )
+    ).toMatch(/platform root domain/i);
+  });
+
+  test("rejects a recordName that only shares a suffix, not a subdomain relationship", () => {
+    // "notplatform.example" ends with "platform.example" as a raw string
+    // suffix but is NOT a subdomain of it — must be rejected.
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "TXT",
+          recordName: "notplatform.example",
+          recordValue: "awcms-verify=abc123"
+        },
+        ROOT_DOMAIN
+      )
+    ).toMatch(/platform root domain/i);
+  });
+
+  test("rejects a TXT value containing a newline (injection defense)", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "TXT",
+          recordName: "tenant1.platform.example",
+          recordValue: "abc\ninjected"
+        },
+        ROOT_DOMAIN
+      )
+    ).toMatch(/recordValue/);
+  });
+
+  test("rejects a TXT value longer than the Cloudflare content limit", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "TXT",
+          recordName: "tenant1.platform.example",
+          recordValue: "a".repeat(2049)
+        },
+        ROOT_DOMAIN
+      )
+    ).toMatch(/recordValue/);
+  });
+
+  test("rejects a CNAME value that is not a plausible hostname", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "CNAME",
+          recordName: "tenant1.platform.example",
+          recordValue: "not a hostname"
+        },
+        ROOT_DOMAIN
+      )
+    ).toMatch(/recordValue/);
+  });
+
+  test("rejects an empty recordValue", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "TXT",
+          recordName: "tenant1.platform.example",
+          recordValue: ""
+        },
+        ROOT_DOMAIN
+      )
+    ).toMatch(/recordValue/);
+  });
+});
+
+type ServerBehavior =
+  | "empty-list-then-create-ok"
+  | "existing-match"
+  | "create-provider-error"
+  | "list-provider-error"
+  | "slow";
+
+describe("createCloudflareDnsProvider", () => {
+  let requestCount = 0;
+  let requests: { method: string; pathname: string; body?: string }[] = [];
+  let behavior: ServerBehavior = "empty-list-then-create-ok";
+  let server: ReturnType<typeof Bun.serve>;
+
+  beforeEach(() => {
+    resetProviderCircuitBreakersForTests();
+    requestCount = 0;
+    requests = [];
+    behavior = "empty-list-then-create-ok";
+
+    server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        requestCount += 1;
+        const url = new URL(request.url);
+        const bodyText = await request.text().catch(() => "");
+        requests.push({
+          method: request.method,
+          pathname: url.pathname,
+          body: bodyText || undefined
+        });
+
+        if (behavior === "slow") {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          return Response.json({ success: true, errors: [], result: [] });
+        }
+
+        if (request.method === "GET") {
+          if (behavior === "existing-match") {
+            return Response.json({
+              success: true,
+              errors: [],
+              result: [
+                {
+                  id: "existing-record-id",
+                  type: url.searchParams.get("type"),
+                  name: url.searchParams.get("name"),
+                  content: "awcms-verify=abc123"
+                }
+              ]
+            });
+          }
+
+          if (behavior === "list-provider-error") {
+            return Response.json(
+              {
+                success: false,
+                errors: [
+                  {
+                    code: 9109,
+                    message: "Invalid access token: super-secret-token-value"
+                  }
+                ]
+              },
+              { status: 400 }
+            );
+          }
+
+          return Response.json({ success: true, errors: [], result: [] });
+        }
+
+        // POST /dns_records
+        if (behavior === "create-provider-error") {
+          return Response.json(
+            {
+              success: false,
+              errors: [
+                {
+                  code: 1004,
+                  message:
+                    "DNS Validation Error (zone super-secret-zone-value not eligible)."
+                }
+              ]
+            },
+            { status: 400 }
+          );
+        }
+
+        return Response.json({
+          success: true,
+          errors: [],
+          result: { id: "new-record-id" }
+        });
+      }
+    });
+  });
+
+  afterEach(() => {
+    server.stop(true);
+    resetProviderCircuitBreakersForTests();
+  });
+
+  function makeProvider(timeoutMs = 5000) {
+    return createCloudflareDnsProvider({
+      zoneId: "super-secret-zone-value",
+      apiToken: "super-secret-token-value",
+      platformRootDomain: ROOT_DOMAIN,
+      baseUrl: `http://127.0.0.1:${server.port}`,
+      timeoutMs
+    });
+  }
+
+  test("creates a new verification record via a real GET-then-POST round trip", async () => {
+    const provider = makeProvider();
+    const result = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      recordValue: "awcms-verify=abc123"
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      providerRecordId: "new-record-id",
+      alreadyExists: false
+    });
+    expect(requestCount).toBe(2);
+    expect(requests[0]?.method).toBe("GET");
+    expect(requests[1]?.method).toBe("POST");
+  });
+
+  test("is idempotent: returns alreadyExists without a second write when a matching record exists", async () => {
+    behavior = "existing-match";
+    const provider = makeProvider();
+    const result = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      recordValue: "awcms-verify=abc123"
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      providerRecordId: "existing-record-id",
+      alreadyExists: true
+    });
+    // Only the GET lookup ran — no POST was issued for an already-present record.
+    expect(requestCount).toBe(1);
+    expect(requests[0]?.method).toBe("GET");
+  });
+
+  test("rejects invalid input without ever calling the network", async () => {
+    const provider = makeProvider();
+    const result = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: "evil.other-domain.example",
+      recordValue: "awcms-verify=abc123"
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { retryable: boolean }).retryable).toBe(false);
+    expect(requestCount).toBe(0);
+  });
+
+  test("surfaces a provider error without leaking the token or zone id", async () => {
+    behavior = "create-provider-error";
+    const provider = makeProvider();
+    const result = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      recordValue: "awcms-verify=abc123"
+    });
+
+    expect(result.ok).toBe(false);
+    const error = (result as { error: string }).error;
+    expect(error).not.toContain("super-secret-token-value");
+    expect(error).not.toContain("super-secret-zone-value");
+    // Only the numeric Cloudflare error code is surfaced, never `.message`.
+    expect(error).toContain("1004");
+    expect(error).not.toContain("DNS Validation Error");
+  });
+
+  test("checkVerificationStatus surfaces a provider error without leaking the token", async () => {
+    behavior = "list-provider-error";
+    const provider = makeProvider();
+    const result = await provider.checkVerificationStatus({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      expectedValue: "awcms-verify=abc123"
+    });
+
+    expect(result.ok).toBe(false);
+    const error = (result as { error: string }).error;
+    expect(error).not.toContain("super-secret-token-value");
+    expect(error).not.toContain("super-secret-zone-value");
+  });
+
+  test("times out a wedged provider instead of hanging forever, without leaking secrets", async () => {
+    behavior = "slow";
+    const provider = makeProvider(20);
+    const result = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      recordValue: "awcms-verify=abc123"
+    });
+
+    expect(result.ok).toBe(false);
+    const error = (result as { error: string }).error;
+    expect(error).toMatch(/timed out/i);
+    expect(error).not.toContain("super-secret-token-value");
+    expect(error).not.toContain("super-secret-zone-value");
+  });
+
+  test("checkVerificationStatus reports verified=true when a matching record exists", async () => {
+    behavior = "existing-match";
+    const provider = makeProvider();
+    const result = await provider.checkVerificationStatus({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      expectedValue: "awcms-verify=abc123"
+    });
+
+    expect(result).toEqual({ ok: true, verified: true });
+  });
+
+  test("checkVerificationStatus reports verified=false when no record matches", async () => {
+    const provider = makeProvider();
+    const result = await provider.checkVerificationStatus({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      expectedValue: "awcms-verify=does-not-match"
+    });
+
+    expect(result).toEqual({ ok: true, verified: false });
+  });
+
+  test("checkVerificationStatus normalizes CNAME comparison (trailing dot, case)", async () => {
+    // A fresh server/provider pair whose GET response echoes a CNAME value
+    // with different case and a trailing dot, to prove comparison
+    // normalizes both before matching.
+    server.stop(true);
+    server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "GET") {
+          return Response.json({
+            success: true,
+            errors: [],
+            result: [
+              {
+                id: "r1",
+                type: "CNAME",
+                name: "tenant1.platform.example",
+                content: "Edge.AWCMS-Mini.Example."
+              }
+            ]
+          });
+        }
+        return Response.json({ success: true, errors: [], result: {} });
+      }
+    });
+
+    const cnameProvider = createCloudflareDnsProvider({
+      zoneId: "super-secret-zone-value",
+      apiToken: "super-secret-token-value",
+      platformRootDomain: ROOT_DOMAIN,
+      baseUrl: `http://127.0.0.1:${server.port}`
+    });
+
+    const result = await cnameProvider.checkVerificationStatus({
+      recordType: "CNAME",
+      recordName: "tenant1.platform.example",
+      expectedValue: "edge.awcms-mini.example"
+    });
+
+    expect(result).toEqual({ ok: true, verified: true });
+  });
+
+  test("opens the circuit breaker after consecutive failures and short-circuits without calling the network", async () => {
+    behavior = "create-provider-error";
+    const provider = makeProvider();
+
+    for (let i = 0; i < 5; i += 1) {
+      const result = await provider.createVerificationRecord({
+        recordType: "TXT",
+        recordName: "tenant1.platform.example",
+        recordValue: `awcms-verify=attempt-${i}`
+      });
+      expect(result.ok).toBe(false);
+    }
+
+    const countBeforeSixth = requestCount;
+
+    const sixth = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      recordValue: "awcms-verify=attempt-6"
+    });
+
+    expect(sixth.ok).toBe(false);
+    expect((sixth as { error: string }).error).toMatch(/circuit breaker/i);
+    expect(requestCount).toBe(countBeforeSixth);
+  });
+});
+
+describe("resolveTenantDomainDnsProvider (missing env behavior)", () => {
+  afterEach(() => {
+    resetProviderCircuitBreakersForTests();
+  });
+
+  test("defaults to a safe manual-mode stub when TENANT_DOMAIN_DNS_PROVIDER is unset", async () => {
+    const provider = resolveTenantDomainDnsProvider({} as NodeJS.ProcessEnv);
+    const result = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      recordValue: "awcms-verify=abc123"
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/manual/i);
+  });
+
+  test("returns a safe stub for an unknown provider value", async () => {
+    const provider = resolveTenantDomainDnsProvider({
+      TENANT_DOMAIN_DNS_PROVIDER: "route53"
+    } as NodeJS.ProcessEnv);
+    const result = await provider.checkVerificationStatus({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      expectedValue: "awcms-verify=abc123"
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(
+      /not a known provider/i
+    );
+  });
+
+  test("returns a safe stub when cloudflare is selected but required vars are missing", async () => {
+    const provider = resolveTenantDomainDnsProvider({
+      TENANT_DOMAIN_DNS_PROVIDER: "cloudflare"
+    } as NodeJS.ProcessEnv);
+    const result = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: "tenant1.platform.example",
+      recordValue: "awcms-verify=abc123"
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(
+      /TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN/
+    );
+  });
+
+  test("reaches real validation logic (not the misconfigured stub) once cloudflare is fully configured", async () => {
+    const provider = resolveTenantDomainDnsProvider({
+      TENANT_DOMAIN_DNS_PROVIDER: "cloudflare",
+      TENANT_DOMAIN_CLOUDFLARE_ZONE_ID: "zone-abc",
+      TENANT_DOMAIN_CLOUDFLARE_API_TOKEN: "token-xyz",
+      TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN: "platform.example"
+    } as NodeJS.ProcessEnv);
+
+    // No fake server involved — this input fails the pure validation step
+    // before any network call would be attempted, proving the resolver
+    // wired up the real adapter rather than the "not configured" stub
+    // (whose error text never mentions "platform root domain").
+    const result = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: "evil.other-domain.example",
+      recordValue: "awcms-verify=abc123"
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(
+      /platform root domain/i
+    );
+  });
+});

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -6,6 +6,7 @@ import {
   checkR2Config,
   checkRequiredVars,
   checkSyncConfig,
+  checkTenantDomainDnsConfig,
   runEnvValidation
 } from "../scripts/validate-env";
 
@@ -333,6 +334,76 @@ describe("checkPublicRoutingConfig", () => {
   });
 });
 
+describe("checkTenantDomainDnsConfig", () => {
+  test("passes (single check) when TENANT_DOMAIN_DNS_PROVIDER is not set", () => {
+    const results = checkTenantDomainDnsConfig({} as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("passes (single check) when TENANT_DOMAIN_DNS_PROVIDER=manual", () => {
+    const results = checkTenantDomainDnsConfig({
+      TENANT_DOMAIN_DNS_PROVIDER: "manual"
+    } as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("fails when TENANT_DOMAIN_DNS_PROVIDER is not a known provider", () => {
+    const results = checkTenantDomainDnsConfig({
+      TENANT_DOMAIN_DNS_PROVIDER: "route53"
+    } as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("fail");
+  });
+
+  test("fails and names each missing Cloudflare var when TENANT_DOMAIN_DNS_PROVIDER=cloudflare", () => {
+    const results = checkTenantDomainDnsConfig({
+      TENANT_DOMAIN_DNS_PROVIDER: "cloudflare"
+    } as NodeJS.ProcessEnv);
+
+    const failedNames = results
+      .filter((result) => result.status === "fail")
+      .map((result) => result.name)
+      .sort();
+
+    expect(failedNames).toEqual(
+      [
+        "TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN",
+        "TENANT_DOMAIN_CLOUDFLARE_ZONE_ID",
+        "TENANT_DOMAIN_CLOUDFLARE_API_TOKEN"
+      ].sort()
+    );
+  });
+
+  test("all pass when TENANT_DOMAIN_DNS_PROVIDER=cloudflare and every var is set", () => {
+    const results = checkTenantDomainDnsConfig({
+      TENANT_DOMAIN_DNS_PROVIDER: "cloudflare",
+      TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN: "platform.example",
+      TENANT_DOMAIN_CLOUDFLARE_ZONE_ID: "zone-abc",
+      TENANT_DOMAIN_CLOUDFLARE_API_TOKEN: "a-real-token"
+    } as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("never includes the configured API token in any result detail", () => {
+    const results = checkTenantDomainDnsConfig({
+      TENANT_DOMAIN_DNS_PROVIDER: "cloudflare",
+      TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN: "platform.example",
+      TENANT_DOMAIN_CLOUDFLARE_ZONE_ID: "zone-abc",
+      TENANT_DOMAIN_CLOUDFLARE_API_TOKEN: "super-secret-token-value"
+    } as NodeJS.ProcessEnv);
+
+    for (const result of results) {
+      expect(result.detail).not.toContain("super-secret-token-value");
+    }
+  });
+});
+
 describe("runEnvValidation", () => {
   test("passes end-to-end for a minimal valid env (sync/R2/email all off)", () => {
     const env = {
@@ -382,6 +453,31 @@ describe("runEnvValidation", () => {
       R2_ENABLED: "false",
       EMAIL_ENABLED: "false",
       PUBLIC_TENANT_RESOLUTION_MODE: "host_default"
+    } as NodeJS.ProcessEnv;
+
+    const results = runEnvValidation(env);
+    expect(results.some((result) => result.status === "fail")).toBe(true);
+  });
+
+  test("passes end-to-end when TENANT_DOMAIN_DNS_PROVIDER is left unset (manual default, Issue #567)", () => {
+    const env = {
+      ...VALID_ENV,
+      AWCMS_MINI_SYNC_ENABLED: "false",
+      R2_ENABLED: "false",
+      EMAIL_ENABLED: "false"
+    } as NodeJS.ProcessEnv;
+
+    const results = runEnvValidation(env);
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("fails end-to-end when TENANT_DOMAIN_DNS_PROVIDER=cloudflare is missing its required vars", () => {
+    const env = {
+      ...VALID_ENV,
+      AWCMS_MINI_SYNC_ENABLED: "false",
+      R2_ENABLED: "false",
+      EMAIL_ENABLED: "false",
+      TENANT_DOMAIN_DNS_PROVIDER: "cloudflare"
     } as NodeJS.ProcessEnv;
 
     const results = runEnvValidation(env);


### PR DESCRIPTION
## Summary
- Final issue of epic #555. Adds an **optional** Cloudflare DNS adapter as a provider boundary for the `tenant_domain` module — manual domain management (Issue #562) remains the MVP default.
- New env vars gate provider selection: `TENANT_DOMAIN_DNS_PROVIDER=manual|cloudflare`, `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN`, `TENANT_DOMAIN_CLOUDFLARE_ZONE_ID`, `TENANT_DOMAIN_CLOUDFLARE_API_TOKEN` — the three Cloudflare vars are required only when `cloudflare` is selected.
- `src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter.ts` — TXT/CNAME verification record creation, verification-status checks, redacted errors, timeout-bound (8s default) provider calls, circuit breaker reuse.

## Scope decision
This adapter is a **pure provider boundary, not wired into any route** — deliberately, per the issue's scope. A future issue is needed to wire it into `.../verify` or a subdomain-provisioning flow. This is documented consistently in the module README, the `awcms-mini-tenant-domain-routing` skill, doc 18, and the changeset so the next contributor doesn't mistake it for active.

## Security
- Cloudflare API token/zone ID are read only from env — never persisted to `awcms_mini_tenant_domains`/`awcms_mini_module_settings`, never rendered in any response, never logged (tested adversarially: a fake server echoes the token/zone id in its error message, and the adapter still only ever surfaces Cloudflare's numeric `errors[].code`, never `.message`).
- `validateDnsRecordInput` rejects any `recordName` outside `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` before any network call (zero requests on rejection, tested).
- Timeout-bounded via a real `Promise.race` (`src/lib/integration/timeout.ts`), proven with a wedged-server test.
- Not run inside any DB transaction — enforced by construction (file never opens `sql.begin`), and unreachable anyway since nothing calls it yet.
- Manual mode remains fully functional with zero Cloudflare env vars set.

## Review chain
- `awcms-mini-coder`: implemented the adapter, config module, and env-validation wiring; full `bun test` against real Postgres (1149 pass, 0 fail), lint/typecheck/build/api:spec:check/check:docs all green.
- `awcms-mini-reviewer`: **Approve** — verified every acceptance criterion in Issue #567 against actual code and tests; no critical/security/functional/testing/documentation gaps found.
- `awcms-mini-security-auditor`: **PASS** — no Critical/High findings. Two Low/informational notes for a future wiring issue (timeout not yet env-tunable; underscore-prefixed labels like `_acme-challenge` are intentionally allowed). Confirmed via grep the adapter has zero live callers today, so there's no active attack surface.

## Test plan
- [x] `bun test tests/unit/cloudflare-dns-adapter.test.ts` — pass
- [x] `bun test tests/validate-env.test.ts` — pass
- [x] `bun run config:validate`
- [x] Full `bun test` against real PostgreSQL — 1149 pass, 0 fail
- [x] `bun run lint` / `bun run typecheck` / `bun run check:docs` / `bun run api:spec:check` / `bun run build` — all pass

## Docs
Updated `src/modules/tenant-domain/README.md`, `docs/awcms-mini/18_configuration_env_reference.md`, `.env.example`, and `.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md` (marks epic #555 / issues #556-#567 100% complete, adds a Cloudflare DNS adapter section, and records the wiring constraints a follow-up issue must respect).

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)