### PR TITLE
feat(auth): add MFA/TOTP login challenge for full-online deployments (#589)

### DIFF
--- a/.changeset/auth-mfa-totp-full-online.md
+++ b/.changeset/auth-mfa-totp-full-online.md
@@ -33,8 +33,13 @@ base64 32-byte key) — the only reversibly-stored secret in this app, since
 verification must recompute the code from the original secret; recovery
 codes and challenge tokens remain hash-only like every other token in this
 codebase. Replay of an already-used TOTP time step is prevented via a
-per-factor `last_used_step` counter. Password reset never disables MFA
-(verified by an explicit integration test).
+per-factor `last_used_step` counter, and challenge/recovery-code/replay
+state transitions are all atomic (`SELECT ... FOR UPDATE` on the
+challenge row plus compare-and-swap `UPDATE`s) so concurrent verification
+attempts against the same challenge or code can't bypass the attempt cap
+or the replay guard — found and fixed during PR review, with regression
+tests proving the race. Password reset never disables MFA (verified by
+an explicit integration test).
 
 New env vars: `AUTH_MFA_ENABLED` (default `false`),
 `AUTH_MFA_SECRET_ENCRYPTION_KEY`, `AUTH_MFA_TOTP_ISSUER` (default

--- a/.changeset/auth-mfa-totp-full-online.md
+++ b/.changeset/auth-mfa-totp-full-online.md
@@ -1,0 +1,56 @@
+---
+"awcms-mini": minor
+---
+
+Add MFA/TOTP login challenge for full-online deployments (Issue #589,
+epic #587-#593) — the second concrete feature built on top of the #587
+full-online security gate, following the same pattern as Cloudflare
+Turnstile (#588).
+
+New tables (migration 034, tenant-scoped, RLS `ENABLE`+`FORCE`):
+`awcms_mini_identity_mfa_factors`, `awcms_mini_identity_mfa_recovery_codes`,
+`awcms_mini_mfa_challenges`. `isMfaRequired(env)` combines the shared
+`isFullOnlineSecurityActive(env)` gate (#587) with a new `AUTH_MFA_ENABLED`
+flag — active only when both agree, and even then MFA is opt-in per
+identity, not mandatory tenant-wide.
+
+`POST /api/v1/auth/login`: a password-valid login for an identity with an
+active TOTP factor no longer creates a session — it issues an MFA
+challenge and returns `401 MFA_REQUIRED` with `mfaChallengeToken`. New
+`POST /api/v1/auth/mfa/totp/verify` (authenticated by possession of that
+token, not a session — mirrors `password/reset`'s pattern) completes the
+login and creates the real session. New self-service endpoints:
+`GET /auth/mfa/status`, `POST /auth/mfa/totp/enroll/start`,
+`POST /auth/mfa/totp/enroll/verify` (activates the factor, returns 10
+one-time recovery codes), `POST /auth/mfa/totp/disable`, and
+`POST /auth/mfa/recovery-codes/regenerate` (both high-risk, audited).
+
+TOTP is a from-scratch, dependency-free RFC 6238-compatible implementation
+(HMAC-SHA1, verified against the RFC's own Appendix B test vectors) —
+Google Authenticator and compatible apps work out of the box. TOTP secrets
+are encrypted at rest with AES-256-GCM (`AUTH_MFA_SECRET_ENCRYPTION_KEY`,
+base64 32-byte key) — the only reversibly-stored secret in this app, since
+verification must recompute the code from the original secret; recovery
+codes and challenge tokens remain hash-only like every other token in this
+codebase. Replay of an already-used TOTP time step is prevented via a
+per-factor `last_used_step` counter. Password reset never disables MFA
+(verified by an explicit integration test).
+
+New env vars: `AUTH_MFA_ENABLED` (default `false`),
+`AUTH_MFA_SECRET_ENCRYPTION_KEY`, `AUTH_MFA_TOTP_ISSUER` (default
+`AWCMS-Mini`), `AUTH_MFA_TOTP_PERIOD_SEC` (default `30`),
+`AUTH_MFA_TOTP_DIGITS` (default `6`), `AUTH_MFA_CHALLENGE_TTL_SEC` (default
+`300`), `AUTH_MFA_RATE_LIMIT_MAX`/`_WINDOW_SEC` (defaults `5`/`300`).
+`AUTH_MFA_ENABLED=true` alone (independent of the #587 gate) requires a
+valid 32-byte base64 encryption key in `bun run config:validate` and
+`security-readiness`.
+
+New error codes `MFA_REQUIRED`/`MFA_DISABLED`/`MFA_ALREADY_ACTIVE`/
+`MFA_NOT_ACTIVE`/`MFA_ENROLLMENT_NOT_FOUND`/`MFA_INVALID_CODE`/
+`MFA_CHALLENGE_INVALID`/`MFA_MISCONFIGURED` with i18n strings (`en`/`id`).
+OpenAPI spec updated for `POST /auth/login`'s new 401 branch and all 6 new
+endpoints.
+
+Docs updated: `.env.example`, `docs/awcms-mini/18_configuration_env_reference.md`,
+`docs/awcms-mini/deployment-profiles.md`, `src/modules/identity-access/README.md`,
+skill `awcms-mini-auth-online-hardening`.

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -177,14 +177,34 @@ isMfaRequired(env)
   pola sama `session-token.ts`/`password-reset-token.ts`) — TIDAK
   reversibel, karena keduanya tidak pernah perlu ditampilkan ulang
   setelah reveal sekali di awal.
-- **Replay prevention**: `awcms_mini_identity_mfa_factors.last_used_step`
-  menyimpan step time-counter TOTP tertinggi yang pernah diterima —
-  verifikasi hanya diterima kalau step yang cocok STRICTLY LEBIH BESAR
-  dari nilai ini, supaya kode yang sama tidak bisa dipakai dua kali
-  walau masih dalam window toleransi clock drift (`src/lib/auth/totp.ts`'s
-  `verifyTotpCode`, default ±1 step). Fitur online lain yang menambah
-  time-based one-time code (kalau ada) harus pola replay yang sama —
-  jangan andalkan TTL/expiry saja.
+- **Replay prevention, dan WAJIB atomik, bukan read-then-write** —
+  `awcms_mini_identity_mfa_factors.last_used_step` menyimpan step
+  time-counter TOTP tertinggi yang pernah diterima; verifikasi hanya
+  diterima kalau step yang cocok STRICTLY LEBIH BESAR dari nilai ini
+  (`src/lib/auth/totp.ts`'s `verifyTotpCode`, default ±1 step window).
+  **PR #597 security review menemukan `verifyMfaChallenge` awalnya
+  melakukan SELECT lalu UPDATE terpisah** (untuk `last_used_step`,
+  `awcms_mini_identity_mfa_recovery_codes.used_at`, DAN
+  `awcms_mini_mfa_challenges.failed_attempts`) — di bawah READ COMMITTED
+  (default Postgres, `withTenant` tidak mengubah isolation level), request
+  verifikasi konkuren semuanya membaca state lama sebelum salah satu
+  commit, sehingga replay guard maupun batas `failed_attempts` bisa
+  dilewati sepenuhnya oleh penyerang yang mengirim tebakan paralel.
+  Diperbaiki dengan: (a) `SELECT ... FOR UPDATE` pada baris challenge di
+  awal `verifyMfaChallenge` (mengunci baris itu untuk sisa transaksi,
+  men-serialize semua request verifikasi terhadap challenge yang sama),
+  (b) compare-and-swap untuk `last_used_step`
+  (`UPDATE ... WHERE last_used_step < $step RETURNING id`, 0 baris = gagal
+  — melindungi replay lintas-challenge yang FOR UPDATE saja tidak
+  jangkau, mis. dua login attempt berbeda membuat dua challenge terpisah
+  untuk identity yang sama), (c) compare-and-swap yang sama untuk
+  recovery code (`UPDATE ... WHERE used_at IS NULL RETURNING id`). Fitur
+  online lain yang menambah state single-use/counter yang bisa
+  diverifikasi berkali-kali (kode OTP lain, dsb.) WAJIB pola atomik yang
+  sama — jangan pernah SELECT untuk mengevaluasi kondisi lalu UPDATE
+  terpisah untuk menandainya terpakai/gagal; regression test-nya:
+  `mfa-flow.integration.test.ts` §"concurrent verification attempts..."
+  dan §"concurrent wrong-code attempts...".
 - **Reset password BUKAN bypass MFA** — `completePasswordReset` tidak
   menyentuh tabel `awcms_mini_identity_mfa_factors` sama sekali;
   diverifikasi test integrasi eksplisit (`mfa-flow.integration.test.ts`
@@ -194,7 +214,15 @@ isMfaRequired(env)
   diam-diam mengganti secret TOTP tanpa lebih dulu `disable`.
 - **Disable & regenerate recovery code = high-risk, diaudit**
   (`mfa_disabled`/`mfa_recovery_codes_regenerated`,
-  severity `warning`) — pola sama `awcms-mini-audit-log`.
+  severity `warning`) — pola sama `awcms-mini-audit-log`. **Catatan
+  desain yang belum ditutup** (PR #597 review, tidak blocking): kedua
+  endpoint ini hanya mensyaratkan sesi valid, tanpa re-autentikasi
+  tambahan (password saat ini/kode TOTP saat ini) — sesi yang dibajak
+  (bukan hanya dicuri sebelum MFA aktif) cukup untuk mematikan MFA korban
+  atau membuang recovery code lama. Diterima sebagai trade-off untuk
+  scope issue #589 saat ini; fitur online lanjutan (mis. #592 admin
+  policy UI) yang menyentuh area ini sebaiknya mempertimbangkan
+  step-up re-auth di titik ini.
 - Error code i18n: `error.mfa_required`/`_disabled`/`_already_active`/
   `_not_active`/`_enrollment_not_found`/`_invalid_code`/
   `_challenge_invalid`/`_misconfigured` (`error-messages.ts`,

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -33,7 +33,7 @@ keputusan desain yang mengikat semua issue di epic ini sekaligus.
 | ----- | ------------------------------------------------------ | -------------------------------------------------- |
 | #587  | Gate bersama `AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE` | **Selesai** — lihat §Gate bersama di bawah         |
 | #588  | Cloudflare Turnstile untuk form auth publik            | **Selesai** — lihat §Cloudflare Turnstile di bawah |
-| #589  | MFA/TOTP login challenge                               | Belum dikerjakan                                   |
+| #589  | MFA/TOTP login challenge                               | **Selesai** — lihat §MFA/TOTP di bawah             |
 | #590  | Google OIDC login                                      | Belum dikerjakan                                   |
 | #591  | Generic tenant OIDC SSO provider                       | Belum dikerjakan                                   |
 | #592  | Admin UI kebijakan auth security online                | Belum dikerjakan (depends #587 selesai + #591)     |
@@ -138,6 +138,68 @@ isTurnstileRequired(env)
 - Error code i18n: `error.turnstile_required`/`error.turnstile_invalid`
   (`src/lib/i18n/error-messages.ts`, `i18n/en.po`+`id.po`).
 
+### MFA/TOTP (Issue #589, `src/modules/identity-access/application/mfa.ts`)
+
+Gate gabungan sama persis polanya dengan Turnstile:
+
+```txt
+isMfaRequired(env)
+  = isFullOnlineSecurityActive(env) AND isMfaEnabled(env)
+  (isMfaEnabled = AUTH_MFA_ENABLED === "true")
+```
+
+- **MFA opt-in per identity, bukan mandatory tenant-wide** — bahkan
+  dengan gate aktif, identity yang belum pernah enroll tetap login
+  normal (`login.ts` mengecek `findActiveMfaFactor` per identity SETELAH
+  password valid, bukan hanya gate env). Jangan asumsikan mengaktifkan
+  `AUTH_MFA_ENABLED=true` otomatis mewajibkan MFA untuk semua user.
+- **Login yang dijeda, bukan ditolak**: password valid + factor `active`
+  → `login.ts` TIDAK membuat session, malah insert row
+  `awcms_mini_mfa_challenges` dan balas `401 MFA_REQUIRED` berisi
+  `error.details.mfaChallengeToken` (bentuk `details` di sini SENGAJA
+  bukan `ErrorDetail[]` seperti endpoint lain — lihat OpenAPI schema
+  `LoginMfaRequiredResponse` — karena payload asli (token) harus
+  dikembalikan, bukan sekadar array pesan validasi).
+  `POST /auth/mfa/totp/verify` adalah **satu-satunya endpoint MFA yang
+  TIDAK butuh session** — diautentikasi lewat possession token
+  challenge, pola sama seperti `password/reset` diautentikasi lewat
+  possession token reset. Kode/recovery code valid → session dibuat
+  identik dengan `login.ts` (token, cookie, response shape sama), supaya
+  client tidak perlu logic berbeda untuk step kedua.
+- **Enkripsi-at-rest, bukan hash, untuk TOTP secret** —
+  `src/lib/auth/mfa-secret-crypto.ts` (AES-256-GCM,
+  `AUTH_MFA_SECRET_ENCRYPTION_KEY`, base64 32-byte, divalidasi
+  `checkMfaConfig`) — satu-satunya secret di aplikasi ini yang
+  reversibel, karena verifikasi TOTP butuh menghitung ulang kode dari
+  secret asli setiap request, tidak seperti password/token yang cukup
+  dibandingkan hash-nya. Recovery code (`mfa-recovery-code.ts`) dan
+  challenge token (`mfa-challenge-token.ts`) tetap hash-only (sha256,
+  pola sama `session-token.ts`/`password-reset-token.ts`) — TIDAK
+  reversibel, karena keduanya tidak pernah perlu ditampilkan ulang
+  setelah reveal sekali di awal.
+- **Replay prevention**: `awcms_mini_identity_mfa_factors.last_used_step`
+  menyimpan step time-counter TOTP tertinggi yang pernah diterima —
+  verifikasi hanya diterima kalau step yang cocok STRICTLY LEBIH BESAR
+  dari nilai ini, supaya kode yang sama tidak bisa dipakai dua kali
+  walau masih dalam window toleransi clock drift (`src/lib/auth/totp.ts`'s
+  `verifyTotpCode`, default ±1 step). Fitur online lain yang menambah
+  time-based one-time code (kalau ada) harus pola replay yang sama —
+  jangan andalkan TTL/expiry saja.
+- **Reset password BUKAN bypass MFA** — `completePasswordReset` tidak
+  menyentuh tabel `awcms_mini_identity_mfa_factors` sama sekali;
+  diverifikasi test integrasi eksplisit (`mfa-flow.integration.test.ts`
+  §"password reset does not disable MFA").
+- **Re-enroll ditolak selagi factor aktif** (`409 MFA_ALREADY_ACTIVE`,
+  `POST /auth/mfa/totp/enroll/start`) — sesi yang di-hijack tidak bisa
+  diam-diam mengganti secret TOTP tanpa lebih dulu `disable`.
+- **Disable & regenerate recovery code = high-risk, diaudit**
+  (`mfa_disabled`/`mfa_recovery_codes_regenerated`,
+  severity `warning`) — pola sama `awcms-mini-audit-log`.
+- Error code i18n: `error.mfa_required`/`_disabled`/`_already_active`/
+  `_not_active`/`_enrollment_not_found`/`_invalid_code`/
+  `_challenge_invalid`/`_misconfigured` (`error-messages.ts`,
+  `i18n/en.po`+`id.po`).
+
 ## Aturan lintas-issue yang wajib diikuti (#588-#593)
 
 1. **Setiap fitur (#588-#592) WAJIB memanggil `isFullOnlineSecurityActive(env)`
@@ -190,10 +252,9 @@ isTurnstileRequired(env)
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Lima fitur (#589-#592) plus dokumentasi/kontrak penutup (#593) masih
-backlog per 2026-07-09 — hanya gate bersama (#587) dan Cloudflare
-Turnstile (#588) yang sudah ada di repo ini. Jangan asumsikan
-`awcms_mini_auth_providers`, `awcms_mini_identity_mfa_factors`, atau
-endpoint `/api/v1/auth/mfa/*`/`/api/v1/auth/providers/google/*`/
-`/api/v1/auth/sso/*` sudah ada — cek langsung sebelum membangun di
-atasnya.
+Tiga fitur (#590-#592) plus dokumentasi/kontrak penutup (#593) masih
+backlog per 2026-07-09 — gate bersama (#587), Cloudflare Turnstile
+(#588), dan MFA/TOTP (#589) sudah ada di repo ini. Jangan asumsikan
+`awcms_mini_auth_providers` atau endpoint
+`/api/v1/auth/providers/google/*`/`/api/v1/auth/sso/*` sudah ada — cek
+langsung sebelum membangun di atasnya.

--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,25 @@ TURNSTILE_ENABLED=false
 # TURNSTILE_SECRET_KEY=
 TURNSTILE_VERIFY_TIMEOUT_MS=5000
 
+# Full-online MFA/TOTP login challenge (Issue #589) — POST /auth/mfa/totp/*,
+# /auth/mfa/status, /auth/mfa/recovery-codes/regenerate, and a new
+# 401 MFA_REQUIRED outcome from POST /auth/login for any identity with an
+# active factor. Only active when the full-online gate above is ALSO on
+# (isMfaRequired() = full-online gate AND AUTH_MFA_ENABLED=true) — MFA is
+# opt-in per identity even then, never mandatory tenant-wide. Independent of
+# the gate for config:validate purposes, same as Turnstile above.
+# AUTH_MFA_SECRET_ENCRYPTION_KEY encrypts TOTP secrets at rest (AES-256-GCM)
+# — must be a base64-encoded 32-byte key, e.g. `openssl rand -base64 32`;
+# never a real value in git.
+AUTH_MFA_ENABLED=false
+# AUTH_MFA_SECRET_ENCRYPTION_KEY=
+AUTH_MFA_TOTP_ISSUER=AWCMS-Mini
+AUTH_MFA_TOTP_PERIOD_SEC=30
+AUTH_MFA_TOTP_DIGITS=6
+AUTH_MFA_CHALLENGE_TTL_SEC=300
+AUTH_MFA_RATE_LIMIT_MAX=5
+AUTH_MFA_RATE_LIMIT_WINDOW_SEC=300
+
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node
 AWCMS_MINI_SYNC_ENABLED=false

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -65,23 +65,31 @@ Legenda: Wajib = perlu untuk boot; Sensitif = jangan bocor ke log/response.
 
 ### Auth & keamanan
 
-| Var                                         | Wajib          | Default    | Sensitif | Fungsi                                                                                                  |
-| ------------------------------------------- | -------------- | ---------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| `AUTH_JWT_SECRET`                           | Ya             | –          | Ya       | Signing token sesi                                                                                      |
-| `AUTH_SESSION_TTL_MIN`                      | –              | `120`      | –        | Umur sesi                                                                                               |
-| `AUTH_COOKIE_SECURE`                        | –              | `true`     | –        | Cookie hanya HTTPS di prod                                                                              |
-| `AUTH_LOGIN_MAX_ATTEMPTS`                   | –              | `5`        | –        | Lockout login (per identitas)                                                                           |
-| `AUTH_LOGIN_RATE_LIMIT_MAX`                 | –              | `20`       | –        | Rate limit login per sumber+tenant (Issue #437)                                                         |
-| `AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC`          | –              | `60`       | –        | Jendela waktu rate limit login (detik)                                                                  |
-| `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`         | –              | `30`       | –        | Umur token reset password (Issue #496)                                                                  |
-| `AUTH_PASSWORD_RESET_RATE_LIMIT_MAX`        | –              | `5`        | –        | Rate limit forgot/reset per sumber+tenant                                                               |
-| `AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC` | –              | `900`      | –        | Jendela waktu rate limit reset password (detik)                                                         |
-| `AUTH_ONLINE_SECURITY_ENABLED`              | –              | `false`    | –        | Gate full-online-only auth hardening (Issue #587) — lihat §Full-online auth security hardening di bawah |
-| `AUTH_ONLINE_SECURITY_PROFILE`              | –              | `disabled` | –        | `disabled` (default) atau `full_online`; wajib `full_online` bila `AUTH_ONLINE_SECURITY_ENABLED=true`   |
-| `TURNSTILE_ENABLED`                         | –              | `false`    | –        | Cloudflare Turnstile bot protection (Issue #588) — lihat §Full-online auth security hardening di bawah  |
-| `TURNSTILE_SITE_KEY`                        | bila Turnstile | –          | –        | Site key publik (bukan secret) — dirender di widget `/login`                                            |
-| `TURNSTILE_SECRET_KEY`                      | bila Turnstile | –          | Ya       | Secret key — hanya untuk verifikasi server-side, tidak pernah ke klien                                  |
-| `TURNSTILE_VERIFY_TIMEOUT_MS`               | –              | `5000`     | –        | Timeout panggilan siteverify Cloudflare (ms)                                                            |
+| Var                                         | Wajib          | Default      | Sensitif | Fungsi                                                                                                  |
+| ------------------------------------------- | -------------- | ------------ | -------- | ------------------------------------------------------------------------------------------------------- |
+| `AUTH_JWT_SECRET`                           | Ya             | –            | Ya       | Signing token sesi                                                                                      |
+| `AUTH_SESSION_TTL_MIN`                      | –              | `120`        | –        | Umur sesi                                                                                               |
+| `AUTH_COOKIE_SECURE`                        | –              | `true`       | –        | Cookie hanya HTTPS di prod                                                                              |
+| `AUTH_LOGIN_MAX_ATTEMPTS`                   | –              | `5`          | –        | Lockout login (per identitas)                                                                           |
+| `AUTH_LOGIN_RATE_LIMIT_MAX`                 | –              | `20`         | –        | Rate limit login per sumber+tenant (Issue #437)                                                         |
+| `AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC`          | –              | `60`         | –        | Jendela waktu rate limit login (detik)                                                                  |
+| `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`         | –              | `30`         | –        | Umur token reset password (Issue #496)                                                                  |
+| `AUTH_PASSWORD_RESET_RATE_LIMIT_MAX`        | –              | `5`          | –        | Rate limit forgot/reset per sumber+tenant                                                               |
+| `AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC` | –              | `900`        | –        | Jendela waktu rate limit reset password (detik)                                                         |
+| `AUTH_ONLINE_SECURITY_ENABLED`              | –              | `false`      | –        | Gate full-online-only auth hardening (Issue #587) — lihat §Full-online auth security hardening di bawah |
+| `AUTH_ONLINE_SECURITY_PROFILE`              | –              | `disabled`   | –        | `disabled` (default) atau `full_online`; wajib `full_online` bila `AUTH_ONLINE_SECURITY_ENABLED=true`   |
+| `TURNSTILE_ENABLED`                         | –              | `false`      | –        | Cloudflare Turnstile bot protection (Issue #588) — lihat §Full-online auth security hardening di bawah  |
+| `TURNSTILE_SITE_KEY`                        | bila Turnstile | –            | –        | Site key publik (bukan secret) — dirender di widget `/login`                                            |
+| `TURNSTILE_SECRET_KEY`                      | bila Turnstile | –            | Ya       | Secret key — hanya untuk verifikasi server-side, tidak pernah ke klien                                  |
+| `TURNSTILE_VERIFY_TIMEOUT_MS`               | –              | `5000`       | –        | Timeout panggilan siteverify Cloudflare (ms)                                                            |
+| `AUTH_MFA_ENABLED`                          | –              | `false`      | –        | MFA/TOTP login challenge (Issue #589) — lihat §Full-online auth security hardening di bawah             |
+| `AUTH_MFA_SECRET_ENCRYPTION_KEY`            | bila MFA       | –            | Ya       | Key AES-256-GCM (base64, 32 byte) untuk enkripsi-at-rest TOTP secret                                    |
+| `AUTH_MFA_TOTP_ISSUER`                      | –              | `AWCMS-Mini` | –        | Nama issuer yang tampil di aplikasi authenticator                                                       |
+| `AUTH_MFA_TOTP_PERIOD_SEC`                  | –              | `30`         | –        | Panjang time-step TOTP (detik)                                                                          |
+| `AUTH_MFA_TOTP_DIGITS`                      | –              | `6`          | –        | Jumlah digit kode TOTP (`6` atau `8`)                                                                   |
+| `AUTH_MFA_CHALLENGE_TTL_SEC`                | –              | `300`        | –        | Umur challenge MFA login (detik)                                                                        |
+| `AUTH_MFA_RATE_LIMIT_MAX`                   | –              | `5`          | –        | Rate limit `POST /auth/mfa/totp/verify` per sumber+tenant                                               |
+| `AUTH_MFA_RATE_LIMIT_WINDOW_SEC`            | –              | `300`        | –        | Jendela waktu rate limit verifikasi MFA (detik)                                                         |
 
 ### Full-online auth security hardening (opsional, Issue #587-#593)
 
@@ -126,7 +134,25 @@ online-only ini (lihat `deployment-profiles.md`).
   sebaiknya memantau log `turnstile.circuit_breaker_open`/
   `turnstile.provider_call_failed` (severity `warning`) sebagai sinyal
   operasional. Detail lengkap: skill `awcms-mini-auth-online-hardening`.
-- #589-#593 (MFA/TOTP, Google login, generic SSO, admin policy UI,
+- **MFA/TOTP (Issue #589, selesai)** — `AUTH_MFA_ENABLED` divalidasi
+  independen dari gate di atas (`checkMfaConfig`), tapi aktivasi
+  runtime-nya butuh KEDUANYA (`isMfaRequired(env)` = gate ∧
+  `AUTH_MFA_ENABLED=true`). MFA **opt-in per identity**, bukan mandatory
+  tenant-wide — identity yang belum pernah enroll tetap login normal
+  meski gate ini aktif. Endpoint baru: `GET /auth/mfa/status`,
+  `POST /auth/mfa/totp/enroll/start|verify`, `POST /auth/mfa/totp/verify`
+  (menyelesaikan login yang di-pause `401 MFA_REQUIRED`),
+  `POST /auth/mfa/totp/disable`,
+  `POST /auth/mfa/recovery-codes/regenerate`. TOTP secret dienkripsi at
+  rest (AES-256-GCM, `AUTH_MFA_SECRET_ENCRYPTION_KEY`,
+  `src/lib/auth/mfa-secret-crypto.ts`) — satu-satunya secret di aplikasi
+  ini yang dienkripsi reversibel, bukan di-hash, karena harus bisa
+  dihitung ulang untuk verifikasi kode. Recovery code disimpan hash-only,
+  ditampilkan sekali. Replay code TOTP dicegah via
+  `last_used_step` per factor. Reset password TIDAK menonaktifkan MFA
+  (diverifikasi test integrasi). Detail lengkap: skill
+  `awcms-mini-auth-online-hardening`.
+- #590-#593 (Google login, generic SSO, admin policy UI,
   dokumentasi/kontrak penutup) masih backlog — belum diimplementasikan di
   repo ini.
 
@@ -360,6 +386,13 @@ AUTH_ONLINE_SECURITY_ENABLED=false
 AUTH_ONLINE_SECURITY_PROFILE=disabled
 TURNSTILE_ENABLED=false
 TURNSTILE_VERIFY_TIMEOUT_MS=5000
+AUTH_MFA_ENABLED=false
+AUTH_MFA_TOTP_ISSUER=AWCMS-Mini
+AUTH_MFA_TOTP_PERIOD_SEC=30
+AUTH_MFA_TOTP_DIGITS=6
+AUTH_MFA_CHALLENGE_TTL_SEC=300
+AUTH_MFA_RATE_LIMIT_MAX=5
+AUTH_MFA_RATE_LIMIT_WINDOW_SEC=300
 
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node

--- a/docs/awcms-mini/deployment-profiles.md
+++ b/docs/awcms-mini/deployment-profiles.md
@@ -133,9 +133,18 @@ hardening).
   `/setup/initialize`. `TURNSTILE_ENABLED` sendiri divalidasi independen
   dari gate `AUTH_ONLINE_SECURITY_*` (operator boleh isi credential
   Turnstile lebih dulu), tapi aktivasi runtime-nya tetap butuh keduanya.
-  #589-#593 (MFA/TOTP, Google login, generic SSO, admin policy UI,
-  dokumentasi/kontrak penutup) masih backlog, belum diimplementasikan di
-  repo ini.
+- **MFA/TOTP (Issue #589, selesai)**: set tambahan `AUTH_MFA_ENABLED=true`
+  - `AUTH_MFA_SECRET_ENCRYPTION_KEY` (base64, 32 byte AES-256 key) untuk
+    mengaktifkan MFA/TOTP login challenge. Sama seperti Turnstile,
+    `AUTH_MFA_ENABLED` divalidasi independen dari gate di atas, aktivasi
+    runtime butuh keduanya. MFA **opt-in per identity** — mengaktifkan flag
+    ini tidak memaksa MFA untuk identity yang belum pernah enroll
+    (`POST /auth/mfa/totp/enroll/start` + `/enroll/verify`); identity dengan
+    factor aktif akan dihentikan di `401 MFA_REQUIRED` saat login sampai
+    menyelesaikan `POST /auth/mfa/totp/verify`.
+    #590-#593 (Google login, generic SSO, admin policy UI,
+    dokumentasi/kontrak penutup) masih backlog, belum diimplementasikan di
+    repo ini.
 
 ## Cara menjalankan tiap profil
 

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -128,6 +128,30 @@ msgstr "Please complete the verification challenge."
 msgid "error.turnstile_invalid"
 msgstr "Verification failed. Please try again."
 
+msgid "error.mfa_required"
+msgstr "Multi-factor authentication is required to complete sign-in."
+
+msgid "error.mfa_disabled"
+msgstr "Multi-factor authentication is not enabled for this deployment."
+
+msgid "error.mfa_already_active"
+msgstr "Multi-factor authentication is already active for this account."
+
+msgid "error.mfa_not_active"
+msgstr "Multi-factor authentication is not currently active for this account."
+
+msgid "error.mfa_enrollment_not_found"
+msgstr "No pending MFA enrollment found. Start enrollment again."
+
+msgid "error.mfa_invalid_code"
+msgstr "Invalid verification code."
+
+msgid "error.mfa_challenge_invalid"
+msgstr "This MFA challenge is invalid, expired, or already used."
+
+msgid "error.mfa_misconfigured"
+msgstr "Multi-factor authentication is misconfigured on this server."
+
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"
 msgstr "No role"

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -128,6 +128,30 @@ msgstr "Mohon selesaikan verifikasi terlebih dahulu."
 msgid "error.turnstile_invalid"
 msgstr "Verifikasi gagal. Silakan coba lagi."
 
+msgid "error.mfa_required"
+msgstr "Autentikasi multi-faktor diperlukan untuk menyelesaikan proses masuk."
+
+msgid "error.mfa_disabled"
+msgstr "Autentikasi multi-faktor tidak diaktifkan untuk deployment ini."
+
+msgid "error.mfa_already_active"
+msgstr "Autentikasi multi-faktor sudah aktif untuk akun ini."
+
+msgid "error.mfa_not_active"
+msgstr "Autentikasi multi-faktor sedang tidak aktif untuk akun ini."
+
+msgid "error.mfa_enrollment_not_found"
+msgstr "Tidak ada pendaftaran MFA yang tertunda. Mulai pendaftaran lagi."
+
+msgid "error.mfa_invalid_code"
+msgstr "Kode verifikasi tidak valid."
+
+msgid "error.mfa_challenge_invalid"
+msgstr "Tantangan MFA ini tidak valid, kedaluwarsa, atau sudah digunakan."
+
+msgid "error.mfa_misconfigured"
+msgstr "Autentikasi multi-faktor salah konfigurasi di server ini."
+
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"
 msgstr "Tanpa role"

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -756,6 +756,16 @@ paths:
         before any password check: missing -> `400 TURNSTILE_REQUIRED`,
         invalid -> `400 TURNSTILE_INVALID`. Absent entirely for every
         local/offline/LAN deployment.
+
+
+        When the same gate is active AND `AUTH_MFA_ENABLED=true` (Issue
+        #589) AND the identity has an active TOTP factor enrolled, a
+        password-valid login does NOT create a session — it returns
+        `401 MFA_REQUIRED` with `error.details.mfaChallengeToken` instead
+        (see `LoginMfaRequiredResponse`). Complete the login by calling
+        `POST /auth/mfa/totp/verify` with that token and a TOTP/recovery
+        code. Identities that have never enrolled MFA are unaffected even
+        when the feature is enabled (opt-in per identity, not tenant-wide).
       operationId: authLogin
       security:
         - tenantHeader: []
@@ -786,7 +796,16 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
-          $ref: "#/components/responses/Unauthorized"
+          description: >-
+            Invalid credentials (`AUTH_INVALID_CREDENTIALS`), OR password
+            was valid but MFA/TOTP (Issue #589) must be completed before a
+            session is issued (`MFA_REQUIRED`, `LoginMfaRequiredResponse`).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/ApiError"
+                  - $ref: "#/components/schemas/LoginMfaRequiredResponse"
         "403":
           $ref: "#/components/responses/Forbidden"
         "500":
@@ -849,6 +868,316 @@ paths:
                         $ref: "#/components/schemas/MeResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/mfa/status:
+    get:
+      tags:
+        - Identity & Access
+      summary: Get the caller's own MFA enrollment status
+      description: >-
+        Full-online-only (Issue #589) — `403 MFA_DISABLED` unless the #587
+        gate AND `AUTH_MFA_ENABLED=true` are both active. Reports the
+        caller's own enrollment only (self-service; no admin-on-behalf-of
+        view in this issue).
+      operationId: authMfaStatus
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Current MFA enrollment status.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/MfaStatusResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Multi-factor authentication is not enabled for this deployment (`MFA_DISABLED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/mfa/totp/enroll/start:
+    post:
+      tags:
+        - Identity & Access
+      summary: Generate a new pending TOTP secret for the caller to confirm
+      description: >-
+        Full-online-only (Issue #589). Returns the plaintext secret/QR URI
+        ONLY here, at enrollment start — never again afterward. The factor
+        is `pending` (unusable for login) until confirmed via
+        `POST /auth/mfa/totp/enroll/verify`. Rejects with
+        `409 MFA_ALREADY_ACTIVE` if the caller already has an active
+        factor — re-enrollment must go through `disable` first.
+      operationId: authMfaTotpEnrollStart
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Pending TOTP factor created.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/MfaEnrollStartResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Multi-factor authentication is not enabled for this deployment (`MFA_DISABLED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: An MFA factor is already active for this account (`MFA_ALREADY_ACTIVE`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/mfa/totp/enroll/verify:
+    post:
+      tags:
+        - Identity & Access
+      summary: Confirm a pending TOTP enrollment with a live code
+      description: >-
+        Full-online-only (Issue #589). Activates the pending factor from
+        `enroll/start` and returns 10 single-use recovery codes shown
+        exactly once (never retrievable again — only
+        `recovery-codes/regenerate` can produce a fresh set afterward).
+      operationId: authMfaTotpEnrollVerify
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MfaEnrollVerifyRequest"
+      responses:
+        "200":
+          description: MFA activated.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/MfaEnrollVerifyResponse"
+        "400":
+          description: >-
+            Validation error, or the code is invalid (`MFA_INVALID_CODE`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Multi-factor authentication is not enabled for this deployment (`MFA_DISABLED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: No pending MFA enrollment found (`MFA_ENROLLMENT_NOT_FOUND`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/mfa/totp/verify:
+    post:
+      tags:
+        - Identity & Access
+      summary: Complete a login paused by 401 MFA_REQUIRED
+      description: >-
+        Full-online-only (Issue #589). Deliberately NOT authenticated via a
+        session — authenticated instead by possession of
+        `mfaChallengeToken` from `POST /auth/login`'s `MFA_REQUIRED`
+        response, exactly like `password/reset` is authenticated by
+        possession of a reset token. Exactly one of `code` (TOTP) or
+        `recoveryCode` must be provided. On success, creates the real
+        AWCMS-Mini session — same response shape as `POST /auth/login`'s
+        200. Rate-limited both by source+tenant
+        (`AUTH_MFA_RATE_LIMIT_MAX`/`_WINDOW_SEC`) and by a per-challenge
+        failed-attempt counter.
+      operationId: authMfaTotpVerify
+      security:
+        - tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MfaChallengeVerifyRequest"
+      responses:
+        "200":
+          description: Challenge verified; session issued.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/LoginResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          description: >-
+            The challenge is invalid, expired, already used, or the
+            code/recovery code is wrong (deliberately not distinguished —
+            anti-enumeration, same principle as `password/reset` —
+            `MFA_CHALLENGE_INVALID`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          description: Too many verification attempts from this source.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/mfa/totp/disable:
+    post:
+      tags:
+        - Identity & Access
+      summary: Disable the caller's own MFA (high-risk, audited)
+      description: >-
+        Full-online-only (Issue #589). Self-service: requires an
+        already-valid session (for an identity with active MFA, only
+        obtainable by already passing an MFA challenge). Deletes the
+        factor's recovery codes too. Audited (`mfa_disabled`).
+      operationId: authMfaTotpDisable
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: MFA disabled.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/MfaDisableResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Multi-factor authentication is not enabled for this deployment (`MFA_DISABLED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: No MFA factor is currently active for this account (`MFA_NOT_ACTIVE`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/mfa/recovery-codes/regenerate:
+    post:
+      tags:
+        - Identity & Access
+      summary: Invalidate existing recovery codes and issue a fresh set (high-risk, audited)
+      description: >-
+        Full-online-only (Issue #589). Requires an active MFA factor.
+        Every previously issued recovery code stops working immediately;
+        the 10 fresh codes are shown exactly once in the response. Audited
+        (`mfa_recovery_codes_regenerated`).
+      operationId: authMfaRecoveryCodesRegenerate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Recovery codes regenerated.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/MfaRecoveryCodesResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Multi-factor authentication is not enabled for this deployment (`MFA_DISABLED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: No MFA factor is currently active for this account (`MFA_NOT_ACTIVE`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/auth/password/forgot:
@@ -6541,6 +6870,151 @@ components:
         expiresAt:
           type: string
           format: date-time
+    LoginMfaRequiredResponse:
+      type: object
+      description: >-
+        `POST /auth/login`'s 401 response shape specifically for
+        `error.code === "MFA_REQUIRED"` (Issue #589) — deliberately NOT the
+        generic `ApiError` shape (`error.details` here is a structured
+        object, not an `ErrorDetail[]` array), since a real payload
+        (`mfaChallengeToken`) must be returned to let the client complete
+        the login via `POST /auth/mfa/totp/verify`.
+      required:
+        - success
+        - error
+        - meta
+      additionalProperties: false
+      properties:
+        success:
+          type: boolean
+          const: false
+        error:
+          type: object
+          required:
+            - code
+            - message
+            - details
+          additionalProperties: false
+          properties:
+            code:
+              type: string
+              enum:
+                - MFA_REQUIRED
+            message:
+              type: string
+            details:
+              type: object
+              required:
+                - mfaChallengeToken
+                - expiresAt
+              additionalProperties: false
+              properties:
+                mfaChallengeToken:
+                  type: string
+                  description: >-
+                    Opaque, single-use token to pass as `mfaChallengeToken`
+                    to `POST /auth/mfa/totp/verify` along with a TOTP or
+                    recovery code.
+                expiresAt:
+                  type: string
+                  format: date-time
+        meta:
+          $ref: "#/components/schemas/ApiMeta"
+    MfaStatusResponse:
+      type: object
+      required:
+        - enabled
+      additionalProperties: false
+      properties:
+        enabled:
+          type: boolean
+        factorType:
+          type: string
+          enum:
+            - totp
+        activatedAt:
+          type: string
+          format: date-time
+    MfaEnrollStartResponse:
+      type: object
+      required:
+        - secret
+        - otpauthUri
+      additionalProperties: false
+      properties:
+        secret:
+          type: string
+          description: >-
+            Base32-encoded TOTP secret, shown ONLY here — manual-entry
+            fallback for authenticator apps that can't scan a QR code.
+        otpauthUri:
+          type: string
+          description: >-
+            `otpauth://totp/...` URI — render as a QR code for the
+            authenticator app to scan.
+    MfaEnrollVerifyRequest:
+      type: object
+      required:
+        - code
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+          description: Current TOTP code from the authenticator app.
+    MfaEnrollVerifyResponse:
+      type: object
+      required:
+        - activated
+        - recoveryCodes
+      additionalProperties: false
+      properties:
+        activated:
+          type: boolean
+        recoveryCodes:
+          type: array
+          items:
+            type: string
+          description: >-
+            10 single-use recovery codes, shown exactly once. Store them
+            securely — they cannot be retrieved again (only
+            `recovery-codes/regenerate` can issue a fresh set, invalidating
+            these).
+    MfaChallengeVerifyRequest:
+      type: object
+      required:
+        - mfaChallengeToken
+      additionalProperties: false
+      properties:
+        mfaChallengeToken:
+          type: string
+          description: From `POST /auth/login`'s `MFA_REQUIRED` response.
+        code:
+          type: string
+          description: Current TOTP code — exactly one of `code`/`recoveryCode` is required.
+        recoveryCode:
+          type: string
+          description: A single-use recovery code — exactly one of `code`/`recoveryCode` is required.
+    MfaDisableResponse:
+      type: object
+      required:
+        - disabled
+      additionalProperties: false
+      properties:
+        disabled:
+          type: boolean
+    MfaRecoveryCodesResponse:
+      type: object
+      required:
+        - recoveryCodes
+      additionalProperties: false
+      properties:
+        recoveryCodes:
+          type: array
+          items:
+            type: string
+          description: >-
+            10 fresh single-use recovery codes, shown exactly once — every
+            previously issued code stops working immediately.
     LogoutResponse:
       type: object
       required:

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -37,6 +37,7 @@ import { resolveAppBaseUrl } from "./lib/app-url";
 import { checkRateLimit } from "../src/lib/security/rate-limit";
 import {
   checkEmailConfig,
+  checkMfaConfig,
   checkOnlineAuthSecurityConfig,
   checkTurnstileConfig
 } from "./validate-env";
@@ -788,10 +789,11 @@ export function checkEmailProviderConfigReady(
  * pattern): the value describes how bad a genuine misconfiguration would
  * be, not this run's outcome — `status` alone is what "disabled ->
  * informational pass, not a failure" (the issue's own acceptance criterion)
- * actually means here. #588 (Turnstile) now exists and has its own
- * `checkTurnstileReady` check below; #589-#592 (MFA/Google login/generic
- * SSO/admin policy UI) still don't, so there is nothing else for this
- * particular check to verify beyond the shared gate itself.
+ * actually means here. #588 (Turnstile) and #589 (MFA/TOTP) now exist and
+ * have their own `checkTurnstileReady`/`checkMfaReady` checks below;
+ * #590-#592 (Google login/generic SSO/admin policy UI) still don't, so
+ * there is nothing else for this particular check to verify beyond the
+ * shared gate itself.
  */
 export function checkOnlineAuthSecurityReady(
   env: NodeJS.ProcessEnv = process.env
@@ -883,6 +885,49 @@ export function checkTurnstileReady(
     status: "pass",
     evidence:
       "TURNSTILE_ENABLED=true and all conditional Turnstile config check(s) pass."
+  };
+}
+
+/**
+ * Reuses `checkMfaConfig` from `validate-env.ts` verbatim — same pattern and
+ * same rationale as `checkTurnstileReady` above (checked independently of
+ * the #587 outer gate; an incomplete `AUTH_MFA_SECRET_ENCRYPTION_KEY` is
+ * worth flagging even if the outer gate is currently off).
+ */
+export function checkMfaReady(
+  env: NodeJS.ProcessEnv = process.env
+): SecurityCheckResult {
+  const name = "MFA/TOTP configuration is complete when enabled";
+  const severity: CheckSeverity = "critical";
+  const results = checkMfaConfig(env);
+  const failed = results.filter((result) => result.status === "fail");
+
+  if (failed.length > 0) {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `AUTH_MFA_ENABLED=true but config is incomplete: ${failed
+        .map((result) => result.detail)
+        .join(" ")}`
+    };
+  }
+
+  if (env.AUTH_MFA_ENABLED !== "true") {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence: 'AUTH_MFA_ENABLED is not "true" — MFA config not required.'
+    };
+  }
+
+  return {
+    name,
+    severity,
+    status: "pass",
+    evidence:
+      "AUTH_MFA_ENABLED=true and all conditional MFA config check(s) pass."
   };
 }
 
@@ -1128,6 +1173,7 @@ export async function runSecurityReadinessChecks(): Promise<
     checkEmailProviderConfigReady(),
     checkOnlineAuthSecurityReady(),
     checkTurnstileReady(),
+    checkMfaReady(),
     await checkErrorsDontLeakStackTraces(),
     await checkSecurityHeadersPresent(),
     checkLoginRateLimitImplemented()

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -614,6 +614,21 @@ export function checkTurnstileConfig(
  * deployment that passes `config:validate` never later hits the
  * `MFA_MISCONFIGURED` fail-closed path due to a malformed key.
  */
+/**
+ * Only whether the key decodes correctly — never the key material itself —
+ * crosses out of this function. Deliberately isolated from
+ * `checkMfaConfig`'s report-building below (a plain boolean computed once,
+ * not inlined into the same expression that also builds the logged
+ * `name`/`detail` strings) so a static analyzer can't mistake "we checked
+ * the key's *validity*" for "we logged the key's *value*" — `detail` below
+ * only ever contains the env var's NAME (`AUTH_MFA_SECRET_ENCRYPTION_KEY`),
+ * a compile-time constant, never `env.AUTH_MFA_SECRET_ENCRYPTION_KEY`'s
+ * actual value.
+ */
+function isMfaEncryptionKeyWellFormed(env: NodeJS.ProcessEnv): boolean {
+  return resolveMfaEncryptionKey(env) !== null;
+}
+
 export function checkMfaConfig(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -627,6 +642,8 @@ export function checkMfaConfig(
     ];
   }
 
+  const encryptionKeyWellFormed = isMfaEncryptionKeyWellFormed(env);
+
   return AUTH_MFA_REQUIRED_WHEN_ENABLED.map((name) => {
     if (!isSet(env[name])) {
       return {
@@ -636,10 +653,7 @@ export function checkMfaConfig(
       };
     }
 
-    if (
-      name === "AUTH_MFA_SECRET_ENCRYPTION_KEY" &&
-      !resolveMfaEncryptionKey(env)
-    ) {
+    if (name === "AUTH_MFA_SECRET_ENCRYPTION_KEY" && !encryptionKeyWellFormed) {
       return {
         name,
         status: "fail",

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -111,6 +111,14 @@
  *     (`../src/lib/security/turnstile`). Whether Turnstile actually
  *     activates at runtime depends on BOTH this flag AND the #587 gate
  *     (`isTurnstileRequired()`), not on this validation alone.
+ *  9. Full-online MFA/TOTP (Issue #589, epic: full-online auth hardening):
+ *     if AUTH_MFA_ENABLED is not "true", nothing else is required —
+ *     independent of the #587 gate, same rationale as item 8. AUTH_MFA_ENABLED=true
+ *     requires AUTH_MFA_SECRET_ENCRYPTION_KEY, which must additionally
+ *     decode as base64 to exactly 32 bytes (`../src/lib/auth/mfa-secret-crypto`'s
+ *     `resolveMfaEncryptionKey`) — not just be present. Whether MFA actually
+ *     activates at runtime depends on BOTH this flag AND the #587 gate
+ *     (`isMfaRequired()`), not on this validation alone.
  *
  * Never prints actual secret values — only which variable name is
  * missing/invalid (doc 18: "Var wajib hilang → gagal start dengan pesan
@@ -134,6 +142,11 @@ import {
   isTurnstileEnabled,
   TURNSTILE_REQUIRED_WHEN_ENABLED
 } from "../src/lib/security/turnstile";
+import {
+  AUTH_MFA_REQUIRED_WHEN_ENABLED,
+  isMfaEnabled
+} from "../src/lib/auth/mfa-config";
+import { resolveMfaEncryptionKey } from "../src/lib/auth/mfa-secret-crypto";
 
 export type EnvCheckResult = {
   name: string;
@@ -589,6 +602,55 @@ export function checkTurnstileConfig(
   });
 }
 
+/**
+ * Full-online MFA/TOTP (Issue #589, epic: full-online auth hardening).
+ * `AUTH_MFA_ENABLED` left unset (or anything other than `"true"`) requires
+ * nothing else — same "unset/off requires nothing" shape as
+ * `checkTurnstileConfig`, and validated independently of the #587 gate for
+ * the same reason (an operator can provision the encryption key ahead of
+ * time). `AUTH_MFA_SECRET_ENCRYPTION_KEY` is checked for more than presence
+ * — it must decode as base64 to exactly 32 bytes (AES-256-GCM), the same
+ * validity `resolveMfaEncryptionKey` itself enforces at runtime, so a
+ * deployment that passes `config:validate` never later hits the
+ * `MFA_MISCONFIGURED` fail-closed path due to a malformed key.
+ */
+export function checkMfaConfig(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult[] {
+  if (!isMfaEnabled(env)) {
+    return [
+      {
+        name: "MFA config (conditional on AUTH_MFA_ENABLED)",
+        status: "pass",
+        detail: 'AUTH_MFA_ENABLED is not "true" — MFA config not required.'
+      }
+    ];
+  }
+
+  return AUTH_MFA_REQUIRED_WHEN_ENABLED.map((name) => {
+    if (!isSet(env[name])) {
+      return {
+        name,
+        status: "fail",
+        detail: `AUTH_MFA_ENABLED=true but ${name} is missing or empty.`
+      };
+    }
+
+    if (
+      name === "AUTH_MFA_SECRET_ENCRYPTION_KEY" &&
+      !resolveMfaEncryptionKey(env)
+    ) {
+      return {
+        name,
+        status: "fail",
+        detail: `${name} must be a base64-encoded 32-byte (AES-256) key, e.g. from "openssl rand -base64 32".`
+      };
+    }
+
+    return { name, status: "pass", detail: `${name} is set.` };
+  });
+}
+
 export function runEnvValidation(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -600,6 +662,7 @@ export function runEnvValidation(
     ...checkPublicRoutingConfig(env),
     ...checkTenantDomainDnsConfig(env),
     ...checkTurnstileConfig(env),
+    ...checkMfaConfig(env),
     ...checkOnlineAuthSecurityConfig(env)
   ];
 }

--- a/sql/034_awcms_mini_mfa_totp_schema.sql
+++ b/sql/034_awcms_mini_mfa_totp_schema.sql
@@ -1,0 +1,122 @@
+-- Full-online MFA/TOTP login challenge (Issue #589, epic: full-online auth
+-- hardening #587-#593). Active only when the #587 gate is active AND
+-- AUTH_MFA_ENABLED=true (`isMfaRequired`, `src/lib/auth/mfa-config.ts`) —
+-- these three tables exist on every deployment (migrations always run), but
+-- stay entirely empty/unused on local/offline/LAN deployments that never
+-- enable the feature.
+--
+-- `awcms_mini_identity_mfa_factors` — one row per identity per factor type.
+-- `secret_ciphertext` is the TOTP shared secret encrypted at rest
+-- (`src/lib/auth/mfa-secret-crypto.ts`, AES-256-GCM keyed by
+-- `AUTH_MFA_SECRET_ENCRYPTION_KEY`) — never stored plaintext, never
+-- returned again after enrollment start. `status`: `pending` (enrolled,
+-- not yet confirmed with a valid code — unusable for login) ->
+-- `active` (confirmed, used at login) -> `disabled` (turned off; kept as a
+-- row, not deleted, for audit/history — mirrors why `awcms_mini_identities`
+-- itself uses a `status` column rather than deleting rows). Partial unique
+-- index below allows only one non-disabled factor per identity at a time
+-- (this issue only implements TOTP; the column still models `factor_type`
+-- for a possible future WebAuthn factor type without a schema change, but
+-- WebAuthn itself is explicitly out of scope here).
+CREATE TABLE IF NOT EXISTS awcms_mini_identity_mfa_factors (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  identity_id uuid NOT NULL REFERENCES awcms_mini_identities (id),
+  factor_type text NOT NULL DEFAULT 'totp',
+  secret_ciphertext text NOT NULL,
+  status text NOT NULL DEFAULT 'pending',
+  -- Replay prevention: the highest TOTP time-step counter ever accepted for
+  -- this factor. A verification is only accepted if its matched step is
+  -- strictly greater than this value, so the exact same code (or an older
+  -- one within the verification window) can never be replayed even before
+  -- it naturally expires.
+  last_used_step bigint NOT NULL DEFAULT -1,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  activated_at timestamptz,
+  disabled_at timestamptz,
+  CONSTRAINT awcms_mini_identity_mfa_factors_factor_type_check
+    CHECK (factor_type IN ('totp')),
+  CONSTRAINT awcms_mini_identity_mfa_factors_status_check
+    CHECK (status IN ('pending', 'active', 'disabled'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_identity_mfa_factors_active_key
+  ON awcms_mini_identity_mfa_factors (tenant_id, identity_id, factor_type)
+  WHERE status <> 'disabled';
+
+ALTER TABLE awcms_mini_identity_mfa_factors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_identity_mfa_factors FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_identity_mfa_factors_tenant_isolation
+  ON awcms_mini_identity_mfa_factors
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- `awcms_mini_identity_mfa_recovery_codes` — single-use backup codes shown
+-- once at enrollment-verify time (and again on regenerate); only `code_hash`
+-- (sha256, same construction as `session-token.ts`/`password-reset-token.ts`)
+-- is ever persisted. `ON DELETE CASCADE` on `factor_id`: disabling/replacing
+-- a factor makes its recovery codes moot, and the application layer deletes
+-- them explicitly on disable/regenerate anyway — the cascade is a backstop,
+-- not the primary cleanup path.
+CREATE TABLE IF NOT EXISTS awcms_mini_identity_mfa_recovery_codes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  identity_id uuid NOT NULL REFERENCES awcms_mini_identities (id),
+  factor_id uuid NOT NULL REFERENCES awcms_mini_identity_mfa_factors (id) ON DELETE CASCADE,
+  code_hash text NOT NULL,
+  used_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_identity_mfa_recovery_codes_hash_key
+  ON awcms_mini_identity_mfa_recovery_codes (code_hash);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_identity_mfa_recovery_codes_factor_idx
+  ON awcms_mini_identity_mfa_recovery_codes (tenant_id, factor_id)
+  WHERE used_at IS NULL;
+
+ALTER TABLE awcms_mini_identity_mfa_recovery_codes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_identity_mfa_recovery_codes FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_identity_mfa_recovery_codes_tenant_isolation
+  ON awcms_mini_identity_mfa_recovery_codes
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- `awcms_mini_mfa_challenges` — the ephemeral bridge between "password
+-- verified" and "session created" for an identity with an active MFA
+-- factor (`login.ts`): password-valid + MFA-active issues a challenge row
+-- (no session yet) whose raw token is returned to the client as
+-- `mfaChallengeToken`; `POST /auth/mfa/totp/verify` looks it up by
+-- `challenge_token_hash`, and only creates the real session once the
+-- submitted TOTP code (or recovery code) is valid. `failed_attempts` bounds
+-- brute-force guessing against one challenge independently of the
+-- source-scoped rate limit at the endpoint (`AUTH_MFA_RATE_LIMIT_MAX`) —
+-- a distributed attacker rotating source IPs against the same challenge is
+-- still capped by this column.
+CREATE TABLE IF NOT EXISTS awcms_mini_mfa_challenges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  identity_id uuid NOT NULL REFERENCES awcms_mini_identities (id),
+  challenge_token_hash text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  failed_attempts integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_mini_mfa_challenges_failed_attempts_check
+    CHECK (failed_attempts >= 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_mfa_challenges_hash_key
+  ON awcms_mini_mfa_challenges (challenge_token_hash);
+
+CREATE INDEX IF NOT EXISTS awcms_mini_mfa_challenges_identity_idx
+  ON awcms_mini_mfa_challenges (tenant_id, identity_id)
+  WHERE consumed_at IS NULL;
+
+ALTER TABLE awcms_mini_mfa_challenges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_mfa_challenges FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_mfa_challenges_tenant_isolation
+  ON awcms_mini_mfa_challenges
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/src/lib/auth/mfa-challenge-token.ts
+++ b/src/lib/auth/mfa-challenge-token.ts
@@ -1,0 +1,16 @@
+/**
+ * MFA challenge token generation/hashing (Issue #589) — same shape as
+ * `session-token.ts`/`password-reset-token.ts` (32 random bytes, base64url;
+ * sha256 hex with a `sha256:` prefix), a distinct pair of functions so a
+ * challenge token can never be confused with a session or reset token at a
+ * call site even though the construction is identical.
+ */
+import { createHash, randomBytes } from "node:crypto";
+
+export function generateChallengeToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function hashChallengeToken(token: string): string {
+  return `sha256:${createHash("sha256").update(token).digest("hex")}`;
+}

--- a/src/lib/auth/mfa-config.ts
+++ b/src/lib/auth/mfa-config.ts
@@ -1,0 +1,74 @@
+/**
+ * MFA/TOTP config gate (Issue #589, epic: full-online auth hardening).
+ * Mirrors `../security/turnstile.ts`'s `isTurnstileRequired` shape exactly —
+ * `isMfaRequired` is the ONE function `login.ts` and every MFA endpoint
+ * checks; local/offline/LAN deployments never read these env vars and never
+ * change login behavior.
+ */
+import { isFullOnlineSecurityActive } from "./online-security-config";
+
+const DEFAULT_TOTP_ISSUER = "AWCMS-Mini";
+const DEFAULT_TOTP_PERIOD_SEC = 30;
+const DEFAULT_TOTP_DIGITS = 6;
+const DEFAULT_CHALLENGE_TTL_SEC = 300;
+const KNOWN_TOTP_DIGITS = [6, 8] as const;
+
+/**
+ * Env var required only when `AUTH_MFA_ENABLED=true`
+ * (`scripts/validate-env.ts`'s `checkMfaConfig`). Only the encryption key
+ * needs its own dedicated required-var check — the TOTP issuer/period/digits/
+ * challenge-TTL/rate-limit vars all have safe numeric/string defaults below
+ * and are never required.
+ */
+export const AUTH_MFA_REQUIRED_WHEN_ENABLED = [
+  "AUTH_MFA_SECRET_ENCRYPTION_KEY"
+] as const;
+
+export function isMfaEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.AUTH_MFA_ENABLED === "true";
+}
+
+/**
+ * The single boolean every MFA endpoint and `login.ts` must check before
+ * doing anything MFA-related — true only when BOTH the full-online gate
+ * (Issue #587) and this feature's own flag agree. Matches the issue's
+ * acceptance criterion "MFA is active only when #587 gate is enabled and
+ * AUTH_MFA_ENABLED=true."
+ */
+export function isMfaRequired(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isFullOnlineSecurityActive(env) && isMfaEnabled(env);
+}
+
+export function resolveTotpIssuer(
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const raw = env.AUTH_MFA_TOTP_ISSUER?.trim();
+
+  return raw && raw.length > 0 ? raw : DEFAULT_TOTP_ISSUER;
+}
+
+export function resolveTotpPeriodSec(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const raw = Number(env.AUTH_MFA_TOTP_PERIOD_SEC);
+
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TOTP_PERIOD_SEC;
+}
+
+export function resolveTotpDigits(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const raw = Number(env.AUTH_MFA_TOTP_DIGITS);
+
+  return (KNOWN_TOTP_DIGITS as readonly number[]).includes(raw)
+    ? raw
+    : DEFAULT_TOTP_DIGITS;
+}
+
+export function resolveChallengeTtlSec(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const raw = Number(env.AUTH_MFA_CHALLENGE_TTL_SEC);
+
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_CHALLENGE_TTL_SEC;
+}

--- a/src/lib/auth/mfa-recovery-code.ts
+++ b/src/lib/auth/mfa-recovery-code.ts
@@ -1,0 +1,28 @@
+/**
+ * MFA recovery codes (Issue #589) — single-use backup codes shown once
+ * (enrollment-verify and regenerate), stored hash-only (never a reversible
+ * form, unlike the TOTP secret itself — a recovery code never needs to be
+ * recovered/displayed again after its one-time reveal, so a one-way hash is
+ * the correct choice here, same as session/reset tokens).
+ *
+ * Named `*RecoveryCode`, not `*Password...` — avoids the same CodeQL
+ * `js/insufficient-password-hash` false positive `password-reset-token.ts`
+ * documents (a fast sha256 hash is correct for an 8-char CSPRNG-derived code,
+ * not a user-chosen password).
+ */
+import { createHash, randomBytes } from "node:crypto";
+import { base32Encode } from "./totp";
+
+/** `XXXX-XXXX` — 8 base32 chars (40 bits of entropy) from 5 random bytes, formatted for easy manual transcription. */
+export function generateRecoveryCode(): string {
+  const encoded = base32Encode(randomBytes(5));
+
+  return `${encoded.slice(0, 4)}-${encoded.slice(4, 8)}`;
+}
+
+/** Normalizes (uppercase, strip non-alphanumerics) before hashing so a code is recognized whether or not the user retypes the dash/case exactly as shown. */
+export function hashRecoveryCode(code: string): string {
+  const normalized = code.toUpperCase().replace(/[^A-Z0-9]/g, "");
+
+  return `sha256:${createHash("sha256").update(normalized).digest("hex")}`;
+}

--- a/src/lib/auth/mfa-secret-crypto.ts
+++ b/src/lib/auth/mfa-secret-crypto.ts
@@ -1,0 +1,80 @@
+/**
+ * Encryption-at-rest for TOTP secrets (Issue #589). Unlike every other
+ * secret this repo hashes one-way (session tokens, reset tokens, recovery
+ * codes — see `session-token.ts`/`password-reset-token.ts`/
+ * `mfa-recovery-code.ts`), a TOTP secret must be *recoverable* to compute
+ * the expected code at verification time, so it's encrypted (reversible),
+ * not hashed. AES-256-GCM keyed by `AUTH_MFA_SECRET_ENCRYPTION_KEY`
+ * (base64-encoded 32 random bytes, e.g. `openssl rand -base64 32`) — an
+ * authenticated cipher so tampering with the stored ciphertext is detected
+ * (`decryptMfaSecret` throws) rather than silently producing garbage that
+ * would then fail every TOTP verification anyway but without a clear signal
+ * why.
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_BYTE_LENGTH = 32;
+const IV_BYTE_LENGTH = 12;
+const FORMAT_VERSION = "v1";
+
+/**
+ * Decodes and validates `AUTH_MFA_SECRET_ENCRYPTION_KEY` from env. Returns
+ * `null` — never throws — if unset or not exactly 32 bytes once
+ * base64-decoded, so every caller can fail closed (treat "no usable key" as
+ * "cannot verify/encrypt", same convention as Turnstile's
+ * `resolveTurnstileConfig`) rather than crash.
+ */
+export function resolveMfaEncryptionKey(
+  env: NodeJS.ProcessEnv = process.env
+): Buffer | null {
+  const raw = env.AUTH_MFA_SECRET_ENCRYPTION_KEY;
+
+  if (!raw) {
+    return null;
+  }
+
+  let key: Buffer;
+
+  try {
+    key = Buffer.from(raw, "base64");
+  } catch {
+    return null;
+  }
+
+  return key.length === KEY_BYTE_LENGTH ? key : null;
+}
+
+/** `v1:<iv-base64>:<authTag-base64>:<ciphertext-base64>` — versioned so the format can evolve without breaking already-encrypted rows. */
+export function encryptMfaSecret(plaintext: Buffer, key: Buffer): string {
+  const iv = randomBytes(IV_BYTE_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return [
+    FORMAT_VERSION,
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    ciphertext.toString("base64")
+  ].join(":");
+}
+
+/** Throws if `encoded` is malformed, the tag doesn't authenticate, or the version is unrecognized — callers must treat any throw as "cannot decrypt", never as "empty secret". */
+export function decryptMfaSecret(encoded: string, key: Buffer): Buffer {
+  const parts = encoded.split(":");
+
+  if (parts.length !== 4 || parts[0] !== FORMAT_VERSION) {
+    throw new Error("Unrecognized MFA secret ciphertext format.");
+  }
+
+  const [, ivPart, tagPart, ciphertextPart] = parts;
+  const iv = Buffer.from(ivPart!, "base64");
+  const authTag = Buffer.from(tagPart!, "base64");
+  const ciphertext = Buffer.from(ciphertextPart!, "base64");
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}

--- a/src/lib/auth/totp.ts
+++ b/src/lib/auth/totp.ts
@@ -1,0 +1,173 @@
+/**
+ * RFC 6238-compatible TOTP (Issue #589, epic: full-online auth hardening).
+ * Pure math/crypto, no I/O and no DB access — deliberately dependency-free
+ * (Bun-only rule: no otplib/speakeasy) since the algorithm is small and
+ * fully specified by RFC 4226 (HOTP) + RFC 6238 (TOTP time-step wrapper).
+ * HMAC-SHA1 only (not SHA256/512) — the issue's own security note requires
+ * "RFC 6238-compatible behavior for Google Authenticator", and Google
+ * Authenticator (and most compatible apps) only implement the SHA1 variant.
+ */
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/** RFC 4648 base32 encode, no padding (Google Authenticator convention). */
+export function base32Encode(buffer: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let output = "";
+
+  for (const byte of buffer) {
+    value = (value << 8) | byte;
+    bits += 8;
+
+    while (bits >= 5) {
+      output += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+
+  if (bits > 0) {
+    output += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  }
+
+  return output;
+}
+
+/** Inverse of `base32Encode` — tolerant of padding, whitespace, and lowercase input. */
+export function base32Decode(input: string): Buffer {
+  const cleaned = input
+    .toUpperCase()
+    .replace(/=+$/, "")
+    .replace(/[^A-Z2-7]/g, "");
+
+  let bits = 0;
+  let value = 0;
+  const bytes: number[] = [];
+
+  for (const char of cleaned) {
+    const index = BASE32_ALPHABET.indexOf(char);
+
+    if (index === -1) {
+      continue;
+    }
+
+    value = (value << 5) | index;
+    bits += 5;
+
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+
+  return Buffer.from(bytes);
+}
+
+/** 160-bit (20-byte) secret — the RFC 4226 recommended length for HMAC-SHA1. */
+export function generateTotpSecret(): Buffer {
+  return randomBytes(20);
+}
+
+function hotp(secret: Buffer, counter: number, digits: number): string {
+  const counterBuffer = Buffer.alloc(8);
+  counterBuffer.writeBigUInt64BE(BigInt(counter));
+
+  const hmac = createHmac("sha1", secret).update(counterBuffer).digest();
+  const offset = hmac[hmac.length - 1]! & 0xf;
+  const binCode =
+    ((hmac[offset]! & 0x7f) << 24) |
+    ((hmac[offset + 1]! & 0xff) << 16) |
+    ((hmac[offset + 2]! & 0xff) << 8) |
+    (hmac[offset + 3]! & 0xff);
+
+  return (binCode % 10 ** digits).toString().padStart(digits, "0");
+}
+
+export type TotpVerifyOptions = {
+  periodSec: number;
+  digits: number;
+  /** Number of time steps to check on either side of the current one, tolerating clock drift. Default 1 (±30s at the default 30s period). */
+  windowSteps?: number;
+};
+
+/**
+ * Computes the current valid code for `secret` — the counterpart to
+ * `verifyTotpCode` a real authenticator app performs. Not used by any
+ * server-side verification path (the server only ever verifies a
+ * client-submitted code); exists for enrollment-flow tests that need to
+ * produce a real code from a freshly generated secret without duplicating
+ * the HOTP calculation.
+ */
+export function generateTotpCode(
+  secret: Buffer,
+  timestampMs: number,
+  options: { periodSec: number; digits: number }
+): string {
+  const step = Math.floor(timestampMs / 1000 / options.periodSec);
+  return hotp(secret, step, options.digits);
+}
+
+/**
+ * Verifies `code` against every time step in `[current - windowSteps,
+ * current + windowSteps]`. Returns the matched *absolute* step counter on
+ * success (callers must reject a step they've already seen — see
+ * `awcms_mini_identity_mfa_factors.last_used_step` — since a valid code
+ * within the window is otherwise replayable until it naturally expires), or
+ * `null` if no step in the window matches. Constant-time comparison
+ * (`timingSafeEqual`) against a fixed-length, zero-padded code so timing
+ * can't leak which digit differs.
+ */
+export function verifyTotpCode(
+  secret: Buffer,
+  code: string,
+  timestampMs: number,
+  options: TotpVerifyOptions
+): number | null {
+  const { periodSec, digits, windowSteps = 1 } = options;
+
+  if (!/^\d+$/.test(code) || code.length !== digits) {
+    return null;
+  }
+
+  const currentStep = Math.floor(timestampMs / 1000 / periodSec);
+  const codeBuffer = Buffer.from(code);
+
+  for (let delta = -windowSteps; delta <= windowSteps; delta += 1) {
+    const step = currentStep + delta;
+
+    if (step < 0) {
+      continue;
+    }
+
+    const candidateBuffer = Buffer.from(hotp(secret, step, digits));
+
+    if (timingSafeEqual(candidateBuffer, codeBuffer)) {
+      return step;
+    }
+  }
+
+  return null;
+}
+
+export type OtpauthUriParams = {
+  secret: Buffer;
+  issuer: string;
+  accountName: string;
+  digits: number;
+  periodSec: number;
+};
+
+/** `otpauth://totp/...` URI for a QR code / manual-entry enrollment screen. */
+export function buildOtpauthUri(params: OtpauthUriParams): string {
+  const label = encodeURIComponent(`${params.issuer}:${params.accountName}`);
+  const query = new URLSearchParams({
+    secret: base32Encode(params.secret),
+    issuer: params.issuer,
+    digits: String(params.digits),
+    period: String(params.periodSec),
+    algorithm: "SHA1"
+  });
+
+  return `otpauth://totp/${label}?${query.toString()}`;
+}

--- a/src/lib/i18n/error-messages.ts
+++ b/src/lib/i18n/error-messages.ts
@@ -6,8 +6,11 @@ import type { Translator } from "./translate";
  * `RESOURCE_CONFLICT`, `PURGE_BLOCKED_BY_DEPENDENTS`,
  * `PURGE_REQUIRES_SOFT_DELETE`, and — Issue #563 — the tenant domain
  * management API's own `HOSTNAME_CONFLICT`/`INVALID_STATUS_TRANSITION`/
- * `CONCURRENT_UPDATE`, Issue #562 — and Issue #588's Cloudflare Turnstile
- * gate's own `TURNSTILE_REQUIRED`/`TURNSTILE_INVALID`) to i18n catalog keys
+ * `CONCURRENT_UPDATE`, Issue #562 — Issue #588's Cloudflare Turnstile
+ * gate's own `TURNSTILE_REQUIRED`/`TURNSTILE_INVALID` — and Issue #589's
+ * MFA/TOTP codes: `MFA_REQUIRED`/`MFA_DISABLED`/`MFA_ALREADY_ACTIVE`/
+ * `MFA_NOT_ACTIVE`/`MFA_ENROLLMENT_NOT_FOUND`/`MFA_INVALID_CODE`/
+ * `MFA_CHALLENGE_INVALID`/`MFA_MISCONFIGURED`) to i18n catalog keys
  * under the `error.` namespace. Used both server-side (SSR error panels)
  * and to build the
  * client-string JSON blob admin pages inline for their fetch-based action
@@ -37,7 +40,15 @@ export const ERROR_CODE_KEYS: Record<string, string> = {
   INVALID_STATUS_TRANSITION: "error.invalid_status_transition",
   CONCURRENT_UPDATE: "error.concurrent_update",
   TURNSTILE_REQUIRED: "error.turnstile_required",
-  TURNSTILE_INVALID: "error.turnstile_invalid"
+  TURNSTILE_INVALID: "error.turnstile_invalid",
+  MFA_REQUIRED: "error.mfa_required",
+  MFA_DISABLED: "error.mfa_disabled",
+  MFA_ALREADY_ACTIVE: "error.mfa_already_active",
+  MFA_NOT_ACTIVE: "error.mfa_not_active",
+  MFA_ENROLLMENT_NOT_FOUND: "error.mfa_enrollment_not_found",
+  MFA_INVALID_CODE: "error.mfa_invalid_code",
+  MFA_CHALLENGE_INVALID: "error.mfa_challenge_invalid",
+  MFA_MISCONFIGURED: "error.mfa_misconfigured"
 };
 
 /**

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -150,14 +150,59 @@ Astro secara default menolak (403, tanpa body) permintaan `POST`/`PUT`/`PATCH`/`
 
 CRUD ABAC policy row (`awcms_mini_abac_policies` — schema tersedia, evaluator masih pakai aturan generik bawaan, belum ada endpoint kelola policy), dan publikasi event `identity.login.succeeded`/`identity.login.failed` (doc 05, menyusul modul Observability/Logging) belum ada pada tahap ini. `/access/decision-logs` tetap `LIMIT 50` per halaman tapi kini punya keyset pagination opsional (Issue #435, `?cursor=`/`nextCursor` — lihat `src/modules/_shared/keyset-pagination.ts`).
 
-MFA/TOTP, Google OIDC login, generic tenant OIDC SSO, dan admin policy
-UI (Issue #589-#592) masih backlog untuk epic full-online auth security
-hardening (#587-#593). #587 (gate bersama, lihat §Full-online-only auth
-security feature gate di bawah) dan #588 (Cloudflare Turnstile,
-`src/lib/security/turnstile.ts` — bukan bagian modul ini, tapi
-dipanggil dari `POST /auth/login` di modul ini via
-`enforceTurnstileIfRequired`, lihat skill `awcms-mini-auth-online-hardening`
-§Cloudflare Turnstile) sudah selesai.
+Google OIDC login, generic tenant OIDC SSO, dan admin policy UI (Issue
+#590-#592) masih backlog untuk epic full-online auth security hardening
+(#587-#593). #587 (gate bersama, lihat §Full-online-only auth security
+feature gate di bawah), #588 (Cloudflare Turnstile,
+`src/lib/security/turnstile.ts` — bukan bagian modul ini, tapi dipanggil
+dari `POST /auth/login` di modul ini via `enforceTurnstileIfRequired`),
+dan #589 (MFA/TOTP, lihat §MFA/TOTP login challenge di bawah) sudah
+selesai. Lihat skill `awcms-mini-auth-online-hardening` untuk detail
+lintas-issue.
+
+## MFA/TOTP login challenge (Issue #589)
+
+`src/modules/identity-access/application/mfa.ts` +
+`src/modules/identity-access/domain/mfa-policy.ts` (challenge, bukan
+factor/token, yang punya logic domain murni di sini — enroll/disable/
+regenerate cukup query+mutate langsung tanpa evaluasi kondisional
+berlapis) + `src/lib/auth/totp.ts`/`mfa-secret-crypto.ts`/
+`mfa-recovery-code.ts`/`mfa-challenge-token.ts`/`mfa-config.ts` (RFC
+6238 TOTP, enkripsi secret AES-256-GCM, recovery code, challenge token,
+gate env — semuanya modul-agnostic, tinggal di `src/lib/auth/` seperti
+`session-token.ts`/`password.ts`).
+
+- Gate gabungan `isMfaRequired(env)` = `isFullOnlineSecurityActive(env)`
+  (#587) ∧ `AUTH_MFA_ENABLED=true` — mengikuti pola persis
+  `isTurnstileRequired()` (#588). MFA **opt-in per identity**: identity
+  yang belum pernah enroll tetap login normal bahkan saat gate ini aktif
+  tenant-wide.
+- Login (`login.ts`): password-valid TAPI identity punya factor TOTP
+  `active` → TIDAK membuat session, malah menerbitkan
+  `awcms_mini_mfa_challenges` row dan balas `401 MFA_REQUIRED` berisi
+  `mfaChallengeToken`. `POST /auth/mfa/totp/verify` (satu-satunya
+  endpoint MFA yang TIDAK butuh session — diautentikasi lewat possession
+  token challenge, sama seperti `password/reset`) menyelesaikan login:
+  kode/recovery code valid → session dibuat persis seperti
+  `login.ts`, cookie sama.
+- Enroll: `POST /auth/mfa/totp/enroll/start` (butuh session; generate
+  secret baru, simpan `pending`, plaintext secret HANYA di respons ini)
+  → `POST /auth/mfa/totp/enroll/verify` (kode valid → `active` +
+  10 recovery code sekali tampil). Re-enroll saat sudah `active` ditolak
+  `409 MFA_ALREADY_ACTIVE` — harus `disable` dulu.
+- `POST /auth/mfa/totp/disable`/`POST /auth/mfa/recovery-codes/regenerate`:
+  high-risk, diaudit (`mfa_disabled`/`mfa_recovery_codes_regenerated`).
+  Reset password (`completePasswordReset`) **tidak** menyentuh MFA sama
+  sekali — diverifikasi test integrasi eksplisit (bukan MFA bypass).
+- TOTP secret dienkripsi AES-256-GCM (`AUTH_MFA_SECRET_ENCRYPTION_KEY`)
+  — satu-satunya secret di aplikasi ini yang reversibel (dienkripsi,
+  bukan di-hash) karena harus dihitung ulang saat verifikasi; recovery
+  code & challenge token tetap hash-only (sha256) seperti
+  session/reset token. Replay kode TOTP dicegah via kolom
+  `last_used_step` per factor (kode/step yang sama tidak bisa dipakai
+  dua kali walau masih dalam window toleransi clock drift).
+- Detail lengkap + rasional lintas-issue: skill
+  `awcms-mini-auth-online-hardening` §MFA/TOTP.
 
 ## Full-online-only auth security feature gate (Issue #587)
 

--- a/src/modules/identity-access/application/mfa.ts
+++ b/src/modules/identity-access/application/mfa.ts
@@ -352,10 +352,20 @@ export async function verifyMfaChallenge(
 ): Promise<VerifyMfaChallengeResult> {
   const tokenHash = hashChallengeToken(challengeToken);
 
+  // `FOR UPDATE` locks this challenge row for the rest of the transaction —
+  // essential, not optional: without it, N concurrent verification
+  // requests for the SAME challenge would all read the same
+  // `failed_attempts` value before any of them commits, all pass the
+  // `>= maxAttempts` check, and all get to guess a code, silently
+  // defeating the attempt limit this column exists to enforce (found in
+  // PR #597 security review). Serializing on this row means the second
+  // concurrent request only proceeds after the first's UPDATE below has
+  // committed, so it always sees the up-to-date count.
   const challengeRows = (await tx`
     SELECT id, identity_id, expires_at, consumed_at, failed_attempts
     FROM awcms_mini_mfa_challenges
     WHERE tenant_id = ${tenantId} AND challenge_token_hash = ${tokenHash}
+    FOR UPDATE
   `) as {
     id: string;
     identity_id: string;
@@ -419,12 +429,23 @@ export async function verifyMfaChallenge(
         );
 
         if (matchedStep !== null && matchedStep > factor.last_used_step) {
-          await tx`
+          // Compare-and-swap, not a blind SET: `last_used_step` is also
+          // read by whichever OTHER challenge might be racing this one for
+          // the same identity (a second login attempt can create a second
+          // challenge row) — the `FOR UPDATE` lock above only serializes
+          // requests against THIS challenge, not against the factor row
+          // shared by every challenge for this identity. Re-asserting
+          // `last_used_step < matchedStep` atomically in the WHERE clause
+          // closes that gap: if another request already advanced the step
+          // first, this UPDATE affects zero rows and the code is correctly
+          // treated as replayed (found in PR #597 security review).
+          const advancedRows = (await tx`
             UPDATE awcms_mini_identity_mfa_factors
             SET last_used_step = ${matchedStep}
-            WHERE id = ${factor.id}
-          `;
-          matched = true;
+            WHERE id = ${factor.id} AND last_used_step < ${matchedStep}
+            RETURNING id
+          `) as { id: string }[];
+          matched = advancedRows.length > 0;
         }
       } catch {
         matched = false;
@@ -432,21 +453,21 @@ export async function verifyMfaChallenge(
     }
   } else if (credentials.recoveryCode) {
     const hash = hashRecoveryCode(credentials.recoveryCode);
-    const recoveryRows = (await tx`
-      SELECT id FROM awcms_mini_identity_mfa_recovery_codes
+
+    // Compare-and-swap: the `WHERE ... AND used_at IS NULL` is re-asserted
+    // atomically in the same UPDATE that consumes the code, rather than
+    // trusting a separate prior SELECT — otherwise two concurrent requests
+    // with the same recovery code could both read "unused" before either
+    // commits, and both would be accepted (same class of race as
+    // `last_used_step` above).
+    const consumedRows = (await tx`
+      UPDATE awcms_mini_identity_mfa_recovery_codes
+      SET used_at = ${now}
       WHERE tenant_id = ${tenantId} AND factor_id = ${factor.id}
         AND code_hash = ${hash} AND used_at IS NULL
+      RETURNING id
     `) as { id: string }[];
-    const recoveryRow = recoveryRows[0];
-
-    if (recoveryRow) {
-      await tx`
-        UPDATE awcms_mini_identity_mfa_recovery_codes
-        SET used_at = ${now}
-        WHERE id = ${recoveryRow.id}
-      `;
-      matched = true;
-    }
+    matched = consumedRows.length > 0;
   }
 
   if (deniedByMisconfiguration) {

--- a/src/modules/identity-access/application/mfa.ts
+++ b/src/modules/identity-access/application/mfa.ts
@@ -1,0 +1,472 @@
+/**
+ * MFA/TOTP application logic (Issue #589, epic: full-online auth hardening).
+ * Reuses the same crypto/token primitives `password-reset.ts` established
+ * for this module: `mfa-challenge-token.ts` mirrors `password-reset-token.ts`,
+ * `mfa-recovery-code.ts` is a distinct one-way hash (never the reversible
+ * TOTP secret encryption `mfa-secret-crypto.ts` uses).
+ *
+ * Every function here is fail-closed on a missing/invalid
+ * `AUTH_MFA_SECRET_ENCRYPTION_KEY` (`resolveMfaEncryptionKey` returning
+ * `null`) — treated as `MFA_MISCONFIGURED`, never as "skip verification."
+ */
+import {
+  base32Encode,
+  buildOtpauthUri,
+  generateTotpSecret,
+  verifyTotpCode
+} from "../../../lib/auth/totp";
+import {
+  decryptMfaSecret,
+  encryptMfaSecret,
+  resolveMfaEncryptionKey
+} from "../../../lib/auth/mfa-secret-crypto";
+import {
+  resolveTotpDigits,
+  resolveTotpPeriodSec,
+  resolveTotpIssuer
+} from "../../../lib/auth/mfa-config";
+import {
+  generateRecoveryCode,
+  hashRecoveryCode
+} from "../../../lib/auth/mfa-recovery-code";
+import {
+  generateChallengeToken,
+  hashChallengeToken
+} from "../../../lib/auth/mfa-challenge-token";
+import {
+  evaluateMfaChallenge,
+  type MfaChallengeDenyReason
+} from "../domain/mfa-policy";
+
+const RECOVERY_CODE_COUNT = 10;
+
+async function insertRecoveryCodes(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string,
+  factorId: string
+): Promise<string[]> {
+  const rawCodes: string[] = [];
+
+  for (let i = 0; i < RECOVERY_CODE_COUNT; i += 1) {
+    const rawCode = generateRecoveryCode();
+    rawCodes.push(rawCode);
+
+    await tx`
+      INSERT INTO awcms_mini_identity_mfa_recovery_codes
+        (tenant_id, identity_id, factor_id, code_hash)
+      VALUES (${tenantId}, ${identityId}, ${factorId}, ${hashRecoveryCode(rawCode)})
+    `;
+  }
+
+  return rawCodes;
+}
+
+export type MfaStatus = {
+  enabled: boolean;
+  factorType?: "totp";
+  activatedAt?: string;
+};
+
+export async function getMfaStatus(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string
+): Promise<MfaStatus> {
+  const rows = (await tx`
+    SELECT factor_type, activated_at
+    FROM awcms_mini_identity_mfa_factors
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId} AND status = 'active'
+  `) as { factor_type: "totp"; activated_at: Date }[];
+  const row = rows[0];
+
+  if (!row) {
+    return { enabled: false };
+  }
+
+  return {
+    enabled: true,
+    factorType: row.factor_type,
+    activatedAt: new Date(row.activated_at).toISOString()
+  };
+}
+
+export type StartEnrollmentResult =
+  | { ok: true; secretBase32: string; otpauthUri: string }
+  | { ok: false; code: "MFA_ALREADY_ACTIVE" | "MFA_MISCONFIGURED" };
+
+/**
+ * Generates a fresh secret and stores it as a `pending` factor — unusable
+ * for login until confirmed via `verifyTotpEnrollment`. Re-starting
+ * enrollment (calling this again before verifying) discards any prior
+ * pending secret, so only the most recently displayed QR/secret is ever
+ * valid to confirm.
+ */
+export async function startTotpEnrollment(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string,
+  loginIdentifier: string,
+  env: NodeJS.ProcessEnv,
+  now: Date
+): Promise<StartEnrollmentResult> {
+  const key = resolveMfaEncryptionKey(env);
+
+  if (!key) {
+    return { ok: false, code: "MFA_MISCONFIGURED" };
+  }
+
+  const activeRows = await tx`
+    SELECT id FROM awcms_mini_identity_mfa_factors
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId} AND status = 'active'
+  `;
+
+  if (activeRows.length > 0) {
+    return { ok: false, code: "MFA_ALREADY_ACTIVE" };
+  }
+
+  await tx`
+    DELETE FROM awcms_mini_identity_mfa_factors
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId} AND status = 'pending'
+  `;
+
+  const secret = generateTotpSecret();
+  const ciphertext = encryptMfaSecret(secret, key);
+  const digits = resolveTotpDigits(env);
+  const periodSec = resolveTotpPeriodSec(env);
+  const issuer = resolveTotpIssuer(env);
+
+  await tx`
+    INSERT INTO awcms_mini_identity_mfa_factors
+      (tenant_id, identity_id, factor_type, secret_ciphertext, status, created_at, updated_at)
+    VALUES (${tenantId}, ${identityId}, 'totp', ${ciphertext}, 'pending', ${now}, ${now})
+  `;
+
+  return {
+    ok: true,
+    secretBase32: base32Encode(secret),
+    otpauthUri: buildOtpauthUri({
+      secret,
+      issuer,
+      accountName: loginIdentifier,
+      digits,
+      periodSec
+    })
+  };
+}
+
+export type VerifyEnrollmentResult =
+  | { ok: true; recoveryCodes: string[] }
+  | {
+      ok: false;
+      code:
+        "MFA_ENROLLMENT_NOT_FOUND" | "MFA_INVALID_CODE" | "MFA_MISCONFIGURED";
+    };
+
+export async function verifyTotpEnrollment(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string,
+  code: string,
+  env: NodeJS.ProcessEnv,
+  now: Date
+): Promise<VerifyEnrollmentResult> {
+  const key = resolveMfaEncryptionKey(env);
+
+  if (!key) {
+    return { ok: false, code: "MFA_MISCONFIGURED" };
+  }
+
+  const rows = (await tx`
+    SELECT id, secret_ciphertext
+    FROM awcms_mini_identity_mfa_factors
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId} AND status = 'pending'
+  `) as { id: string; secret_ciphertext: string }[];
+  const row = rows[0];
+
+  if (!row) {
+    return { ok: false, code: "MFA_ENROLLMENT_NOT_FOUND" };
+  }
+
+  let matchedStep: number | null;
+
+  try {
+    const secret = decryptMfaSecret(row.secret_ciphertext, key);
+    matchedStep = verifyTotpCode(secret, code, now.getTime(), {
+      periodSec: resolveTotpPeriodSec(env),
+      digits: resolveTotpDigits(env)
+    });
+  } catch {
+    matchedStep = null;
+  }
+
+  if (matchedStep === null) {
+    return { ok: false, code: "MFA_INVALID_CODE" };
+  }
+
+  await tx`
+    UPDATE awcms_mini_identity_mfa_factors
+    SET status = 'active', activated_at = ${now}, updated_at = ${now},
+        last_used_step = ${matchedStep}
+    WHERE id = ${row.id}
+  `;
+
+  const recoveryCodes = await insertRecoveryCodes(
+    tx,
+    tenantId,
+    identityId,
+    row.id
+  );
+
+  return { ok: true, recoveryCodes };
+}
+
+export type DisableMfaResult =
+  { ok: true } | { ok: false; code: "MFA_NOT_ACTIVE" };
+
+export async function disableMfa(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string,
+  now: Date
+): Promise<DisableMfaResult> {
+  const rows = await tx`
+    SELECT id FROM awcms_mini_identity_mfa_factors
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId} AND status IN ('active', 'pending')
+  `;
+
+  if (rows.length === 0) {
+    return { ok: false, code: "MFA_NOT_ACTIVE" };
+  }
+
+  await tx`
+    UPDATE awcms_mini_identity_mfa_factors
+    SET status = 'disabled', disabled_at = ${now}, updated_at = ${now}
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId} AND status IN ('active', 'pending')
+  `;
+
+  await tx`
+    DELETE FROM awcms_mini_identity_mfa_recovery_codes
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId}
+  `;
+
+  return { ok: true };
+}
+
+export type RegenerateRecoveryCodesResult =
+  { ok: true; recoveryCodes: string[] } | { ok: false; code: "MFA_NOT_ACTIVE" };
+
+export async function regenerateRecoveryCodes(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string
+): Promise<RegenerateRecoveryCodesResult> {
+  const rows = (await tx`
+    SELECT id FROM awcms_mini_identity_mfa_factors
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId} AND status = 'active'
+  `) as { id: string }[];
+  const row = rows[0];
+
+  if (!row) {
+    return { ok: false, code: "MFA_NOT_ACTIVE" };
+  }
+
+  await tx`
+    DELETE FROM awcms_mini_identity_mfa_recovery_codes
+    WHERE tenant_id = ${tenantId} AND factor_id = ${row.id}
+  `;
+
+  const recoveryCodes = await insertRecoveryCodes(
+    tx,
+    tenantId,
+    identityId,
+    row.id
+  );
+
+  return { ok: true, recoveryCodes };
+}
+
+export type ActiveMfaFactor = { id: string };
+
+/** Used by `login.ts` to decide whether a password-valid login must stop at a challenge instead of creating a session. */
+export async function findActiveMfaFactor(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string
+): Promise<ActiveMfaFactor | null> {
+  const rows = (await tx`
+    SELECT id FROM awcms_mini_identity_mfa_factors
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId} AND status = 'active'
+  `) as { id: string }[];
+
+  return rows[0] ?? null;
+}
+
+export async function createMfaChallenge(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string,
+  ttlSec: number,
+  now: Date
+): Promise<{ token: string; expiresAt: Date }> {
+  const rawToken = generateChallengeToken();
+  const tokenHash = hashChallengeToken(rawToken);
+  const expiresAt = new Date(now.getTime() + ttlSec * 1000);
+
+  await tx`
+    INSERT INTO awcms_mini_mfa_challenges (tenant_id, identity_id, challenge_token_hash, expires_at)
+    VALUES (${tenantId}, ${identityId}, ${tokenHash}, ${expiresAt})
+  `;
+
+  return { token: rawToken, expiresAt };
+}
+
+export type MfaChallengeFailureCode =
+  "MFA_CHALLENGE_INVALID" | "MFA_MISCONFIGURED";
+
+export type VerifyMfaChallengeResult =
+  | { ok: true; identityId: string }
+  | { ok: false; code: MfaChallengeFailureCode };
+
+/**
+ * Verifies a challenge issued by `createMfaChallenge` against either a TOTP
+ * `code` or a `recoveryCode` (exactly one should be provided by the caller).
+ * Every deny path — challenge not found/expired/already used/too many
+ * attempts, wrong code, factor no longer active — collapses to the same
+ * generic `MFA_CHALLENGE_INVALID`, mirroring `completePasswordReset`'s
+ * "response never distinguishes why" convention so this endpoint can't be
+ * used to fingerprint challenge/account state. The specific
+ * `MfaChallengeDenyReason` is only used internally (never returned) — a
+ * future audit-log caller could log it, but this function itself has no DB
+ * transaction ownership beyond the challenge/factor rows, so audit logging
+ * stays the endpoint's responsibility (matches `completePasswordReset`).
+ */
+export async function verifyMfaChallenge(
+  tx: Bun.SQL,
+  tenantId: string,
+  challengeToken: string,
+  credentials: { code?: string; recoveryCode?: string },
+  env: NodeJS.ProcessEnv,
+  maxAttempts: number,
+  now: Date
+): Promise<VerifyMfaChallengeResult> {
+  const tokenHash = hashChallengeToken(challengeToken);
+
+  const challengeRows = (await tx`
+    SELECT id, identity_id, expires_at, consumed_at, failed_attempts
+    FROM awcms_mini_mfa_challenges
+    WHERE tenant_id = ${tenantId} AND challenge_token_hash = ${tokenHash}
+  `) as {
+    id: string;
+    identity_id: string;
+    expires_at: Date;
+    consumed_at: Date | null;
+    failed_attempts: number;
+  }[];
+  const challenge = challengeRows[0];
+
+  const evaluation = evaluateMfaChallenge(
+    challenge
+      ? {
+          expiresAt: new Date(challenge.expires_at),
+          consumedAt: challenge.consumed_at,
+          failedAttempts: challenge.failed_attempts
+        }
+      : null,
+    now,
+    maxAttempts
+  );
+
+  if (evaluation.outcome === "invalid") {
+    return { ok: false, code: "MFA_CHALLENGE_INVALID" };
+  }
+
+  const factorRows = (await tx`
+    SELECT id, secret_ciphertext, last_used_step
+    FROM awcms_mini_identity_mfa_factors
+    WHERE tenant_id = ${tenantId} AND identity_id = ${challenge!.identity_id} AND status = 'active'
+  `) as { id: string; secret_ciphertext: string; last_used_step: number }[];
+  const factor = factorRows[0];
+
+  if (!factor) {
+    // MFA was disabled between login and challenge completion — burn the
+    // challenge so it can't be retried once a factor exists again.
+    await tx`
+      UPDATE awcms_mini_mfa_challenges SET consumed_at = ${now} WHERE id = ${challenge!.id}
+    `;
+    return { ok: false, code: "MFA_CHALLENGE_INVALID" };
+  }
+
+  let matched = false;
+  let deniedByMisconfiguration = false;
+
+  if (credentials.code) {
+    const key = resolveMfaEncryptionKey(env);
+
+    if (!key) {
+      deniedByMisconfiguration = true;
+    } else {
+      try {
+        const secret = decryptMfaSecret(factor.secret_ciphertext, key);
+        const matchedStep = verifyTotpCode(
+          secret,
+          credentials.code,
+          now.getTime(),
+          {
+            periodSec: resolveTotpPeriodSec(env),
+            digits: resolveTotpDigits(env)
+          }
+        );
+
+        if (matchedStep !== null && matchedStep > factor.last_used_step) {
+          await tx`
+            UPDATE awcms_mini_identity_mfa_factors
+            SET last_used_step = ${matchedStep}
+            WHERE id = ${factor.id}
+          `;
+          matched = true;
+        }
+      } catch {
+        matched = false;
+      }
+    }
+  } else if (credentials.recoveryCode) {
+    const hash = hashRecoveryCode(credentials.recoveryCode);
+    const recoveryRows = (await tx`
+      SELECT id FROM awcms_mini_identity_mfa_recovery_codes
+      WHERE tenant_id = ${tenantId} AND factor_id = ${factor.id}
+        AND code_hash = ${hash} AND used_at IS NULL
+    `) as { id: string }[];
+    const recoveryRow = recoveryRows[0];
+
+    if (recoveryRow) {
+      await tx`
+        UPDATE awcms_mini_identity_mfa_recovery_codes
+        SET used_at = ${now}
+        WHERE id = ${recoveryRow.id}
+      `;
+      matched = true;
+    }
+  }
+
+  if (deniedByMisconfiguration) {
+    return { ok: false, code: "MFA_MISCONFIGURED" };
+  }
+
+  if (!matched) {
+    await tx`
+      UPDATE awcms_mini_mfa_challenges
+      SET failed_attempts = failed_attempts + 1
+      WHERE id = ${challenge!.id}
+    `;
+    return { ok: false, code: "MFA_CHALLENGE_INVALID" };
+  }
+
+  await tx`
+    UPDATE awcms_mini_mfa_challenges SET consumed_at = ${now} WHERE id = ${challenge!.id}
+  `;
+
+  return { ok: true, identityId: challenge!.identity_id };
+}
+
+export type { MfaChallengeDenyReason };

--- a/src/modules/identity-access/domain/mfa-policy.ts
+++ b/src/modules/identity-access/domain/mfa-policy.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure MFA challenge validity evaluation (Issue #589). Same "pure decision,
+ * DB does the fetching" shape as `login-policy.ts`'s `evaluateLoginAttempt`
+ * and `password-reset-policy.ts`'s `evaluatePasswordResetToken` — testable
+ * without a database.
+ */
+export type MfaChallengeSnapshot = {
+  expiresAt: Date;
+  consumedAt: Date | null;
+  failedAttempts: number;
+};
+
+export type MfaChallengeDenyReason =
+  "not_found" | "already_used" | "too_many_attempts" | "expired";
+
+export type MfaChallengeEvaluation =
+  { outcome: "valid" } | { outcome: "invalid"; reason: MfaChallengeDenyReason };
+
+export function evaluateMfaChallenge(
+  row: MfaChallengeSnapshot | null,
+  now: Date,
+  maxAttempts: number
+): MfaChallengeEvaluation {
+  if (!row) {
+    return { outcome: "invalid", reason: "not_found" };
+  }
+
+  if (row.consumedAt !== null) {
+    return { outcome: "invalid", reason: "already_used" };
+  }
+
+  if (row.failedAttempts >= maxAttempts) {
+    return { outcome: "invalid", reason: "too_many_attempts" };
+  }
+
+  if (row.expiresAt.getTime() <= now.getTime()) {
+    return { outcome: "invalid", reason: "expired" };
+  }
+
+  return { outcome: "valid" };
+}

--- a/src/pages/api/v1/auth/login.ts
+++ b/src/pages/api/v1/auth/login.ts
@@ -17,6 +17,15 @@ import {
   resolveClientIp
 } from "../../../../lib/security/rate-limit";
 import { enforceTurnstileIfRequired } from "../../../../lib/security/turnstile";
+import {
+  isMfaRequired,
+  resolveChallengeTtlSec
+} from "../../../../lib/auth/mfa-config";
+import {
+  createMfaChallenge,
+  findActiveMfaFactor
+} from "../../../../modules/identity-access/application/mfa";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
 
 const MAX_FAILED_ATTEMPTS = Number(process.env.AUTH_LOGIN_MAX_ATTEMPTS ?? 5);
 const LOCKOUT_MINUTES = 15;
@@ -47,7 +56,12 @@ type LoginBody = {
   turnstileToken?: unknown;
 };
 
-export const POST: APIRoute = async ({ request, cookies, clientAddress }) => {
+export const POST: APIRoute = async ({
+  request,
+  cookies,
+  clientAddress,
+  locals
+}) => {
   const tenantId = request.headers.get("x-awcms-mini-tenant-id");
 
   if (!tenantId) {
@@ -192,6 +206,54 @@ export const POST: APIRoute = async ({ request, cookies, clientAddress }) => {
         "AUTH_INVALID_CREDENTIALS",
         "Invalid login identifier or password."
       );
+    }
+
+    // Full-online-only (Issue #587/#589): a no-op on every local/offline/LAN
+    // deployment and for every identity that has never enrolled MFA (MFA is
+    // opt-in per identity, not mandatory tenant-wide, even when the feature
+    // is enabled). Checked AFTER password verification succeeds but BEFORE
+    // any session is created — a password-valid login with an active MFA
+    // factor must never receive a session, only a challenge.
+    if (isMfaRequired()) {
+      const factor = await findActiveMfaFactor(tx, tenantId, identityRow!.id);
+
+      if (factor) {
+        await tx`
+          UPDATE awcms_mini_identities
+          SET failed_login_count = 0
+          WHERE id = ${identityRow!.id}
+        `;
+
+        const challenge = await createMfaChallenge(
+          tx,
+          tenantId,
+          identityRow!.id,
+          resolveChallengeTtlSec(),
+          now
+        );
+
+        await recordAuditEvent(tx, {
+          tenantId,
+          moduleKey: "identity_access",
+          action: "mfa_challenge_issued",
+          resourceType: "identity",
+          resourceId: identityRow!.id,
+          severity: "info",
+          message: "Password verified; MFA challenge issued.",
+          correlationId: locals.correlationId
+        });
+
+        return fail(
+          401,
+          "MFA_REQUIRED",
+          "Multi-factor authentication is required to complete sign-in.",
+          {},
+          {
+            mfaChallengeToken: challenge.token,
+            expiresAt: challenge.expiresAt.toISOString()
+          }
+        );
+      }
     }
 
     const token = generateSessionToken();

--- a/src/pages/api/v1/auth/mfa/recovery-codes/regenerate.ts
+++ b/src/pages/api/v1/auth/mfa/recovery-codes/regenerate.ts
@@ -1,0 +1,89 @@
+import type { APIRoute } from "astro";
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../lib/auth/ssr-session";
+import {
+  extractBearerToken,
+  resolveActiveSession
+} from "../../../../../../modules/identity-access/application/session-lookup";
+import { isMfaRequired } from "../../../../../../lib/auth/mfa-config";
+import { regenerateRecoveryCodes } from "../../../../../../modules/identity-access/application/mfa";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+
+/**
+ * `POST /api/v1/auth/mfa/recovery-codes/regenerate` (Issue #589) —
+ * high-risk, self-service action: invalidates every existing recovery code
+ * and issues 10 fresh ones, shown exactly once in the response (never
+ * retrievable again afterward, same as `enroll/verify`'s initial set).
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  if (!isMfaRequired()) {
+    return fail(
+      403,
+      "MFA_DISABLED",
+      "Multi-factor authentication is not enabled for this deployment."
+    );
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token =
+    extractBearerToken(request.headers.get("authorization")) ??
+    cookies.get(SESSION_COOKIE_NAME)?.value ??
+    null;
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const session = await resolveActiveSession(tx, tenantId, tokenHash, now);
+
+    if (!session) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const result = await regenerateRecoveryCodes(
+      tx,
+      tenantId,
+      session.identity_id
+    );
+
+    if (!result.ok) {
+      return fail(
+        409,
+        result.code,
+        "Multi-factor authentication is not currently active for this account."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      moduleKey: "identity_access",
+      action: "mfa_recovery_codes_regenerated",
+      resourceType: "identity",
+      resourceId: session.identity_id,
+      severity: "warning",
+      message: "MFA recovery codes regenerated; previous codes invalidated.",
+      correlationId: locals.correlationId
+    });
+
+    return ok({ recoveryCodes: result.recoveryCodes });
+  });
+};

--- a/src/pages/api/v1/auth/mfa/status.ts
+++ b/src/pages/api/v1/auth/mfa/status.ts
@@ -1,0 +1,67 @@
+import type { APIRoute } from "astro";
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../lib/auth/ssr-session";
+import {
+  extractBearerToken,
+  resolveActiveSession
+} from "../../../../../modules/identity-access/application/session-lookup";
+import { isMfaRequired } from "../../../../../lib/auth/mfa-config";
+import { getMfaStatus } from "../../../../../modules/identity-access/application/mfa";
+
+/**
+ * `GET /api/v1/auth/mfa/status` (Issue #589) — the current identity's own
+ * MFA enrollment state. Same bearer-token-with-cookie-fallback
+ * authentication as `POST /auth/logout`. `403 MFA_DISABLED` when the
+ * feature isn't active for this deployment (Issue #587 gate off or
+ * `AUTH_MFA_ENABLED` not `"true"`) — every MFA endpoint gates identically so
+ * the feature is entirely inert (no DB read even attempted) when disabled.
+ */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  if (!isMfaRequired()) {
+    return fail(
+      403,
+      "MFA_DISABLED",
+      "Multi-factor authentication is not enabled for this deployment."
+    );
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token =
+    extractBearerToken(request.headers.get("authorization")) ??
+    cookies.get(SESSION_COOKIE_NAME)?.value ??
+    null;
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const session = await resolveActiveSession(tx, tenantId, tokenHash, now);
+
+    if (!session) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const status = await getMfaStatus(tx, tenantId, session.identity_id);
+
+    return ok(status);
+  });
+};

--- a/src/pages/api/v1/auth/mfa/totp/disable.ts
+++ b/src/pages/api/v1/auth/mfa/totp/disable.ts
@@ -1,0 +1,88 @@
+import type { APIRoute } from "astro";
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../lib/auth/ssr-session";
+import {
+  extractBearerToken,
+  resolveActiveSession
+} from "../../../../../../modules/identity-access/application/session-lookup";
+import { isMfaRequired } from "../../../../../../lib/auth/mfa-config";
+import { disableMfa } from "../../../../../../modules/identity-access/application/mfa";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+
+/**
+ * `POST /api/v1/auth/mfa/totp/disable` (Issue #589) — high-risk,
+ * self-service action: authenticated identity turns off its own MFA.
+ * Requires an already-valid session (which, for an identity with active MFA,
+ * can only have been obtained by already passing an MFA challenge) plus an
+ * audit trail — matches the issue's "disable MFA... must require
+ * authorization and audit" requirement without inventing a second
+ * confirmation step beyond the session itself.
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  if (!isMfaRequired()) {
+    return fail(
+      403,
+      "MFA_DISABLED",
+      "Multi-factor authentication is not enabled for this deployment."
+    );
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token =
+    extractBearerToken(request.headers.get("authorization")) ??
+    cookies.get(SESSION_COOKIE_NAME)?.value ??
+    null;
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const session = await resolveActiveSession(tx, tenantId, tokenHash, now);
+
+    if (!session) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const result = await disableMfa(tx, tenantId, session.identity_id, now);
+
+    if (!result.ok) {
+      return fail(
+        409,
+        result.code,
+        "Multi-factor authentication is not currently active for this account."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      moduleKey: "identity_access",
+      action: "mfa_disabled",
+      resourceType: "identity",
+      resourceId: session.identity_id,
+      severity: "warning",
+      message: "Multi-factor authentication disabled.",
+      correlationId: locals.correlationId
+    });
+
+    return ok({ disabled: true });
+  });
+};

--- a/src/pages/api/v1/auth/mfa/totp/enroll/start.ts
+++ b/src/pages/api/v1/auth/mfa/totp/enroll/start.ts
@@ -1,0 +1,92 @@
+import type { APIRoute } from "astro";
+import { fail, ok } from "../../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../../lib/auth/ssr-session";
+import {
+  extractBearerToken,
+  resolveActiveSession
+} from "../../../../../../../modules/identity-access/application/session-lookup";
+import { isMfaRequired } from "../../../../../../../lib/auth/mfa-config";
+import { startTotpEnrollment } from "../../../../../../../modules/identity-access/application/mfa";
+
+/**
+ * `POST /api/v1/auth/mfa/totp/enroll/start` (Issue #589) — generates a fresh
+ * TOTP secret and stores it as a `pending` factor (unusable for login until
+ * `enroll/verify` confirms a code against it). The plaintext secret/QR URI
+ * is only ever returned here, at enrollment start — never again afterward.
+ */
+export const POST: APIRoute = async ({ request, cookies }) => {
+  if (!isMfaRequired()) {
+    return fail(
+      403,
+      "MFA_DISABLED",
+      "Multi-factor authentication is not enabled for this deployment."
+    );
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token =
+    extractBearerToken(request.headers.get("authorization")) ??
+    cookies.get(SESSION_COOKIE_NAME)?.value ??
+    null;
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const session = await resolveActiveSession(tx, tenantId, tokenHash, now);
+
+    if (!session) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const identityRows = (await tx`
+      SELECT login_identifier FROM awcms_mini_identities WHERE id = ${session.identity_id}
+    `) as { login_identifier: string }[];
+    const loginIdentifier = identityRows[0]?.login_identifier ?? "user";
+
+    const result = await startTotpEnrollment(
+      tx,
+      tenantId,
+      session.identity_id,
+      loginIdentifier,
+      process.env,
+      now
+    );
+
+    if (!result.ok) {
+      const status = result.code === "MFA_ALREADY_ACTIVE" ? 409 : 500;
+
+      return fail(
+        status,
+        result.code,
+        result.code === "MFA_ALREADY_ACTIVE"
+          ? "Multi-factor authentication is already active for this account."
+          : "Multi-factor authentication is misconfigured on this server."
+      );
+    }
+
+    return ok({
+      secret: result.secretBase32,
+      otpauthUri: result.otpauthUri
+    });
+  });
+};

--- a/src/pages/api/v1/auth/mfa/totp/enroll/verify.ts
+++ b/src/pages/api/v1/auth/mfa/totp/enroll/verify.ts
@@ -1,0 +1,115 @@
+import type { APIRoute } from "astro";
+import { fail, ok } from "../../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../../lib/auth/ssr-session";
+import {
+  extractBearerToken,
+  resolveActiveSession
+} from "../../../../../../../modules/identity-access/application/session-lookup";
+import { isMfaRequired } from "../../../../../../../lib/auth/mfa-config";
+import { verifyTotpEnrollment } from "../../../../../../../modules/identity-access/application/mfa";
+import { recordAuditEvent } from "../../../../../../../modules/logging/application/audit-log";
+
+type VerifyEnrollmentBody = { code?: unknown };
+
+/**
+ * `POST /api/v1/auth/mfa/totp/enroll/verify` (Issue #589) — confirms the
+ * pending secret from `enroll/start` with a live TOTP code, activating the
+ * factor and returning 10 single-use recovery codes shown exactly once
+ * (never retrievable again — only `recovery-codes/regenerate` can produce a
+ * fresh set afterward, invalidating these).
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  if (!isMfaRequired()) {
+    return fail(
+      403,
+      "MFA_DISABLED",
+      "Multi-factor authentication is not enabled for this deployment."
+    );
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token =
+    extractBearerToken(request.headers.get("authorization")) ??
+    cookies.get(SESSION_COOKIE_NAME)?.value ??
+    null;
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const body = (await request
+    .json()
+    .catch(() => null)) as VerifyEnrollmentBody | null;
+
+  if (!body || typeof body.code !== "string") {
+    return fail(400, "VALIDATION_ERROR", "code is required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const session = await resolveActiveSession(tx, tenantId, tokenHash, now);
+
+    if (!session) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const result = await verifyTotpEnrollment(
+      tx,
+      tenantId,
+      session.identity_id,
+      body.code as string,
+      process.env,
+      now
+    );
+
+    if (!result.ok) {
+      const status =
+        result.code === "MFA_ENROLLMENT_NOT_FOUND"
+          ? 404
+          : result.code === "MFA_INVALID_CODE"
+            ? 400
+            : 500;
+
+      return fail(
+        status,
+        result.code,
+        result.code === "MFA_ENROLLMENT_NOT_FOUND"
+          ? "No pending MFA enrollment found. Start enrollment again."
+          : result.code === "MFA_INVALID_CODE"
+            ? "Invalid verification code."
+            : "Multi-factor authentication is misconfigured on this server."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: undefined,
+      moduleKey: "identity_access",
+      action: "mfa_enrolled",
+      resourceType: "identity",
+      resourceId: session.identity_id,
+      severity: "warning",
+      message: "Multi-factor authentication (TOTP) enrolled and activated.",
+      correlationId: locals.correlationId
+    });
+
+    return ok({ activated: true, recoveryCodes: result.recoveryCodes });
+  });
+};

--- a/src/pages/api/v1/auth/mfa/totp/verify.ts
+++ b/src/pages/api/v1/auth/mfa/totp/verify.ts
@@ -1,0 +1,166 @@
+import type { APIRoute } from "astro";
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  generateSessionToken,
+  hashSessionToken
+} from "../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../lib/auth/ssr-session";
+import {
+  checkRateLimit,
+  resolveClientIp
+} from "../../../../../../lib/security/rate-limit";
+import { verifyMfaChallenge } from "../../../../../../modules/identity-access/application/mfa";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+
+const SESSION_TTL_MIN = Number(process.env.AUTH_SESSION_TTL_MIN ?? 120);
+const RATE_LIMIT_MAX_ATTEMPTS = Number(
+  process.env.AUTH_MFA_RATE_LIMIT_MAX ?? 5
+);
+const RATE_LIMIT_WINDOW_SEC = Number(
+  process.env.AUTH_MFA_RATE_LIMIT_WINDOW_SEC ?? 300
+);
+const CHALLENGE_MAX_ATTEMPTS = RATE_LIMIT_MAX_ATTEMPTS;
+
+type VerifyChallengeBody = {
+  mfaChallengeToken?: unknown;
+  code?: unknown;
+  recoveryCode?: unknown;
+};
+
+/**
+ * `POST /api/v1/auth/mfa/totp/verify` (Issue #589) — completes a login that
+ * `POST /auth/login` paused with `401 MFA_REQUIRED`. Deliberately NOT
+ * authenticated via the existing session cookie/bearer token (there isn't
+ * one yet — that's the whole point of the challenge) — authenticated
+ * instead by possession of `mfaChallengeToken`, exactly like
+ * `password/reset.ts` is authenticated by possession of a reset token
+ * rather than a session. On success, creates the real AWCMS-Mini session
+ * exactly like `login.ts` does (same cookies, same response shape) so
+ * client code doesn't need to special-case a two-step login.
+ *
+ * Rate-limited two ways: source+tenant scoped (same shape as
+ * `login.ts`/`password/forgot.ts`) AND per-challenge `failed_attempts`
+ * (`verifyMfaChallenge`) — the latter bounds a distributed attacker
+ * rotating source IPs against one stolen/guessed challenge token, which the
+ * former alone would not catch.
+ */
+export const POST: APIRoute = async ({
+  request,
+  cookies,
+  clientAddress,
+  locals
+}) => {
+  const tenantId = request.headers.get("x-awcms-mini-tenant-id");
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const clientIp = resolveClientIp(request, clientAddress);
+  const rateLimit = checkRateLimit(`${clientIp}:${tenantId}:mfa-verify`, {
+    maxAttempts: RATE_LIMIT_MAX_ATTEMPTS,
+    windowMs: RATE_LIMIT_WINDOW_SEC * 1000
+  });
+
+  if (!rateLimit.allowed) {
+    return fail(
+      429,
+      "RATE_LIMITED",
+      "Too many verification attempts from this source. Try again later.",
+      {},
+      undefined,
+      { "retry-after": String(rateLimit.retryAfterSec) }
+    );
+  }
+
+  const body = (await request
+    .json()
+    .catch(() => null)) as VerifyChallengeBody | null;
+
+  if (
+    !body ||
+    typeof body.mfaChallengeToken !== "string" ||
+    (typeof body.code !== "string" && typeof body.recoveryCode !== "string")
+  ) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "mfaChallengeToken and either code or recoveryCode are required."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const result = await verifyMfaChallenge(
+      tx,
+      tenantId,
+      body.mfaChallengeToken as string,
+      {
+        code: typeof body.code === "string" ? body.code : undefined,
+        recoveryCode:
+          typeof body.recoveryCode === "string" ? body.recoveryCode : undefined
+      },
+      process.env,
+      CHALLENGE_MAX_ATTEMPTS,
+      now
+    );
+
+    if (!result.ok) {
+      const status = result.code === "MFA_MISCONFIGURED" ? 500 : 401;
+
+      return fail(
+        status,
+        result.code,
+        result.code === "MFA_MISCONFIGURED"
+          ? "Multi-factor authentication is misconfigured on this server."
+          : "This MFA challenge is invalid, expired, or already used."
+      );
+    }
+
+    const identityId = result.identityId;
+    const token = generateSessionToken();
+    const tokenHash = hashSessionToken(token);
+    const expiresAt = new Date(now.getTime() + SESSION_TTL_MIN * 60_000);
+
+    await tx`
+      UPDATE awcms_mini_identities
+      SET failed_login_count = 0, last_login_at = ${now}
+      WHERE id = ${identityId}
+    `;
+
+    await tx`
+      INSERT INTO awcms_mini_sessions (tenant_id, identity_id, token_hash, expires_at)
+      VALUES (${tenantId}, ${identityId}, ${tokenHash}, ${expiresAt})
+    `;
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      moduleKey: "identity_access",
+      action: "mfa_challenge_verified",
+      resourceType: "identity",
+      resourceId: identityId,
+      severity: "info",
+      message: "MFA challenge verified; session created.",
+      correlationId: locals.correlationId
+    });
+
+    const cookieOptions = {
+      httpOnly: true,
+      sameSite: "lax" as const,
+      path: "/",
+      maxAge: SESSION_TTL_MIN * 60,
+      secure: process.env.AUTH_COOKIE_SECURE === "true"
+    };
+    cookies.set(SESSION_COOKIE_NAME, token, cookieOptions);
+    cookies.set(TENANT_COOKIE_NAME, tenantId, cookieOptions);
+
+    return ok({ token, expiresAt: expiresAt.toISOString() });
+  });
+};

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -236,7 +236,8 @@ describe("database migration runner helpers", () => {
       "030_awcms_mini_blog_content_presentation_permissions.sql",
       "031_awcms_mini_tenant_domain_schema.sql",
       "032_awcms_mini_tenant_domain_permissions.sql",
-      "033_awcms_mini_tenant_domain_lookup_function.sql"
+      "033_awcms_mini_tenant_domain_lookup_function.sql",
+      "034_awcms_mini_mfa_totp_schema.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/mfa-flow.integration.test.ts
+++ b/tests/integration/mfa-flow.integration.test.ts
@@ -1,0 +1,606 @@
+/**
+ * Integration tests for the MFA/TOTP login-challenge flow (Issue #589, epic:
+ * full-online auth hardening) across the real route handlers against a real
+ * PostgreSQL — enrollment, login-time challenge issuance/verification,
+ * disable, and recovery-code regeneration. The pure TOTP math/crypto is
+ * already covered by `tests/unit/totp.test.ts`/`mfa-crypto.test.ts`; this
+ * file proves the endpoints are wired correctly end to end, mirroring
+ * `turnstile-gate.integration.test.ts`'s shape for the #588 feature this
+ * epic shares a gate with.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { POST as passwordForgot } from "../../src/pages/api/v1/auth/password/forgot";
+import { POST as passwordReset } from "../../src/pages/api/v1/auth/password/reset";
+import { GET as mfaStatus } from "../../src/pages/api/v1/auth/mfa/status";
+import { POST as enrollStart } from "../../src/pages/api/v1/auth/mfa/totp/enroll/start";
+import { POST as enrollVerify } from "../../src/pages/api/v1/auth/mfa/totp/enroll/verify";
+import { POST as mfaVerify } from "../../src/pages/api/v1/auth/mfa/totp/verify";
+import { POST as mfaDisable } from "../../src/pages/api/v1/auth/mfa/totp/disable";
+import { POST as recoveryCodesRegenerate } from "../../src/pages/api/v1/auth/mfa/recovery-codes/regenerate";
+import { base32Decode, generateTotpCode } from "../../src/lib/auth/totp";
+import { resetRateLimitStoreForTests } from "../../src/lib/security/rate-limit";
+import { getAdminSql } from "./harness";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+const VALID_MFA_KEY_BASE64 = Buffer.alloc(32, 11).toString("base64");
+
+const FULL_ONLINE_MFA_ENV: Record<string, string> = {
+  AUTH_ONLINE_SECURITY_ENABLED: "true",
+  AUTH_ONLINE_SECURITY_PROFILE: "full_online",
+  AUTH_MFA_ENABLED: "true",
+  AUTH_MFA_SECRET_ENCRYPTION_KEY: VALID_MFA_KEY_BASE64
+};
+
+type ErrorEnvelope = {
+  error: { code: string; details?: { mfaChallengeToken?: string } };
+};
+
+/** Same pattern `turnstile-gate.integration.test.ts` uses. */
+async function withEnvOverride<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+
+  for (const key of Object.keys(overrides)) {
+    previous[key] = process.env[key];
+    const value = overrides[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(overrides)) {
+      const value = previous[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function bootstrapTenant(tenantCode = "acme") {
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: `Tenant ${tenantCode}`,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "Head Office",
+      ownerLoginIdentifier: OWNER_LOGIN,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId };
+}
+
+async function loginAndGetToken(tenantId: string): Promise<string> {
+  const result = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(result.status).toBe(200);
+  return result.body.data.token;
+}
+
+function totpCodeFor(secretBase32: string, at: number = Date.now()): string {
+  return generateTotpCode(base32Decode(secretBase32), at, {
+    periodSec: 30,
+    digits: 6
+  });
+}
+
+/** Enrolls and activates TOTP MFA for the already-logged-in owner, returning the base32 secret (to compute future codes) and the one-time recovery codes. */
+async function enrollMfa(
+  tenantId: string,
+  sessionToken: string
+): Promise<{ secretBase32: string; recoveryCodes: string[] }> {
+  const start = await invoke<{ data: { secret: string; otpauthUri: string } }>(
+    enrollStart,
+    {
+      method: "POST",
+      path: "/api/v1/auth/mfa/totp/enroll/start",
+      headers: {
+        "content-type": "application/json",
+        "x-awcms-mini-tenant-id": tenantId,
+        authorization: `Bearer ${sessionToken}`
+      }
+    }
+  );
+  expect(start.status).toBe(200);
+
+  const secretBase32 = start.body.data.secret;
+  const code = totpCodeFor(secretBase32);
+
+  const verify = await invoke<{
+    data: { activated: boolean; recoveryCodes: string[] };
+  }>(enrollVerify, {
+    method: "POST",
+    path: "/api/v1/auth/mfa/totp/enroll/verify",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId,
+      authorization: `Bearer ${sessionToken}`
+    },
+    body: { code }
+  });
+  expect(verify.status).toBe(200);
+  expect(verify.body.data.activated).toBe(true);
+
+  return { secretBase32, recoveryCodes: verify.body.data.recoveryCodes };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("MFA/TOTP login-challenge flow (Issue #589)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    resetRateLimitStoreForTests();
+  });
+
+  test("disabled mode (default): MFA endpoints report disabled without touching the DB", async () => {
+    const owner = await bootstrapTenant();
+    const token = await loginAndGetToken(owner.tenantId);
+
+    const status = await invoke<ErrorEnvelope>(mfaStatus, {
+      method: "GET",
+      path: "/api/v1/auth/mfa/status",
+      headers: {
+        "x-awcms-mini-tenant-id": owner.tenantId,
+        authorization: `Bearer ${token}`
+      }
+    });
+    expect(status.status).toBe(403);
+    expect(status.body.error.code).toBe("MFA_DISABLED");
+  });
+
+  test("gate enabled but identity never enrolled: login still succeeds normally (opt-in per identity)", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_MFA_ENV, async () => {
+      const token = await loginAndGetToken(owner.tenantId);
+      expect(typeof token).toBe("string");
+    });
+  });
+
+  test("enroll/start rejects an invalid confirmation code", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_MFA_ENV, async () => {
+      const token = await loginAndGetToken(owner.tenantId);
+
+      const start = await invoke<{ data: { secret: string } }>(enrollStart, {
+        method: "POST",
+        path: "/api/v1/auth/mfa/totp/enroll/start",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId,
+          authorization: `Bearer ${token}`
+        }
+      });
+      expect(start.status).toBe(200);
+
+      const verify = await invoke<ErrorEnvelope>(enrollVerify, {
+        method: "POST",
+        path: "/api/v1/auth/mfa/totp/enroll/verify",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId,
+          authorization: `Bearer ${token}`
+        },
+        body: { code: "000000" }
+      });
+      expect(verify.status).toBe(400);
+      expect(verify.body.error.code).toBe("MFA_INVALID_CODE");
+    });
+  });
+
+  test("full enroll -> login challenge -> verify -> session flow", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_MFA_ENV, async () => {
+      const initialToken = await loginAndGetToken(owner.tenantId);
+
+      const statusBefore = await invoke<{ data: { enabled: boolean } }>(
+        mfaStatus,
+        {
+          method: "GET",
+          path: "/api/v1/auth/mfa/status",
+          headers: {
+            "x-awcms-mini-tenant-id": owner.tenantId,
+            authorization: `Bearer ${initialToken}`
+          }
+        }
+      );
+      expect(statusBefore.body.data.enabled).toBe(false);
+
+      const { secretBase32, recoveryCodes } = await enrollMfa(
+        owner.tenantId,
+        initialToken
+      );
+      expect(recoveryCodes).toHaveLength(10);
+
+      const statusAfter = await invoke<{
+        data: { enabled: boolean; factorType?: string };
+      }>(mfaStatus, {
+        method: "GET",
+        path: "/api/v1/auth/mfa/status",
+        headers: {
+          "x-awcms-mini-tenant-id": owner.tenantId,
+          authorization: `Bearer ${initialToken}`
+        }
+      });
+      expect(statusAfter.body.data.enabled).toBe(true);
+      expect(statusAfter.body.data.factorType).toBe("totp");
+
+      // Re-enrolling while a factor is already active must be rejected —
+      // an authenticated attacker/hijacked session can't silently replace a
+      // live factor's secret.
+      const restart = await invoke<ErrorEnvelope>(enrollStart, {
+        method: "POST",
+        path: "/api/v1/auth/mfa/totp/enroll/start",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId,
+          authorization: `Bearer ${initialToken}`
+        }
+      });
+      expect(restart.status).toBe(409);
+      expect(restart.body.error.code).toBe("MFA_ALREADY_ACTIVE");
+
+      // Next login must stop at a challenge, not a session — even with the
+      // correct password.
+      const loginAttempt = await invoke<ErrorEnvelope>(authLogin, {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+        cookies: createCookieJar()
+      });
+      expect(loginAttempt.status).toBe(401);
+      expect(loginAttempt.body.error.code).toBe("MFA_REQUIRED");
+      const challengeToken = loginAttempt.body.error.details?.mfaChallengeToken;
+      expect(typeof challengeToken).toBe("string");
+
+      // Wrong code: challenge stays open, no session created.
+      const wrongCode = await invoke<ErrorEnvelope>(mfaVerify, {
+        method: "POST",
+        path: "/api/v1/auth/mfa/totp/verify",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { mfaChallengeToken: challengeToken, code: "000000" }
+      });
+      expect(wrongCode.status).toBe(401);
+      expect(wrongCode.body.error.code).toBe("MFA_CHALLENGE_INVALID");
+
+      // Correct code completes the challenge and creates a real session.
+      // One period later than enrollment's own confirmation code (replay
+      // prevention correctly rejects reusing the exact same time step —
+      // see `last_used_step` — so this must be a genuinely later step).
+      const rightCode = totpCodeFor(secretBase32, Date.now() + 30_000);
+      const completed = await invoke<{ data: { token: string } }>(mfaVerify, {
+        method: "POST",
+        path: "/api/v1/auth/mfa/totp/verify",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { mfaChallengeToken: challengeToken, code: rightCode }
+      });
+      expect(completed.status).toBe(200);
+      expect(typeof completed.body.data.token).toBe("string");
+
+      // The same challenge token can't be replayed after being consumed.
+      const replay = await invoke<ErrorEnvelope>(mfaVerify, {
+        method: "POST",
+        path: "/api/v1/auth/mfa/totp/verify",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { mfaChallengeToken: challengeToken, code: rightCode }
+      });
+      expect(replay.status).toBe(401);
+      expect(replay.body.error.code).toBe("MFA_CHALLENGE_INVALID");
+    });
+  });
+
+  test("recovery code completes a challenge and is single-use", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_MFA_ENV, async () => {
+      const initialToken = await loginAndGetToken(owner.tenantId);
+      const { recoveryCodes } = await enrollMfa(owner.tenantId, initialToken);
+
+      const loginAttempt = await invoke<ErrorEnvelope>(authLogin, {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+        cookies: createCookieJar()
+      });
+      const challengeToken = loginAttempt.body.error.details?.mfaChallengeToken;
+
+      const firstUse = await invoke<{ data: { token: string } }>(mfaVerify, {
+        method: "POST",
+        path: "/api/v1/auth/mfa/totp/verify",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: {
+          mfaChallengeToken: challengeToken,
+          recoveryCode: recoveryCodes[0]
+        }
+      });
+      expect(firstUse.status).toBe(200);
+
+      // A second login challenge + the SAME recovery code must fail (single-use).
+      const secondLoginAttempt = await invoke<ErrorEnvelope>(authLogin, {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+        cookies: createCookieJar()
+      });
+      const secondChallengeToken =
+        secondLoginAttempt.body.error.details?.mfaChallengeToken;
+
+      const reusedCode = await invoke<ErrorEnvelope>(mfaVerify, {
+        method: "POST",
+        path: "/api/v1/auth/mfa/totp/verify",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: {
+          mfaChallengeToken: secondChallengeToken,
+          recoveryCode: recoveryCodes[0]
+        }
+      });
+      expect(reusedCode.status).toBe(401);
+      expect(reusedCode.body.error.code).toBe("MFA_CHALLENGE_INVALID");
+    });
+  });
+
+  test("disable: removes the factor, login goes back to creating a session directly", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_MFA_ENV, async () => {
+      const initialToken = await loginAndGetToken(owner.tenantId);
+      await enrollMfa(owner.tenantId, initialToken);
+
+      const disable = await invoke<{ data: { disabled: boolean } }>(
+        mfaDisable,
+        {
+          method: "POST",
+          path: "/api/v1/auth/mfa/totp/disable",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId,
+            authorization: `Bearer ${initialToken}`
+          }
+        }
+      );
+      expect(disable.status).toBe(200);
+      expect(disable.body.data.disabled).toBe(true);
+
+      // Disabling again (nothing active) is a conflict, not a silent no-op success.
+      const disableAgain = await invoke<ErrorEnvelope>(mfaDisable, {
+        method: "POST",
+        path: "/api/v1/auth/mfa/totp/disable",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId,
+          authorization: `Bearer ${initialToken}`
+        }
+      });
+      expect(disableAgain.status).toBe(409);
+      expect(disableAgain.body.error.code).toBe("MFA_NOT_ACTIVE");
+
+      const loginAfterDisable = await invoke<{ data: { token: string } }>(
+        authLogin,
+        {
+          method: "POST",
+          path: "/api/v1/auth/login",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId
+          },
+          body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+          cookies: createCookieJar()
+        }
+      );
+      expect(loginAfterDisable.status).toBe(200);
+      expect(typeof loginAfterDisable.body.data.token).toBe("string");
+    });
+  });
+
+  test("recovery-codes/regenerate invalidates the previous set and issues a fresh one", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_MFA_ENV, async () => {
+      const initialToken = await loginAndGetToken(owner.tenantId);
+      const { recoveryCodes: originalCodes } = await enrollMfa(
+        owner.tenantId,
+        initialToken
+      );
+
+      const regenerate = await invoke<{ data: { recoveryCodes: string[] } }>(
+        recoveryCodesRegenerate,
+        {
+          method: "POST",
+          path: "/api/v1/auth/mfa/recovery-codes/regenerate",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId,
+            authorization: `Bearer ${initialToken}`
+          }
+        }
+      );
+      expect(regenerate.status).toBe(200);
+      const freshCodes = regenerate.body.data.recoveryCodes;
+      expect(freshCodes).toHaveLength(10);
+      expect(freshCodes).not.toEqual(originalCodes);
+
+      const loginAttempt = await invoke<ErrorEnvelope>(authLogin, {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+        cookies: createCookieJar()
+      });
+      const challengeToken = loginAttempt.body.error.details?.mfaChallengeToken;
+
+      // An old (pre-regeneration) recovery code must no longer work.
+      const oldCodeAttempt = await invoke<ErrorEnvelope>(mfaVerify, {
+        method: "POST",
+        path: "/api/v1/auth/mfa/totp/verify",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: {
+          mfaChallengeToken: challengeToken,
+          recoveryCode: originalCodes[0]
+        }
+      });
+      expect(oldCodeAttempt.status).toBe(401);
+
+      // A fresh code does.
+      const freshCodeAttempt = await invoke<{ data: { token: string } }>(
+        mfaVerify,
+        {
+          method: "POST",
+          path: "/api/v1/auth/mfa/totp/verify",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId
+          },
+          body: {
+            mfaChallengeToken: challengeToken,
+            recoveryCode: freshCodes[0]
+          }
+        }
+      );
+      expect(freshCodeAttempt.status).toBe(200);
+    });
+  });
+
+  test("password reset does not disable MFA (no bypass)", async () => {
+    const owner = await bootstrapTenant();
+    const NEW_PASSWORD = "New-Owner-Password-456";
+
+    await withEnvOverride(FULL_ONLINE_MFA_ENV, async () => {
+      const initialToken = await loginAndGetToken(owner.tenantId);
+      await enrollMfa(owner.tenantId, initialToken);
+
+      const forgot = await invoke(passwordForgot, {
+        method: "POST",
+        path: "/api/v1/auth/password/forgot",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: OWNER_LOGIN }
+      });
+      expect(forgot.status).toBe(200);
+
+      const admin = getAdminSql();
+      const rows = (await admin`
+        SELECT variables ->> 'resetUrl' AS reset_url
+        FROM awcms_mini_email_messages
+        WHERE tenant_id = ${owner.tenantId} AND category = 'auth.password_reset'
+        ORDER BY created_at DESC
+        LIMIT 1
+      `) as { reset_url: string }[];
+      const rawToken = new URL(rows[0]!.reset_url).searchParams.get("token");
+      expect(typeof rawToken).toBe("string");
+
+      const reset = await invoke(passwordReset, {
+        method: "POST",
+        path: "/api/v1/auth/password/reset",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { token: rawToken, newPassword: NEW_PASSWORD }
+      });
+      expect(reset.status).toBe(200);
+
+      // The MFA factor row must survive a completed password reset intact.
+      const factorRows = (await admin`
+        SELECT status FROM awcms_mini_identity_mfa_factors
+        WHERE tenant_id = ${owner.tenantId} AND status = 'active'
+      `) as { status: string }[];
+      expect(factorRows).toHaveLength(1);
+
+      // Logging in with the NEW password must still stop at an MFA
+      // challenge, not a session — password reset is not an MFA bypass.
+      const loginAttempt = await invoke<ErrorEnvelope>(authLogin, {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: OWNER_LOGIN, password: NEW_PASSWORD },
+        cookies: createCookieJar()
+      });
+      expect(loginAttempt.status).toBe(401);
+      expect(loginAttempt.body.error.code).toBe("MFA_REQUIRED");
+    });
+  });
+});

--- a/tests/integration/mfa-flow.integration.test.ts
+++ b/tests/integration/mfa-flow.integration.test.ts
@@ -348,6 +348,129 @@ suite("MFA/TOTP login-challenge flow (Issue #589)", () => {
     });
   });
 
+  test("concurrent verification attempts with the same valid code only succeed once (race-safe replay prevention)", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_MFA_ENV, async () => {
+      const initialToken = await loginAndGetToken(owner.tenantId);
+      const { secretBase32 } = await enrollMfa(owner.tenantId, initialToken);
+
+      const loginAttempt = await invoke<ErrorEnvelope>(authLogin, {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+        cookies: createCookieJar()
+      });
+      const challengeToken = loginAttempt.body.error.details?.mfaChallengeToken;
+      const code = totpCodeFor(secretBase32, Date.now() + 30_000);
+
+      const verifyOnce = () =>
+        invoke<{ data?: { token: string } } & Partial<ErrorEnvelope>>(
+          mfaVerify,
+          {
+            method: "POST",
+            path: "/api/v1/auth/mfa/totp/verify",
+            headers: {
+              "content-type": "application/json",
+              "x-awcms-mini-tenant-id": owner.tenantId
+            },
+            body: { mfaChallengeToken: challengeToken, code }
+          }
+        );
+
+      // Fire 5 concurrent requests with the IDENTICAL valid code against
+      // the SAME challenge. Without the FOR UPDATE lock + compare-and-swap
+      // on last_used_step (PR #597 security review), a read-then-write
+      // race would let more than one of these succeed.
+      const results = await Promise.all([
+        verifyOnce(),
+        verifyOnce(),
+        verifyOnce(),
+        verifyOnce(),
+        verifyOnce()
+      ]);
+
+      const succeeded = results.filter((result) => result.status === 200);
+      expect(succeeded).toHaveLength(1);
+    });
+  });
+
+  test("concurrent wrong-code attempts against one challenge never exceed the failed-attempt cap", async () => {
+    // `totp/verify.ts` reads AUTH_MFA_RATE_LIMIT_MAX into a module-level
+    // constant at import time (same convention as login.ts's own rate
+    // limit constants), so overriding it per-test has no effect — the cap
+    // enforced here is whatever the real default is (5).
+    const DEFAULT_MAX_ATTEMPTS = 5;
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_MFA_ENV, async () => {
+      const initialToken = await loginAndGetToken(owner.tenantId);
+      await enrollMfa(owner.tenantId, initialToken);
+
+      const loginAttempt = await invoke<ErrorEnvelope>(authLogin, {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+        cookies: createCookieJar()
+      });
+      const challengeToken = loginAttempt.body.error.details?.mfaChallengeToken;
+
+      const wrongAttempt = (code: string) =>
+        invoke<ErrorEnvelope>(mfaVerify, {
+          method: "POST",
+          path: "/api/v1/auth/mfa/totp/verify",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId
+          },
+          body: { mfaChallengeToken: challengeToken, code }
+        });
+
+      // 10 concurrent wrong-code attempts against one challenge whose cap
+      // is 5 — without the FOR UPDATE lock, every one of these would read
+      // failed_attempts=0 before any commit and all "pass" the
+      // attempt-limit check (PR #597 security review). (The source+tenant
+      // in-memory rate limiter also bounds this independently, at the
+      // same default of 5 — reset below so it doesn't mask the DB-level
+      // assertion that follows.)
+      await Promise.all(
+        Array.from({ length: 10 }, (_, i) =>
+          wrongAttempt(`00000${i}`.slice(-6))
+        )
+      );
+
+      // `evaluateMfaChallenge` rejects (without incrementing further) once
+      // `failed_attempts >= maxAttempts`, so the counter must cap at
+      // exactly the configured max — not creep past it the way an
+      // unlocked read-then-write race would allow.
+      const admin = getAdminSql();
+      const rows = (await admin`
+        SELECT failed_attempts FROM awcms_mini_mfa_challenges
+        WHERE tenant_id = ${owner.tenantId}
+      `) as { failed_attempts: number }[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.failed_attempts).toBe(DEFAULT_MAX_ATTEMPTS);
+
+      // The challenge must now be unusable via too_many_attempts — even a
+      // subsequently correct code must not be accepted once the cap is
+      // reached. Reset the in-memory rate limiter first so this assertion
+      // is purely about the DB-level cap, not the independent source+
+      // tenant limiter (already proven capped above).
+      resetRateLimitStoreForTests();
+      const afterCap = await wrongAttempt("000000");
+      expect(afterCap.status).toBe(401);
+      expect(afterCap.body.error.code).toBe("MFA_CHALLENGE_INVALID");
+    });
+  });
+
   test("recovery code completes a challenge and is single-use", async () => {
     const owner = await bootstrapTenant();
 

--- a/tests/integration/mfa-schema.integration.test.ts
+++ b/tests/integration/mfa-schema.integration.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Integration tests for the MFA/TOTP foundation schema/RLS (Issue #589,
+ * epic: full-online auth hardening) against a real PostgreSQL — migration
+ * 034's three new tables. Same pattern `blog-content-schema.integration.test.ts`
+ * (#537) and `module-management-schema.integration.test.ts` (#512) used:
+ * exercise constraints and RLS enforcement directly via `withTenant`/raw
+ * admin SQL, independent of the endpoint-level flow covered by
+ * `mfa-flow.integration.test.ts`.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+
+const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const PROFILE_A = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+const PROFILE_B = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+const IDENTITY_A = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+const IDENTITY_B = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+async function seedFixtures(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES
+      (${TENANT_A}, 'tenant-a', 'Tenant A', 'Tenant A Legal', 'active', 'en', 'light'),
+      (${TENANT_B}, 'tenant-b', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+  `;
+  await admin`
+    INSERT INTO awcms_mini_profiles (id, tenant_id, profile_type, display_name)
+    VALUES
+      (${PROFILE_A}, ${TENANT_A}, 'person', 'Owner A'),
+      (${PROFILE_B}, ${TENANT_B}, 'person', 'Owner B')
+  `;
+  await admin`
+    INSERT INTO awcms_mini_identities
+      (id, tenant_id, profile_id, login_identifier, password_hash)
+    VALUES
+      (${IDENTITY_A}, ${TENANT_A}, ${PROFILE_A}, 'owner-a@example.com', 'hash'),
+      (${IDENTITY_B}, ${TENANT_B}, ${PROFILE_B}, 'owner-b@example.com', 'hash')
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("MFA/TOTP schema — RLS isolation and constraints (Issue #589)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedFixtures();
+  });
+
+  test("tenant A cannot see tenant B's MFA factor (RLS isolation)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_identity_mfa_factors
+        (tenant_id, identity_id, factor_type, secret_ciphertext, status)
+      VALUES
+        (${TENANT_A}, ${IDENTITY_A}, 'totp', 'v1:a:b:c', 'active'),
+        (${TENANT_B}, ${IDENTITY_B}, 'totp', 'v1:d:e:f', 'active')
+    `;
+
+    const sql = getDatabaseClient();
+    const rows = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT identity_id FROM awcms_mini_identity_mfa_factors`
+    );
+
+    expect(rows).toHaveLength(1);
+    expect((rows as { identity_id: string }[])[0]?.identity_id).toBe(
+      IDENTITY_A
+    );
+  });
+
+  test("querying factors without a tenant GUC set returns no rows (fail-closed)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_identity_mfa_factors
+        (tenant_id, identity_id, factor_type, secret_ciphertext, status)
+      VALUES (${TENANT_A}, ${IDENTITY_A}, 'totp', 'v1:a:b:c', 'active')
+    `;
+
+    const sql = getDatabaseClient();
+    const rows =
+      await sql`SELECT identity_id FROM awcms_mini_identity_mfa_factors`;
+    expect(rows).toHaveLength(0);
+  });
+
+  test("only one non-disabled factor per identity is allowed (partial unique index)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_identity_mfa_factors
+        (tenant_id, identity_id, factor_type, secret_ciphertext, status)
+      VALUES (${TENANT_A}, ${IDENTITY_A}, 'totp', 'v1:a:b:c', 'pending')
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_identity_mfa_factors
+          (tenant_id, identity_id, factor_type, secret_ciphertext, status)
+        VALUES (${TENANT_A}, ${IDENTITY_A}, 'totp', 'v1:x:y:z', 'active')
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+
+    // A disabled factor doesn't count toward the constraint — a fresh
+    // pending/active factor can coexist with a prior disabled one.
+    await admin`
+      UPDATE awcms_mini_identity_mfa_factors
+      SET status = 'disabled'
+      WHERE tenant_id = ${TENANT_A} AND identity_id = ${IDENTITY_A}
+    `;
+    let secondDidThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_identity_mfa_factors
+          (tenant_id, identity_id, factor_type, secret_ciphertext, status)
+        VALUES (${TENANT_A}, ${IDENTITY_A}, 'totp', 'v1:x:y:z', 'active')
+      `;
+    } catch {
+      secondDidThrow = true;
+    }
+    expect(secondDidThrow).toBe(false);
+  });
+
+  test("factors rejects an unknown status", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+
+    try {
+      await admin`
+        INSERT INTO awcms_mini_identity_mfa_factors
+          (tenant_id, identity_id, factor_type, secret_ciphertext, status)
+        VALUES (${TENANT_A}, ${IDENTITY_A}, 'totp', 'v1:a:b:c', 'bogus')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("recovery codes: tenant A cannot see tenant B's codes (RLS isolation)", async () => {
+    const admin = getAdminSql();
+    const [factorA] = (await admin`
+      INSERT INTO awcms_mini_identity_mfa_factors
+        (tenant_id, identity_id, factor_type, secret_ciphertext, status)
+      VALUES (${TENANT_A}, ${IDENTITY_A}, 'totp', 'v1:a:b:c', 'active')
+      RETURNING id
+    `) as { id: string }[];
+    const [factorB] = (await admin`
+      INSERT INTO awcms_mini_identity_mfa_factors
+        (tenant_id, identity_id, factor_type, secret_ciphertext, status)
+      VALUES (${TENANT_B}, ${IDENTITY_B}, 'totp', 'v1:d:e:f', 'active')
+      RETURNING id
+    `) as { id: string }[];
+
+    await admin`
+      INSERT INTO awcms_mini_identity_mfa_recovery_codes
+        (tenant_id, identity_id, factor_id, code_hash)
+      VALUES
+        (${TENANT_A}, ${IDENTITY_A}, ${factorA!.id}, 'sha256:aaa'),
+        (${TENANT_B}, ${IDENTITY_B}, ${factorB!.id}, 'sha256:bbb')
+    `;
+
+    const sql = getDatabaseClient();
+    const rows = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT code_hash FROM awcms_mini_identity_mfa_recovery_codes`
+    );
+
+    expect(rows).toHaveLength(1);
+    expect((rows as { code_hash: string }[])[0]?.code_hash).toBe("sha256:aaa");
+  });
+
+  test("recovery codes are deleted when their factor is deleted (ON DELETE CASCADE)", async () => {
+    const admin = getAdminSql();
+    const [factorA] = (await admin`
+      INSERT INTO awcms_mini_identity_mfa_factors
+        (tenant_id, identity_id, factor_type, secret_ciphertext, status)
+      VALUES (${TENANT_A}, ${IDENTITY_A}, 'totp', 'v1:a:b:c', 'active')
+      RETURNING id
+    `) as { id: string }[];
+    await admin`
+      INSERT INTO awcms_mini_identity_mfa_recovery_codes
+        (tenant_id, identity_id, factor_id, code_hash)
+      VALUES (${TENANT_A}, ${IDENTITY_A}, ${factorA!.id}, 'sha256:aaa')
+    `;
+
+    await admin`DELETE FROM awcms_mini_identity_mfa_factors WHERE id = ${factorA!.id}`;
+
+    const remaining = await admin`
+      SELECT id FROM awcms_mini_identity_mfa_recovery_codes WHERE factor_id = ${factorA!.id}
+    `;
+    expect(remaining).toHaveLength(0);
+  });
+
+  test("challenges: tenant A cannot see tenant B's challenge (RLS isolation)", async () => {
+    const admin = getAdminSql();
+    const future = new Date(Date.now() + 5 * 60_000);
+    await admin`
+      INSERT INTO awcms_mini_mfa_challenges
+        (tenant_id, identity_id, challenge_token_hash, expires_at)
+      VALUES
+        (${TENANT_A}, ${IDENTITY_A}, 'sha256:aaa', ${future}),
+        (${TENANT_B}, ${IDENTITY_B}, 'sha256:bbb', ${future})
+    `;
+
+    const sql = getDatabaseClient();
+    const rows = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT challenge_token_hash FROM awcms_mini_mfa_challenges`
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(
+      (rows as { challenge_token_hash: string }[])[0]?.challenge_token_hash
+    ).toBe("sha256:aaa");
+  });
+
+  test("challenges rejects a negative failed_attempts", async () => {
+    const admin = getAdminSql();
+    const future = new Date(Date.now() + 5 * 60_000);
+    let didThrow = false;
+
+    try {
+      await admin`
+        INSERT INTO awcms_mini_mfa_challenges
+          (tenant_id, identity_id, challenge_token_hash, expires_at, failed_attempts)
+        VALUES (${TENANT_A}, ${IDENTITY_A}, 'sha256:aaa', ${future}, -1)
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+});

--- a/tests/security-readiness.test.ts
+++ b/tests/security-readiness.test.ts
@@ -7,6 +7,7 @@ import {
   checkLoginRateLimitImplemented,
   checkOnlineAuthSecurityReady,
   checkSyncHmacSecretNotDefault,
+  checkMfaReady,
   checkTurnstileReady,
   scanLineForHardcodedSecret
 } from "../scripts/security-readiness";
@@ -239,6 +240,36 @@ describe("checkTurnstileReady", () => {
       TURNSTILE_ENABLED: "true",
       TURNSTILE_SITE_KEY: "site-key-abc",
       TURNSTILE_SECRET_KEY: "a-real-secret"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("pass");
+  });
+});
+
+describe("checkMfaReady", () => {
+  const validKey = Buffer.alloc(32, 5).toString("base64");
+
+  test("is critical/pass (informational, not a failure) when MFA is not enabled", () => {
+    const result = checkMfaReady({} as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when AUTH_MFA_ENABLED=true but the encryption key is missing", () => {
+    const result = checkMfaReady({
+      AUTH_MFA_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("fail");
+  });
+
+  test("passes when AUTH_MFA_ENABLED=true and the key is a valid 32-byte base64 value", () => {
+    const result = checkMfaReady({
+      AUTH_MFA_ENABLED: "true",
+      AUTH_MFA_SECRET_ENCRYPTION_KEY: validKey
     } as NodeJS.ProcessEnv);
 
     expect(result.severity).toBe("critical");

--- a/tests/unit/mfa-config.test.ts
+++ b/tests/unit/mfa-config.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isMfaEnabled,
+  isMfaRequired,
+  resolveChallengeTtlSec,
+  resolveTotpDigits,
+  resolveTotpIssuer,
+  resolveTotpPeriodSec
+} from "../../src/lib/auth/mfa-config";
+
+const FULL_ONLINE_ENV = {
+  AUTH_ONLINE_SECURITY_ENABLED: "true",
+  AUTH_ONLINE_SECURITY_PROFILE: "full_online"
+} as const;
+
+describe("isMfaEnabled", () => {
+  test("false when unset", () => {
+    expect(isMfaEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  test('true only for the literal string "true"', () => {
+    expect(
+      isMfaEnabled({ AUTH_MFA_ENABLED: "true" } as NodeJS.ProcessEnv)
+    ).toBe(true);
+    expect(
+      isMfaEnabled({ AUTH_MFA_ENABLED: "TRUE" } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+});
+
+describe("isMfaRequired — the shared gate login.ts and every MFA endpoint checks", () => {
+  test("false when the full-online gate (#587) is off, even if AUTH_MFA_ENABLED=true", () => {
+    expect(
+      isMfaRequired({ AUTH_MFA_ENABLED: "true" } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("false when AUTH_MFA_ENABLED is not set, even if the full-online gate is on", () => {
+    expect(isMfaRequired({ ...FULL_ONLINE_ENV } as NodeJS.ProcessEnv)).toBe(
+      false
+    );
+  });
+
+  test("true only when both the full-online gate and AUTH_MFA_ENABLED agree", () => {
+    expect(
+      isMfaRequired({
+        ...FULL_ONLINE_ENV,
+        AUTH_MFA_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+});
+
+describe("resolveTotpIssuer", () => {
+  test("defaults to AWCMS-Mini when unset", () => {
+    expect(resolveTotpIssuer({} as NodeJS.ProcessEnv)).toBe("AWCMS-Mini");
+  });
+
+  test("uses a trimmed override", () => {
+    expect(
+      resolveTotpIssuer({
+        AUTH_MFA_TOTP_ISSUER: "  My App  "
+      } as NodeJS.ProcessEnv)
+    ).toBe("My App");
+  });
+
+  test("falls back to the default for an empty/whitespace-only override", () => {
+    expect(
+      resolveTotpIssuer({ AUTH_MFA_TOTP_ISSUER: "   " } as NodeJS.ProcessEnv)
+    ).toBe("AWCMS-Mini");
+  });
+});
+
+describe("resolveTotpPeriodSec", () => {
+  test("defaults to 30", () => {
+    expect(resolveTotpPeriodSec({} as NodeJS.ProcessEnv)).toBe(30);
+  });
+
+  test("uses a valid positive override", () => {
+    expect(
+      resolveTotpPeriodSec({
+        AUTH_MFA_TOTP_PERIOD_SEC: "60"
+      } as NodeJS.ProcessEnv)
+    ).toBe(60);
+  });
+
+  test("falls back to the default for non-numeric/zero/negative values", () => {
+    expect(
+      resolveTotpPeriodSec({
+        AUTH_MFA_TOTP_PERIOD_SEC: "not-a-number"
+      } as NodeJS.ProcessEnv)
+    ).toBe(30);
+    expect(
+      resolveTotpPeriodSec({
+        AUTH_MFA_TOTP_PERIOD_SEC: "0"
+      } as NodeJS.ProcessEnv)
+    ).toBe(30);
+  });
+});
+
+describe("resolveTotpDigits", () => {
+  test("defaults to 6", () => {
+    expect(resolveTotpDigits({} as NodeJS.ProcessEnv)).toBe(6);
+  });
+
+  test("accepts 8", () => {
+    expect(
+      resolveTotpDigits({ AUTH_MFA_TOTP_DIGITS: "8" } as NodeJS.ProcessEnv)
+    ).toBe(8);
+  });
+
+  test("falls back to 6 for any other value", () => {
+    expect(
+      resolveTotpDigits({ AUTH_MFA_TOTP_DIGITS: "7" } as NodeJS.ProcessEnv)
+    ).toBe(6);
+    expect(
+      resolveTotpDigits({
+        AUTH_MFA_TOTP_DIGITS: "not-a-number"
+      } as NodeJS.ProcessEnv)
+    ).toBe(6);
+  });
+});
+
+describe("resolveChallengeTtlSec", () => {
+  test("defaults to 300", () => {
+    expect(resolveChallengeTtlSec({} as NodeJS.ProcessEnv)).toBe(300);
+  });
+
+  test("uses a valid positive override", () => {
+    expect(
+      resolveChallengeTtlSec({
+        AUTH_MFA_CHALLENGE_TTL_SEC: "120"
+      } as NodeJS.ProcessEnv)
+    ).toBe(120);
+  });
+
+  test("falls back to the default for non-numeric/zero/negative values", () => {
+    expect(
+      resolveChallengeTtlSec({
+        AUTH_MFA_CHALLENGE_TTL_SEC: "-5"
+      } as NodeJS.ProcessEnv)
+    ).toBe(300);
+  });
+});

--- a/tests/unit/mfa-crypto.test.ts
+++ b/tests/unit/mfa-crypto.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  decryptMfaSecret,
+  encryptMfaSecret,
+  resolveMfaEncryptionKey
+} from "../../src/lib/auth/mfa-secret-crypto";
+import {
+  generateRecoveryCode,
+  hashRecoveryCode
+} from "../../src/lib/auth/mfa-recovery-code";
+import {
+  generateChallengeToken,
+  hashChallengeToken
+} from "../../src/lib/auth/mfa-challenge-token";
+
+const VALID_KEY_BASE64 = Buffer.alloc(32, 7).toString("base64");
+
+describe("resolveMfaEncryptionKey", () => {
+  test("null when unset", () => {
+    expect(resolveMfaEncryptionKey({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  test("null when the decoded key is not exactly 32 bytes", () => {
+    const shortKey = Buffer.alloc(16, 1).toString("base64");
+    expect(
+      resolveMfaEncryptionKey({
+        AUTH_MFA_SECRET_ENCRYPTION_KEY: shortKey
+      } as NodeJS.ProcessEnv)
+    ).toBeNull();
+  });
+
+  test("returns a 32-byte buffer for a valid key", () => {
+    const key = resolveMfaEncryptionKey({
+      AUTH_MFA_SECRET_ENCRYPTION_KEY: VALID_KEY_BASE64
+    } as NodeJS.ProcessEnv);
+    expect(key).not.toBeNull();
+    expect(key).toHaveLength(32);
+  });
+});
+
+describe("encryptMfaSecret/decryptMfaSecret", () => {
+  const key = resolveMfaEncryptionKey({
+    AUTH_MFA_SECRET_ENCRYPTION_KEY: VALID_KEY_BASE64
+  } as NodeJS.ProcessEnv)!;
+
+  test("round-trips a secret", () => {
+    const plaintext = Buffer.from("a-totp-secret-payload");
+    const ciphertext = encryptMfaSecret(plaintext, key);
+    expect(ciphertext).not.toContain("a-totp-secret-payload");
+    expect(decryptMfaSecret(ciphertext, key)).toEqual(plaintext);
+  });
+
+  test("two encryptions of the same plaintext produce different ciphertext (random IV)", () => {
+    const plaintext = Buffer.from("same-secret");
+    const a = encryptMfaSecret(plaintext, key);
+    const b = encryptMfaSecret(plaintext, key);
+    expect(a).not.toBe(b);
+  });
+
+  test("decrypting with the wrong key throws (authenticated cipher rejects it)", () => {
+    const otherKey = Buffer.alloc(32, 9);
+    const ciphertext = encryptMfaSecret(Buffer.from("secret"), key);
+    expect(() => decryptMfaSecret(ciphertext, otherKey)).toThrow();
+  });
+
+  test("decrypting a tampered ciphertext throws", () => {
+    const ciphertext = encryptMfaSecret(Buffer.from("secret"), key);
+    const parts = ciphertext.split(":");
+    const tamperedCiphertextPart = Buffer.from(parts[3]!, "base64");
+    tamperedCiphertextPart[0] = (tamperedCiphertextPart[0]! + 1) % 256;
+    const tampered = [
+      parts[0],
+      parts[1],
+      parts[2],
+      tamperedCiphertextPart.toString("base64")
+    ].join(":");
+
+    expect(() => decryptMfaSecret(tampered, key)).toThrow();
+  });
+
+  test("decrypting an unrecognized format throws", () => {
+    expect(() => decryptMfaSecret("not-a-valid-format", key)).toThrow();
+    expect(() => decryptMfaSecret("v2:a:b:c", key)).toThrow();
+  });
+});
+
+describe("generateRecoveryCode/hashRecoveryCode", () => {
+  test("produces an XXXX-XXXX shaped code", () => {
+    const code = generateRecoveryCode();
+    expect(code).toMatch(/^[A-Z2-7]{4}-[A-Z2-7]{4}$/);
+  });
+
+  test("generates distinct codes across calls", () => {
+    const codes = new Set(
+      Array.from({ length: 20 }, () => generateRecoveryCode())
+    );
+    expect(codes.size).toBe(20);
+  });
+
+  test("hash is stable and normalizes case/dash before hashing", () => {
+    const code = generateRecoveryCode();
+    const hash = hashRecoveryCode(code);
+    expect(hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(hashRecoveryCode(code.toLowerCase())).toBe(hash);
+    expect(hashRecoveryCode(code.replace("-", ""))).toBe(hash);
+    expect(hashRecoveryCode(` ${code} `.trim())).toBe(hash);
+  });
+
+  test("different codes hash differently", () => {
+    expect(hashRecoveryCode("AAAA-AAAA")).not.toBe(
+      hashRecoveryCode("BBBB-BBBB")
+    );
+  });
+});
+
+describe("generateChallengeToken/hashChallengeToken", () => {
+  test("generates a base64url token and a stable sha256 hash", () => {
+    const token = generateChallengeToken();
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const hash = hashChallengeToken(token);
+    expect(hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(hashChallengeToken(token)).toBe(hash);
+  });
+
+  test("different tokens hash differently", () => {
+    const a = generateChallengeToken();
+    const b = generateChallengeToken();
+    expect(hashChallengeToken(a)).not.toBe(hashChallengeToken(b));
+  });
+});

--- a/tests/unit/mfa-policy.test.ts
+++ b/tests/unit/mfa-policy.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { evaluateMfaChallenge } from "../../src/modules/identity-access/domain/mfa-policy";
+
+const NOW = new Date("2026-01-01T00:00:00Z");
+const FUTURE = new Date(NOW.getTime() + 60_000);
+const PAST = new Date(NOW.getTime() - 60_000);
+
+describe("evaluateMfaChallenge", () => {
+  test("invalid: not_found when there is no row", () => {
+    expect(evaluateMfaChallenge(null, NOW, 5)).toEqual({
+      outcome: "invalid",
+      reason: "not_found"
+    });
+  });
+
+  test("invalid: already_used when consumedAt is set", () => {
+    const result = evaluateMfaChallenge(
+      { expiresAt: FUTURE, consumedAt: PAST, failedAttempts: 0 },
+      NOW,
+      5
+    );
+    expect(result).toEqual({ outcome: "invalid", reason: "already_used" });
+  });
+
+  test("invalid: too_many_attempts when failedAttempts reaches the max", () => {
+    const result = evaluateMfaChallenge(
+      { expiresAt: FUTURE, consumedAt: null, failedAttempts: 5 },
+      NOW,
+      5
+    );
+    expect(result).toEqual({ outcome: "invalid", reason: "too_many_attempts" });
+  });
+
+  test("invalid: expired when expiresAt is in the past", () => {
+    const result = evaluateMfaChallenge(
+      { expiresAt: PAST, consumedAt: null, failedAttempts: 0 },
+      NOW,
+      5
+    );
+    expect(result).toEqual({ outcome: "invalid", reason: "expired" });
+  });
+
+  test("valid when none of the deny conditions apply", () => {
+    const result = evaluateMfaChallenge(
+      { expiresAt: FUTURE, consumedAt: null, failedAttempts: 2 },
+      NOW,
+      5
+    );
+    expect(result).toEqual({ outcome: "valid" });
+  });
+
+  test("checks failed_attempts and already_used before expiry (deny-reason priority)", () => {
+    // A row that is BOTH already used AND expired should report already_used
+    // first — matches evaluatePasswordResetToken's own priority ordering.
+    const result = evaluateMfaChallenge(
+      { expiresAt: PAST, consumedAt: PAST, failedAttempts: 0 },
+      NOW,
+      5
+    );
+    expect(result).toEqual({ outcome: "invalid", reason: "already_used" });
+  });
+});

--- a/tests/unit/totp.test.ts
+++ b/tests/unit/totp.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  base32Decode,
+  base32Encode,
+  buildOtpauthUri,
+  generateTotpCode,
+  generateTotpSecret,
+  verifyTotpCode
+} from "../../src/lib/auth/totp";
+
+describe("base32Encode/base32Decode", () => {
+  test("round-trips arbitrary byte buffers", () => {
+    const buffers = [
+      Buffer.from([]),
+      Buffer.from([0]),
+      Buffer.from([255]),
+      Buffer.from("hello world"),
+      Buffer.from(Array.from({ length: 32 }, (_, i) => i * 7))
+    ];
+
+    for (const buffer of buffers) {
+      const encoded = base32Encode(buffer);
+      expect(base32Decode(encoded)).toEqual(buffer);
+    }
+  });
+
+  test("encodes using only the RFC 4648 base32 alphabet, no padding", () => {
+    const encoded = base32Encode(Buffer.from("12345678901234567890"));
+    expect(encoded).toMatch(/^[A-Z2-7]+$/);
+    expect(encoded).not.toContain("=");
+  });
+
+  test("decode tolerates lowercase, padding, and stray whitespace", () => {
+    const original = Buffer.from("test-secret-bytes!!");
+    const encoded = base32Encode(original);
+    const messy = `  ${encoded.toLowerCase()}==  `;
+    expect(base32Decode(messy)).toEqual(original);
+  });
+});
+
+describe("generateTotpSecret", () => {
+  test("returns 20 random bytes (160 bits, RFC 4226 recommended length)", () => {
+    const a = generateTotpSecret();
+    const b = generateTotpSecret();
+    expect(a).toHaveLength(20);
+    expect(a.equals(b)).toBe(false);
+  });
+});
+
+describe("verifyTotpCode — RFC 6238 Appendix B test vectors", () => {
+  // The 20-byte ASCII secret "12345678901234567890" and its known 8-digit
+  // SHA1 codes at fixed Unix timestamps, straight from RFC 6238 Appendix B —
+  // proves this implementation is bit-for-bit RFC-compatible (and therefore
+  // Google Authenticator-compatible), not just internally self-consistent.
+  const SECRET = Buffer.from("12345678901234567890", "ascii");
+  const VECTORS: Array<[number, string]> = [
+    [59, "94287082"],
+    [1111111109, "07081804"],
+    [1111111111, "14050471"],
+    [1234567890, "89005924"],
+    [2000000000, "69279037"],
+    [20000000000, "65353130"]
+  ];
+
+  for (const [timeSec, expectedCode] of VECTORS) {
+    test(`matches at T=${timeSec}`, () => {
+      const step = Math.floor(timeSec / 30);
+      const matchedStep = verifyTotpCode(SECRET, expectedCode, timeSec * 1000, {
+        periodSec: 30,
+        digits: 8,
+        windowSteps: 0
+      });
+      expect(matchedStep).toBe(step);
+    });
+  }
+
+  test("rejects a wrong code at a known-good timestamp", () => {
+    const matchedStep = verifyTotpCode(SECRET, "00000000", 59 * 1000, {
+      periodSec: 30,
+      digits: 8,
+      windowSteps: 0
+    });
+    expect(matchedStep).toBeNull();
+  });
+
+  test("rejects a code of the wrong length even if numeric", () => {
+    const matchedStep = verifyTotpCode(SECRET, "9428708", 59 * 1000, {
+      periodSec: 30,
+      digits: 8,
+      windowSteps: 0
+    });
+    expect(matchedStep).toBeNull();
+  });
+
+  test("rejects a non-numeric code", () => {
+    const matchedStep = verifyTotpCode(SECRET, "abcdefgh", 59 * 1000, {
+      periodSec: 30,
+      digits: 8,
+      windowSteps: 0
+    });
+    expect(matchedStep).toBeNull();
+  });
+
+  test("tolerates clock drift within the window (±1 step by default)", () => {
+    // T=59 -> step 1, code 94287082. One period later (step 2) is outside a
+    // zero-window check but inside the default ±1 window.
+    const oneStepLater = (59 + 30) * 1000;
+    const matchedStep = verifyTotpCode(SECRET, "94287082", oneStepLater, {
+      periodSec: 30,
+      digits: 8
+    });
+    expect(matchedStep).toBe(1);
+  });
+
+  test("rejects drift beyond the configured window", () => {
+    const twoStepsLater = (59 + 60) * 1000;
+    const matchedStep = verifyTotpCode(SECRET, "94287082", twoStepsLater, {
+      periodSec: 30,
+      digits: 8,
+      windowSteps: 1
+    });
+    expect(matchedStep).toBeNull();
+  });
+});
+
+describe("generateTotpCode", () => {
+  test("matches the known RFC 6238 vector at T=59", () => {
+    const secret = Buffer.from("12345678901234567890", "ascii");
+    expect(
+      generateTotpCode(secret, 59 * 1000, { periodSec: 30, digits: 8 })
+    ).toBe("94287082");
+  });
+
+  test("round-trips with verifyTotpCode for a freshly generated secret", () => {
+    const secret = generateTotpSecret();
+    const now = Date.now();
+    const code = generateTotpCode(secret, now, { periodSec: 30, digits: 6 });
+    const matchedStep = verifyTotpCode(secret, code, now, {
+      periodSec: 30,
+      digits: 6
+    });
+    expect(matchedStep).toBe(Math.floor(now / 1000 / 30));
+  });
+});
+
+describe("buildOtpauthUri", () => {
+  test("produces a well-formed otpauth:// URI with the expected query params", () => {
+    const uri = buildOtpauthUri({
+      secret: Buffer.from("12345678901234567890", "ascii"),
+      issuer: "AWCMS-Mini",
+      accountName: "owner@example.com",
+      digits: 6,
+      periodSec: 30
+    });
+
+    expect(uri.startsWith("otpauth://totp/")).toBe(true);
+    expect(uri).toContain("issuer=AWCMS-Mini");
+    expect(uri).toContain("digits=6");
+    expect(uri).toContain("period=30");
+    expect(uri).toContain("algorithm=SHA1");
+    expect(decodeURIComponent(uri)).toContain("AWCMS-Mini:owner@example.com");
+  });
+});

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -8,6 +8,7 @@ import {
   checkRequiredVars,
   checkSyncConfig,
   checkTenantDomainDnsConfig,
+  checkMfaConfig,
   checkTurnstileConfig,
   runEnvValidation
 } from "../scripts/validate-env";
@@ -504,6 +505,67 @@ describe("checkTurnstileConfig", () => {
 
     for (const result of results) {
       expect(result.detail).not.toContain("super-secret-turnstile-value");
+    }
+  });
+});
+
+const VALID_MFA_KEY_BASE64 = Buffer.alloc(32, 3).toString("base64");
+
+describe("checkMfaConfig", () => {
+  test("passes (single check) when AUTH_MFA_ENABLED is not set", () => {
+    const results = checkMfaConfig({} as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("passes when AUTH_MFA_ENABLED=false", () => {
+    const results = checkMfaConfig({
+      AUTH_MFA_ENABLED: "false"
+    } as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("fails when AUTH_MFA_ENABLED=true but the encryption key is missing", () => {
+    const results = checkMfaConfig({
+      AUTH_MFA_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    const failed = results.filter((result) => result.status === "fail");
+    expect(failed).toHaveLength(1);
+    expect(failed[0]?.name).toBe("AUTH_MFA_SECRET_ENCRYPTION_KEY");
+  });
+
+  test("fails when the encryption key is set but not a valid 32-byte base64 value", () => {
+    const results = checkMfaConfig({
+      AUTH_MFA_ENABLED: "true",
+      AUTH_MFA_SECRET_ENCRYPTION_KEY: "too-short"
+    } as NodeJS.ProcessEnv);
+
+    const failed = results.filter((result) => result.status === "fail");
+    expect(failed).toHaveLength(1);
+    expect(failed[0]?.name).toBe("AUTH_MFA_SECRET_ENCRYPTION_KEY");
+  });
+
+  test("all pass when AUTH_MFA_ENABLED=true and the key is a valid 32-byte base64 value", () => {
+    const results = checkMfaConfig({
+      AUTH_MFA_ENABLED: "true",
+      AUTH_MFA_SECRET_ENCRYPTION_KEY: VALID_MFA_KEY_BASE64
+    } as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("never includes the configured key value in any result detail", () => {
+    const results = checkMfaConfig({
+      AUTH_MFA_ENABLED: "true",
+      AUTH_MFA_SECRET_ENCRYPTION_KEY: VALID_MFA_KEY_BASE64
+    } as NodeJS.ProcessEnv);
+
+    for (const result of results) {
+      expect(result.detail).not.toContain(VALID_MFA_KEY_BASE64);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Adds tenant-scoped MFA/TOTP enrollment and a login-challenge flow (Issue #589, epic #587-#593), gated by the shared full-online security gate (#587) combined with a new `AUTH_MFA_ENABLED` flag. Every local/offline/LAN deployment is unaffected — MFA is also opt-in per identity even when the feature is enabled tenant-wide (an identity that never enrolls keeps logging in exactly as before).
- New tables (migration 034, tenant-scoped, RLS `ENABLE`+`FORCE`): `awcms_mini_identity_mfa_factors`, `awcms_mini_identity_mfa_recovery_codes`, `awcms_mini_mfa_challenges`.
- `POST /api/v1/auth/login`: a password-valid login for an identity with an active TOTP factor no longer creates a session — it issues a challenge and returns `401 MFA_REQUIRED` with `mfaChallengeToken`. New `POST /auth/mfa/totp/verify` (authenticated by possession of that token, not a session — mirrors `password/reset`'s pattern) completes the login and creates the real session.
- Self-service endpoints: `GET /auth/mfa/status`, `POST /auth/mfa/totp/enroll/start` + `/enroll/verify` (activates the factor, returns 10 one-time recovery codes), `POST /auth/mfa/totp/disable`, `POST /auth/mfa/recovery-codes/regenerate` (disable/regenerate are high-risk, audited).
- From-scratch, dependency-free RFC 6238 TOTP implementation (HMAC-SHA1), verified against the RFC's own Appendix B test vectors — Google Authenticator-compatible. TOTP secrets are encrypted at rest with AES-256-GCM (`AUTH_MFA_SECRET_ENCRYPTION_KEY`) — the only reversibly-stored secret in this app (verification must recompute the code); recovery codes and challenge tokens stay hash-only like every other token here. Replay of an already-used TOTP step is prevented via a per-factor `last_used_step` counter.
- Password reset never disables MFA — verified by an explicit integration test.
- New env vars, error codes (`MFA_REQUIRED`/`MFA_DISABLED`/`MFA_ALREADY_ACTIVE`/`MFA_NOT_ACTIVE`/`MFA_ENROLLMENT_NOT_FOUND`/`MFA_INVALID_CODE`/`MFA_CHALLENGE_INVALID`/`MFA_MISCONFIGURED`) with `en`/`id` i18n, OpenAPI spec updates, and docs/skill updates.

Closes #589

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run check:docs`
- [x] `bun run api:spec:check`
- [x] `bun run build`
- [x] `bun test` with real Postgres — 1306 pass, 0 fail (includes new unit tests for TOTP math against RFC 6238 vectors, secret encryption round-trip/tamper detection, recovery/challenge token helpers, config gate, domain challenge policy; new RLS/constraint integration tests for the 3 new tables; new end-to-end integration tests covering enroll → login-challenge → verify → session, wrong-code rejection, recovery-code single-use, disable, recovery-code regeneration, and password-reset-does-not-disable-MFA)
- [x] Live `bun run config:validate`: default (disabled) passes with 14 checks; `AUTH_MFA_ENABLED=true` without the encryption key fails closed as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)