### PR TITLE
feat(auth): add Cloudflare Turnstile for full-online public auth forms (#588)

### DIFF
--- a/.changeset/auth-turnstile-full-online.md
+++ b/.changeset/auth-turnstile-full-online.md
@@ -18,7 +18,12 @@ query or password hashing. Verification is server-side against
 Cloudflare's siteverify endpoint, timeout-bounded and circuit-breaker
 gated (same pattern as `cloudflare-dns-adapter.ts`/
 `mailketing-provider.ts`), and fails closed: misconfiguration is treated
-as an invalid token, not skipped.
+as an invalid token, not skipped. The circuit breaker only trips on
+genuine provider-transport failures (HTTP 5xx, network error, timeout)
+— a well-formed "token rejected" response never trips it, so an
+unauthenticated caller can't lock out login/password-reset/setup for
+every tenant by submitting a handful of invalid tokens (found and fixed
+during PR review).
 
 New env vars: `TURNSTILE_ENABLED` (default `false`), `TURNSTILE_SITE_KEY`,
 `TURNSTILE_SECRET_KEY`, `TURNSTILE_VERIFY_TIMEOUT_MS` (default `5000`).

--- a/.changeset/auth-turnstile-full-online.md
+++ b/.changeset/auth-turnstile-full-online.md
@@ -1,0 +1,40 @@
+---
+"awcms-mini": minor
+---
+
+Add Cloudflare Turnstile bot protection for full-online public auth forms
+(Issue #588, epic #587-#593) — the first concrete feature built on top of
+the #587 full-online security gate.
+
+New `src/lib/security/turnstile.ts`: `isTurnstileRequired(env)` combines
+the shared `isFullOnlineSecurityActive(env)` gate (#587) with a new
+`TURNSTILE_ENABLED` flag — active only when both agree. Every local/
+offline/LAN deployment (the default) is completely unaffected. The one
+enforcement entrypoint, `enforceTurnstileIfRequired(turnstileToken,
+remoteIp, env)`, is now called from `POST /api/v1/auth/login`,
+`/auth/password/forgot`, `/auth/password/reset`, and
+`/setup/initialize`, right after body validation but before any DB
+query or password hashing. Verification is server-side against
+Cloudflare's siteverify endpoint, timeout-bounded and circuit-breaker
+gated (same pattern as `cloudflare-dns-adapter.ts`/
+`mailketing-provider.ts`), and fails closed: misconfiguration is treated
+as an invalid token, not skipped.
+
+New env vars: `TURNSTILE_ENABLED` (default `false`), `TURNSTILE_SITE_KEY`,
+`TURNSTILE_SECRET_KEY`, `TURNSTILE_VERIFY_TIMEOUT_MS` (default `5000`).
+`TURNSTILE_ENABLED=true` alone (independent of the #587 gate) requires
+both keys in `bun run config:validate` and `security-readiness`.
+
+The login page (`src/pages/login.astro`) conditionally renders the
+Turnstile widget only when `isTurnstileRequired()` is true. Astro's CSP
+(`astro.config.mjs`) now unconditionally allows
+`https://challenges.cloudflare.com` in `script-src`/`frame-src` (CSP is
+build-time only, while `TURNSTILE_ENABLED` is meant to be runtime-
+toggleable) — the widget itself remains runtime-gated.
+
+New error codes `TURNSTILE_REQUIRED`/`TURNSTILE_INVALID` with i18n
+strings (`en`/`id`). OpenAPI spec updated for all 4 affected endpoints.
+
+Docs updated: `.env.example`, `docs/awcms-mini/18_configuration_env_reference.md`,
+`docs/awcms-mini/deployment-profiles.md`, `src/modules/identity-access/README.md`,
+skill `awcms-mini-auth-online-hardening`.

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -105,7 +105,24 @@ isTurnstileRequired(env)
   (issue's security note: "client widget alone is not security"),
   timeout-bounded (`withTimeout`) + circuit breaker
   (`getProviderCircuitBreaker("turnstile")`), pola sama seperti
-  `cloudflare-dns-adapter.ts`/`mailketing-provider.ts`.
+  `cloudflare-dns-adapter.ts`/`mailketing-provider.ts` — **dengan satu
+  perbedaan penting yang wajib dipertahankan**: `breaker.recordFailure()`
+  HANYA dipanggil untuk kegagalan transport genuine ke Cloudflare (HTTP
+  non-2xx, body tak terparse, network error/timeout), TIDAK PERNAH untuk
+  respons 2xx yang sah dengan `success:false` (itu Cloudflare menjawab
+  dengan benar bahwa token client-nya salah — hasil normal yang bisa
+  dipicu siapa pun tanpa autentikasi). PR #596 security review menemukan
+  versi awal menyamakan keduanya: breaker ini shared/cross-tenant, dan
+  `enforceTurnstileIfRequired` fail-closed saat breaker terbuka, jadi
+  penyerang bisa mengunci login/password-reset/setup SEMUA tenant hanya
+  dengan mengirim segelintir token sampah setiap ~30 detik. Jangan
+  regresi pola ini di fitur online lain (#589-#592) yang menambah
+  circuit breaker provider baru — bedakan selalu "provider tidak sehat"
+  dari "input client ditolak provider dengan benar". Log
+  `turnstile.circuit_breaker_open`/`turnstile.provider_call_failed`/
+  `turnstile.provider_call_errored` (severity `warning`,
+  `src/lib/logging/logger.ts`) memberi visibilitas operasional untuk
+  keduanya.
 - **CSP** (`astro.config.mjs`): `script-src`/`frame-src` mengizinkan
   `https://challenges.cloudflare.com` **tanpa syarat** (tidak digerbangi
   `TURNSTILE_ENABLED` di build time) — alasannya didokumentasikan

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -29,15 +29,15 @@ keputusan desain yang mengikat semua issue di epic ini sekaligus.
 
 ## Status per issue (jangan bangun ulang yang sudah ada)
 
-| Issue | Scope                                                  | Status                                         |
-| ----- | ------------------------------------------------------ | ---------------------------------------------- |
-| #587  | Gate bersama `AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE` | **Selesai** — lihat §Gate bersama di bawah     |
-| #588  | Cloudflare Turnstile untuk form auth publik            | Belum dikerjakan                               |
-| #589  | MFA/TOTP login challenge                               | Belum dikerjakan                               |
-| #590  | Google OIDC login                                      | Belum dikerjakan                               |
-| #591  | Generic tenant OIDC SSO provider                       | Belum dikerjakan                               |
-| #592  | Admin UI kebijakan auth security online                | Belum dikerjakan (depends #587 selesai + #591) |
-| #593  | Docs/kontrak/readiness penutup epic                    | Belum dikerjakan (finalisasi setelah #588-592) |
+| Issue | Scope                                                  | Status                                             |
+| ----- | ------------------------------------------------------ | -------------------------------------------------- |
+| #587  | Gate bersama `AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE` | **Selesai** — lihat §Gate bersama di bawah         |
+| #588  | Cloudflare Turnstile untuk form auth publik            | **Selesai** — lihat §Cloudflare Turnstile di bawah |
+| #589  | MFA/TOTP login challenge                               | Belum dikerjakan                                   |
+| #590  | Google OIDC login                                      | Belum dikerjakan                                   |
+| #591  | Generic tenant OIDC SSO provider                       | Belum dikerjakan                                   |
+| #592  | Admin UI kebijakan auth security online                | Belum dikerjakan (depends #587 selesai + #591)     |
+| #593  | Docs/kontrak/readiness penutup epic                    | Belum dikerjakan (finalisasi setelah #588-592)     |
 
 ## Yang sudah ada — pakai ulang, jangan re-derive
 
@@ -73,6 +73,53 @@ disabled — informational, bukan kegagalan, sesuai acceptance criteria
 `docs/awcms-mini/deployment-profiles.md` §Full-online auth security
 hardening, `src/modules/identity-access/README.md` §Full-online-only
 auth security feature gate.
+
+### Cloudflare Turnstile (Issue #588, `src/lib/security/turnstile.ts`)
+
+Fitur konkret **pertama** yang dibangun di atas gate #587 — pola
+referensi untuk #589-#592 berikutnya. Gate gabungan:
+
+```txt
+isTurnstileRequired(env)
+  = isFullOnlineSecurityActive(env) AND isTurnstileEnabled(env)
+  (isTurnstileEnabled = TURNSTILE_ENABLED === "true")
+```
+
+- **Satu fungsi enforcement dipanggil dari 4 endpoint**:
+  `enforceTurnstileIfRequired(turnstileToken, remoteIp, env)` — dipanggil
+  di `POST /api/v1/auth/login`, `/auth/password/forgot`, `/auth/password/reset`,
+  dan `/setup/initialize`, tepat setelah body divalidasi tapi **sebelum**
+  DB/password hashing (issue's security note: verifikasi Turnstile lebih
+  murah, jangan buang kerja mahal untuk request yang bahkan tidak lolos
+  bot-check). Mengembalikan `{ok:true}` atau `{ok:false, code:
+"TURNSTILE_REQUIRED" | "TURNSTILE_INVALID"}` — **fail closed**:
+  misconfiguration (`resolveTurnstileConfig` → `null`) diperlakukan sama
+  seperti token invalid, bukan dilewati.
+- **Verifikasi env var independen dari gate #587**: `TURNSTILE_ENABLED=true`
+  sendiri sudah mewajibkan `TURNSTILE_SITE_KEY`+`TURNSTILE_SECRET_KEY`
+  di `config:validate`/`security-readiness` (`checkTurnstileConfig`,
+  `scripts/validate-env.ts`) — operator boleh isi kredensial ini lebih
+  dulu tanpa menyalakan `AUTH_ONLINE_SECURITY_ENABLED`; aktivasi runtime
+  tetap butuh KEDUA gate setuju.
+- **`verifyTurnstileToken`** memanggil Cloudflare siteverify server-side
+  (issue's security note: "client widget alone is not security"),
+  timeout-bounded (`withTimeout`) + circuit breaker
+  (`getProviderCircuitBreaker("turnstile")`), pola sama seperti
+  `cloudflare-dns-adapter.ts`/`mailketing-provider.ts`.
+- **CSP** (`astro.config.mjs`): `script-src`/`frame-src` mengizinkan
+  `https://challenges.cloudflare.com` **tanpa syarat** (tidak digerbangi
+  `TURNSTILE_ENABLED` di build time) — alasannya didokumentasikan
+  langsung di file itu: CSP Astro cuma bisa di-bake saat build,
+  sedangkan `TURNSTILE_ENABLED` didesain runtime-toggleable seperti flag
+  lain; widget sendiri tetap runtime-gated lewat `isTurnstileRequired()`
+  di `login.astro`.
+- **Widget UI** hanya di-render di `login.astro` (form publik lain —
+  forgot/reset/setup — belum punya halaman UI di repo ini, baru endpoint
+  API-nya) saat `isTurnstileRequired()` true; token dikirim sebagai field
+  opsional `turnstileToken` di body JSON, dibaca dari hidden field
+  `cf-turnstile-response` yang otomatis diisi widget.
+- Error code i18n: `error.turnstile_required`/`error.turnstile_invalid`
+  (`src/lib/i18n/error-messages.ts`, `i18n/en.po`+`id.po`).
 
 ## Aturan lintas-issue yang wajib diikuti (#588-#593)
 
@@ -126,9 +173,10 @@ auth security feature gate.
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Semua enam fitur konkret (#588-#592) plus dokumentasi/kontrak penutup
-(#593) masih backlog per 2026-07-09 — hanya gate bersama (#587) yang
-sudah ada di repo ini. Jangan asumsikan `awcms_mini_auth_providers`,
-endpoint `/api/v1/auth/mfa/*`/`/api/v1/auth/providers/google/*`/`/api/v1/auth/sso/*`,
-atau `src/lib/security/turnstile.ts` sudah ada — cek langsung sebelum
-membangun di atasnya.
+Lima fitur (#589-#592) plus dokumentasi/kontrak penutup (#593) masih
+backlog per 2026-07-09 — hanya gate bersama (#587) dan Cloudflare
+Turnstile (#588) yang sudah ada di repo ini. Jangan asumsikan
+`awcms_mini_auth_providers`, `awcms_mini_identity_mfa_factors`, atau
+endpoint `/api/v1/auth/mfa/*`/`/api/v1/auth/providers/google/*`/
+`/api/v1/auth/sso/*` sudah ada — cek langsung sebelum membangun di
+atasnya.

--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,19 @@ AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC=900
 AUTH_ONLINE_SECURITY_ENABLED=false
 AUTH_ONLINE_SECURITY_PROFILE=disabled
 
+# Cloudflare Turnstile (Issue #588) — bot protection for POST /auth/login,
+# /auth/password/forgot, /auth/password/reset, and /setup/initialize. Only
+# active when the full-online gate above is ALSO on
+# (isTurnstileRequired() = full-online gate AND TURNSTILE_ENABLED=true).
+# Independent of the gate for config:validate purposes: you can set these
+# credentials ahead of time without flipping AUTH_ONLINE_SECURITY_ENABLED on
+# yet. TURNSTILE_SITE_KEY is not a secret (public, embedded in the widget);
+# TURNSTILE_SECRET_KEY is (server-side verification only).
+TURNSTILE_ENABLED=false
+# TURNSTILE_SITE_KEY=
+# TURNSTILE_SECRET_KEY=
+TURNSTILE_VERIFY_TIMEOUT_MS=5000
+
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node
 AWCMS_MINI_SYNC_ENABLED=false

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -50,6 +50,28 @@ export default defineConfig({
   // hash added here instead. See `src/lib/security/theme-init-script.ts`
   // for the single source of truth this hash is computed from, and
   // `tests/theme-init-script.test.ts` for the test that keeps them in sync.
+  //
+  // Cloudflare Turnstile (Issue #588, epic: full-online auth hardening) —
+  // `scriptDirective.resources` allows loading its widget script
+  // (`https://challenges.cloudflare.com/turnstile/v0/api.js`,
+  // `src/pages/login.astro`) and `frame-src` allows rendering its widget
+  // iframe. Deliberately NOT gated on `TURNSTILE_ENABLED` at build time: CSP
+  // here is a build-time-only Astro feature (see the doc comment above —
+  // unsupported in `astro dev`, baked into the built output), while every
+  // other Turnstile-related behavior in this app is a runtime env toggle
+  // (`isTurnstileRequired()`) — gating this one directive on a build-time
+  // env read would mean flipping `TURNSTILE_ENABLED` on/off requires a
+  // rebuild just for the CSP header to catch up, unlike every other flag in
+  // this app. The two origins added are narrow and specific to Cloudflare's
+  // own official Turnstile CDN (not a broad allowlist), and are inert on
+  // every page/deployment that never renders the widget — `login.astro`
+  // still only emits the widget markup/script tag when
+  // `isTurnstileRequired()` is true at *request* time, so allowing the
+  // origin in CSP doesn't by itself introduce a live third-party call
+  // anywhere. `scriptDirective.resources` replaces (not adds to) Astro's
+  // default script-src sources, so `'self'` must be repeated here
+  // explicitly to keep every same-origin bundled script Astro itself emits
+  // working.
   security: {
     csp: {
       directives: [
@@ -57,10 +79,12 @@ export default defineConfig({
         "object-src 'none'",
         "base-uri 'none'",
         "form-action 'self'",
-        "frame-ancestors 'none'"
+        "frame-ancestors 'none'",
+        "frame-src 'self' https://challenges.cloudflare.com"
       ],
       scriptDirective: {
-        hashes: [THEME_INIT_SCRIPT_HASH]
+        hashes: [THEME_INIT_SCRIPT_HASH],
+        resources: ["'self'", "https://challenges.cloudflare.com"]
       }
     }
   }

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -65,21 +65,25 @@ Legenda: Wajib = perlu untuk boot; Sensitif = jangan bocor ke log/response.
 
 ### Auth & keamanan
 
-| Var                                         | Wajib | Default    | Sensitif | Fungsi                                                                                                  |
-| ------------------------------------------- | ----- | ---------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| `AUTH_JWT_SECRET`                           | Ya    | –          | Ya       | Signing token sesi                                                                                      |
-| `AUTH_SESSION_TTL_MIN`                      | –     | `120`      | –        | Umur sesi                                                                                               |
-| `AUTH_COOKIE_SECURE`                        | –     | `true`     | –        | Cookie hanya HTTPS di prod                                                                              |
-| `AUTH_LOGIN_MAX_ATTEMPTS`                   | –     | `5`        | –        | Lockout login (per identitas)                                                                           |
-| `AUTH_LOGIN_RATE_LIMIT_MAX`                 | –     | `20`       | –        | Rate limit login per sumber+tenant (Issue #437)                                                         |
-| `AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC`          | –     | `60`       | –        | Jendela waktu rate limit login (detik)                                                                  |
-| `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`         | –     | `30`       | –        | Umur token reset password (Issue #496)                                                                  |
-| `AUTH_PASSWORD_RESET_RATE_LIMIT_MAX`        | –     | `5`        | –        | Rate limit forgot/reset per sumber+tenant                                                               |
-| `AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC` | –     | `900`      | –        | Jendela waktu rate limit reset password (detik)                                                         |
-| `AUTH_ONLINE_SECURITY_ENABLED`              | –     | `false`    | –        | Gate full-online-only auth hardening (Issue #587) — lihat §Full-online auth security hardening di bawah |
-| `AUTH_ONLINE_SECURITY_PROFILE`              | –     | `disabled` | –        | `disabled` (default) atau `full_online`; wajib `full_online` bila `AUTH_ONLINE_SECURITY_ENABLED=true`   |
+| Var                                         | Wajib          | Default    | Sensitif | Fungsi                                                                                                  |
+| ------------------------------------------- | -------------- | ---------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `AUTH_JWT_SECRET`                           | Ya             | –          | Ya       | Signing token sesi                                                                                      |
+| `AUTH_SESSION_TTL_MIN`                      | –              | `120`      | –        | Umur sesi                                                                                               |
+| `AUTH_COOKIE_SECURE`                        | –              | `true`     | –        | Cookie hanya HTTPS di prod                                                                              |
+| `AUTH_LOGIN_MAX_ATTEMPTS`                   | –              | `5`        | –        | Lockout login (per identitas)                                                                           |
+| `AUTH_LOGIN_RATE_LIMIT_MAX`                 | –              | `20`       | –        | Rate limit login per sumber+tenant (Issue #437)                                                         |
+| `AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC`          | –              | `60`       | –        | Jendela waktu rate limit login (detik)                                                                  |
+| `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`         | –              | `30`       | –        | Umur token reset password (Issue #496)                                                                  |
+| `AUTH_PASSWORD_RESET_RATE_LIMIT_MAX`        | –              | `5`        | –        | Rate limit forgot/reset per sumber+tenant                                                               |
+| `AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC` | –              | `900`      | –        | Jendela waktu rate limit reset password (detik)                                                         |
+| `AUTH_ONLINE_SECURITY_ENABLED`              | –              | `false`    | –        | Gate full-online-only auth hardening (Issue #587) — lihat §Full-online auth security hardening di bawah |
+| `AUTH_ONLINE_SECURITY_PROFILE`              | –              | `disabled` | –        | `disabled` (default) atau `full_online`; wajib `full_online` bila `AUTH_ONLINE_SECURITY_ENABLED=true`   |
+| `TURNSTILE_ENABLED`                         | –              | `false`    | –        | Cloudflare Turnstile bot protection (Issue #588) — lihat §Full-online auth security hardening di bawah  |
+| `TURNSTILE_SITE_KEY`                        | bila Turnstile | –          | –        | Site key publik (bukan secret) — dirender di widget `/login`                                            |
+| `TURNSTILE_SECRET_KEY`                      | bila Turnstile | –          | Ya       | Secret key — hanya untuk verifikasi server-side, tidak pernah ke klien                                  |
+| `TURNSTILE_VERIFY_TIMEOUT_MS`               | –              | `5000`     | –        | Timeout panggilan siteverify Cloudflare (ms)                                                            |
 
-### Full-online auth security hardening (opsional, Issue #587-#592)
+### Full-online auth security hardening (opsional, Issue #587-#593)
 
 Gate bersama untuk enam fitur online-only dalam epic ini: Cloudflare
 Turnstile (#588), MFA/TOTP (#589), Google OIDC login (#590), generic tenant
@@ -100,8 +104,18 @@ online-only ini (lihat `deployment-profiles.md`).
   dipanggil setiap fitur #588-#592 sebelum melakukan apa pun yang
   online/provider-terkait; jangan re-derive aturan "keduanya harus setuju" di
   tempat lain.
-- Issue #587 sendiri baru menambahkan gate bersama ini — belum ada fitur
-  Turnstile/MFA/Google/SSO/admin UI yang benar-benar diimplementasikan di
+- **Cloudflare Turnstile (Issue #588, selesai)** — `TURNSTILE_ENABLED`
+  divalidasi independen dari gate di atas (`checkTurnstileConfig`,
+  operator boleh isi credential Turnstile lebih dulu sebelum
+  mengaktifkan gate), tapi aktivasi runtime-nya butuh KEDUANYA
+  (`isTurnstileRequired(env)` = gate ∧ `TURNSTILE_ENABLED=true`). Berlaku
+  di `POST /auth/login`, `/auth/password/forgot`, `/auth/password/reset`,
+  `/setup/initialize` — token diverifikasi server-side ke Cloudflare
+  siteverify SEBELUM proses password/DB yang mahal
+  (`src/lib/security/turnstile.ts`). Detail lengkap: skill
+  `awcms-mini-auth-online-hardening`.
+- #589-#593 (MFA/TOTP, Google login, generic SSO, admin policy UI,
+  dokumentasi/kontrak penutup) masih backlog — belum diimplementasikan di
   repo ini.
 
 ### Sync & node
@@ -332,6 +346,8 @@ AUTH_PASSWORD_RESET_RATE_LIMIT_MAX=5
 AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC=900
 AUTH_ONLINE_SECURITY_ENABLED=false
 AUTH_ONLINE_SECURITY_PROFILE=disabled
+TURNSTILE_ENABLED=false
+TURNSTILE_VERIFY_TIMEOUT_MS=5000
 
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -112,8 +112,20 @@ online-only ini (lihat `deployment-profiles.md`).
   di `POST /auth/login`, `/auth/password/forgot`, `/auth/password/reset`,
   `/setup/initialize` — token diverifikasi server-side ke Cloudflare
   siteverify SEBELUM proses password/DB yang mahal
-  (`src/lib/security/turnstile.ts`). Detail lengkap: skill
-  `awcms-mini-auth-online-hardening`.
+  (`src/lib/security/turnstile.ts`). **Catatan operasional**: verifikasi
+  fail-closed by design (token hilang/invalid/misconfigured semuanya
+  ditolak) — hanya kegagalan transport genuine ke Cloudflare (HTTP 5xx,
+  network error, timeout) yang membuka circuit breaker-nya; respons
+  `success:false` yang normal (token client memang salah) TIDAK memicu
+  breaker (lihat PR #596 security review — versi awal keliru menyamakan
+  keduanya, memungkinkan siapa pun mengunci login/reset/setup semua
+  tenant dengan mengirim token sampah berulang). Saat breaker benar-benar
+  terbuka (outage Cloudflare sungguhan), seluruh permintaan login/
+  password-reset/setup untuk SEMUA tenant akan ditolak selama jendela
+  breaker (default 30 detik) — operator yang mengaktifkan fitur ini
+  sebaiknya memantau log `turnstile.circuit_breaker_open`/
+  `turnstile.provider_call_failed` (severity `warning`) sebagai sinyal
+  operasional. Detail lengkap: skill `awcms-mini-auth-online-hardening`.
 - #589-#593 (MFA/TOTP, Google login, generic SSO, admin policy UI,
   dokumentasi/kontrak penutup) masih backlog — belum diimplementasikan di
   repo ini.

--- a/docs/awcms-mini/deployment-profiles.md
+++ b/docs/awcms-mini/deployment-profiles.md
@@ -103,7 +103,7 @@ men-set `PUBLIC_*` apa pun tetap berperilaku identik dengan sebelum epic
   dicatat sebagai anomali di log; ini bukan pengganti memperbaiki
   konfigurasi proxy yang salah.
 
-## Full-online auth security hardening (opsional, Issue #587-#592)
+## Full-online auth security hardening (opsional, Issue #587-#593)
 
 Gate terpisah dari profil routing publik di atas — **bukan** bagian dari
 model deployment (`APP_ENV=production` sendiri **tidak** setara dengan
@@ -124,8 +124,18 @@ hardening).
   `AUTH_ONLINE_SECURITY_PROFILE=full_online` — kombinasi lain gagal
   `config:validate`. Mengaktifkan gate ini sendiri tidak mengaktifkan fitur
   apa pun secara konkret; setiap fitur (#588-#592) punya flag env-nya
-  sendiri di atas gate ini, dan belum ada satu pun yang diimplementasikan
-  di repo ini (Issue #587 baru menambahkan gate bersamanya).
+  sendiri di atas gate ini.
+- **Cloudflare Turnstile (Issue #588, selesai)** adalah fitur pertama yang
+  benar-benar diimplementasikan di atas gate ini: set tambahan
+  `TURNSTILE_ENABLED=true` + `TURNSTILE_SITE_KEY`/`TURNSTILE_SECRET_KEY`
+  untuk mengaktifkan bot protection di `POST /auth/login`,
+  `/auth/password/forgot`, `/auth/password/reset`, dan
+  `/setup/initialize`. `TURNSTILE_ENABLED` sendiri divalidasi independen
+  dari gate `AUTH_ONLINE_SECURITY_*` (operator boleh isi credential
+  Turnstile lebih dulu), tapi aktivasi runtime-nya tetap butuh keduanya.
+  #589-#593 (MFA/TOTP, Google login, generic SSO, admin policy UI,
+  dokumentasi/kontrak penutup) masih backlog, belum diimplementasikan di
+  repo ini.
 
 ## Cara menjalankan tiap profil
 

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -122,6 +122,12 @@ msgstr "This action is not allowed for the current status."
 msgid "error.concurrent_update"
 msgstr "Another request already changed this. Please try again."
 
+msgid "error.turnstile_required"
+msgstr "Please complete the verification challenge."
+
+msgid "error.turnstile_invalid"
+msgstr "Verification failed. Please try again."
+
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"
 msgstr "No role"

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -122,6 +122,12 @@ msgstr "Aksi ini tidak diizinkan untuk status saat ini."
 msgid "error.concurrent_update"
 msgstr "Permintaan lain sudah mengubah data ini. Silakan coba lagi."
 
+msgid "error.turnstile_required"
+msgstr "Mohon selesaikan verifikasi terlebih dahulu."
+
+msgid "error.turnstile_invalid"
+msgstr "Verifikasi gagal. Silakan coba lagi."
+
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"
 msgstr "Tanpa role"

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -702,6 +702,12 @@ paths:
       tags:
         - Tenant Admin
       summary: Bootstrap the first tenant, owner, office, and access assignment
+      description: >-
+        When full-online auth security hardening AND
+        `TURNSTILE_ENABLED=true` are both active (Issue #588),
+        `turnstileToken` is verified before creating the tenant/owner:
+        missing -> `400 TURNSTILE_REQUIRED`, invalid ->
+        `400 TURNSTILE_INVALID`.
       operationId: setupInitialize
       security: []
       parameters:
@@ -742,6 +748,14 @@ paths:
       tags:
         - Identity & Access
       summary: Authenticate an identity and issue a session token
+      description: >-
+        When full-online auth security hardening is active
+        (`AUTH_ONLINE_SECURITY_ENABLED=true` and
+        `AUTH_ONLINE_SECURITY_PROFILE=full_online`) AND
+        `TURNSTILE_ENABLED=true` (Issue #588), `turnstileToken` is verified
+        before any password check: missing -> `400 TURNSTILE_REQUIRED`,
+        invalid -> `400 TURNSTILE_INVALID`. Absent entirely for every
+        local/offline/LAN deployment.
       operationId: authLogin
       security:
         - tenantHeader: []
@@ -844,6 +858,12 @@ paths:
       summary: >-
         Request a password reset email; always returns a generic response
         regardless of whether the identifier matches an account
+      description: >-
+        When full-online auth security hardening AND
+        `TURNSTILE_ENABLED=true` are both active (Issue #588),
+        `turnstileToken` is verified before the reset-token DB write/email
+        enqueue: missing -> `400 TURNSTILE_REQUIRED`, invalid ->
+        `400 TURNSTILE_INVALID`.
       operationId: authPasswordForgot
       security:
         - tenantHeader: []
@@ -887,6 +907,12 @@ paths:
       tags:
         - Identity & Access
       summary: Complete a password reset with a valid one-time token
+      description: >-
+        When full-online auth security hardening AND
+        `TURNSTILE_ENABLED=true` are both active (Issue #588),
+        `turnstileToken` is verified before the token lookup/password
+        update: missing -> `400 TURNSTILE_REQUIRED`, invalid ->
+        `400 TURNSTILE_INVALID`.
       operationId: authPasswordReset
       security:
         - tenantHeader: []
@@ -6492,6 +6518,16 @@ components:
           type: string
           minLength: 1
           writeOnly: true
+        turnstileToken:
+          type: string
+          description: >-
+            Cloudflare Turnstile response token (Issue #588). Required only
+            when full-online auth security hardening is active
+            (`AUTH_ONLINE_SECURITY_ENABLED=true` and
+            `AUTH_ONLINE_SECURITY_PROFILE=full_online`) AND
+            `TURNSTILE_ENABLED=true` — absent entirely for every
+            local/offline/LAN deployment. Missing when required ->
+            `400 TURNSTILE_REQUIRED`; invalid -> `400 TURNSTILE_INVALID`.
     LoginResponse:
       type: object
       required:
@@ -6522,6 +6558,13 @@ components:
         loginIdentifier:
           type: string
           minLength: 1
+        turnstileToken:
+          type: string
+          description: >-
+            Cloudflare Turnstile response token (Issue #588). Required only
+            when full-online auth security hardening AND
+            `TURNSTILE_ENABLED=true` are both active — see `LoginRequest`'s
+            `turnstileToken` for the full gating rule.
     ForgotPasswordResponse:
       type: object
       required:
@@ -6551,6 +6594,13 @@ components:
           type: string
           minLength: 8
           writeOnly: true
+        turnstileToken:
+          type: string
+          description: >-
+            Cloudflare Turnstile response token (Issue #588). Required only
+            when full-online auth security hardening AND
+            `TURNSTILE_ENABLED=true` are both active — see `LoginRequest`'s
+            `turnstileToken` for the full gating rule.
     ResetPasswordResponse:
       type: object
       required:
@@ -7113,6 +7163,13 @@ components:
         ownerDisplayName:
           type: string
           minLength: 1
+        turnstileToken:
+          type: string
+          description: >-
+            Cloudflare Turnstile response token (Issue #588). Required only
+            when full-online auth security hardening AND
+            `TURNSTILE_ENABLED=true` are both active — see `LoginRequest`'s
+            `turnstileToken` for the full gating rule.
     SetupInitializeResponse:
       type: object
       required:

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -37,7 +37,8 @@ import { resolveAppBaseUrl } from "./lib/app-url";
 import { checkRateLimit } from "../src/lib/security/rate-limit";
 import {
   checkEmailConfig,
-  checkOnlineAuthSecurityConfig
+  checkOnlineAuthSecurityConfig,
+  checkTurnstileConfig
 } from "./validate-env";
 
 export type CheckSeverity = "critical" | "warning" | "info";
@@ -787,9 +788,10 @@ export function checkEmailProviderConfigReady(
  * pattern): the value describes how bad a genuine misconfiguration would
  * be, not this run's outcome — `status` alone is what "disabled ->
  * informational pass, not a failure" (the issue's own acceptance criterion)
- * actually means here. None of #588-#592 (Turnstile/MFA/Google
- * login/generic SSO/admin policy UI) exist yet in this repo, so there is
- * nothing else for this check to verify beyond the shared gate itself.
+ * actually means here. #588 (Turnstile) now exists and has its own
+ * `checkTurnstileReady` check below; #589-#592 (MFA/Google login/generic
+ * SSO/admin policy UI) still don't, so there is nothing else for this
+ * particular check to verify beyond the shared gate itself.
  */
 export function checkOnlineAuthSecurityReady(
   env: NodeJS.ProcessEnv = process.env
@@ -827,6 +829,60 @@ export function checkOnlineAuthSecurityReady(
     status: "pass",
     evidence:
       "AUTH_ONLINE_SECURITY_ENABLED=true and AUTH_ONLINE_SECURITY_PROFILE=full_online — full-online auth hardening gate is active."
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 9d. Cloudflare Turnstile configuration is complete when enabled (critical
+// when misconfigured, informational when disabled — Issue #588)
+// ---------------------------------------------------------------------------
+
+/**
+ * Reuses `checkTurnstileConfig` from `validate-env.ts` verbatim — same
+ * pattern as `checkEmailProviderConfigReady`/`checkOnlineAuthSecurityReady`
+ * above. Deliberately does NOT check whether the #587 gate
+ * (`isFullOnlineSecurityActive`) is also active: `TURNSTILE_ENABLED=true`
+ * with incomplete `TURNSTILE_SITE_KEY`/`_SECRET_KEY` is a real
+ * misconfiguration worth flagging even if the outer gate happens to be off
+ * right now (an operator plausibly enables Turnstile credentials before
+ * flipping the outer gate on) — `checkOnlineAuthSecurityReady` above
+ * already covers the outer gate's own correctness independently.
+ */
+export function checkTurnstileReady(
+  env: NodeJS.ProcessEnv = process.env
+): SecurityCheckResult {
+  const name = "Turnstile configuration is complete when enabled";
+  const severity: CheckSeverity = "critical";
+  const results = checkTurnstileConfig(env);
+  const failed = results.filter((result) => result.status === "fail");
+
+  if (failed.length > 0) {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `TURNSTILE_ENABLED=true but config is incomplete: ${failed
+        .map((result) => result.detail)
+        .join(" ")}`
+    };
+  }
+
+  if (env.TURNSTILE_ENABLED !== "true") {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence:
+        'TURNSTILE_ENABLED is not "true" — Turnstile config not required.'
+    };
+  }
+
+  return {
+    name,
+    severity,
+    status: "pass",
+    evidence:
+      "TURNSTILE_ENABLED=true and all conditional Turnstile config check(s) pass."
   };
 }
 
@@ -1071,6 +1127,7 @@ export async function runSecurityReadinessChecks(): Promise<
     checkSyncHmacSecretNotDefault(),
     checkEmailProviderConfigReady(),
     checkOnlineAuthSecurityReady(),
+    checkTurnstileReady(),
     await checkErrorsDontLeakStackTraces(),
     await checkSecurityHeadersPresent(),
     checkLoginRateLimitImplemented()

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -99,9 +99,18 @@
  *     deployment. If AUTH_ONLINE_SECURITY_ENABLED=true, AUTH_ONLINE_SECURITY_PROFILE
  *     must be exactly "full_online" (`../src/lib/auth/online-security-config`);
  *     any other value (including the explicitly-contradictory "disabled")
- *     fails validation. This issue only adds the shared gate itself — no
- *     provider (Turnstile/Google/OIDC/TOTP) config is validated here yet,
- *     that lands with each feature's own issue.
+ *     fails validation. Was the shared gate itself only when first added —
+ *     this file now also validates the first concrete feature to consume
+ *     it (item 8 below).
+ *  8. Cloudflare Turnstile (Issue #588, epic: full-online auth hardening):
+ *     if TURNSTILE_ENABLED is not "true", nothing else is required —
+ *     independent of the #587 gate above, so a deployment can configure
+ *     Turnstile credentials ahead of time without flipping
+ *     AUTH_ONLINE_SECURITY_ENABLED on yet. TURNSTILE_ENABLED=true requires
+ *     both TURNSTILE_SITE_KEY and TURNSTILE_SECRET_KEY
+ *     (`../src/lib/security/turnstile`). Whether Turnstile actually
+ *     activates at runtime depends on BOTH this flag AND the #587 gate
+ *     (`isTurnstileRequired()`), not on this validation alone.
  *
  * Never prints actual secret values — only which variable name is
  * missing/invalid (doc 18: "Var wajib hilang → gagal start dengan pesan
@@ -121,6 +130,10 @@ import {
   TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED
 } from "../src/modules/tenant-domain/domain/tenant-domain-dns-config";
 import { isOnlineSecurityEnabled } from "../src/lib/auth/online-security-config";
+import {
+  isTurnstileEnabled,
+  TURNSTILE_REQUIRED_WHEN_ENABLED
+} from "../src/lib/security/turnstile";
 
 export type EnvCheckResult = {
   name: string;
@@ -538,6 +551,44 @@ export function checkOnlineAuthSecurityConfig(
   ];
 }
 
+/**
+ * Cloudflare Turnstile (Issue #588, epic: full-online auth hardening).
+ * `TURNSTILE_ENABLED` left unset (or anything other than `"true"`) requires
+ * nothing else — mirrors `checkTenantDomainDnsConfig`'s "unset/off requires
+ * nothing" shape. Validated independently of the #587 full-online gate
+ * (`AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE`) — a deployment can have its
+ * Turnstile credentials configured ahead of time without yet flipping the
+ * outer gate on; the outer gate (checked separately by
+ * `checkOnlineAuthSecurityConfig` above) is what actually decides whether
+ * `isTurnstileRequired()` returns true at runtime.
+ */
+export function checkTurnstileConfig(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult[] {
+  if (!isTurnstileEnabled(env)) {
+    return [
+      {
+        name: "Turnstile config (conditional on TURNSTILE_ENABLED)",
+        status: "pass",
+        detail:
+          'TURNSTILE_ENABLED is not "true" — Turnstile config not required.'
+      }
+    ];
+  }
+
+  return TURNSTILE_REQUIRED_WHEN_ENABLED.map((name) => {
+    if (isSet(env[name])) {
+      return { name, status: "pass", detail: `${name} is set.` };
+    }
+
+    return {
+      name,
+      status: "fail",
+      detail: `TURNSTILE_ENABLED=true but ${name} is missing or empty.`
+    };
+  });
+}
+
 export function runEnvValidation(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -548,6 +599,7 @@ export function runEnvValidation(
     ...checkEmailConfig(env),
     ...checkPublicRoutingConfig(env),
     ...checkTenantDomainDnsConfig(env),
+    ...checkTurnstileConfig(env),
     ...checkOnlineAuthSecurityConfig(env)
   ];
 }

--- a/src/lib/i18n/error-messages.ts
+++ b/src/lib/i18n/error-messages.ts
@@ -6,8 +6,10 @@ import type { Translator } from "./translate";
  * `RESOURCE_CONFLICT`, `PURGE_BLOCKED_BY_DEPENDENTS`,
  * `PURGE_REQUIRES_SOFT_DELETE`, and — Issue #563 — the tenant domain
  * management API's own `HOSTNAME_CONFLICT`/`INVALID_STATUS_TRANSITION`/
- * `CONCURRENT_UPDATE`, Issue #562) to i18n catalog keys under the `error.`
- * namespace. Used both server-side (SSR error panels) and to build the
+ * `CONCURRENT_UPDATE`, Issue #562 — and Issue #588's Cloudflare Turnstile
+ * gate's own `TURNSTILE_REQUIRED`/`TURNSTILE_INVALID`) to i18n catalog keys
+ * under the `error.` namespace. Used both server-side (SSR error panels)
+ * and to build the
  * client-string JSON blob admin pages inline for their fetch-based action
  * banners (see `AdminLayout.astro`'s client i18n script pattern).
  */
@@ -33,7 +35,9 @@ export const ERROR_CODE_KEYS: Record<string, string> = {
   PURGE_REQUIRES_SOFT_DELETE: "error.purge_requires_soft_delete",
   HOSTNAME_CONFLICT: "error.hostname_conflict",
   INVALID_STATUS_TRANSITION: "error.invalid_status_transition",
-  CONCURRENT_UPDATE: "error.concurrent_update"
+  CONCURRENT_UPDATE: "error.concurrent_update",
+  TURNSTILE_REQUIRED: "error.turnstile_required",
+  TURNSTILE_INVALID: "error.turnstile_invalid"
 };
 
 /**

--- a/src/lib/security/turnstile.ts
+++ b/src/lib/security/turnstile.ts
@@ -1,0 +1,257 @@
+/**
+ * Cloudflare Turnstile bot-protection adapter (Issue #588, epic: full-online
+ * auth hardening #587-#593). Active only when the full-online security gate
+ * (Issue #587, `../auth/online-security-config.ts`'s
+ * `isFullOnlineSecurityActive`) is on AND `TURNSTILE_ENABLED=true` —
+ * `isTurnstileRequired` below is the ONE function every gated endpoint
+ * checks; local/offline/LAN deployments never call Cloudflare, never
+ * require these env vars, and never change behavior.
+ *
+ * Verifies a client-submitted Turnstile response token against Cloudflare's
+ * siteverify endpoint server-side (issue's own security note: "Verify token
+ * server-side; client widget alone is not security"). Timeout-bounded
+ * (`withTimeout`) and gated by a shared circuit breaker
+ * (`getProviderCircuitBreaker("turnstile")`) — same pattern
+ * `tenant-domain/infrastructure/cloudflare-dns-adapter.ts` and
+ * `email/infrastructure/mailketing-provider.ts` already use for outbound
+ * provider calls. Never opens or participates in a DB transaction (this
+ * file has zero DB access) — callers run it before entering `withTenant`.
+ */
+import { getProviderCircuitBreaker } from "../database/circuit-breaker";
+import { withTimeout } from "../integration/timeout";
+import { isFullOnlineSecurityActive } from "../auth/online-security-config";
+
+const PROVIDER_KEY = "turnstile";
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_ERROR_MESSAGE_LENGTH = 300;
+const DEFAULT_SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/**
+ * Env var names required only when `TURNSTILE_ENABLED=true`
+ * (`scripts/validate-env.ts`'s `checkTurnstileConfig`). `TURNSTILE_SITE_KEY`
+ * is not a secret (Cloudflare's own docs: it's embedded in the public HTML
+ * widget), but the feature can't work without it either, so it's still
+ * required-when-enabled — only `TURNSTILE_SECRET_KEY` needs the redaction
+ * discipline `verifyTurnstileToken` above applies.
+ */
+export const TURNSTILE_REQUIRED_WHEN_ENABLED = [
+  "TURNSTILE_SITE_KEY",
+  "TURNSTILE_SECRET_KEY"
+] as const;
+
+export type TurnstileConfig = {
+  secretKey: string;
+  /** Override for tests only — a local fake HTTP server standing in for Cloudflare's siteverify endpoint. Always from configuration, never request input (SSRF-safe, same convention as the Cloudflare DNS adapter's `baseUrl` override). */
+  verifyUrl?: string;
+  timeoutMs?: number;
+};
+
+export type TurnstileVerifyResult =
+  { ok: true } | { ok: false; error: string; retryable: boolean };
+
+type SiteverifyResponse = {
+  success?: boolean;
+  "error-codes"?: string[];
+};
+
+function truncate(message: string): string {
+  return message.length > MAX_ERROR_MESSAGE_LENGTH
+    ? `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`
+    : message;
+}
+
+/**
+ * Strips the configured secret out of `message` before it is ever returned
+ * to a caller or logged — defense in depth against a thrown error
+ * accidentally echoing part of the request. Same pattern as the Cloudflare
+ * DNS adapter's own `redact()`.
+ */
+function redact(message: string, secrets: readonly string[]): string {
+  let sanitized = message;
+
+  for (const secret of secrets) {
+    if (secret) {
+      sanitized = sanitized.split(secret).join("[redacted]");
+    }
+  }
+
+  return sanitized;
+}
+
+/**
+ * Verifies `token` (the client-submitted Turnstile response, e.g. from the
+ * widget's auto-injected `cf-turnstile-response` form field) against
+ * Cloudflare's siteverify endpoint. `remoteIp`, if provided, is forwarded
+ * per Cloudflare's own API (optional, improves their fraud scoring — never
+ * required).
+ */
+export async function verifyTurnstileToken(
+  token: string,
+  config: TurnstileConfig,
+  remoteIp?: string
+): Promise<TurnstileVerifyResult> {
+  const verifyUrl = config.verifyUrl ?? DEFAULT_SITEVERIFY_URL;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const breaker = getProviderCircuitBreaker(PROVIDER_KEY);
+  const attemptedAt = new Date();
+  const secrets = [config.secretKey];
+
+  if (!breaker.canAttempt(attemptedAt)) {
+    return {
+      ok: false,
+      error: "Turnstile circuit breaker is open; skipping attempt.",
+      retryable: true
+    };
+  }
+
+  const formData = new URLSearchParams();
+  formData.set("secret", config.secretKey);
+  formData.set("response", token);
+
+  if (remoteIp) {
+    formData.set("remoteip", remoteIp);
+  }
+
+  try {
+    const response = await withTimeout(
+      fetch(verifyUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: formData.toString()
+      }),
+      timeoutMs,
+      "turnstile siteverify"
+    );
+
+    const rawBody = await response.text().catch(() => "");
+    let body: SiteverifyResponse | undefined;
+
+    try {
+      body = rawBody ? (JSON.parse(rawBody) as SiteverifyResponse) : undefined;
+    } catch {
+      body = undefined;
+    }
+
+    if (response.status < 200 || response.status >= 300 || !body?.success) {
+      breaker.recordFailure(attemptedAt);
+
+      return {
+        ok: false,
+        error: truncate(
+          redact(
+            `Turnstile verification failed (HTTP ${response.status}, error codes: ${
+              (body?.["error-codes"] ?? []).join(", ") || "none"
+            }).`,
+            secrets
+          )
+        ),
+        retryable: response.status >= 500 || response.status === 0
+      };
+    }
+
+    breaker.recordSuccess(attemptedAt);
+    return { ok: true };
+  } catch (error) {
+    breaker.recordFailure(attemptedAt);
+    const message = error instanceof Error ? error.message : String(error);
+
+    return {
+      ok: false,
+      error: truncate(redact(message, secrets)),
+      retryable: true
+    };
+  }
+}
+
+export function isTurnstileEnabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return env.TURNSTILE_ENABLED === "true";
+}
+
+export function resolveTurnstileTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const raw = Number(env.TURNSTILE_VERIFY_TIMEOUT_MS);
+
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MS;
+}
+
+/**
+ * The single boolean every one of the four gated endpoints
+ * (`POST /auth/login`, `/auth/password/forgot`, `/auth/password/reset`,
+ * `/setup/initialize`) must check before requiring/verifying a Turnstile
+ * token — true only when BOTH the full-online security gate (Issue #587)
+ * is active AND this feature's own flag is set. Matches this issue's
+ * acceptance criterion "Turnstile is active only when #587 gate is enabled
+ * and TURNSTILE_ENABLED=true."
+ */
+export function isTurnstileRequired(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return isFullOnlineSecurityActive(env) && isTurnstileEnabled(env);
+}
+
+/**
+ * Builds a `TurnstileConfig` from env. Returns `null` if misconfigured
+ * (enabled but missing the secret key) — never throws. Callers must treat
+ * `null` as "cannot verify" and fail closed (reject the request), not as
+ * "skip verification", since `isTurnstileRequired` already said this
+ * deployment wants Turnstile enforced.
+ */
+export function resolveTurnstileConfig(
+  env: NodeJS.ProcessEnv = process.env
+): TurnstileConfig | null {
+  const secretKey = env.TURNSTILE_SECRET_KEY;
+
+  if (!secretKey) {
+    return null;
+  }
+
+  return { secretKey, timeoutMs: resolveTurnstileTimeoutMs(env) };
+}
+
+export type TurnstileEnforcementResult =
+  | { ok: true }
+  | { ok: false; code: "TURNSTILE_REQUIRED" | "TURNSTILE_INVALID" };
+
+/**
+ * The one function every gated endpoint calls — consolidates the
+ * "skip if not required / reject if missing / reject if misconfigured /
+ * verify and reject if invalid" branching so it isn't duplicated four
+ * times. `turnstileToken` is deliberately typed `unknown`: it comes
+ * straight from an untrusted parsed JSON request body.
+ */
+export async function enforceTurnstileIfRequired(
+  turnstileToken: unknown,
+  remoteIp: string | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<TurnstileEnforcementResult> {
+  if (!isTurnstileRequired(env)) {
+    return { ok: true };
+  }
+
+  if (typeof turnstileToken !== "string" || turnstileToken.length === 0) {
+    return { ok: false, code: "TURNSTILE_REQUIRED" };
+  }
+
+  const config = resolveTurnstileConfig(env);
+
+  // Fail closed rather than silently skipping verification — a misconfigured
+  // deployment (TURNSTILE_ENABLED=true but no secret key) should never be
+  // indistinguishable from "verification passed" to the client. Reusing
+  // TURNSTILE_INVALID (rather than a distinct code) avoids telling an
+  // unauthenticated caller that the server is misconfigured.
+  if (!config) {
+    return { ok: false, code: "TURNSTILE_INVALID" };
+  }
+
+  const result = await verifyTurnstileToken(turnstileToken, config, remoteIp);
+
+  if (!result.ok) {
+    return { ok: false, code: "TURNSTILE_INVALID" };
+  }
+
+  return { ok: true };
+}

--- a/src/lib/security/turnstile.ts
+++ b/src/lib/security/turnstile.ts
@@ -20,6 +20,7 @@
 import { getProviderCircuitBreaker } from "../database/circuit-breaker";
 import { withTimeout } from "../integration/timeout";
 import { isFullOnlineSecurityActive } from "../auth/online-security-config";
+import { log } from "../logging/logger";
 
 const PROVIDER_KEY = "turnstile";
 const DEFAULT_TIMEOUT_MS = 5_000;
@@ -98,6 +99,12 @@ export async function verifyTurnstileToken(
   const secrets = [config.secretKey];
 
   if (!breaker.canAttempt(attemptedAt)) {
+    // Operationally significant: while open, `enforceTurnstileIfRequired`
+    // fails closed and blocks every login/password-reset/setup request for
+    // every tenant. Logged at `warning` so a sustained open breaker (real
+    // Cloudflare outage) is distinguishable from normal traffic.
+    log("warning", "turnstile.circuit_breaker_open");
+
     return {
       ok: false,
       error: "Turnstile circuit breaker is open; skipping attempt.",
@@ -133,20 +140,49 @@ export async function verifyTurnstileToken(
       body = undefined;
     }
 
-    if (response.status < 200 || response.status >= 300 || !body?.success) {
+    // Only a transport-level problem with Cloudflare itself (non-2xx HTTP
+    // status, or a 2xx response we couldn't even parse) counts as a
+    // *provider* failure for circuit-breaker purposes. A well-formed 2xx
+    // response with `success: false` is Cloudflare correctly telling us the
+    // client-submitted token was bad — the normal, expected, and trivially
+    // attacker-repeatable outcome for a garbage/expired/reused token. Feeding
+    // that into `recordFailure` would let anyone trip this shared,
+    // cross-tenant breaker (and, since `enforceTurnstileIfRequired` fails
+    // closed while it's open, lock out login/password-reset/setup for every
+    // tenant) just by submitting a handful of invalid tokens — see PR #596
+    // security review.
+    if (response.status < 200 || response.status >= 300 || !body) {
       breaker.recordFailure(attemptedAt);
+      log("warning", "turnstile.provider_call_failed", {
+        httpStatus: response.status
+      });
 
       return {
         ok: false,
         error: truncate(
           redact(
-            `Turnstile verification failed (HTTP ${response.status}, error codes: ${
-              (body?.["error-codes"] ?? []).join(", ") || "none"
-            }).`,
+            `Turnstile provider call failed (HTTP ${response.status}).`,
             secrets
           )
         ),
         retryable: response.status >= 500 || response.status === 0
+      };
+    }
+
+    if (!body.success) {
+      breaker.recordSuccess(attemptedAt);
+
+      return {
+        ok: false,
+        error: truncate(
+          redact(
+            `Turnstile token rejected (error codes: ${
+              (body["error-codes"] ?? []).join(", ") || "none"
+            }).`,
+            secrets
+          )
+        ),
+        retryable: false
       };
     }
 
@@ -155,6 +191,9 @@ export async function verifyTurnstileToken(
   } catch (error) {
     breaker.recordFailure(attemptedAt);
     const message = error instanceof Error ? error.message : String(error);
+    log("warning", "turnstile.provider_call_errored", {
+      error: redact(truncate(message), secrets)
+    });
 
     return {
       ok: false,

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -150,13 +150,14 @@ Astro secara default menolak (403, tanpa body) permintaan `POST`/`PUT`/`PATCH`/`
 
 CRUD ABAC policy row (`awcms_mini_abac_policies` — schema tersedia, evaluator masih pakai aturan generik bawaan, belum ada endpoint kelola policy), dan publikasi event `identity.login.succeeded`/`identity.login.failed` (doc 05, menyusul modul Observability/Logging) belum ada pada tahap ini. `/access/decision-logs` tetap `LIMIT 50` per halaman tapi kini punya keyset pagination opsional (Issue #435, `?cursor=`/`nextCursor` — lihat `src/modules/_shared/keyset-pagination.ts`).
 
-Belum ada implementasi konkret untuk epic full-online auth security
-hardening (Issue #587-#593): Cloudflare Turnstile, MFA/TOTP, Google OIDC
-login, generic tenant OIDC SSO, dan admin policy UI-nya semua masih
-backlog. Issue #587 sendiri sudah selesai (lihat §Full-online-only auth
-security feature gate di bawah) — hanya menambahkan gate bersama
-(`AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE`), belum ada satu pun fitur
-konkret yang memakainya.
+MFA/TOTP, Google OIDC login, generic tenant OIDC SSO, dan admin policy
+UI (Issue #589-#592) masih backlog untuk epic full-online auth security
+hardening (#587-#593). #587 (gate bersama, lihat §Full-online-only auth
+security feature gate di bawah) dan #588 (Cloudflare Turnstile,
+`src/lib/security/turnstile.ts` — bukan bagian modul ini, tapi
+dipanggil dari `POST /auth/login` di modul ini via
+`enforceTurnstileIfRequired`, lihat skill `awcms-mini-auth-online-hardening`
+§Cloudflare Turnstile) sudah selesai.
 
 ## Full-online-only auth security feature gate (Issue #587)
 

--- a/src/pages/api/v1/auth/login.ts
+++ b/src/pages/api/v1/auth/login.ts
@@ -16,6 +16,7 @@ import {
   checkRateLimit,
   resolveClientIp
 } from "../../../../lib/security/rate-limit";
+import { enforceTurnstileIfRequired } from "../../../../lib/security/turnstile";
 
 const MAX_FAILED_ATTEMPTS = Number(process.env.AUTH_LOGIN_MAX_ATTEMPTS ?? 5);
 const LOCKOUT_MINUTES = 15;
@@ -43,6 +44,7 @@ const LOGIN_RATE_LIMIT_WINDOW_SEC = Number(
 type LoginBody = {
   loginIdentifier?: unknown;
   password?: unknown;
+  turnstileToken?: unknown;
 };
 
 export const POST: APIRoute = async ({ request, cookies, clientAddress }) => {
@@ -85,6 +87,24 @@ export const POST: APIRoute = async ({ request, cookies, clientAddress }) => {
       400,
       "VALIDATION_ERROR",
       "loginIdentifier and password are required."
+    );
+  }
+
+  // Full-online-only (Issue #587/#588): a no-op on every local/offline/LAN
+  // deployment (isTurnstileRequired() is false there), and cheaper than the
+  // DB/password-hash work below when it does apply — verify before either.
+  const turnstileResult = await enforceTurnstileIfRequired(
+    body.turnstileToken,
+    clientIp
+  );
+
+  if (!turnstileResult.ok) {
+    return fail(
+      400,
+      turnstileResult.code,
+      turnstileResult.code === "TURNSTILE_REQUIRED"
+        ? "Turnstile verification token is required."
+        : "Turnstile verification failed."
     );
   }
 

--- a/src/pages/api/v1/auth/password/forgot.ts
+++ b/src/pages/api/v1/auth/password/forgot.ts
@@ -7,6 +7,7 @@ import {
   checkRateLimit,
   resolveClientIp
 } from "../../../../../lib/security/rate-limit";
+import { enforceTurnstileIfRequired } from "../../../../../lib/security/turnstile";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import { requestPasswordReset } from "../../../../../modules/identity-access/application/password-reset";
 import { validateForgotIdentifierInput } from "../../../../../modules/identity-access/domain/password-reset-validation";
@@ -62,9 +63,8 @@ export const POST: APIRoute = async ({ request, clientAddress, locals }) => {
     );
   }
 
-  const validation = validateForgotIdentifierInput(
-    await request.json().catch(() => null)
-  );
+  const rawBody = await request.json().catch(() => null);
+  const validation = validateForgotIdentifierInput(rawBody);
 
   if (!validation.valid) {
     return fail(
@@ -73,6 +73,24 @@ export const POST: APIRoute = async ({ request, clientAddress, locals }) => {
       "loginIdentifier is required.",
       {},
       validation.errors
+    );
+  }
+
+  // Full-online-only (Issue #587/#588): a no-op on every local/offline/LAN
+  // deployment, and cheaper than the DB write + email enqueue below when it
+  // does apply — verify before either.
+  const turnstileResult = await enforceTurnstileIfRequired(
+    (rawBody as Record<string, unknown> | null)?.turnstileToken,
+    clientIp
+  );
+
+  if (!turnstileResult.ok) {
+    return fail(
+      400,
+      turnstileResult.code,
+      turnstileResult.code === "TURNSTILE_REQUIRED"
+        ? "Turnstile verification token is required."
+        : "Turnstile verification failed."
     );
   }
 

--- a/src/pages/api/v1/auth/password/reset.ts
+++ b/src/pages/api/v1/auth/password/reset.ts
@@ -7,6 +7,7 @@ import {
   checkRateLimit,
   resolveClientIp
 } from "../../../../../lib/security/rate-limit";
+import { enforceTurnstileIfRequired } from "../../../../../lib/security/turnstile";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import { completePasswordReset } from "../../../../../modules/identity-access/application/password-reset";
 import { validateCompleteResetInput } from "../../../../../modules/identity-access/domain/password-reset-validation";
@@ -56,9 +57,8 @@ export const POST: APIRoute = async ({ request, clientAddress, locals }) => {
     );
   }
 
-  const validation = validateCompleteResetInput(
-    await request.json().catch(() => null)
-  );
+  const rawBody = await request.json().catch(() => null);
+  const validation = validateCompleteResetInput(rawBody);
 
   if (!validation.valid) {
     return fail(
@@ -67,6 +67,24 @@ export const POST: APIRoute = async ({ request, clientAddress, locals }) => {
       "token and newPassword are required.",
       {},
       validation.errors
+    );
+  }
+
+  // Full-online-only (Issue #587/#588): a no-op on every local/offline/LAN
+  // deployment, and cheaper than the password-hash + DB mutation below when
+  // it does apply — verify before either.
+  const turnstileResult = await enforceTurnstileIfRequired(
+    (rawBody as Record<string, unknown> | null)?.turnstileToken,
+    clientIp
+  );
+
+  if (!turnstileResult.ok) {
+    return fail(
+      400,
+      turnstileResult.code,
+      turnstileResult.code === "TURNSTILE_REQUIRED"
+        ? "Turnstile verification token is required."
+        : "Turnstile verification failed."
     );
   }
 

--- a/src/pages/api/v1/setup/initialize.ts
+++ b/src/pages/api/v1/setup/initialize.ts
@@ -3,9 +3,11 @@ import { fail, ok } from "../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../lib/database/client";
 import { assertUuid } from "../../../../lib/database/tenant-context";
 import { hashPassword } from "../../../../lib/auth/password";
+import { resolveClientIp } from "../../../../lib/security/rate-limit";
+import { enforceTurnstileIfRequired } from "../../../../lib/security/turnstile";
 import { validateSetupInitializeInput } from "../../../../modules/tenant-admin/domain/setup-validation";
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, clientAddress }) => {
   const body = await request.json().catch(() => null);
   const validation = validateSetupInitializeInput(body);
 
@@ -16,6 +18,28 @@ export const POST: APIRoute = async ({ request }) => {
       "Setup input is invalid.",
       {},
       validation.errors
+    );
+  }
+
+  // Full-online-only (Issue #587/#588): a no-op on every local/offline/LAN
+  // deployment, and cheaper than the multi-row tenant/owner INSERT sequence
+  // below when it does apply — verify before either. Setup is a once-only,
+  // singleton-locked endpoint (see the `ON CONFLICT DO NOTHING` claim below),
+  // but still worth gating: an attacker racing this endpoint before a real
+  // operator completes setup is exactly the kind of public, unauthenticated,
+  // high-value target Turnstile exists for.
+  const turnstileResult = await enforceTurnstileIfRequired(
+    (body as Record<string, unknown> | null)?.turnstileToken,
+    resolveClientIp(request, clientAddress)
+  );
+
+  if (!turnstileResult.ok) {
+    return fail(
+      400,
+      turnstileResult.code,
+      turnstileResult.code === "TURNSTILE_REQUIRED"
+        ? "Turnstile verification token is required."
+        : "Turnstile verification failed."
     );
   }
 

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -11,13 +11,27 @@
  * via `Bun.file`), so the strings/error-code map it needs are injected as a
  * `<script type="application/json">` blob — the same pattern the admin
  * pages' action banners use.
+ *
+ * Cloudflare Turnstile (Issue #588, epic: full-online auth hardening) —
+ * the widget only renders when `isTurnstileRequired()` (Issue #587's
+ * full-online gate AND `TURNSTILE_ENABLED=true`) is true; every local/
+ * offline/LAN deployment (the default) renders this page identically to
+ * before this issue. `TURNSTILE_SITE_KEY` is not a secret (Cloudflare's own
+ * docs: embedded in every public Turnstile widget) — only
+ * `TURNSTILE_SECRET_KEY` (server-side verification only, never sent here)
+ * needs the redaction discipline `src/lib/security/turnstile.ts` applies.
  */
 import "../styles/tokens.css";
 import { createTranslator } from "../lib/i18n/translate";
 import { buildClientErrorMessages } from "../lib/i18n/error-messages";
+import { isTurnstileRequired } from "../lib/security/turnstile";
 
 const locale = Astro.locals.locale;
 const t = await createTranslator(locale);
+const turnstileActive = isTurnstileRequired();
+const turnstileSiteKey = turnstileActive
+  ? process.env.TURNSTILE_SITE_KEY
+  : null;
 
 const clientStrings = {
   genericError: t("auth.login.generic_error"),
@@ -74,11 +88,27 @@ const clientStrings = {
           autocomplete="current-password"
         />
 
+        {
+          turnstileActive && turnstileSiteKey && (
+            <div class="cf-turnstile" data-sitekey={turnstileSiteKey} />
+          )
+        }
+
         <button type="submit" id="login-submit">
           {t("auth.login.submit")}
         </button>
       </form>
     </main>
+
+    {
+      turnstileActive && turnstileSiteKey && (
+        <script
+          src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+          async
+          defer
+        />
+      )
+    }
 
     <script
       type="application/json"
@@ -136,6 +166,11 @@ const clientStrings = {
           formData.get("loginIdentifier") ?? ""
         ).trim();
         const password = String(formData.get("password") ?? "");
+        // Cloudflare Turnstile (Issue #588) auto-injects a hidden
+        // `cf-turnstile-response` field into this form once solved — absent
+        // entirely when the widget isn't rendered (Turnstile not required
+        // for this deployment), matching the server's own optional field.
+        const turnstileToken = formData.get("cf-turnstile-response");
 
         try {
           const response = await fetch("/api/v1/auth/login", {
@@ -145,7 +180,11 @@ const clientStrings = {
               "X-AWCMS-Mini-Tenant-ID": tenantId
             },
             credentials: "same-origin",
-            body: JSON.stringify({ loginIdentifier, password })
+            body: JSON.stringify({
+              loginIdentifier,
+              password,
+              ...(turnstileToken ? { turnstileToken } : {})
+            })
           });
 
           const payload = await response.json().catch(() => null);

--- a/tests/integration/turnstile-gate.integration.test.ts
+++ b/tests/integration/turnstile-gate.integration.test.ts
@@ -239,6 +239,30 @@ suite("Turnstile gate across auth endpoints (Issue #588)", () => {
     expect(result.body.error.code).toBe("TURNSTILE_REQUIRED");
   });
 
+  test("password/forgot: enabled mode accepts a valid turnstileToken end to end", async () => {
+    const owner = await bootstrapTenant();
+
+    const result = await withEnvOverride(FULL_ONLINE_TURNSTILE_ENV, () =>
+      withStubbedSiteverify(true, () =>
+        invoke<{ data: { requested: boolean } }>(passwordForgot, {
+          method: "POST",
+          path: "/api/v1/auth/password/forgot",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId
+          },
+          body: {
+            loginIdentifier: OWNER_LOGIN,
+            turnstileToken: "good-token"
+          }
+        })
+      )
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.requested).toBe(true);
+  });
+
   test("password/reset: enabled mode rejects a request with no turnstileToken, before any token lookup", async () => {
     const owner = await bootstrapTenant();
 

--- a/tests/integration/turnstile-gate.integration.test.ts
+++ b/tests/integration/turnstile-gate.integration.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Integration tests for the Cloudflare Turnstile gate (Issue #588, epic:
+ * full-online auth hardening) across the four endpoints it applies to:
+ * `POST /auth/login`, `/auth/password/forgot`, `/auth/password/reset`, and
+ * `/setup/initialize`. Exercises the real handlers against a real
+ * PostgreSQL — the pure verify-logic itself (timeout, redaction, circuit
+ * breaker) is already covered by `tests/unit/turnstile.test.ts`; this file
+ * proves the four endpoints actually call `enforceTurnstileIfRequired`
+ * before their expensive DB/password work, not just that the function
+ * itself is correct in isolation.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { POST as passwordForgot } from "../../src/pages/api/v1/auth/password/forgot";
+import { POST as passwordReset } from "../../src/pages/api/v1/auth/password/reset";
+import { resetRateLimitStoreForTests } from "../../src/lib/security/rate-limit";
+import { resetProviderCircuitBreakersForTests } from "../../src/lib/database/circuit-breaker";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+const FULL_ONLINE_TURNSTILE_ENV: Record<string, string> = {
+  AUTH_ONLINE_SECURITY_ENABLED: "true",
+  AUTH_ONLINE_SECURITY_PROFILE: "full_online",
+  TURNSTILE_ENABLED: "true",
+  TURNSTILE_SITE_KEY: "site-key-test",
+  TURNSTILE_SECRET_KEY: "secret-key-test"
+};
+
+/**
+ * Temporarily overrides `process.env` keys for the duration of `fn`, then
+ * restores the previous values (or deletes the key if it was previously
+ * unset). Same pattern `blog-content-public-news.integration.test.ts` uses
+ * for the same reason: route handlers read the real `process.env`, so this
+ * is the only way to exercise a non-default gate state through the real
+ * handler.
+ */
+async function withEnvOverride<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+
+  for (const key of Object.keys(overrides)) {
+    previous[key] = process.env[key];
+    const value = overrides[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(overrides)) {
+      const value = previous[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+/** Stubs global `fetch` for the duration of `fn` — stands in for Cloudflare's siteverify endpoint, which `resolveTurnstileConfig` gives no way to redirect via env. */
+async function withStubbedSiteverify<T>(
+  success: boolean,
+  fn: () => Promise<T>
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    Response.json({ success })) as unknown as typeof fetch;
+
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+async function bootstrapTenant(tenantCode = "acme") {
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: `Tenant ${tenantCode}`,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "Head Office",
+      ownerLoginIdentifier: OWNER_LOGIN,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("Turnstile gate across auth endpoints (Issue #588)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    resetRateLimitStoreForTests();
+    resetProviderCircuitBreakersForTests();
+  });
+
+  test("login: disabled mode (default) requires no turnstileToken, unaffected", async () => {
+    const owner = await bootstrapTenant();
+
+    const result = await invoke(authLogin, {
+      method: "POST",
+      path: "/api/v1/auth/login",
+      headers: {
+        "content-type": "application/json",
+        "x-awcms-mini-tenant-id": owner.tenantId
+      },
+      body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+      cookies: createCookieJar()
+    });
+
+    expect(result.status).toBe(200);
+  });
+
+  test("login: enabled mode rejects a request with no turnstileToken (400 TURNSTILE_REQUIRED), before any password verification", async () => {
+    const owner = await bootstrapTenant();
+
+    const result = await withEnvOverride(FULL_ONLINE_TURNSTILE_ENV, () =>
+      invoke<{ error: { code: string } }>(authLogin, {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        // Deliberately wrong password — if Turnstile were checked AFTER
+        // password verification, this would surface AUTH_INVALID_CREDENTIALS
+        // instead, proving the ordering is wrong.
+        body: { loginIdentifier: OWNER_LOGIN, password: "wrong-password" },
+        cookies: createCookieJar()
+      })
+    );
+
+    expect(result.status).toBe(400);
+    expect(result.body.error.code).toBe("TURNSTILE_REQUIRED");
+  });
+
+  test("login: enabled mode rejects an invalid turnstileToken (400 TURNSTILE_INVALID)", async () => {
+    const owner = await bootstrapTenant();
+
+    const result = await withEnvOverride(FULL_ONLINE_TURNSTILE_ENV, () =>
+      withStubbedSiteverify(false, () =>
+        invoke<{ error: { code: string } }>(authLogin, {
+          method: "POST",
+          path: "/api/v1/auth/login",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId
+          },
+          body: {
+            loginIdentifier: OWNER_LOGIN,
+            password: OWNER_PASSWORD,
+            turnstileToken: "bad-token"
+          },
+          cookies: createCookieJar()
+        })
+      )
+    );
+
+    expect(result.status).toBe(400);
+    expect(result.body.error.code).toBe("TURNSTILE_INVALID");
+  });
+
+  test("login: enabled mode accepts a valid turnstileToken end to end", async () => {
+    const owner = await bootstrapTenant();
+
+    const result = await withEnvOverride(FULL_ONLINE_TURNSTILE_ENV, () =>
+      withStubbedSiteverify(true, () =>
+        invoke<{ data: { token: string } }>(authLogin, {
+          method: "POST",
+          path: "/api/v1/auth/login",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId
+          },
+          body: {
+            loginIdentifier: OWNER_LOGIN,
+            password: OWNER_PASSWORD,
+            turnstileToken: "good-token"
+          },
+          cookies: createCookieJar()
+        })
+      )
+    );
+
+    expect(result.status).toBe(200);
+    expect(typeof result.body.data.token).toBe("string");
+  });
+
+  test("password/forgot: enabled mode rejects a request with no turnstileToken, before any DB write", async () => {
+    const owner = await bootstrapTenant();
+
+    const result = await withEnvOverride(FULL_ONLINE_TURNSTILE_ENV, () =>
+      invoke<{ error: { code: string } }>(passwordForgot, {
+        method: "POST",
+        path: "/api/v1/auth/password/forgot",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: OWNER_LOGIN }
+      })
+    );
+
+    expect(result.status).toBe(400);
+    expect(result.body.error.code).toBe("TURNSTILE_REQUIRED");
+  });
+
+  test("password/reset: enabled mode rejects a request with no turnstileToken, before any token lookup", async () => {
+    const owner = await bootstrapTenant();
+
+    const result = await withEnvOverride(FULL_ONLINE_TURNSTILE_ENV, () =>
+      invoke<{ error: { code: string } }>(passwordReset, {
+        method: "POST",
+        path: "/api/v1/auth/password/reset",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { token: "irrelevant-token", newPassword: "New-Password-123" }
+      })
+    );
+
+    expect(result.status).toBe(400);
+    expect(result.body.error.code).toBe("TURNSTILE_REQUIRED");
+  });
+
+  test("setup/initialize: enabled mode rejects a request with no turnstileToken, before creating the tenant", async () => {
+    const result = await withEnvOverride(FULL_ONLINE_TURNSTILE_ENV, () =>
+      invoke<{ error: { code: string } }>(setupInitialize, {
+        method: "POST",
+        path: "/api/v1/setup/initialize",
+        headers: { "content-type": "application/json" },
+        body: {
+          tenantName: "Tenant no-token",
+          tenantCode: "no-token",
+          officeCode: "hq",
+          officeName: "Head Office",
+          ownerLoginIdentifier: OWNER_LOGIN,
+          ownerPassword: OWNER_PASSWORD,
+          ownerDisplayName: "Owner"
+        }
+      })
+    );
+
+    expect(result.status).toBe(400);
+    expect(result.body.error.code).toBe("TURNSTILE_REQUIRED");
+  });
+
+  test("setup/initialize: enabled mode accepts a valid turnstileToken end to end", async () => {
+    const result = await withEnvOverride(FULL_ONLINE_TURNSTILE_ENV, () =>
+      withStubbedSiteverify(true, () =>
+        invoke<{ data: { tenantId: string } }>(setupInitialize, {
+          method: "POST",
+          path: "/api/v1/setup/initialize",
+          headers: { "content-type": "application/json" },
+          body: {
+            tenantName: "Tenant with token",
+            tenantCode: "with-token",
+            officeCode: "hq",
+            officeName: "Head Office",
+            ownerLoginIdentifier: OWNER_LOGIN,
+            ownerPassword: OWNER_PASSWORD,
+            ownerDisplayName: "Owner",
+            turnstileToken: "good-token"
+          }
+        })
+      )
+    );
+
+    expect(result.status).toBe(200);
+    expect(typeof result.body.data.tenantId).toBe("string");
+  });
+});

--- a/tests/security-readiness.test.ts
+++ b/tests/security-readiness.test.ts
@@ -7,6 +7,7 @@ import {
   checkLoginRateLimitImplemented,
   checkOnlineAuthSecurityReady,
   checkSyncHmacSecretNotDefault,
+  checkTurnstileReady,
   scanLineForHardcodedSecret
 } from "../scripts/security-readiness";
 
@@ -209,6 +210,35 @@ describe("checkEmailProviderConfigReady", () => {
       EMAIL_MAILKETING_ACCOUNT_ID: "acc",
       EMAIL_MAILKETING_API_TOKEN: "token",
       EMAIL_MAILKETING_API_BASE_URL: "https://api.mailketing.co.id"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("pass");
+  });
+});
+
+describe("checkTurnstileReady", () => {
+  test("is critical/pass (informational, not a failure) when Turnstile is not enabled", () => {
+    const result = checkTurnstileReady({} as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when TURNSTILE_ENABLED=true but the site/secret keys are missing", () => {
+    const result = checkTurnstileReady({
+      TURNSTILE_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("fail");
+  });
+
+  test("passes when TURNSTILE_ENABLED=true and both keys are set", () => {
+    const result = checkTurnstileReady({
+      TURNSTILE_ENABLED: "true",
+      TURNSTILE_SITE_KEY: "site-key-abc",
+      TURNSTILE_SECRET_KEY: "a-real-secret"
     } as NodeJS.ProcessEnv);
 
     expect(result.severity).toBe("critical");

--- a/tests/unit/turnstile.test.ts
+++ b/tests/unit/turnstile.test.ts
@@ -203,11 +203,11 @@ describe("verifyTurnstileToken", () => {
     expect((result as { error: string }).error).toMatch(/timed out/i);
   });
 
-  test("opens the circuit breaker after consecutive failures", async () => {
+  test("opens the circuit breaker after consecutive PROVIDER failures (5xx), not client-rejected tokens", async () => {
     using server = Bun.serve({
       port: 0,
       fetch() {
-        return Response.json({ success: false, "error-codes": ["boom"] });
+        return new Response("upstream error", { status: 500 });
       }
     });
 
@@ -224,6 +224,38 @@ describe("verifyTurnstileToken", () => {
 
     expect(sixth.ok).toBe(false);
     expect((sixth as { error: string }).error).toMatch(/circuit breaker/i);
+  });
+
+  test("never trips the circuit breaker on repeated client-rejected tokens (success:false) — an unauthenticated caller must not be able to lock out every tenant's login/reset/setup by submitting garbage tokens", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({
+          success: false,
+          "error-codes": ["invalid-input-response"]
+        });
+      }
+    });
+
+    const config = {
+      secretKey: "super-secret-turnstile-value",
+      verifyUrl: `http://127.0.0.1:${server.port}`
+    };
+
+    let lastResult:
+      Awaited<ReturnType<typeof verifyTurnstileToken>> | undefined;
+
+    for (let i = 0; i < 10; i += 1) {
+      lastResult = await verifyTurnstileToken("bad-token", config);
+    }
+
+    expect(lastResult?.ok).toBe(false);
+    expect((lastResult as { error: string }).error).not.toMatch(
+      /circuit breaker/i
+    );
+    expect((lastResult as { error: string }).error).toMatch(
+      /invalid-input-response/
+    );
   });
 });
 

--- a/tests/unit/turnstile.test.ts
+++ b/tests/unit/turnstile.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resetProviderCircuitBreakersForTests } from "../../src/lib/database/circuit-breaker";
+import {
+  enforceTurnstileIfRequired,
+  isTurnstileEnabled,
+  isTurnstileRequired,
+  resolveTurnstileConfig,
+  resolveTurnstileTimeoutMs,
+  verifyTurnstileToken
+} from "../../src/lib/security/turnstile";
+
+const FULL_ONLINE_ENV = {
+  AUTH_ONLINE_SECURITY_ENABLED: "true",
+  AUTH_ONLINE_SECURITY_PROFILE: "full_online"
+} as const;
+
+describe("isTurnstileEnabled", () => {
+  test("false when unset", () => {
+    expect(isTurnstileEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  test('true only for the literal string "true"', () => {
+    expect(
+      isTurnstileEnabled({ TURNSTILE_ENABLED: "true" } as NodeJS.ProcessEnv)
+    ).toBe(true);
+    expect(
+      isTurnstileEnabled({ TURNSTILE_ENABLED: "TRUE" } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+});
+
+describe("resolveTurnstileTimeoutMs", () => {
+  test("defaults to 5000ms when unset", () => {
+    expect(resolveTurnstileTimeoutMs({} as NodeJS.ProcessEnv)).toBe(5000);
+  });
+
+  test("uses a valid positive override", () => {
+    expect(
+      resolveTurnstileTimeoutMs({
+        TURNSTILE_VERIFY_TIMEOUT_MS: "2000"
+      } as NodeJS.ProcessEnv)
+    ).toBe(2000);
+  });
+
+  test("falls back to the default for non-numeric/zero/negative values", () => {
+    expect(
+      resolveTurnstileTimeoutMs({
+        TURNSTILE_VERIFY_TIMEOUT_MS: "not-a-number"
+      } as NodeJS.ProcessEnv)
+    ).toBe(5000);
+    expect(
+      resolveTurnstileTimeoutMs({
+        TURNSTILE_VERIFY_TIMEOUT_MS: "0"
+      } as NodeJS.ProcessEnv)
+    ).toBe(5000);
+  });
+});
+
+describe("isTurnstileRequired — the shared gate every endpoint checks", () => {
+  test("false when the full-online gate (#587) is off, even if TURNSTILE_ENABLED=true", () => {
+    expect(
+      isTurnstileRequired({
+        TURNSTILE_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("false when TURNSTILE_ENABLED is not set, even if the full-online gate is on", () => {
+    expect(
+      isTurnstileRequired({ ...FULL_ONLINE_ENV } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("true only when both the full-online gate and TURNSTILE_ENABLED agree", () => {
+    expect(
+      isTurnstileRequired({
+        ...FULL_ONLINE_ENV,
+        TURNSTILE_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+});
+
+describe("resolveTurnstileConfig", () => {
+  test("null when TURNSTILE_SECRET_KEY is missing", () => {
+    expect(resolveTurnstileConfig({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  test("returns a config when the secret key is set", () => {
+    const config = resolveTurnstileConfig({
+      TURNSTILE_SECRET_KEY: "a-secret"
+    } as NodeJS.ProcessEnv);
+
+    expect(config).toEqual({ secretKey: "a-secret", timeoutMs: 5000 });
+  });
+});
+
+describe("verifyTurnstileToken", () => {
+  beforeEach(() => {
+    resetProviderCircuitBreakersForTests();
+  });
+
+  afterEach(() => {
+    resetProviderCircuitBreakersForTests();
+  });
+
+  test("succeeds when Cloudflare reports success", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ success: true });
+      }
+    });
+
+    const result = await verifyTurnstileToken("a-real-token", {
+      secretKey: "super-secret-turnstile-value",
+      verifyUrl: `http://127.0.0.1:${server.port}`
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("fails cleanly when Cloudflare reports success=false, with error codes surfaced", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({
+          success: false,
+          "error-codes": ["invalid-input-response"]
+        });
+      }
+    });
+
+    const result = await verifyTurnstileToken("bad-token", {
+      secretKey: "super-secret-turnstile-value",
+      verifyUrl: `http://127.0.0.1:${server.port}`
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toContain(
+      "invalid-input-response"
+    );
+  });
+
+  test("never includes the configured secret in a failure error message, even from a server that echoes it back", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        // A deliberately adversarial server that echoes the posted secret
+        // back in its response body — the built error message only ever
+        // uses the HTTP status and Cloudflare's own numeric error-codes
+        // array, never the raw response text, so this can't leak either
+        // way; `redact()` is defense in depth for the catch-block path
+        // below, not this one.
+        return new Response("super-secret-turnstile-value not authorized", {
+          status: 401
+        });
+      }
+    });
+
+    const result = await verifyTurnstileToken("some-token", {
+      secretKey: "super-secret-turnstile-value",
+      verifyUrl: `http://127.0.0.1:${server.port}`
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).not.toContain(
+      "super-secret-turnstile-value"
+    );
+  });
+
+  test("redacts the configured secret out of a thrown network-error message", async () => {
+    const result = await verifyTurnstileToken("some-token", {
+      secretKey: "super-secret-turnstile-value",
+      // No server listening on this port — fetch() rejects, exercising the
+      // catch block's redact() call directly.
+      verifyUrl: "http://127.0.0.1:1"
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).not.toContain(
+      "super-secret-turnstile-value"
+    );
+  });
+
+  test("times out a wedged provider instead of hanging forever", async () => {
+    using server = Bun.serve({
+      port: 0,
+      async fetch() {
+        await Bun.sleep(500);
+        return Response.json({ success: true });
+      }
+    });
+
+    const result = await verifyTurnstileToken("some-token", {
+      secretKey: "super-secret-turnstile-value",
+      verifyUrl: `http://127.0.0.1:${server.port}`,
+      timeoutMs: 20
+    });
+
+    expect(result.ok).toBe(false);
+    expect((result as { error: string }).error).toMatch(/timed out/i);
+  });
+
+  test("opens the circuit breaker after consecutive failures", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ success: false, "error-codes": ["boom"] });
+      }
+    });
+
+    const config = {
+      secretKey: "super-secret-turnstile-value",
+      verifyUrl: `http://127.0.0.1:${server.port}`
+    };
+
+    for (let i = 0; i < 5; i += 1) {
+      await verifyTurnstileToken("some-token", config);
+    }
+
+    const sixth = await verifyTurnstileToken("some-token", config);
+
+    expect(sixth.ok).toBe(false);
+    expect((sixth as { error: string }).error).toMatch(/circuit breaker/i);
+  });
+});
+
+describe("enforceTurnstileIfRequired", () => {
+  test("skips (ok:true) without any network call when the gate is not active", async () => {
+    const result = await enforceTurnstileIfRequired(
+      undefined,
+      "1.2.3.4",
+      {} as NodeJS.ProcessEnv
+    );
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("rejects with TURNSTILE_REQUIRED when the gate is active but no token was submitted", async () => {
+    const result = await enforceTurnstileIfRequired(undefined, "1.2.3.4", {
+      ...FULL_ONLINE_ENV,
+      TURNSTILE_ENABLED: "true",
+      TURNSTILE_SECRET_KEY: "a-secret"
+    } as NodeJS.ProcessEnv);
+
+    expect(result).toEqual({ ok: false, code: "TURNSTILE_REQUIRED" });
+  });
+
+  test("rejects with TURNSTILE_REQUIRED when the token is an empty string", async () => {
+    const result = await enforceTurnstileIfRequired("", "1.2.3.4", {
+      ...FULL_ONLINE_ENV,
+      TURNSTILE_ENABLED: "true",
+      TURNSTILE_SECRET_KEY: "a-secret"
+    } as NodeJS.ProcessEnv);
+
+    expect(result).toEqual({ ok: false, code: "TURNSTILE_REQUIRED" });
+  });
+
+  test("fails closed with TURNSTILE_INVALID when the gate is active but misconfigured (no secret key)", async () => {
+    const result = await enforceTurnstileIfRequired("a-token", "1.2.3.4", {
+      ...FULL_ONLINE_ENV,
+      TURNSTILE_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    expect(result).toEqual({ ok: false, code: "TURNSTILE_INVALID" });
+  });
+});

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -8,6 +8,7 @@ import {
   checkRequiredVars,
   checkSyncConfig,
   checkTenantDomainDnsConfig,
+  checkTurnstileConfig,
   runEnvValidation
 } from "../scripts/validate-env";
 
@@ -449,6 +450,61 @@ describe("checkOnlineAuthSecurityConfig", () => {
 
     expect(results).toHaveLength(1);
     expect(results[0]?.status).toBe("pass");
+  });
+});
+
+describe("checkTurnstileConfig", () => {
+  test("passes (single check) when TURNSTILE_ENABLED is not set", () => {
+    const results = checkTurnstileConfig({} as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("passes when TURNSTILE_ENABLED=false", () => {
+    const results = checkTurnstileConfig({
+      TURNSTILE_ENABLED: "false"
+    } as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("fails and names each missing var when TURNSTILE_ENABLED=true", () => {
+    const results = checkTurnstileConfig({
+      TURNSTILE_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    const failedNames = results
+      .filter((result) => result.status === "fail")
+      .map((result) => result.name)
+      .sort();
+
+    expect(failedNames).toEqual(
+      ["TURNSTILE_SITE_KEY", "TURNSTILE_SECRET_KEY"].sort()
+    );
+  });
+
+  test("all pass when TURNSTILE_ENABLED=true and both vars are set", () => {
+    const results = checkTurnstileConfig({
+      TURNSTILE_ENABLED: "true",
+      TURNSTILE_SITE_KEY: "site-key-abc",
+      TURNSTILE_SECRET_KEY: "a-real-secret"
+    } as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("never includes the configured secret key in any result detail", () => {
+    const results = checkTurnstileConfig({
+      TURNSTILE_ENABLED: "true",
+      TURNSTILE_SITE_KEY: "site-key-abc",
+      TURNSTILE_SECRET_KEY: "super-secret-turnstile-value"
+    } as NodeJS.ProcessEnv);
+
+    for (const result of results) {
+      expect(result.detail).not.toContain("super-secret-turnstile-value");
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds Cloudflare Turnstile bot protection (Issue #588, epic #587-#593) to the four public auth-adjacent POST endpoints: `/auth/login`, `/auth/password/forgot`, `/auth/password/reset`, `/setup/initialize`.
- Active only when the full-online security gate (`isFullOnlineSecurityActive`, #587) AND a new `TURNSTILE_ENABLED=true` flag both agree (`isTurnstileRequired`). Every local/offline/LAN deployment is unaffected — no new env var required, `config:validate` passes unchanged.
- New `src/lib/security/turnstile.ts`: server-side siteverify call, timeout-bounded + circuit-breaker gated (same pattern as `cloudflare-dns-adapter.ts`/`mailketing-provider.ts`), fails closed on misconfiguration.
- Enforcement runs after body validation but before any DB query or password hashing (verified via integration test: wrong password + missing token → `TURNSTILE_REQUIRED`, not `AUTH_INVALID_CREDENTIALS`).
- `login.astro` conditionally renders the Turnstile widget only when required; CSP (`astro.config.mjs`) allows the narrow Cloudflare origin unconditionally at build time (documented rationale: CSP is build-time-only, `TURNSTILE_ENABLED` is meant to be runtime-toggleable).
- New error codes `TURNSTILE_REQUIRED`/`TURNSTILE_INVALID` with `en`/`id` i18n strings; OpenAPI spec updated for all 4 endpoints.
- Docs/skill updated: `.env.example`, doc 18 (env reference), `deployment-profiles.md`, `identity-access/README.md`, skill `awcms-mini-auth-online-hardening`.

Closes #588

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run check:docs`
- [x] `bun run api:spec:check`
- [x] `bun run build`
- [x] `bun test` with real Postgres — 1224 pass, 0 fail (includes 20 new unit tests + 8 new integration tests covering all 4 endpoints, disabled/enabled/invalid-token/valid-token paths)
- [x] Manually verified against the real built server (`bun ./dist/server/entry.mjs`) with Turnstile off and on: CSP header contents, HTML widget absence/presence, site key rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)