### PR TITLE
docs(github): close epic #555 and its 5 stale-open children, refresh snapshot

### DIFF
--- a/.claude/skills/awcms-mini-github-snapshot/SKILL.md
+++ b/.claude/skills/awcms-mini-github-snapshot/SKILL.md
@@ -9,6 +9,28 @@ Ikuti `docs/awcms-mini/github/README.md`. Snapshot ini adalah salinan
 faktual state GitHub (issue, label, milestone, security alert) — bukan
 backlog rencana (itu tetap `docs/awcms-mini/06_github_issues_detail.md`).
 
+## Sebelum refresh: cek issue yang PR-nya sudah merge tapi belum ke-close
+
+**Recurring, sudah terjadi dua kali** (epic `blog_content` #537-#540;
+epic online public tenant routing #556-#560): PR di repo ini kadang tidak
+menyertakan kata kunci `Closes #NNN` di body-nya, jadi merge PR **tidak**
+otomatis menutup issue terkait — issue-nya tertinggal `open` di GitHub
+walau kodenya sudah live di `main`. `gh issue list --state open` saja
+**tidak cukup** untuk tahu backlog nyata (lihat memori
+`pr-body-missing-closes-keyword`). Sebelum menjalankan refresh:
+
+```bash
+gh issue list --state open --limit 50 --json number,title
+gh pr list --state merged --limit 30 --json number,title,mergedAt
+```
+
+Cocokkan tiap issue open dengan judul PR yang menyebut nomor issue itu
+(pola judul di repo ini: `... (Issue #NNN)`). Untuk setiap match yang
+PR-nya sudah `mergedAt` terisi, tutup issue-nya manual dengan komentar
+yang menyebut PR penutupnya, baru lanjut ke command refresh di bawah —
+jangan biarkan refresh berjalan dengan open-issue count yang sebenarnya
+sudah salah.
+
 ## Command
 
 ```bash

--- a/docs/awcms-mini/github/README.md
+++ b/docs/awcms-mini/github/README.md
@@ -5,10 +5,10 @@ Dokumen ini mencatat snapshot live repository GitHub `ahliweb/awcms-mini`. Folde
 | Metadata     | Nilai                           |
 | ------------ | ------------------------------- |
 | Repository   | `ahliweb/awcms-mini`            |
-| Snapshot     | 2026-07-08T01:11:10.873Z        |
-| Total issue  | 94                              |
+| Snapshot     | 2026-07-09T03:50:52.565Z        |
+| Total issue  | 107                             |
 | Open issue   | 0                               |
-| Closed issue | 94                              |
+| Closed issue | 107                             |
 | Labels       | 99 (25 doc 06 + 74 peninggalan) |
 | Milestones   | 25 (6 doc 06 + 19 peninggalan)  |
 
@@ -17,7 +17,7 @@ Dokumen ini mencatat snapshot live repository GitHub `ahliweb/awcms-mini`. Folde
 | State           | File                                         |                                         Jumlah issue |
 | --------------- | -------------------------------------------- | ---------------------------------------------------: |
 | OPEN            | [issues-open-001.md](issues-open-001.md)     |                                                    0 |
-| CLOSED          | [issues-closed-001.md](issues-closed-001.md) |                                                   94 |
+| CLOSED          | [issues-closed-001.md](issues-closed-001.md) |                                                  107 |
 | LABEL/MILESTONE | [labels-milestones.md](labels-milestones.md) |                             99 labels, 25 milestones |
 | SECURITY        | [security.md](security.md)                   | Security policy, Dependabot, secret scanning, CodeQL |
 
@@ -65,10 +65,45 @@ Update juga metadata di `docs/awcms-mini/README.md`, `06_github_issues_detail.md
 
 ## Ringkasan state saat snapshot
 
-| State  | Jumlah | Catatan                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ------ | -----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| OPEN   |      0 | Tidak ada issue open — seluruh backlog (doc06 dan pasca-doc06) sudah `completed`/`not planned`.                                                                                                                                                                                                                                                                                                                                                                           |
-| CLOSED |     94 | 20 issue domain ditutup `not planned`; 18 issue backlog doc06 (#371-#373, #376-#379, #391-#393, #398, #401, #403-#408) ditutup `completed`; epic M9 (#433-#438, #447), 12 issue pasca-analisis lanjutan (#450-#454, #461-#465, #473, #475), epic reusable wizard form (#479, #481-#485), epic reusable email module (#492-#500), epic Module Management (#510-#522), dan epic blog_content (#536-#543) ditutup `completed` di luar backlog doc06 — lihat bagian di bawah. |
+| State  | Jumlah | Catatan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------ | -----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| OPEN   |      0 | Tidak ada issue open — seluruh backlog (doc06 dan pasca-doc06) sudah `completed`/`not planned`.                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| CLOSED |    107 | 20 issue domain ditutup `not planned`; 18 issue backlog doc06 (#371-#373, #376-#379, #391-#393, #398, #401, #403-#408) ditutup `completed`; epic M9 (#433-#438, #447), 12 issue pasca-analisis lanjutan (#450-#454, #461-#465, #473, #475), epic reusable wizard form (#479, #481-#485), epic reusable email module (#492-#500), epic Module Management (#510-#522), epic blog_content (#536-#543), dan epic online public tenant routing (#555-#567) ditutup `completed` di luar backlog doc06 — lihat bagian di bawah. |
+
+### Epic online public tenant routing #555-#567 completed (2026-07-08 s.d. 2026-07-09)
+
+Epic kedua yang mendaftarkan modul domain langsung di repo base ini
+(setelah `blog_content`) — menambah `tenant_domain` module dan online-primary
+public routing tanpa menghapus kapabilitas offline/LAN-first. Dua belas
+issue anak, seluruhnya `completed`:
+
+- **[#556](https://github.com/ahliweb/awcms-mini/issues/556)** — config online public tenant routing mode (`PUBLIC_TENANT_RESOLUTION_MODE` dkk.), fallback offline/LAN dipertahankan. PR [#568](https://github.com/ahliweb/awcms-mini/pull/568).
+- **[#557](https://github.com/ahliweb/awcms-mini/issues/557)** — schema `awcms_mini_tenant_domains` (migration 031), RLS, unique index primary-dedup. PR [#569](https://github.com/ahliweb/awcms-mini/pull/569).
+- **[#558](https://github.com/ahliweb/awcms-mini/issues/558)** — descriptor module `tenant_domain` terdaftar di `listModules()`. PR [#570](https://github.com/ahliweb/awcms-mini/pull/570).
+- **[#559](https://github.com/ahliweb/awcms-mini/issues/559)** — `resolvePublicTenantFromRequest` (host/domain -> env/setup default -> 404 generic), migration 033 timing-parity. PR [#571](https://github.com/ahliweb/awcms-mini/pull/571).
+- **[#560](https://github.com/ahliweb/awcms-mini/issues/560)** — rute publik `/news` (index/slug/category/tag/search/feed/sitemap), reuse resolver #559. PR [#572](https://github.com/ahliweb/awcms-mini/pull/572).
+- **[#561](https://github.com/ahliweb/awcms-mini/issues/561)** — `/blog/{tenantCode}` didokumentasikan legacy (ADR-0010), tidak dihapus. PR [#573](https://github.com/ahliweb/awcms-mini/pull/573).
+- **[#562](https://github.com/ahliweb/awcms-mini/issues/562)** — API manajemen tenant domain (CRUD, verify, set-primary), idempotency + audit. PR [#574](https://github.com/ahliweb/awcms-mini/pull/574).
+- **[#563](https://github.com/ahliweb/awcms-mini/issues/563)** — admin UI domain/subdomain management. PR [#575](https://github.com/ahliweb/awcms-mini/pull/575).
+- **[#564](https://github.com/ahliweb/awcms-mini/issues/564)** — tenant settings untuk `/news` route dan legacy route behavior (`publicRouteMode`). PR [#577](https://github.com/ahliweb/awcms-mini/pull/577).
+- **[#565](https://github.com/ahliweb/awcms-mini/issues/565)** — tenant module presets (`online_website`/`news_portal`/`saas_online`/`pos_lan`/`minimal`), service layer. PR [#578](https://github.com/ahliweb/awcms-mini/pull/578).
+- **[#566](https://github.com/ahliweb/awcms-mini/issues/566)** — layar admin tenant-module matrix, single-tenant scope. PR [#579](https://github.com/ahliweb/awcms-mini/pull/579).
+- **[#567](https://github.com/ahliweb/awcms-mini/issues/567)** — adapter Cloudflare DNS opsional, provider boundary saja (belum di-wire ke rute). PR [#580](https://github.com/ahliweb/awcms-mini/pull/580).
+
+Empat follow-up non-blocking dari rantai security audit epic ini juga
+ditutup sebelum snapshot ini: race idempotency-store lintas-modul
+(PR [#581](https://github.com/ahliweb/awcms-mini/pull/581)), value-shape
+heuristic untuk module settings
+(PR [#582](https://github.com/ahliweb/awcms-mini/pull/582)), single-module
+lookup untuk gate publik `/news`
+(PR [#583](https://github.com/ahliweb/awcms-mini/pull/583)), dan timeout
+adapter Cloudflare yang env-tunable
+(PR [#584](https://github.com/ahliweb/awcms-mini/pull/584)).
+
+Sama seperti epic `blog_content` sebelumnya: #556-#560 sempat tertinggal
+`open` di GitHub selama ~1 hari meski PR-nya sudah merge (badan PR tidak
+menyertakan kata kunci `Closes #NNN`) — ditutup manual bersama epic
+#555 sendiri saat refresh snapshot ini.
 
 ### Epic blog_content #536-#543 completed (2026-07-07 s.d. 2026-07-08)
 

--- a/docs/awcms-mini/github/issues-closed-001.md
+++ b/docs/awcms-mini/github/issues-closed-001.md
@@ -3,11 +3,11 @@
 | Metadata           | Nilai                                                                                                                                    |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | Repository         | `ahliweb/awcms-mini`                                                                                                                     |
-| Snapshot           | 2026-07-08T01:11:10.873Z                                                                                                                 |
+| Snapshot           | 2026-07-09T03:50:52.565Z                                                                                                                 |
 | State              | `CLOSED`                                                                                                                                 |
 | File page          | 1/1                                                                                                                                      |
 | Max issue per file | 100                                                                                                                                      |
-| Issue dalam file   | 94                                                                                                                                       |
+| Issue dalam file   | 107                                                                                                                                      |
 | Range              | #371-#454 (#409-#432, #439-#446, #448-#449, #455-#460 adalah nomor PR, bukan issue — issue/PR berbagi satu urutan nomor per repo GitHub) |
 
 > File ini adalah snapshot dari GitHub. Refresh dengan proses di `docs/awcms-mini/github/README.md` bila state issue berubah.
@@ -123,6 +123,19 @@ Ditutup `completed` pada 2026-07-06 s.d. 2026-07-07, setelah seluruh 18 issue ba
 | [#541](https://github.com/ahliweb/awcms-mini/issues/541) | Issue 5: Implement Revisions and Scheduled Publishing                                                                               | -                                            |
 | [#542](https://github.com/ahliweb/awcms-mini/issues/542) | Issue 6: Implement Templates, Menus, Widgets, Media/Gallery, Multilingual, Theme Mode, and Ads                                      | -                                            |
 | [#543](https://github.com/ahliweb/awcms-mini/issues/543) | Issue 7: Implement Admin UI, Documentation, and Final Hardening for blog_content                                                    | -                                            |
+| [#555](https://github.com/ahliweb/awcms-mini/issues/555) | epic: online public tenant routing, news routes, and tenant domain management                                                       | -                                            |
+| [#556](https://github.com/ahliweb/awcms-mini/issues/556) | feat(config): add online public tenant routing mode while preserving offline/LAN fallback                                           | -                                            |
+| [#557](https://github.com/ahliweb/awcms-mini/issues/557) | feat(tenant-domain): add tenant domain and subdomain mapping schema                                                                 | -                                            |
+| [#558](https://github.com/ahliweb/awcms-mini/issues/558) | feat(tenant-domain): register tenant domain management module descriptor                                                            | -                                            |
+| [#559](https://github.com/ahliweb/awcms-mini/issues/559) | feat(tenant): resolve public tenant by host with safe fallback                                                                      | -                                            |
+| [#560](https://github.com/ahliweb/awcms-mini/issues/560) | feat(blog-content): add /news public routes using default public tenant resolver                                                    | -                                            |
+| [#561](https://github.com/ahliweb/awcms-mini/issues/561) | docs(blog-content): mark /blog/{tenantCode} as legacy and document /news as default public route                                    | -                                            |
+| [#562](https://github.com/ahliweb/awcms-mini/issues/562) | feat(tenant-domain): add tenant domain management API                                                                               | -                                            |
+| [#563](https://github.com/ahliweb/awcms-mini/issues/563) | feat(tenant-domain): add admin UI for domain and subdomain management                                                               | -                                            |
+| [#564](https://github.com/ahliweb/awcms-mini/issues/564) | feat(blog-content): add tenant settings for news route and legacy route behavior                                                    | -                                            |
+| [#565](https://github.com/ahliweb/awcms-mini/issues/565) | feat(module-management): add tenant module presets for online, news, LAN, and minimal profiles                                      | -                                            |
+| [#566](https://github.com/ahliweb/awcms-mini/issues/566) | feat(module-management): add tenant-module matrix management screen                                                                 | -                                            |
+| [#567](https://github.com/ahliweb/awcms-mini/issues/567) | feat(tenant-domain): add optional Cloudflare DNS adapter for managed platform subdomains                                            | -                                            |
 
 <!-- github-snapshot:closed-issues-post-doc06:end -->
 <!-- Regenerated by `bun run github:snapshot:refresh` (Issue #464) between the

--- a/docs/awcms-mini/github/issues-open-001.md
+++ b/docs/awcms-mini/github/issues-open-001.md
@@ -3,7 +3,7 @@
 | Metadata           | Nilai                    |
 | ------------------ | ------------------------ |
 | Repository         | `ahliweb/awcms-mini`     |
-| Snapshot           | 2026-07-08T01:11:10.873Z |
+| Snapshot           | 2026-07-09T03:50:52.565Z |
 | State              | `OPEN`                   |
 | File page          | 1/1                      |
 | Max issue per file | 100                      |

--- a/docs/awcms-mini/github/labels-milestones.md
+++ b/docs/awcms-mini/github/labels-milestones.md
@@ -3,7 +3,7 @@
 | Metadata         | Nilai                    |
 | ---------------- | ------------------------ |
 | Repository       | `ahliweb/awcms-mini`     |
-| Snapshot         | 2026-07-08T01:11:10.873Z |
+| Snapshot         | 2026-07-09T03:50:52.565Z |
 | Total labels     | 99                       |
 | Total milestones | 25                       |
 

--- a/docs/awcms-mini/github/security.md
+++ b/docs/awcms-mini/github/security.md
@@ -1,6 +1,6 @@
 # GitHub Security Setup AWCMS-Mini
 
-Snapshot: 2026-07-08T01:11:10.873Z
+Snapshot: 2026-07-09T03:50:52.565Z
 
 Dokumen ini mencatat konfigurasi GitHub Security untuk `ahliweb/awcms-mini`: Bun + Astro 7 + PostgreSQL, base generik selesai (v0.23.5). Baris konfigurasi diperbarui saat setup berubah (baris CodeQL code scanning disegarkan untuk Issue #452 — coverage `javascript-typescript`); metrik point-in-time (alert count, commit run) mengikuti timestamp snapshot di atas dan disegarkan lewat §Proses Refresh. Refresh 2026-07-06 (Issue #461): dua temuan nyata dari scan `javascript-typescript` pertama (alert #8 `js/file-system-race`, #9 `js/unused-local-variable`) diperbaiki dan dikonfirmasi `state: fixed` via API — lihat §Alert Count Saat Setup.
 
@@ -20,7 +20,7 @@ Dokumen ini mencatat konfigurasi GitHub Security untuk `ahliweb/awcms-mini`: Bun
 | Secret scanning validity checks       | Disabled pada GitHub saat setup                                                                                                                                                                                     |
 | Code scanning                         | Enabled lewat `.github/workflows/codeql.yml` untuk GitHub Actions **dan** `javascript-typescript` (source TypeScript/Astro, Issue #452); default setup `not-configured` agar tidak konflik dengan advanced workflow |
 | Private vulnerability reporting       | Enabled; gunakan link GitHub advisory di `SECURITY.md`                                                                                                                                                              |
-| Latest CodeQL run                     | Success pada `main` commit `dba8b10` (2026-07-08T01:04:51Z)                                                                                                                                                         |
+| Latest CodeQL run                     | Success pada `main` commit `2c8888b` (2026-07-09T03:47:32Z)                                                                                                                                                         |
 
 ## Alert Count Saat Setup
 


### PR DESCRIPTION
## Summary
- Analyzed open GitHub issues against merged PRs (per the recurring "PR merged but issue never auto-closed" gap this repo has hit before with the blog_content epic): issues #556-#560 were all done — their PRs (#568-#572) merged 2026-07-08 — but stayed open because those PR bodies never included a `Closes #NNN` keyword.
- Closed #556, #557, #558, #559, #560 individually, each with a comment naming the PR that resolved it.
- Closed epic #555 itself last, with a full summary of all 12 child issues (#556-#567) and the 4 post-merge security-audit follow-ups (#581-#584) that came out of this epic's review chain.
- Result: **0 open issues** (was 6), 107 closed (was 101).

## Docs
- Refreshed `docs/awcms-mini/github/` via `bun run github:snapshot:refresh` (mechanical tables: snapshot timestamp, issue counts, closed-issues list).
- Added a hand-written "Epic online public tenant routing #555-#567 completed" narrative section to `docs/awcms-mini/github/README.md`, matching the existing blog_content epic section's structure exactly (per-issue one-liner + PR link, plus the 4 follow-up PRs).
- Updated skill `awcms-mini-github-snapshot`: added an explicit pre-refresh step to cross-check open issues against merged PRs before trusting the open-issue count — this exact gap has now recurred twice (blog_content epic, this epic), so it's now a documented part of the workflow instead of something that has to be rediscovered each time.

## Test plan
- [x] `bun run lint` / `bun run check:docs` — pass.
- [x] Full `bun test` against real PostgreSQL — 1168 pass, 0 fail (docs/skill-only change, no test-affecting code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)