### PR TITLE
docs+skills: fix 8 verified drift findings from repo-wide consistency audit

### DIFF
--- a/.claude/skills/awcms-mini-abac-guard/SKILL.md
+++ b/.claude/skills/awcms-mini-abac-guard/SKILL.md
@@ -44,7 +44,9 @@ type AccessRequest = {
     | "check"
     | "publish"
     | "schedule"
-    | "archive";
+    | "archive"
+    | "verify"
+    | "set_primary"; // Issue #562 (tenant_domain) — see access-control.ts's own comment for why neither is in HIGH_RISK_ACTIONS
   resourceType?: string;
   resourceId?: string;
   resourceAttributes?: Record<string, unknown>;

--- a/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md
@@ -49,13 +49,13 @@ Enam env var baru, semuanya **opsional** dan backward-compatible — kalau
 tidak diset sama sekali, `config:validate` tetap PASS dan perilaku tetap
 offline/LAN-first (`tenant_code_legacy` implisit):
 
-- `PUBLIC_TENANT_RESOLUTION_MODE` — enum `host_default | env_default | setup_default | tenant_code_legacy`. Divalidasi `isKnownPublicTenantResolutionMode` (`scripts/validate-env.ts:114`); value lain gagal validasi dengan pesan daftar value yang sah.
+- `PUBLIC_TENANT_RESOLUTION_MODE` — enum `host_default | env_default | setup_default | tenant_code_legacy`. Divalidasi `isKnownPublicTenantResolutionMode` (`scripts/validate-env.ts`, cari nama fungsinya — nomor baris di file ini bergeser tiap ada penyisipan check baru di atasnya, jangan percaya angka baris statis); value lain gagal validasi dengan pesan daftar value yang sah.
 - `PUBLIC_DEFAULT_TENANT_ID` / `PUBLIC_DEFAULT_TENANT_CODE` — wajib **minimal salah satu** saat mode `env_default` (bukan keduanya).
 - `PUBLIC_PLATFORM_ROOT_DOMAIN` — wajib saat mode `host_default` (landasan untuk resolver berbasis host di Issue #559 — tanpa root domain, resolver tidak bisa membedakan subdomain tenant valid dari `Host` header sembarangan).
-- `PUBLIC_CANONICAL_BASE_PATH` — default `/news` (belum ada rute nyata di sana sampai #560), divalidasi `isValidCanonicalBasePath` (`scripts/validate-env.ts:129`): wajib absolute path (`/...`), tanpa whitespace, tanpa `//`, tanpa trailing slash kecuali `/` itu sendiri. Divalidasi **selalu**, independen dari mode.
+- `PUBLIC_CANONICAL_BASE_PATH` — default `/news` (belum ada rute nyata di sana sampai #560), divalidasi `isValidCanonicalBasePath` (`scripts/validate-env.ts`, cari nama fungsinya): wajib absolute path (`/...`), tanpa whitespace, tanpa `//`, tanpa trailing slash kecuali `/` itu sendiri. Divalidasi **selalu**, independen dari mode.
 - `PUBLIC_TRUST_PROXY` — default `false` (aman). Kalau `true`, app **wajib** jalan di belakang reverse proxy tepercaya yang men-sanitize `X-Forwarded-Host` — jangan pernah percaya header itu tanpa proxy tepercaya di depan (catatan keamanan eksplisit epic #555, relevan untuk resolver #559).
 
-Entry point: `checkPublicRoutingConfig()` (`scripts/validate-env.ts:304`),
+Entry point: `checkPublicRoutingConfig()` (`scripts/validate-env.ts`, cari nama fungsinya),
 dipanggil dari `runEnvValidation()`. Semua pesan fail hanya menyebut nama
 var, tidak pernah value-nya (pola sama seperti check lain di file ini) —
 kecuali `PUBLIC_CANONICAL_BASE_PATH`/`PUBLIC_TENANT_RESOLUTION_MODE` yang
@@ -381,8 +381,10 @@ memusatkan dua langkah wajib sebelum query post apa pun:
    seluruh helper return `null`.
 2. **Module-disabled gate (acceptance criterion eksplisit Issue #560, DAN
    gap yang belum ada bahkan di `/blog/{tenantCode}` existing)**: setelah
-   tenant resolve, `fetchTenantModuleEntries(tx, tenantId)`
-   (`module-management/application/tenant-module-lifecycle.ts`, sudah ada)
+   tenant resolve, `fetchTenantModuleEntry(tx, tenantId, "blog_content")`
+   (`module-management/application/tenant-module-lifecycle.ts` — single-module
+   narrowing dari `fetchTenantModuleEntries`, lihat "Sudah diperbaiki" di
+   bawah untuk alasannya)
    dipanggil **di dalam** `withTenant(...)` yang sama, **sebelum** `handler`
    (yang query post) dijalankan. Kalau entry `blog_content`'s
    `tenantEnabled === false`, helper return `null` — rute memetakannya ke

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -154,15 +154,17 @@ metadata, `ModuleDescriptor.permissions`) and the actual
   it to write permissions too is a real, separate capability the
   acceptance criteria for this issue doesn't actually require (only the
   read-side report does), so it's left out rather than half-built.
-- **Only `module_management` and `blog_content`'s descriptors currently
-  declare `permissions`** (`blog_content` added its full 36-entry array in
-  Issue #543, closing epic #536 — grep `permissions:` across
-  `src/modules/*/module.ts` to confirm which modules declare it as code
-  evolves). The other 9 registered modules' permissions (email,
-  form-drafts, identity-access, logging, profile-identity, reporting,
-  sync-storage, tenant-admin, workflow-approval) were seeded directly by
-  their own migrations, e.g. migration 005/010/014, without ever being
-  added to their `module.ts`. This means every one of those 9 modules'
+- **Only `module_management`, `blog_content`, and `tenant_domain`'s
+  descriptors currently declare `permissions`** (`blog_content` added its
+  full 36-entry array in Issue #543, closing epic #536; `tenant_domain`
+  added a six-entry array in Issue #558, epic #555 — grep `permissions:`
+  across `src/modules/*/module.ts` to confirm which modules declare it as
+  code evolves, since this list has already grown twice). The other 9
+  registered modules' permissions (email, form-drafts, identity-access,
+  logging, profile-identity, reporting, sync-storage, tenant-admin,
+  workflow-approval) were seeded directly by their own migrations, e.g.
+  migration 005/010/014, without ever being added to their `module.ts`.
+  This means every one of those 9 modules'
   catalog permissions legitimately shows as `orphaned` today — an honest
   reflection of incomplete descriptor metadata, not a real drift/incident.
   Backfilling every other module's `permissions` array is out of scope
@@ -202,9 +204,14 @@ each would risk _changing_ who sees them (their current checks are
 "holds any `identity_access.*`/`sync_storage.*` permission", not one
 specific permission key) — out of scope for this issue, which only needs
 to add the registry _alongside_ the existing items, not migrate them onto
-it. The registry-driven list is appended after those 4, currently
-surfacing exactly one entry: `module_management`'s own `/admin/modules`.
-A failure loading the registry (e.g. a transient DB hiccup) falls back to
+it. The registry-driven list is appended after those 4 — at the time
+this was written it surfaced exactly one entry (`module_management`'s
+own `/admin/modules`); `blog_content` (`/admin/blog`, Issue #543) and
+`tenant_domain` (`/admin/tenant/domains`, Issue #563) have since added
+their own `navigation` entries, so it now surfaces three (grep
+`navigation:` across `src/modules/*/module.ts` to confirm the current
+count as more modules add entries). A failure loading the registry (e.g.
+a transient DB hiccup) falls back to
 an empty list — same defensive pattern as `tenantName`/`syncActive` above
 it — so it never hides the 4 hardcoded items or otherwise locks an admin
 out.
@@ -234,6 +241,9 @@ Job ownership (`ModuleDescriptor.jobs`) by module:
 - `form_drafts` — `form-drafts:purge`.
 - `email` — `email:dispatch`, `email:provider:health`,
   `email:templates:seed-defaults`.
+- `blog_content` — `blog:publish:scheduled` (Issue #541, epic #536 —
+  publishes every due `status='scheduled'` post; idempotent, no external
+  provider call, safe in any deployment profile).
 - `module_management` — `security:readiness`, `config:validate`,
   `production:preflight` (platform-wide/deployment-level checks that
   aren't owned by any single domain module — `module_management` is
@@ -322,8 +332,10 @@ also syncs the registry first (same reasoning as
 `/admin/modules/{moduleKey}` (full detail) — the last issue in epic #510.
 
 - **List**: catalog table + client-side type/status/health filters (pure
-  `data-*` attribute show/hide — only 10 modules exist in this base, a
-  server round-trip per filter change would be pure overhead) + a health
+  `data-*` attribute show/hide — only a dozen or so modules exist in this
+  base (12 as of epic #555, see `src/modules/index.ts`'s `modules` array
+  for the current count), a server round-trip per filter change would be
+  pure overhead) + a health
   status column (every module's `fetchModuleHealthReport`, #520, computed
   in parallel — each check is individually cheap/bounded by design, and
   this only runs on an explicit admin page load).

--- a/src/modules/tenant-domain/README.md
+++ b/src/modules/tenant-domain/README.md
@@ -97,22 +97,24 @@ uses `/blog/{tenantCode}` legacy routing never needs a domain mapping at
 all.
 
 `api.basePath: "/api/v1/tenant/domains"` and `navigation.path:
-"/admin/tenant/domains"` are declared now even though neither the API
-(#562) nor the admin UI (#563) exist yet, per this issue's own explicit
-descriptor requirements. Two consequences worth knowing about until those
-issues land:
+"/admin/tenant/domains"` were declared as part of this module's initial
+descriptor (Issue #558) even though neither the API (#562) nor the admin
+UI (#563) existed yet at that point, per this issue's own explicit
+descriptor requirements. Both have since shipped (#562's API landed real
+`/api/v1/tenant/domains` OpenAPI paths; #563's admin UI is live at
+`/admin/tenant/domains`), so the two consequences below were real only
+in the window between #558 and #562/#563 — kept here as history, not a
+live caveat:
 
 - Module Management's readiness check (`openApiDocumentedSignal`,
-  `application/health-registry.ts`) will report this module's
-  `openapi_documented` signal as `fail` until #562 adds real
-  `/api/v1/tenant/domains` paths to the OpenAPI document — this is
-  expected, not a regression.
+  `application/health-registry.ts`) reported this module's
+  `openapi_documented` signal as `fail` until #562 added real
+  `/api/v1/tenant/domains` paths to the OpenAPI document — expected at
+  the time, not a regression, and passing since #562 merged.
 - The navigation entry only ever appears in the admin sidebar for a
-  caller holding `tenant_domain.domains.read`, and (per §Permission seed)
-  no role has that permission yet. If an operator manually grants it via
-  Access & Users before #563 ships, the link will 404 — a known,
-  low-probability gap accepted for this issue rather than withholding the
-  descriptor requirement the issue asked for.
+  caller holding `tenant_domain.domains.read`. Before #563 shipped, a
+  role manually granted that permission early would have hit a 404 —
+  moot now that the admin UI exists at that path.
 
 `settings.defaults: { defaultVerificationMethod: "manual" }` — the only
 non-secret operational preference this module currently declares


### PR DESCRIPTION
## Summary
Repo-wide docs/skills-vs-code consistency audit, using the established pattern from PR #554 (3 parallel `general-purpose` agents split by area: scripts/docs, module READMEs, skills). This is a recurring bug class in this repo — confirmed a third time — and was worth re-running since epic #555 (~17 PRs) plus 4 follow-up security-audit fixes landed since the last audit.

8 verified findings, all fixed:

**`src/modules/module-management/README.md`**
- "Only `module_management` and `blog_content`'s descriptors...declare `permissions`" — `tenant_domain` also does now (Issue #558, 6-entry array), 3 modules total.
- "only 10 modules exist in this base" — actually 12 (`src/modules/index.ts`).
- Job ownership list omitted `blog_content`'s `blog:publish:scheduled` job (pre-existing gap since Issue #541/epic #536, not caused by the recent epic — found in the same pass).
- "registry-driven [nav] list...surfacing exactly one entry" — now 3 (`blog-content`'s `/admin/blog`, `tenant-domain`'s `/admin/tenant/domains` also declare `navigation`).

**`src/modules/tenant-domain/README.md`**
- Rewrote present-tense "will report...fail until #562"/"the link will 404" language into past-tense history — both #562 and #563 shipped long ago; the caveats were only ever true in the narrow window right after the module descriptor (#558) landed.

**`.claude/skills/awcms-mini-abac-guard/SKILL.md`**
- The skill's inline copy of the `AccessAction` union was missing `"verify"`/`"set_primary"` (added to the real union in `access-control.ts` for `tenant_domain`, Issue #562) — same union-drift bug class PR #535 fixed once before.

**`.claude/skills/awcms-mini-tenant-domain-routing/SKILL.md`**
- The `/news` module-disabled gate's live architecture description still said it calls the plural `fetchTenantModuleEntries`, contradicting the same file's own later "Sudah diperbaiki" section documenting the singular `fetchTenantModuleEntry` fix (PR #583) — an internal self-contradiction within one skill file.
- Three stale `scripts/validate-env.ts:NNN` line-number citations (all off by the same +34 lines, from a later insertion shifting everything below it) replaced with "find the function name" guidance instead of a number that will keep drifting.

## Test plan
- [x] `bun run lint` / `bun run check:docs` / `bun run typecheck` — pass.
- [x] Full `bun test` against real PostgreSQL — 1168 pass, 0 fail (docs/skill-only change, no regressions).
- [x] `bun run build` — pass.

## Not changed (checked, confirmed accurate)
Both `fetchTenantModuleEntries`/`fetchTenantModuleEntry` plural/singular usage across all real call sites, Cloudflare DNS adapter env vars and "not wired into any route" claim, `awcms-mini-idempotency`'s replay-on-race description, `awcms-mini-new-migration`'s `FORCE ROW LEVEL SECURITY` template (confirming the PR #554 fix wasn't reverted), and every `scripts/*.ts` vs its citing docs (validate-env, github-snapshot-refresh, production-preflight, security-readiness, api-spec-check) all matched current code exactly — no changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)