### PR TITLE
feat(auth): add full-online-only auth security feature gate (Issue #587)

### DIFF
--- a/.changeset/auth-online-security-gate.md
+++ b/.changeset/auth-online-security-gate.md
@@ -1,0 +1,33 @@
+---
+"awcms-mini": minor
+---
+
+Add the full-online-only auth security feature gate (Issue #587), the
+foundational config gate for the new full-online auth hardening epic
+(#587-#593): Cloudflare Turnstile (#588), MFA/TOTP (#589), Google OIDC
+login (#590), generic tenant OIDC SSO (#591), and an admin policy UI
+(#592) will all depend on this gate before doing anything online/
+provider-related — none of them exist yet in this repo, only the shared
+gate itself.
+
+Two new env vars, both optional/backward-compatible:
+`AUTH_ONLINE_SECURITY_ENABLED` (default `false`) and
+`AUTH_ONLINE_SECURITY_PROFILE` (default `disabled`, only other valid
+value `full_online`). Left unset — the default for every local/offline/
+LAN deployment — nothing changes and no provider credential is ever
+required. Setting `AUTH_ONLINE_SECURITY_ENABLED=true` requires
+`AUTH_ONLINE_SECURITY_PROFILE=full_online`; any other combination fails
+`bun run config:validate`.
+
+New `src/lib/auth/online-security-config.ts`: `isOnlineSecurityEnabled`,
+`resolveOnlineSecurityProfile`, and `isFullOnlineSecurityActive` — the
+one function every future full-online-only feature should call rather
+than re-deriving the "both vars must agree" rule itself. Also adds
+`checkOnlineAuthSecurityConfig` to `scripts/validate-env.ts` and
+`checkOnlineAuthSecurityReady` to `scripts/security-readiness.ts`
+(critical severity, but `status: pass` when the gate is simply
+disabled — informational, not a failure, per the issue's own
+acceptance criteria).
+
+Docs updated: `.env.example`, `docs/awcms-mini/18_configuration_env_reference.md`,
+`docs/awcms-mini/deployment-profiles.md`, `src/modules/identity-access/README.md`.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -37,6 +37,7 @@ Skill Claude Code tingkat-proyek untuk AWCMS-Mini. Setiap skill meng-encode stan
 | `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                          | 07, 06                         |
 | `awcms-mini-blog-content`                              | Kerjakan bagian mana pun epic blog_content (Issue #537-#543)                          | blog-content/README.md         |
 | `awcms-mini-tenant-domain-routing`                     | Kerjakan bagian mana pun epic online public routing & tenant domain (Issue #556-#567) | tenant-domain-routing/SKILL.md |
+| `awcms-mini-auth-online-hardening`                     | Kerjakan bagian mana pun epic full-online auth security hardening (Issue #587-#593)   | auth-online-hardening/SKILL.md |
 
 ## Katalog peningkatan (improvement/hardening)
 
@@ -95,6 +96,12 @@ flowchart TD
   TDR --> NM
   TDR --> BLOG
   TDR --> MM[awcms-mini-module-management]
+  II --> AOH[awcms-mini-auth-online-hardening]
+  AOH --> EP
+  AOH --> IDEM
+  AOH --> ABAC
+  AOH --> AUD
+  AOH --> SD
   II --> PR[awcms-mini-pr-review]
   PR --> SEC[awcms-mini-security-review]
   PR --> CQ[awcms-mini-codeql-triage]

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: awcms-mini-auth-online-hardening
+description: Kerjakan bagian mana pun dari epic full-online auth security hardening AWCMS-Mini (Issue #587-#593). Gunakan saat menambah/mengubah AUTH_ONLINE_SECURITY_* gate, Cloudflare Turnstile, MFA/TOTP, Google OIDC login, generic tenant OIDC SSO, atau admin auth policy UI. Merangkum keputusan yang sudah dibuat supaya issue lanjutan tidak mengulang/kontradiksi.
+---
+
+# AWCMS-Mini — Full-Online Auth Security Hardening
+
+Epic menambahkan enam fitur hardening auth **online-only** (Cloudflare
+Turnstile, MFA/TOTP, Google OIDC login, generic tenant OIDC SSO, admin
+policy UI, plus penutup docs/kontrak) di atas login lokal/password +
+session opaque yang sudah ada, tanpa mengubah perilaku default
+offline/LAN/local sama sekali. Target model:
+
+```txt
+AUTH_ONLINE_SECURITY_ENABLED + AUTH_ONLINE_SECURITY_PROFILE=full_online
+  -> isFullOnlineSecurityActive(env) === true
+    -> Turnstile / MFA / Google OIDC / generic SSO boleh aktif
+```
+
+## Kapan pakai skill ini vs skill generik
+
+Skill ini melengkapi (bukan menggantikan) `awcms-mini-new-endpoint`,
+`awcms-mini-new-migration`, `awcms-mini-idempotency`,
+`awcms-mini-abac-guard`, `awcms-mini-audit-log`, dan
+`awcms-mini-sensitive-data` (kredensial provider, TOTP seed, recovery
+code semua data sensitif). Skill ini menyediakan konteks **cross-cutting
+epic ini spesifik**: gate bersama yang wajib dicek setiap fitur, dan
+keputusan desain yang mengikat semua issue di epic ini sekaligus.
+
+## Status per issue (jangan bangun ulang yang sudah ada)
+
+| Issue | Scope                                                  | Status                                         |
+| ----- | ------------------------------------------------------ | ---------------------------------------------- |
+| #587  | Gate bersama `AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE` | **Selesai** — lihat §Gate bersama di bawah     |
+| #588  | Cloudflare Turnstile untuk form auth publik            | Belum dikerjakan                               |
+| #589  | MFA/TOTP login challenge                               | Belum dikerjakan                               |
+| #590  | Google OIDC login                                      | Belum dikerjakan                               |
+| #591  | Generic tenant OIDC SSO provider                       | Belum dikerjakan                               |
+| #592  | Admin UI kebijakan auth security online                | Belum dikerjakan (depends #587 selesai + #591) |
+| #593  | Docs/kontrak/readiness penutup epic                    | Belum dikerjakan (finalisasi setelah #588-592) |
+
+## Yang sudah ada — pakai ulang, jangan re-derive
+
+### Gate bersama (Issue #587, `src/lib/auth/online-security-config.ts`)
+
+Dua env var, **keduanya opsional/backward-compatible** — tidak di-set
+sama sekali (default setiap deployment offline/LAN/local), `config:validate`
+tetap PASS dan tidak ada perubahan perilaku login sama sekali:
+
+- `AUTH_ONLINE_SECURITY_ENABLED` — `"true"` mengaktifkan gate,
+  nilai lain (termasuk unset) berarti nonaktif.
+- `AUTH_ONLINE_SECURITY_PROFILE` — `"disabled"` (default) atau
+  `"full_online"`. **Wajib** `"full_online"` kalau `AUTH_ONLINE_SECURITY_ENABLED=true`
+  — kombinasi lain gagal `bun run config:validate`
+  (`checkOnlineAuthSecurityConfig`, `scripts/validate-env.ts`).
+
+Tiga fungsi diekspor:
+
+- `isOnlineSecurityEnabled(env)` — cek flag saja.
+- `resolveOnlineSecurityProfile(env)` — selalu jatuh ke `"disabled"`
+  untuk nilai kosong/tidak dikenal, tidak pernah throw.
+- **`isFullOnlineSecurityActive(env)` — satu-satunya fungsi yang WAJIB
+  dipanggil setiap fitur #588-#592 sebelum melakukan apa pun yang
+  online/provider-terkait.** Jangan re-derive aturan "keduanya harus
+  setuju" di modul lain — impor fungsi ini langsung.
+
+`scripts/security-readiness.ts`'s `checkOnlineAuthSecurityReady`
+melaporkan status gate ini (severity `critical` supaya misconfiguration
+sungguhan tetap blokir go-live, tapi `status: pass` untuk kondisi
+disabled — informational, bukan kegagalan, sesuai acceptance criteria
+#587). Detail env var lengkap: `docs/awcms-mini/18_configuration_env_reference.md`
+§Full-online auth security hardening,
+`docs/awcms-mini/deployment-profiles.md` §Full-online auth security
+hardening, `src/modules/identity-access/README.md` §Full-online-only
+auth security feature gate.
+
+## Aturan lintas-issue yang wajib diikuti (#588-#593)
+
+1. **Setiap fitur (#588-#592) WAJIB memanggil `isFullOnlineSecurityActive(env)`
+   sebelum melakukan apa pun online/provider-terkait** — jangan cek
+   `AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE` langsung atau bikin gate
+   sendiri. Tidak aktifnya gate ini harus berarti: tidak ada panggilan
+   Cloudflare/Google/OIDC apa pun, tidak ada MFA challenge, form login
+   tetap seperti hari ini persis.
+2. **`AUTH_ONLINE_SECURITY_ENABLED=false`/unset tidak boleh pernah
+   mewajibkan credential provider apa pun** — `.env.example` default dan
+   setiap deployment offline/LAN yang tidak pernah menyentuh var
+   `AUTH_ONLINE_SECURITY_*`/`AUTH_SSO_*`/`AUTH_MFA_*`/`AUTH_GOOGLE_*`/
+   `TURNSTILE_*` harus tetap `config:validate` PASS dan berperilaku
+   identik dengan sebelum epic ini ada.
+3. **`APP_ENV=production` BUKAN setara dengan full-online** — deployment
+   offline/LAN bisa production-grade secara operasional (lihat
+   `deployment-profiles.md`) tanpa pernah mengaktifkan gate ini. Jangan
+   pernah menjadikan `APP_ENV=production` sebagai proxy untuk
+   `isFullOnlineSecurityActive`.
+4. **Login password lokal tidak pernah dihapus/dinonaktifkan secara
+   default** oleh fitur mana pun di epic ini — `sso_required`/kebijakan
+   serupa (#591) hanya boleh aktif kalau ada break-glass local
+   owner/account valid, dicek server-side sebelum kebijakan itu bisa
+   disimpan.
+5. **Kredensial provider (Google client secret, OIDC client secret,
+   Turnstile secret key, TOTP seed, recovery code) tidak pernah
+   disimpan plaintext** — dari environment variable/secret manager, atau
+   dienkripsi at-rest dengan key dari environment (`AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY`/
+   `AUTH_MFA_SECRET_ENCRYPTION_KEY`, dsb.) — tidak pernah muncul di
+   response API, log, atau audit attributes (`awcms-mini-sensitive-data`).
+6. **Link/unlink provider account, perubahan kebijakan auth, enroll/disable
+   MFA, dan regenerate recovery code semuanya high-risk actions** — wajib
+   diaudit (`awcms-mini-audit-log`) dan idempotent kalau mutation
+   (`awcms-mini-idempotency`).
+7. **Provider identifier stabil adalah `sub` (subject OIDC), bukan
+   email** — auto-link by email (kalau diimplementasikan) wajib
+   mensyaratkan email terverifikasi + kebijakan allowed-domain eksplisit,
+   tidak pernah linking implisit murni dari kecocokan string email.
+8. **Semua panggilan provider eksternal (OIDC discovery/JWKS, Turnstile
+   siteverify) wajib timeout-bounded** — pola sama seperti
+   `cloudflare-dns-adapter.ts`/`mailketing-provider.ts` (`withTimeout`,
+   circuit breaker `getProviderCircuitBreaker`), dan tidak pernah
+   dipanggil di dalam DB transaction (ADR-0006).
+9. **Tabel baru yang tenant-scoped (`awcms_mini_auth_providers`,
+   `awcms_mini_identity_provider_accounts`, `awcms_mini_tenant_auth_policies`,
+   `awcms_mini_identity_mfa_factors`, dst.) wajib RLS `ENABLE` + `FORCE`**
+   — pola sama seperti setiap migration sejak 013 (`awcms-mini-new-migration`).
+10. **MFA reset password tidak boleh jadi bypass MFA** — reset password
+    yang berhasil tidak otomatis menonaktifkan MFA milik identity itu.
+
+## Belum ada — jangan asumsikan sudah dikerjakan
+
+Semua enam fitur konkret (#588-#592) plus dokumentasi/kontrak penutup
+(#593) masih backlog per 2026-07-09 — hanya gate bersama (#587) yang
+sudah ada di repo ini. Jangan asumsikan `awcms_mini_auth_providers`,
+endpoint `/api/v1/auth/mfa/*`/`/api/v1/auth/providers/google/*`/`/api/v1/auth/sso/*`,
+atau `src/lib/security/turnstile.ts` sudah ada — cek langsung sebelum
+membangun di atasnya.

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,16 @@ AUTH_PASSWORD_RESET_TOKEN_TTL_MIN=30
 AUTH_PASSWORD_RESET_RATE_LIMIT_MAX=5
 AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC=900
 
+# Full-online-only auth security hardening gate (Issue #587). Shared by every
+# online-only feature in this epic (Cloudflare Turnstile #588, MFA/TOTP #589,
+# Google OIDC login #590, generic tenant OIDC SSO #591, admin policy UI #592)
+# — none of them activate unless BOTH vars below agree. Left as-is (disabled),
+# local/offline/LAN deployments are completely unaffected and require no
+# provider credentials at all. If enabling, AUTH_ONLINE_SECURITY_PROFILE must
+# be exactly "full_online" — any other value fails config:validate.
+AUTH_ONLINE_SECURITY_ENABLED=false
+AUTH_ONLINE_SECURITY_PROFILE=disabled
+
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node
 AWCMS_MINI_SYNC_ENABLED=false

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -65,17 +65,44 @@ Legenda: Wajib = perlu untuk boot; Sensitif = jangan bocor ke log/response.
 
 ### Auth & keamanan
 
-| Var                                         | Wajib | Default | Sensitif | Fungsi                                          |
-| ------------------------------------------- | ----- | ------- | -------- | ----------------------------------------------- |
-| `AUTH_JWT_SECRET`                           | Ya    | –       | Ya       | Signing token sesi                              |
-| `AUTH_SESSION_TTL_MIN`                      | –     | `120`   | –        | Umur sesi                                       |
-| `AUTH_COOKIE_SECURE`                        | –     | `true`  | –        | Cookie hanya HTTPS di prod                      |
-| `AUTH_LOGIN_MAX_ATTEMPTS`                   | –     | `5`     | –        | Lockout login (per identitas)                   |
-| `AUTH_LOGIN_RATE_LIMIT_MAX`                 | –     | `20`    | –        | Rate limit login per sumber+tenant (Issue #437) |
-| `AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC`          | –     | `60`    | –        | Jendela waktu rate limit login (detik)          |
-| `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`         | –     | `30`    | –        | Umur token reset password (Issue #496)          |
-| `AUTH_PASSWORD_RESET_RATE_LIMIT_MAX`        | –     | `5`     | –        | Rate limit forgot/reset per sumber+tenant       |
-| `AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC` | –     | `900`   | –        | Jendela waktu rate limit reset password (detik) |
+| Var                                         | Wajib | Default    | Sensitif | Fungsi                                                                                                  |
+| ------------------------------------------- | ----- | ---------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `AUTH_JWT_SECRET`                           | Ya    | –          | Ya       | Signing token sesi                                                                                      |
+| `AUTH_SESSION_TTL_MIN`                      | –     | `120`      | –        | Umur sesi                                                                                               |
+| `AUTH_COOKIE_SECURE`                        | –     | `true`     | –        | Cookie hanya HTTPS di prod                                                                              |
+| `AUTH_LOGIN_MAX_ATTEMPTS`                   | –     | `5`        | –        | Lockout login (per identitas)                                                                           |
+| `AUTH_LOGIN_RATE_LIMIT_MAX`                 | –     | `20`       | –        | Rate limit login per sumber+tenant (Issue #437)                                                         |
+| `AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC`          | –     | `60`       | –        | Jendela waktu rate limit login (detik)                                                                  |
+| `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`         | –     | `30`       | –        | Umur token reset password (Issue #496)                                                                  |
+| `AUTH_PASSWORD_RESET_RATE_LIMIT_MAX`        | –     | `5`        | –        | Rate limit forgot/reset per sumber+tenant                                                               |
+| `AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC` | –     | `900`      | –        | Jendela waktu rate limit reset password (detik)                                                         |
+| `AUTH_ONLINE_SECURITY_ENABLED`              | –     | `false`    | –        | Gate full-online-only auth hardening (Issue #587) — lihat §Full-online auth security hardening di bawah |
+| `AUTH_ONLINE_SECURITY_PROFILE`              | –     | `disabled` | –        | `disabled` (default) atau `full_online`; wajib `full_online` bila `AUTH_ONLINE_SECURITY_ENABLED=true`   |
+
+### Full-online auth security hardening (opsional, Issue #587-#592)
+
+Gate bersama untuk enam fitur online-only dalam epic ini: Cloudflare
+Turnstile (#588), MFA/TOTP (#589), Google OIDC login (#590), generic tenant
+OIDC SSO (#591), admin policy UI (#592), dan dokumentasi/kontrak penutup
+(#593). **Bukan** pengganti model deployment `APP_ENV=production` — deployment
+offline/LAN bisa production-grade secara operasional tanpa pernah butuh fitur
+online-only ini (lihat `deployment-profiles.md`).
+
+- `AUTH_ONLINE_SECURITY_ENABLED` tidak di-set (atau bukan `"true"`) → seluruh
+  fitur hardening online-only dianggap nonaktif; tidak ada credential
+  provider apa pun yang dibutuhkan. Ini default setiap deployment
+  offline/LAN.
+- `AUTH_ONLINE_SECURITY_ENABLED=true` mewajibkan `AUTH_ONLINE_SECURITY_PROFILE=full_online`
+  — nilai lain (termasuk `"disabled"` yang eksplisit kontradiktif) gagal
+  `bun run config:validate`.
+- Helper terpusat: `isFullOnlineSecurityActive(env)`
+  (`src/lib/auth/online-security-config.ts`) — satu-satunya fungsi yang wajib
+  dipanggil setiap fitur #588-#592 sebelum melakukan apa pun yang
+  online/provider-terkait; jangan re-derive aturan "keduanya harus setuju" di
+  tempat lain.
+- Issue #587 sendiri baru menambahkan gate bersama ini — belum ada fitur
+  Turnstile/MFA/Google/SSO/admin UI yang benar-benar diimplementasikan di
+  repo ini.
 
 ### Sync & node
 
@@ -303,6 +330,8 @@ AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC=60
 AUTH_PASSWORD_RESET_TOKEN_TTL_MIN=30
 AUTH_PASSWORD_RESET_RATE_LIMIT_MAX=5
 AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC=900
+AUTH_ONLINE_SECURITY_ENABLED=false
+AUTH_ONLINE_SECURITY_PROFILE=disabled
 
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node

--- a/docs/awcms-mini/deployment-profiles.md
+++ b/docs/awcms-mini/deployment-profiles.md
@@ -103,6 +103,30 @@ men-set `PUBLIC_*` apa pun tetap berperilaku identik dengan sebelum epic
   dicatat sebagai anomali di log; ini bukan pengganti memperbaiki
   konfigurasi proxy yang salah.
 
+## Full-online auth security hardening (opsional, Issue #587-#592)
+
+Gate terpisah dari profil routing publik di atas — **bukan** bagian dari
+model deployment (`APP_ENV=production` sendiri **tidak** setara dengan
+full-online; offline/LAN bisa production-grade secara operasional tanpa
+pernah butuh fitur ini). Enam fitur online-only (Cloudflare Turnstile,
+MFA/TOTP, Google OIDC login, generic tenant OIDC SSO, admin policy UI,
+dan dokumentasi/kontrak penutup) semuanya digerbangi satu pasang var:
+`AUTH_ONLINE_SECURITY_ENABLED` + `AUTH_ONLINE_SECURITY_PROFILE` (detail
+lengkap: `18_configuration_env_reference.md` §Full-online auth security
+hardening).
+
+- **offline/LAN & development**: biarkan kedua var tidak di-set (default).
+  `config:validate` lulus tanpa credential provider apa pun — login lokal
+  berperilaku identik dengan sebelum epic #587 ada.
+- **production (online)**, hanya bila operator benar-benar ingin
+  mengaktifkan salah satu fitur hardening ini: set
+  `AUTH_ONLINE_SECURITY_ENABLED=true` DAN
+  `AUTH_ONLINE_SECURITY_PROFILE=full_online` — kombinasi lain gagal
+  `config:validate`. Mengaktifkan gate ini sendiri tidak mengaktifkan fitur
+  apa pun secara konkret; setiap fitur (#588-#592) punya flag env-nya
+  sendiri di atas gate ini, dan belum ada satu pun yang diimplementasikan
+  di repo ini (Issue #587 baru menambahkan gate bersamanya).
+
 ## Cara menjalankan tiap profil
 
 ### development

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -35,7 +35,10 @@ import { evaluateLoginAttempt } from "../src/modules/identity-access/domain/logi
 import { hashPassword } from "../src/lib/auth/password";
 import { resolveAppBaseUrl } from "./lib/app-url";
 import { checkRateLimit } from "../src/lib/security/rate-limit";
-import { checkEmailConfig } from "./validate-env";
+import {
+  checkEmailConfig,
+  checkOnlineAuthSecurityConfig
+} from "./validate-env";
 
 export type CheckSeverity = "critical" | "warning" | "info";
 export type CheckStatus = "pass" | "fail";
@@ -772,6 +775,62 @@ export function checkEmailProviderConfigReady(
 }
 
 // ---------------------------------------------------------------------------
+// 9c. Full-online auth security hardening gate is correctly configured
+// (critical when misconfigured, informational when disabled — Issue #587)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reuses `checkOnlineAuthSecurityConfig` from `validate-env.ts` verbatim —
+ * same "don't reimplement the same conditional check a second, divergent
+ * way" rule `checkEmailProviderConfigReady` above already follows. Severity
+ * is `critical` even for the "disabled" branch (matching that function's
+ * pattern): the value describes how bad a genuine misconfiguration would
+ * be, not this run's outcome — `status` alone is what "disabled ->
+ * informational pass, not a failure" (the issue's own acceptance criterion)
+ * actually means here. None of #588-#592 (Turnstile/MFA/Google
+ * login/generic SSO/admin policy UI) exist yet in this repo, so there is
+ * nothing else for this check to verify beyond the shared gate itself.
+ */
+export function checkOnlineAuthSecurityReady(
+  env: NodeJS.ProcessEnv = process.env
+): SecurityCheckResult {
+  const name =
+    "Full-online auth security hardening gate is correctly configured";
+  const severity: CheckSeverity = "critical";
+  const results = checkOnlineAuthSecurityConfig(env);
+  const failed = results.filter((result) => result.status === "fail");
+
+  if (failed.length > 0) {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `AUTH_ONLINE_SECURITY_ENABLED=true but config is invalid: ${failed
+        .map((result) => result.detail)
+        .join(" ")}`
+    };
+  }
+
+  if (env.AUTH_ONLINE_SECURITY_ENABLED !== "true") {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence:
+        'AUTH_ONLINE_SECURITY_ENABLED is not "true" — full-online auth hardening (Turnstile/MFA/Google login/SSO) is disabled; local/offline/LAN deployments are unaffected.'
+    };
+  }
+
+  return {
+    name,
+    severity,
+    status: "pass",
+    evidence:
+      "AUTH_ONLINE_SECURITY_ENABLED=true and AUTH_ONLINE_SECURITY_PROFILE=full_online — full-online auth hardening gate is active."
+  };
+}
+
+// ---------------------------------------------------------------------------
 // 10. Errors don't leak stack traces (warning/info, best-effort)
 // ---------------------------------------------------------------------------
 
@@ -1011,6 +1070,7 @@ export async function runSecurityReadinessChecks(): Promise<
     await checkSoftDeletePermissionsSeededAndAudited(),
     checkSyncHmacSecretNotDefault(),
     checkEmailProviderConfigReady(),
+    checkOnlineAuthSecurityReady(),
     await checkErrorsDontLeakStackTraces(),
     await checkSecurityHeadersPresent(),
     checkLoginRateLimitImplemented()

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -91,6 +91,17 @@
  *     default and keeps working with none of these vars present. Mirrors
  *     the EMAIL_PROVIDER conditional check above. See
  *     `src/modules/tenant-domain/README.md` §Cloudflare DNS adapter.
+ *  7. Full-online-only auth security feature gate (Issue #587, epic:
+ *     full-online auth hardening — #588-#592): if AUTH_ONLINE_SECURITY_ENABLED
+ *     is not "true", nothing else is required and every online auth
+ *     hardening feature (Turnstile, MFA/TOTP, Google login, generic SSO) is
+ *     considered disabled — the default for every local/offline/LAN
+ *     deployment. If AUTH_ONLINE_SECURITY_ENABLED=true, AUTH_ONLINE_SECURITY_PROFILE
+ *     must be exactly "full_online" (`../src/lib/auth/online-security-config`);
+ *     any other value (including the explicitly-contradictory "disabled")
+ *     fails validation. This issue only adds the shared gate itself — no
+ *     provider (Turnstile/Google/OIDC/TOTP) config is validated here yet,
+ *     that lands with each feature's own issue.
  *
  * Never prints actual secret values — only which variable name is
  * missing/invalid (doc 18: "Var wajib hilang → gagal start dengan pesan
@@ -109,6 +120,7 @@ import {
   KNOWN_TENANT_DOMAIN_DNS_PROVIDERS,
   TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED
 } from "../src/modules/tenant-domain/domain/tenant-domain-dns-config";
+import { isOnlineSecurityEnabled } from "../src/lib/auth/online-security-config";
 
 export type EnvCheckResult = {
   name: string;
@@ -475,6 +487,57 @@ export function checkTenantDomainDnsConfig(
   return results;
 }
 
+/**
+ * Full-online-only auth security feature gate (Issue #587, epic: full-online
+ * auth hardening). `AUTH_ONLINE_SECURITY_ENABLED` left unset (or anything
+ * other than `"true"`) requires nothing else and `config:validate` passes
+ * exactly as it does today — mirrors `checkTenantDomainDnsConfig`'s
+ * "manual/unset requires nothing" shape. Only `AUTH_ONLINE_SECURITY_ENABLED=true`
+ * gates `AUTH_ONLINE_SECURITY_PROFILE`, which must then be exactly
+ * `"full_online"` (the only other known value, `"disabled"`, would be a
+ * contradiction — enabled but explicitly disabled profile).
+ */
+export function checkOnlineAuthSecurityConfig(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult[] {
+  const name =
+    "AUTH_ONLINE_SECURITY_PROFILE (conditional on AUTH_ONLINE_SECURITY_ENABLED)";
+
+  if (!isOnlineSecurityEnabled(env)) {
+    return [
+      {
+        name,
+        status: "pass",
+        detail:
+          'AUTH_ONLINE_SECURITY_ENABLED is not "true" — full-online auth hardening (Turnstile/MFA/Google login/SSO) is disabled; no online auth provider config required.'
+      }
+    ];
+  }
+
+  const profile = env.AUTH_ONLINE_SECURITY_PROFILE;
+
+  if (profile !== "full_online") {
+    return [
+      {
+        name,
+        status: "fail",
+        detail: `AUTH_ONLINE_SECURITY_ENABLED=true requires AUTH_ONLINE_SECURITY_PROFILE=full_online; got ${
+          profile ? `"${profile}"` : "unset"
+        }.`
+      }
+    ];
+  }
+
+  return [
+    {
+      name,
+      status: "pass",
+      detail:
+        "AUTH_ONLINE_SECURITY_ENABLED=true and AUTH_ONLINE_SECURITY_PROFILE=full_online."
+    }
+  ];
+}
+
 export function runEnvValidation(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -484,7 +547,8 @@ export function runEnvValidation(
     ...checkR2Config(env),
     ...checkEmailConfig(env),
     ...checkPublicRoutingConfig(env),
-    ...checkTenantDomainDnsConfig(env)
+    ...checkTenantDomainDnsConfig(env),
+    ...checkOnlineAuthSecurityConfig(env)
   ];
 }
 

--- a/src/lib/auth/online-security-config.ts
+++ b/src/lib/auth/online-security-config.ts
@@ -1,0 +1,75 @@
+/**
+ * Full-online-only auth security feature gate (Issue #587, epic: full-online
+ * auth hardening — #588 Cloudflare Turnstile, #589 MFA/TOTP, #590 Google
+ * OIDC login, #591 generic tenant OIDC SSO, #592 admin policy UI). Pure — no
+ * `process.env` reads here; `scripts/validate-env.ts` and
+ * `scripts/security-readiness.ts` both pass in whatever `env` they were
+ * given, the same split `email/domain/email-config.ts` and
+ * `tenant-domain/domain/tenant-domain-dns-config.ts` already use for their
+ * own conditional provider config.
+ *
+ * This is the SHARED gate every full-online auth hardening feature in this
+ * epic must check before doing anything online/provider-related —
+ * `isFullOnlineSecurityActive(env)` is the one function every one of those
+ * features (and their tests) should call, rather than re-deriving the "both
+ * the enable flag AND the profile must agree" rule themselves. Local/
+ * offline/LAN deployments (the default — this pair of env vars is entirely
+ * unset) always get `false` here and never depend on this gate for
+ * anything: no Cloudflare/Google/OIDC call, no MFA challenge, no changed
+ * login behavior.
+ *
+ * Deliberately an auth-specific gate, not a reuse of `APP_ENV=production` or
+ * the deployment-profile concept — offline/LAN deployments can be
+ * production-grade operationally without ever wanting these online-only
+ * hardening features (see `docs/awcms-mini/deployment-profiles.md`).
+ */
+export const KNOWN_ONLINE_SECURITY_PROFILES = [
+  "disabled",
+  "full_online"
+] as const;
+
+export type OnlineSecurityProfile =
+  (typeof KNOWN_ONLINE_SECURITY_PROFILES)[number];
+
+export function isKnownOnlineSecurityProfile(
+  value: string | undefined
+): value is OnlineSecurityProfile {
+  return (KNOWN_ONLINE_SECURITY_PROFILES as readonly string[]).includes(
+    value ?? ""
+  );
+}
+
+export function isOnlineSecurityEnabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return env.AUTH_ONLINE_SECURITY_ENABLED === "true";
+}
+
+/** Falls back to `"disabled"` for unset or unrecognized values — never throws. */
+export function resolveOnlineSecurityProfile(
+  env: NodeJS.ProcessEnv = process.env
+): OnlineSecurityProfile {
+  const raw = env.AUTH_ONLINE_SECURITY_PROFILE;
+
+  return isKnownOnlineSecurityProfile(raw) ? raw : "disabled";
+}
+
+/**
+ * The single boolean every full-online-only feature (#588-#592) gates on.
+ * True only when BOTH the enable flag is `"true"` AND the profile is
+ * exactly `"full_online"` — matches `checkOnlineAuthSecurityConfig`
+ * (`scripts/validate-env.ts`)'s own rule that `AUTH_ONLINE_SECURITY_ENABLED=true`
+ * requires `AUTH_ONLINE_SECURITY_PROFILE=full_online`, so any deployment
+ * that has passed `bun run config:validate` will always have this agree
+ * with `isOnlineSecurityEnabled` alone. Checking both here (rather than
+ * trusting `config:validate` already ran) keeps this gate fail-closed even
+ * if a deployment somehow skipped that step.
+ */
+export function isFullOnlineSecurityActive(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return (
+    isOnlineSecurityEnabled(env) &&
+    resolveOnlineSecurityProfile(env) === "full_online"
+  );
+}

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -149,3 +149,40 @@ Astro secara default menolak (403, tanpa body) permintaan `POST`/`PUT`/`PATCH`/`
 ## Belum tersedia
 
 CRUD ABAC policy row (`awcms_mini_abac_policies` — schema tersedia, evaluator masih pakai aturan generik bawaan, belum ada endpoint kelola policy), dan publikasi event `identity.login.succeeded`/`identity.login.failed` (doc 05, menyusul modul Observability/Logging) belum ada pada tahap ini. `/access/decision-logs` tetap `LIMIT 50` per halaman tapi kini punya keyset pagination opsional (Issue #435, `?cursor=`/`nextCursor` — lihat `src/modules/_shared/keyset-pagination.ts`).
+
+Belum ada implementasi konkret untuk epic full-online auth security
+hardening (Issue #587-#593): Cloudflare Turnstile, MFA/TOTP, Google OIDC
+login, generic tenant OIDC SSO, dan admin policy UI-nya semua masih
+backlog. Issue #587 sendiri sudah selesai (lihat §Full-online-only auth
+security feature gate di bawah) — hanya menambahkan gate bersama
+(`AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE`), belum ada satu pun fitur
+konkret yang memakainya.
+
+## Full-online-only auth security feature gate (Issue #587)
+
+`src/lib/auth/online-security-config.ts` — gate bersama yang WAJIB dicek
+setiap fitur hardening online-only di epic ini (#588-#592) sebelum
+melakukan apa pun yang online/provider-terkait. Dua env var, keduanya
+opsional/backward-compatible (`AUTH_ONLINE_SECURITY_ENABLED=false` dan
+`AUTH_ONLINE_SECURITY_PROFILE=disabled` — default setiap deployment
+offline/LAN, tidak mengubah perilaku login apa pun):
+
+- `isOnlineSecurityEnabled(env)` — `true` hanya kalau
+  `AUTH_ONLINE_SECURITY_ENABLED === "true"` persis.
+- `resolveOnlineSecurityProfile(env)` — `"full_online"` kalau di-set
+  persis begitu, selalu jatuh ke `"disabled"` untuk nilai lain/tidak
+  di-set (tidak pernah throw).
+- `isFullOnlineSecurityActive(env)` — **satu-satunya fungsi yang wajib
+  dipanggil** fitur #588-#592: `true` hanya kalau KEDUA di atas setuju.
+  Jangan re-derive aturan "keduanya harus setuju" di modul lain.
+
+Divalidasi `scripts/validate-env.ts`'s `checkOnlineAuthSecurityConfig`
+(`AUTH_ONLINE_SECURITY_ENABLED=true` mewajibkan
+`AUTH_ONLINE_SECURITY_PROFILE=full_online`, nilai lain gagal
+`config:validate`) dan dilaporkan `scripts/security-readiness.ts`'s
+`checkOnlineAuthSecurityReady` (severity `critical`, tapi `status: pass`
+untuk kondisi disabled — bukan kegagalan, murni informational, sesuai
+acceptance criteria issue ini). Detail env var lengkap:
+`docs/awcms-mini/18_configuration_env_reference.md` §Full-online auth
+security hardening, `docs/awcms-mini/deployment-profiles.md` §Full-online
+auth security hardening.

--- a/tests/security-readiness.test.ts
+++ b/tests/security-readiness.test.ts
@@ -5,6 +5,7 @@ import {
   checkEmailProviderConfigReady,
   checkLoginLockoutImplemented,
   checkLoginRateLimitImplemented,
+  checkOnlineAuthSecurityReady,
   checkSyncHmacSecretNotDefault,
   scanLineForHardcodedSecret
 } from "../scripts/security-readiness";
@@ -208,6 +209,34 @@ describe("checkEmailProviderConfigReady", () => {
       EMAIL_MAILKETING_ACCOUNT_ID: "acc",
       EMAIL_MAILKETING_API_TOKEN: "token",
       EMAIL_MAILKETING_API_BASE_URL: "https://api.mailketing.co.id"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("pass");
+  });
+});
+
+describe("checkOnlineAuthSecurityReady", () => {
+  test("is critical/pass (informational, not a failure) when the gate is disabled", () => {
+    const result = checkOnlineAuthSecurityReady({} as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when AUTH_ONLINE_SECURITY_ENABLED=true but AUTH_ONLINE_SECURITY_PROFILE is missing/invalid", () => {
+    const result = checkOnlineAuthSecurityReady({
+      AUTH_ONLINE_SECURITY_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("fail");
+  });
+
+  test("passes when AUTH_ONLINE_SECURITY_ENABLED=true and AUTH_ONLINE_SECURITY_PROFILE=full_online", () => {
+    const result = checkOnlineAuthSecurityReady({
+      AUTH_ONLINE_SECURITY_ENABLED: "true",
+      AUTH_ONLINE_SECURITY_PROFILE: "full_online"
     } as NodeJS.ProcessEnv);
 
     expect(result.severity).toBe("critical");

--- a/tests/unit/online-security-config.test.ts
+++ b/tests/unit/online-security-config.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isFullOnlineSecurityActive,
+  isKnownOnlineSecurityProfile,
+  isOnlineSecurityEnabled,
+  resolveOnlineSecurityProfile
+} from "../../src/lib/auth/online-security-config";
+
+describe("isKnownOnlineSecurityProfile", () => {
+  test("accepts the two known profiles", () => {
+    expect(isKnownOnlineSecurityProfile("disabled")).toBe(true);
+    expect(isKnownOnlineSecurityProfile("full_online")).toBe(true);
+  });
+
+  test("rejects unknown/undefined values", () => {
+    expect(isKnownOnlineSecurityProfile("production")).toBe(false);
+    expect(isKnownOnlineSecurityProfile(undefined)).toBe(false);
+    expect(isKnownOnlineSecurityProfile("")).toBe(false);
+  });
+});
+
+describe("isOnlineSecurityEnabled", () => {
+  test("false when unset (default, every local/offline/LAN deployment)", () => {
+    expect(isOnlineSecurityEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  test('false for any value other than the literal string "true"', () => {
+    expect(
+      isOnlineSecurityEnabled({
+        AUTH_ONLINE_SECURITY_ENABLED: "false"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+    expect(
+      isOnlineSecurityEnabled({
+        AUTH_ONLINE_SECURITY_ENABLED: "TRUE"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test('true only for the literal string "true"', () => {
+    expect(
+      isOnlineSecurityEnabled({
+        AUTH_ONLINE_SECURITY_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+});
+
+describe("resolveOnlineSecurityProfile", () => {
+  test('defaults to "disabled" when unset', () => {
+    expect(resolveOnlineSecurityProfile({} as NodeJS.ProcessEnv)).toBe(
+      "disabled"
+    );
+  });
+
+  test('falls back to "disabled" for an unrecognized value — never throws', () => {
+    expect(
+      resolveOnlineSecurityProfile({
+        AUTH_ONLINE_SECURITY_PROFILE: "production"
+      } as NodeJS.ProcessEnv)
+    ).toBe("disabled");
+  });
+
+  test('returns "full_online" when explicitly set', () => {
+    expect(
+      resolveOnlineSecurityProfile({
+        AUTH_ONLINE_SECURITY_PROFILE: "full_online"
+      } as NodeJS.ProcessEnv)
+    ).toBe("full_online");
+  });
+});
+
+describe("isFullOnlineSecurityActive — the shared gate #588-#592 must check", () => {
+  test("false when unset (default, every local/offline/LAN deployment)", () => {
+    expect(isFullOnlineSecurityActive({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  test('false when enabled but profile is still "disabled" (contradictory config)', () => {
+    expect(
+      isFullOnlineSecurityActive({
+        AUTH_ONLINE_SECURITY_ENABLED: "true",
+        AUTH_ONLINE_SECURITY_PROFILE: "disabled"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test('false when profile is full_online but the enable flag is not "true" (profile alone is not enough)', () => {
+    expect(
+      isFullOnlineSecurityActive({
+        AUTH_ONLINE_SECURITY_PROFILE: "full_online"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("true only when both agree", () => {
+    expect(
+      isFullOnlineSecurityActive({
+        AUTH_ONLINE_SECURITY_ENABLED: "true",
+        AUTH_ONLINE_SECURITY_PROFILE: "full_online"
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+});

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   checkEmailConfig,
+  checkOnlineAuthSecurityConfig,
   checkPublicRoutingConfig,
   checkR2Config,
   checkRequiredVars,
@@ -401,6 +402,53 @@ describe("checkTenantDomainDnsConfig", () => {
     for (const result of results) {
       expect(result.detail).not.toContain("super-secret-token-value");
     }
+  });
+});
+
+describe("checkOnlineAuthSecurityConfig", () => {
+  test("passes (single check) when AUTH_ONLINE_SECURITY_ENABLED is not set", () => {
+    const results = checkOnlineAuthSecurityConfig({} as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("passes when AUTH_ONLINE_SECURITY_ENABLED=false", () => {
+    const results = checkOnlineAuthSecurityConfig({
+      AUTH_ONLINE_SECURITY_ENABLED: "false"
+    } as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("fails when AUTH_ONLINE_SECURITY_ENABLED=true and AUTH_ONLINE_SECURITY_PROFILE is unset", () => {
+    const results = checkOnlineAuthSecurityConfig({
+      AUTH_ONLINE_SECURITY_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("fail");
+  });
+
+  test("fails when AUTH_ONLINE_SECURITY_ENABLED=true and AUTH_ONLINE_SECURITY_PROFILE=disabled (contradictory)", () => {
+    const results = checkOnlineAuthSecurityConfig({
+      AUTH_ONLINE_SECURITY_ENABLED: "true",
+      AUTH_ONLINE_SECURITY_PROFILE: "disabled"
+    } as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("fail");
+  });
+
+  test("passes when AUTH_ONLINE_SECURITY_ENABLED=true and AUTH_ONLINE_SECURITY_PROFILE=full_online", () => {
+    const results = checkOnlineAuthSecurityConfig({
+      AUTH_ONLINE_SECURITY_ENABLED: "true",
+      AUTH_ONLINE_SECURITY_PROFILE: "full_online"
+    } as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
   });
 });
 


### PR DESCRIPTION
Closes #587

## Summary
- Implements Issue #587, the foundational config gate for the new "full-online auth security hardening" epic (#587-#593): Cloudflare Turnstile (#588), MFA/TOTP (#589), Google OIDC login (#590), generic tenant OIDC SSO (#591), and an admin policy UI (#592) will all depend on this gate before doing anything online/provider-related. #587 itself has zero dependencies and is explicitly listed as blocking all five other issues.
- This PR only adds the shared gate — none of those six features exist yet in this repo.

## Implementation
- Two new env vars, both optional/backward-compatible: `AUTH_ONLINE_SECURITY_ENABLED` (default `false`) and `AUTH_ONLINE_SECURITY_PROFILE` (default `disabled`, only other valid value `full_online`). Left unset — the default for every local/offline/LAN deployment — nothing changes and no provider credential is ever required.
- `AUTH_ONLINE_SECURITY_ENABLED=true` requires `AUTH_ONLINE_SECURITY_PROFILE=full_online`; any other combination fails `bun run config:validate`.
- New `src/lib/auth/online-security-config.ts`: `isOnlineSecurityEnabled`, `resolveOnlineSecurityProfile`, and `isFullOnlineSecurityActive` — the one function every future full-online-only feature must call, rather than re-deriving the "both vars must agree" rule itself.
- `scripts/validate-env.ts`: new `checkOnlineAuthSecurityConfig`, wired into `runEnvValidation`.
- `scripts/security-readiness.ts`: new `checkOnlineAuthSecurityReady` — `critical` severity so a genuine misconfiguration blocks go-live, but `status: pass` when the gate is simply disabled (informational, per the issue's own acceptance criterion "reports online auth hardening as disabled... as an informational result rather than a failure").

## Skill added
`awcms-mini-auth-online-hardening` — tracks this epic's per-issue status and the cross-issue rules every future issue (#588-#592) must follow (matching the established pattern from `awcms-mini-tenant-domain-routing` for epic #555): every feature must call `isFullOnlineSecurityActive`, `APP_ENV=production` is not equivalent to full-online, local password login is never disabled by default, `sso_required` needs a break-glass account, provider secrets are never plaintext, provider identity uses OIDC `sub` not email, provider calls are timeout-bounded, new tenant-scoped tables need RLS `ENABLE`+`FORCE`, and password reset never bypasses MFA.

## Test plan
- [x] New unit tests: `tests/unit/online-security-config.test.ts` (the three gate functions in isolation), `tests/validate-env.test.ts`'s `checkOnlineAuthSecurityConfig` describe block, `tests/security-readiness.test.ts`'s `checkOnlineAuthSecurityReady` describe block.
- [x] Manually verified all three `bun run config:validate` scenarios: unset (pass), enabled+missing profile (fail), enabled+full_online (pass).
- [x] Full `bun test` against real PostgreSQL — 1188 pass, 0 fail (was 1168; +20 new tests, 0 regressions).
- [x] `bun run lint` / `bun run typecheck` / `bun run check:docs` / `bun run api:spec:check` / `bun run db:migrate` (0 applied, 33 skipped — no schema change) / `bun run build` — all pass.

## Docs
Updated `.env.example`, `docs/awcms-mini/18_configuration_env_reference.md`, `docs/awcms-mini/deployment-profiles.md`, `src/modules/identity-access/README.md`, `.claude/skills/README.md` (catalog + flowchart). Changeset added (`minor` — new feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)