### PR TITLE
feat(auth): add Google OIDC login for full-online deployments (#590)

### DIFF
--- a/.changeset/auth-google-oidc-full-online.md
+++ b/.changeset/auth-google-oidc-full-online.md
@@ -33,7 +33,21 @@ gated, with the breaker only tripping on genuine transport failures
 (5xx/network/timeout) — a well-formed `400 invalid_grant` for a bad/reused
 authorization code is Google correctly rejecting attacker-controlled
 input, not an outage, and must never trip the breaker (the same class of
-bug found and fixed in Turnstile's PR #596).
+bug found and fixed in Turnstile's PR #596). The OAuth state/nonce
+exchange is single-use and race-safe (`SELECT ... FOR UPDATE` plus
+compare-and-swap, the same fix PR #597 applied to MFA challenges).
+
+Security review of this PR also found that `GET .../start` inserted a
+row keyed by an unauthenticated, caller-supplied `tenantId` before
+verifying the tenant existed — a nonexistent tenant tripped a
+foreign-key violation that `withTenant`'s catch-all recorded against the
+single, application-wide database circuit breaker (shared by every
+tenant and every endpoint, not just this feature), letting an
+unauthenticated caller take down the entire deployment for 30 seconds at
+a time, repeatedly, with a handful of garbage tenant ids. Fixed by
+checking tenant existence/status via a plain `SELECT` (which never
+throws for a missing row) before ever attempting the insert, plus adding
+source-scoped rate limiting to `start.ts` matching `login.ts`.
 
 Account linking is by Google's `sub` only. Auto-linking a Google login to
 an existing identity by email is fail-closed: it requires both a verified

--- a/.changeset/auth-google-oidc-full-online.md
+++ b/.changeset/auth-google-oidc-full-online.md
@@ -1,0 +1,61 @@
+---
+"awcms-mini": minor
+---
+
+Add Google OIDC login for full-online deployments (Issue #590, epic
+#587-#593) — the third concrete feature built on top of the #587
+full-online security gate, following the same pattern as Cloudflare
+Turnstile (#588) and MFA/TOTP (#589).
+
+New tables (migration 035, tenant-scoped, RLS `ENABLE`+`FORCE`):
+`awcms_mini_identity_provider_accounts` (links an identity to a Google
+account by its stable `sub`, never by email), `awcms_mini_oidc_auth_requests`
+(the ephemeral state/nonce bridge across the OAuth redirect round-trip).
+`isGoogleLoginRequired(env)` combines the shared `isFullOnlineSecurityActive(env)`
+gate (#587) with a new `AUTH_GOOGLE_LOGIN_ENABLED` flag.
+
+New endpoints: `GET /api/v1/auth/providers/google/start` (unauthenticated,
+redirects to Google; reached from a new conditional "Continue with Google"
+button on `/login`), `GET .../callback` (Google's redirect target —
+validates `state`/nonce (CSRF/replay defense) and cryptographically
+verifies the ID token's RS256 signature, issuer, audience, expiry, and
+nonce before trusting any claim; creates the existing AWCMS-Mini session
+type, or — if Issue #589's MFA gate is active for the identity — returns
+`401 MFA_REQUIRED` exactly like `POST /auth/login`, so Google login never
+bypasses MFA), `POST .../link` (authenticated; starts a link-purpose OAuth
+request for the caller's own identity and returns the authorization URL as
+JSON), `POST .../unlink` (authenticated, high-risk, audited).
+
+The RS256 signature verification is implemented via the platform's own
+WebCrypto (`crypto.subtle`) rather than a JWT library dependency. Google's
+token exchange and JWKS fetch are timeout-bounded and circuit-breaker
+gated, with the breaker only tripping on genuine transport failures
+(5xx/network/timeout) — a well-formed `400 invalid_grant` for a bad/reused
+authorization code is Google correctly rejecting attacker-controlled
+input, not an outage, and must never trip the breaker (the same class of
+bug found and fixed in Turnstile's PR #596).
+
+Account linking is by Google's `sub` only. Auto-linking a Google login to
+an existing identity by email is fail-closed: it requires both a verified
+email and the email's domain to be explicitly listed in the new
+`AUTH_GOOGLE_ALLOWED_DOMAINS` env var (default unset — auto-linking never
+happens by default). Without an existing link or an eligible auto-link,
+login is rejected (`GOOGLE_ACCOUNT_NOT_LINKED`), never silently
+provisioning a new account.
+
+New env vars: `AUTH_GOOGLE_LOGIN_ENABLED` (default `false`),
+`AUTH_GOOGLE_CLIENT_ID`, `AUTH_GOOGLE_CLIENT_SECRET`,
+`AUTH_GOOGLE_ALLOWED_DOMAINS` (default unset), `AUTH_GOOGLE_REDIRECT_PATH`
+(default `/api/v1/auth/providers/google/callback`). `AUTH_GOOGLE_LOGIN_ENABLED=true`
+alone (independent of the #587 gate) requires a client id and secret in
+`bun run config:validate` and `security-readiness`.
+
+New error codes `GOOGLE_LOGIN_DISABLED`/`GOOGLE_OAUTH_STATE_INVALID`/
+`GOOGLE_TOKEN_EXCHANGE_FAILED`/`GOOGLE_ID_TOKEN_INVALID`/
+`GOOGLE_ACCOUNT_NOT_LINKED`/`GOOGLE_ALREADY_LINKED`/`GOOGLE_NOT_LINKED`/
+`GOOGLE_MISCONFIGURED` with i18n strings (`en`/`id`). OpenAPI spec updated
+for all 4 new endpoints.
+
+Docs updated: `.env.example`, `docs/awcms-mini/18_configuration_env_reference.md`,
+`docs/awcms-mini/deployment-profiles.md`, `src/modules/identity-access/README.md`,
+skill `awcms-mini-auth-online-hardening`.

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -34,7 +34,7 @@ keputusan desain yang mengikat semua issue di epic ini sekaligus.
 | #587  | Gate bersama `AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE` | **Selesai** — lihat §Gate bersama di bawah         |
 | #588  | Cloudflare Turnstile untuk form auth publik            | **Selesai** — lihat §Cloudflare Turnstile di bawah |
 | #589  | MFA/TOTP login challenge                               | **Selesai** — lihat §MFA/TOTP di bawah             |
-| #590  | Google OIDC login                                      | Belum dikerjakan                                   |
+| #590  | Google OIDC login                                      | **Selesai** — lihat §Google OIDC login di bawah    |
 | #591  | Generic tenant OIDC SSO provider                       | Belum dikerjakan                                   |
 | #592  | Admin UI kebijakan auth security online                | Belum dikerjakan (depends #587 selesai + #591)     |
 | #593  | Docs/kontrak/readiness penutup epic                    | Belum dikerjakan (finalisasi setelah #588-592)     |
@@ -228,6 +228,89 @@ isMfaRequired(env)
   `_challenge_invalid`/`_misconfigured` (`error-messages.ts`,
   `i18n/en.po`+`id.po`).
 
+### Google OIDC login (Issue #590, `src/modules/identity-access/application/google-oidc.ts`)
+
+Gate gabungan sama persis polanya dengan Turnstile/MFA:
+
+```txt
+isGoogleLoginRequired(env)
+  = isFullOnlineSecurityActive(env) AND isGoogleLoginEnabled(env)
+  (isGoogleLoginEnabled = AUTH_GOOGLE_LOGIN_ENABLED === "true")
+```
+
+- **Tenant id lewat `state`, bukan header** — `GET .../callback` adalah
+  redirect target Google (navigasi browser murni), yang TIDAK BISA
+  membawa header `X-AWCMS-Mini-Tenant-ID` seperti endpoint lain. `state`
+  yang dikirim ke Google berbentuk `${tenantId}.${rawToken}`
+  (`src/lib/auth/oauth-state-token.ts`'s `buildOAuthStateParam`/
+  `parseOAuthStateParam`) — tenant id BUKAN secret, jadi aman muncul di
+  URL; bagian token (pertahanan CSRF/replay sesungguhnya, ≥32 byte
+  random) tetap di-hash at rest seperti `state`/session/reset/challenge
+  token lain di aplikasi ini. Fitur online lain yang butuh redirect ke
+  provider eksternal (mis. #591 generic SSO) WAJIB pola yang sama untuk
+  membawa tenant id — jangan asumsikan header selalu tersedia di
+  endpoint redirect-target.
+- **Dua flow berbeda dari satu orkestrator**: `GET .../start`
+  (unauthenticated, dari tombol "Continue with Google" di `/login`)
+  selalu `purpose='login'`. `POST .../link` (BUTUH session — identity
+  diambil server-side dari session yang sedang login, TIDAK PERNAH
+  dipercaya dari request callback) mengembalikan `authorizationUrl`
+  sebagai JSON (bukan redirect 302), karena dipanggil lewat `fetch()`
+  dari konteks yang sudah authenticated — client men-`window.location`
+  sendiri. `GET .../callback` (satu-satunya redirect target Google)
+  menangani KEDUA purpose lewat satu orkestrator
+  `completeGoogleOAuthCallback` (application layer) berdasarkan kolom
+  `purpose`/`identity_id` di baris `awcms_mini_oidc_auth_requests` yang
+  tersimpan saat start/link — BUKAN dua implementasi terpisah yang bisa
+  divergen soal keamanan.
+- **Verifikasi ID token kriptografis PENUH, bukan sekadar decode JSON**
+  (issue's security note: "Do not trust query parameters alone; validate
+  ID token cryptographically") — signature RS256 lewat WebCrypto
+  `crypto.subtle` (`src/lib/auth/jwt-verify.ts`, TIDAK ada library JWT
+  eksternal), lalu issuer/audience/expiry/nonce
+  (`google-oidc-policy.ts`'s `validateIdTokenClaims`, pure/testable).
+  Setiap kegagalan collapse ke `GOOGLE_ID_TOKEN_INVALID` generik
+  (anti-enumeration, pola sama `MFA_CHALLENGE_INVALID`) — JANGAN
+  bocorkan alasan spesifik (issuer salah vs audience salah vs signature
+  invalid) ke response.
+- **Provider account ditautkan via `sub`, TIDAK PERNAH via email**
+  (issue's security note: "Use `sub` as the stable provider key") —
+  `awcms_mini_identity_provider_accounts`, unique per
+  (tenant, provider, subject) DAN per (tenant, identity, provider).
+  Auto-link by email HANYA aktif bila `email_verified=true` DAN domain
+  email ada di `AUTH_GOOGLE_ALLOWED_DOMAINS` (`isEmailDomainAllowed` —
+  **fail-closed**: list kosong/tidak di-set = auto-link SELALU ditolak,
+  bukan "izinkan semua domain"). Kalau tidak ada provider account yang
+  cocok dan auto-link tidak berlaku → `401 GOOGLE_ACCOUNT_NOT_LINKED`,
+  TIDAK PERNAH provisioning identity baru (self-service registration via
+  Google eksplisit out-of-scope issue ini).
+- **Google login TIDAK PERNAH bypass MFA** (issue's acceptance
+  criterion: "If #589 is implemented and MFA is required, Google login
+  still proceeds through MFA challenge before session creation") —
+  `completeGoogleOAuthCallback` memanggil `findActiveMfaFactor`/
+  `createMfaChallenge` yang SAMA persis dengan `login.ts` (bukan jalur
+  MFA terpisah yang bisa lupa di-wire). Endpoint `callback.ts`
+  mengembalikan `401 MFA_REQUIRED` dengan `mfaChallengeToken` yang sama
+  bentuknya seperti dari `login.ts` — client menyelesaikan lewat
+  `POST /auth/mfa/totp/verify` yang sudah ada, tidak perlu endpoint MFA
+  baru untuk provider OIDC lain.
+- **Circuit breaker HANYA trip pada kegagalan transport genuine** —
+  pelajaran langsung dari bug Turnstile (PR #596 security review, lihat
+  §Cloudflare Turnstile di atas): token exchange yang menjawab `400
+invalid_grant` untuk `code` yang salah/bekas/kedaluwarsa adalah Google
+  BENAR menolak input attacker-controlled, bukan tanda Google unhealthy
+  — `google-oauth-client.ts`'s `exchangeAuthorizationCode` HANYA
+  `recordFailure` pada 5xx/network error/timeout, tidak pernah pada
+  respons 4xx yang valid. JWKS di-cache 1 jam (`fetchGoogleJwks`) —
+  jangan fetch JWKS setiap request.
+- `POST .../link`/`.../unlink`: high-risk, diaudit
+  (`google_account_linked`/`google_account_unlinked`); `callback.ts`
+  login sukses diaudit `google_login_succeeded`.
+- Error code i18n: `error.google_login_disabled`/
+  `_oauth_state_invalid`/`_token_exchange_failed`/`_id_token_invalid`/
+  `_account_not_linked`/`_already_linked`/`_not_linked`/`_misconfigured`
+  (`error-messages.ts`, `i18n/en.po`+`id.po`).
+
 ## Aturan lintas-issue yang wajib diikuti (#588-#593)
 
 1. **Setiap fitur (#588-#592) WAJIB memanggil `isFullOnlineSecurityActive(env)`
@@ -263,26 +346,36 @@ isMfaRequired(env)
    diaudit (`awcms-mini-audit-log`) dan idempotent kalau mutation
    (`awcms-mini-idempotency`).
 7. **Provider identifier stabil adalah `sub` (subject OIDC), bukan
-   email** — auto-link by email (kalau diimplementasikan) wajib
-   mensyaratkan email terverifikasi + kebijakan allowed-domain eksplisit,
-   tidak pernah linking implisit murni dari kecocokan string email.
+   email** — auto-link by email wajib mensyaratkan email terverifikasi +
+   kebijakan allowed-domain eksplisit, tidak pernah linking implisit
+   murni dari kecocokan string email. Sudah diimplementasikan konkret di
+   #590 (`isEmailDomainAllowed`, fail-closed) — #591 (generic tenant OIDC
+   SSO) WAJIB reuse pola yang sama, jangan re-derive.
 8. **Semua panggilan provider eksternal (OIDC discovery/JWKS, Turnstile
-   siteverify) wajib timeout-bounded** — pola sama seperti
-   `cloudflare-dns-adapter.ts`/`mailketing-provider.ts` (`withTimeout`,
-   circuit breaker `getProviderCircuitBreaker`), dan tidak pernah
-   dipanggil di dalam DB transaction (ADR-0006).
-9. **Tabel baru yang tenant-scoped (`awcms_mini_auth_providers`,
-   `awcms_mini_identity_provider_accounts`, `awcms_mini_tenant_auth_policies`,
-   `awcms_mini_identity_mfa_factors`, dst.) wajib RLS `ENABLE` + `FORCE`**
-   — pola sama seperti setiap migration sejak 013 (`awcms-mini-new-migration`).
+   siteverify, Google token exchange) wajib timeout-bounded DAN circuit
+   breaker-nya hanya boleh trip pada kegagalan transport genuine** — pola
+   sama seperti `cloudflare-dns-adapter.ts`/`mailketing-provider.ts`/
+   `turnstile.ts`/`google-oauth-client.ts` (`withTimeout`, circuit
+   breaker `getProviderCircuitBreaker`), dan tidak pernah dipanggil di
+   dalam DB transaction (ADR-0006). JANGAN treat respons 4xx yang valid
+   (input attacker-controlled ditolak provider dengan benar) sebagai
+   provider-failure — pelajaran dari bug Turnstile PR #596, diulang
+   benar di #590's `exchangeAuthorizationCode`.
+9. **Tabel baru yang tenant-scoped (`awcms_mini_identity_provider_accounts`,
+   `awcms_mini_oidc_auth_requests` — #590; `awcms_mini_tenant_auth_policies`
+   dst. untuk #591-#592; `awcms_mini_identity_mfa_factors` dkk. — #589)
+   wajib RLS `ENABLE` + `FORCE`** — pola sama seperti setiap migration
+   sejak 013 (`awcms-mini-new-migration`).
 10. **MFA reset password tidak boleh jadi bypass MFA** — reset password
     yang berhasil tidak otomatis menonaktifkan MFA milik identity itu.
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Tiga fitur (#590-#592) plus dokumentasi/kontrak penutup (#593) masih
+Dua fitur (#591-#592) plus dokumentasi/kontrak penutup (#593) masih
 backlog per 2026-07-09 — gate bersama (#587), Cloudflare Turnstile
-(#588), dan MFA/TOTP (#589) sudah ada di repo ini. Jangan asumsikan
-`awcms_mini_auth_providers` atau endpoint
-`/api/v1/auth/providers/google/*`/`/api/v1/auth/sso/*` sudah ada — cek
-langsung sebelum membangun di atasnya.
+(#588), MFA/TOTP (#589), dan Google OIDC login (#590) sudah ada di repo
+ini. Jangan asumsikan `awcms_mini_auth_providers`,
+`awcms_mini_tenant_auth_policies`, atau endpoint
+`/api/v1/auth/sso/*`/admin policy UI sudah ada — cek langsung sebelum
+membangun di atasnya. `/api/v1/auth/providers/google/*` SUDAH ada
+(#590) — jangan bangun ulang.

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -303,6 +303,32 @@ invalid_grant` untuk `code` yang salah/bekas/kedaluwarsa adalah Google
   `recordFailure` pada 5xx/network error/timeout, tidak pernah pada
   respons 4xx yang valid. JWKS di-cache 1 jam (`fetchGoogleJwks`) —
   jangan fetch JWKS setiap request.
+- **JANGAN pernah INSERT/UPDATE dengan `tenantId` yang belum divalidasi
+  SEBELUM `SELECT` yang aman** — security review PR #598 menemukan
+  `GET .../start` awalnya langsung `INSERT INTO
+awcms_mini_oidc_auth_requests` dengan `tenantId` dari query param
+  tak terautentikasi TANPA mengecek tenant itu benar-benar ada lebih
+  dulu. `tenant_id` punya FK ke `awcms_mini_tenants` — tenant palsu
+  memicu foreign-key violation, dan exception itu ditangkap
+  `withTenant`'s catch-all lalu di-record ke
+  **`getDatabaseCircuitBreaker()`, breaker tunggal APLIKASI-LEBAR**
+  (beda dari breaker per-provider seperti punya Turnstile/Google
+  sendiri — breaker ini dipakai SEMUA endpoint, SEMUA tenant). Lima
+  request dengan `tenantId` acak dari penyerang tak terautentikasi bisa
+  membuka breaker ini dan menjatuhkan SELURUH aplikasi 30 detik,
+  diulang tanpa henti — blast radius lebih besar dari bug Turnstile
+  PR #596. Diperbaiki dengan `SELECT status FROM awcms_mini_tenants
+WHERE id = tenantId` (aman, tidak pernah throw untuk baris kosong)
+  SEBELUM memanggil `createOAuthRequest`, plus rate limiting
+  (`checkRateLimit`, pola sama `login.ts`) sebagai lapis kedua. Fitur
+  online lain (mis. #591 generic SSO) yang punya endpoint tak
+  terautentikasi dengan INSERT/UPDATE ber-FK ke tabel tenant-scoped
+  WAJIB pola yang sama — cek keberadaan/status via SELECT dulu, jangan
+  pernah biarkan sebuah write yang bisa gagal FK constraint jadi baris
+  pertama yang menyentuh DB untuk input tak terautentikasi.
+  Regression test: `google-oidc-flow.integration.test.ts` §"start
+  rejects a nonexistent tenant WITHOUT tripping the shared database
+  circuit breaker".
 - `POST .../link`/`.../unlink`: high-risk, diaudit
   (`google_account_linked`/`google_account_unlinked`); `callback.ts`
   login sukses diaudit `google_login_succeeded`.
@@ -360,7 +386,18 @@ invalid_grant` untuk `code` yang salah/bekas/kedaluwarsa adalah Google
    dalam DB transaction (ADR-0006). JANGAN treat respons 4xx yang valid
    (input attacker-controlled ditolak provider dengan benar) sebagai
    provider-failure — pelajaran dari bug Turnstile PR #596, diulang
-   benar di #590's `exchangeAuthorizationCode`.
+   benar di #590's `exchangeAuthorizationCode`. **Aturan yang sama
+   berlaku untuk breaker DATABASE bawaan** (`getDatabaseCircuitBreaker()`,
+   dipakai `withTenant` untuk SEMUA endpoint/tenant, bukan sekadar satu
+   provider) — endpoint tak terautentikasi TIDAK BOLEH melakukan
+   INSERT/UPDATE ber-FK ke tabel tenant-scoped dengan `tenantId` yang
+   belum divalidasi keberadaannya; exception (mis. foreign-key
+   violation) dari input attacker-controlled akan ditangkap
+   `withTenant`'s catch-all dan mentrip breaker aplikasi-lebar ini —
+   blast radius JAUH lebih besar dari breaker per-provider mana pun
+   (pelajaran PR #598, lihat §Google OIDC login di atas). Selalu
+   `SELECT` (aman, tidak throw untuk baris kosong) sebelum write
+   ber-FK di endpoint yang bisa dijangkau tanpa autentikasi.
 9. **Tabel baru yang tenant-scoped (`awcms_mini_identity_provider_accounts`,
    `awcms_mini_oidc_auth_requests` — #590; `awcms_mini_tenant_auth_policies`
    dst. untuk #591-#592; `awcms_mini_identity_mfa_factors` dkk. — #589)

--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,22 @@ AUTH_MFA_CHALLENGE_TTL_SEC=300
 AUTH_MFA_RATE_LIMIT_MAX=5
 AUTH_MFA_RATE_LIMIT_WINDOW_SEC=300
 
+# Google OIDC login (Issue #590) — GET /auth/providers/google/start,
+# /callback, POST .../link, .../unlink, and a conditional "Continue with
+# Google" button on /login. Only active when the full-online gate above is
+# ALSO on (isGoogleLoginRequired() = full-online gate AND
+# AUTH_GOOGLE_LOGIN_ENABLED=true). Independent of the gate for
+# config:validate purposes, same as Turnstile/MFA above.
+# AUTH_GOOGLE_ALLOWED_DOMAINS gates auto-linking-by-email ONLY — left unset
+# (the default), a verified Google email never auto-links to an existing
+# identity; the user must use POST .../link from an authenticated session
+# instead. Never a secret; comma-separated (e.g. "example.com,example.org").
+AUTH_GOOGLE_LOGIN_ENABLED=false
+# AUTH_GOOGLE_CLIENT_ID=
+# AUTH_GOOGLE_CLIENT_SECRET=
+# AUTH_GOOGLE_ALLOWED_DOMAINS=
+AUTH_GOOGLE_REDIRECT_PATH=/api/v1/auth/providers/google/callback
+
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node
 AWCMS_MINI_SYNC_ENABLED=false

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -65,31 +65,36 @@ Legenda: Wajib = perlu untuk boot; Sensitif = jangan bocor ke log/response.
 
 ### Auth & keamanan
 
-| Var                                         | Wajib          | Default      | Sensitif | Fungsi                                                                                                  |
-| ------------------------------------------- | -------------- | ------------ | -------- | ------------------------------------------------------------------------------------------------------- |
-| `AUTH_JWT_SECRET`                           | Ya             | –            | Ya       | Signing token sesi                                                                                      |
-| `AUTH_SESSION_TTL_MIN`                      | –              | `120`        | –        | Umur sesi                                                                                               |
-| `AUTH_COOKIE_SECURE`                        | –              | `true`       | –        | Cookie hanya HTTPS di prod                                                                              |
-| `AUTH_LOGIN_MAX_ATTEMPTS`                   | –              | `5`          | –        | Lockout login (per identitas)                                                                           |
-| `AUTH_LOGIN_RATE_LIMIT_MAX`                 | –              | `20`         | –        | Rate limit login per sumber+tenant (Issue #437)                                                         |
-| `AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC`          | –              | `60`         | –        | Jendela waktu rate limit login (detik)                                                                  |
-| `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`         | –              | `30`         | –        | Umur token reset password (Issue #496)                                                                  |
-| `AUTH_PASSWORD_RESET_RATE_LIMIT_MAX`        | –              | `5`          | –        | Rate limit forgot/reset per sumber+tenant                                                               |
-| `AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC` | –              | `900`        | –        | Jendela waktu rate limit reset password (detik)                                                         |
-| `AUTH_ONLINE_SECURITY_ENABLED`              | –              | `false`      | –        | Gate full-online-only auth hardening (Issue #587) — lihat §Full-online auth security hardening di bawah |
-| `AUTH_ONLINE_SECURITY_PROFILE`              | –              | `disabled`   | –        | `disabled` (default) atau `full_online`; wajib `full_online` bila `AUTH_ONLINE_SECURITY_ENABLED=true`   |
-| `TURNSTILE_ENABLED`                         | –              | `false`      | –        | Cloudflare Turnstile bot protection (Issue #588) — lihat §Full-online auth security hardening di bawah  |
-| `TURNSTILE_SITE_KEY`                        | bila Turnstile | –            | –        | Site key publik (bukan secret) — dirender di widget `/login`                                            |
-| `TURNSTILE_SECRET_KEY`                      | bila Turnstile | –            | Ya       | Secret key — hanya untuk verifikasi server-side, tidak pernah ke klien                                  |
-| `TURNSTILE_VERIFY_TIMEOUT_MS`               | –              | `5000`       | –        | Timeout panggilan siteverify Cloudflare (ms)                                                            |
-| `AUTH_MFA_ENABLED`                          | –              | `false`      | –        | MFA/TOTP login challenge (Issue #589) — lihat §Full-online auth security hardening di bawah             |
-| `AUTH_MFA_SECRET_ENCRYPTION_KEY`            | bila MFA       | –            | Ya       | Key AES-256-GCM (base64, 32 byte) untuk enkripsi-at-rest TOTP secret                                    |
-| `AUTH_MFA_TOTP_ISSUER`                      | –              | `AWCMS-Mini` | –        | Nama issuer yang tampil di aplikasi authenticator                                                       |
-| `AUTH_MFA_TOTP_PERIOD_SEC`                  | –              | `30`         | –        | Panjang time-step TOTP (detik)                                                                          |
-| `AUTH_MFA_TOTP_DIGITS`                      | –              | `6`          | –        | Jumlah digit kode TOTP (`6` atau `8`)                                                                   |
-| `AUTH_MFA_CHALLENGE_TTL_SEC`                | –              | `300`        | –        | Umur challenge MFA login (detik)                                                                        |
-| `AUTH_MFA_RATE_LIMIT_MAX`                   | –              | `5`          | –        | Rate limit `POST /auth/mfa/totp/verify` per sumber+tenant                                               |
-| `AUTH_MFA_RATE_LIMIT_WINDOW_SEC`            | –              | `300`        | –        | Jendela waktu rate limit verifikasi MFA (detik)                                                         |
+| Var                                         | Wajib          | Default                                  | Sensitif | Fungsi                                                                                                  |
+| ------------------------------------------- | -------------- | ---------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `AUTH_JWT_SECRET`                           | Ya             | –                                        | Ya       | Signing token sesi                                                                                      |
+| `AUTH_SESSION_TTL_MIN`                      | –              | `120`                                    | –        | Umur sesi                                                                                               |
+| `AUTH_COOKIE_SECURE`                        | –              | `true`                                   | –        | Cookie hanya HTTPS di prod                                                                              |
+| `AUTH_LOGIN_MAX_ATTEMPTS`                   | –              | `5`                                      | –        | Lockout login (per identitas)                                                                           |
+| `AUTH_LOGIN_RATE_LIMIT_MAX`                 | –              | `20`                                     | –        | Rate limit login per sumber+tenant (Issue #437)                                                         |
+| `AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC`          | –              | `60`                                     | –        | Jendela waktu rate limit login (detik)                                                                  |
+| `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`         | –              | `30`                                     | –        | Umur token reset password (Issue #496)                                                                  |
+| `AUTH_PASSWORD_RESET_RATE_LIMIT_MAX`        | –              | `5`                                      | –        | Rate limit forgot/reset per sumber+tenant                                                               |
+| `AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC` | –              | `900`                                    | –        | Jendela waktu rate limit reset password (detik)                                                         |
+| `AUTH_ONLINE_SECURITY_ENABLED`              | –              | `false`                                  | –        | Gate full-online-only auth hardening (Issue #587) — lihat §Full-online auth security hardening di bawah |
+| `AUTH_ONLINE_SECURITY_PROFILE`              | –              | `disabled`                               | –        | `disabled` (default) atau `full_online`; wajib `full_online` bila `AUTH_ONLINE_SECURITY_ENABLED=true`   |
+| `TURNSTILE_ENABLED`                         | –              | `false`                                  | –        | Cloudflare Turnstile bot protection (Issue #588) — lihat §Full-online auth security hardening di bawah  |
+| `TURNSTILE_SITE_KEY`                        | bila Turnstile | –                                        | –        | Site key publik (bukan secret) — dirender di widget `/login`                                            |
+| `TURNSTILE_SECRET_KEY`                      | bila Turnstile | –                                        | Ya       | Secret key — hanya untuk verifikasi server-side, tidak pernah ke klien                                  |
+| `TURNSTILE_VERIFY_TIMEOUT_MS`               | –              | `5000`                                   | –        | Timeout panggilan siteverify Cloudflare (ms)                                                            |
+| `AUTH_MFA_ENABLED`                          | –              | `false`                                  | –        | MFA/TOTP login challenge (Issue #589) — lihat §Full-online auth security hardening di bawah             |
+| `AUTH_MFA_SECRET_ENCRYPTION_KEY`            | bila MFA       | –                                        | Ya       | Key AES-256-GCM (base64, 32 byte) untuk enkripsi-at-rest TOTP secret                                    |
+| `AUTH_MFA_TOTP_ISSUER`                      | –              | `AWCMS-Mini`                             | –        | Nama issuer yang tampil di aplikasi authenticator                                                       |
+| `AUTH_MFA_TOTP_PERIOD_SEC`                  | –              | `30`                                     | –        | Panjang time-step TOTP (detik)                                                                          |
+| `AUTH_MFA_TOTP_DIGITS`                      | –              | `6`                                      | –        | Jumlah digit kode TOTP (`6` atau `8`)                                                                   |
+| `AUTH_MFA_CHALLENGE_TTL_SEC`                | –              | `300`                                    | –        | Umur challenge MFA login (detik)                                                                        |
+| `AUTH_MFA_RATE_LIMIT_MAX`                   | –              | `5`                                      | –        | Rate limit `POST /auth/mfa/totp/verify` per sumber+tenant                                               |
+| `AUTH_MFA_RATE_LIMIT_WINDOW_SEC`            | –              | `300`                                    | –        | Jendela waktu rate limit verifikasi MFA (detik)                                                         |
+| `AUTH_GOOGLE_LOGIN_ENABLED`                 | –              | `false`                                  | –        | Google OIDC login (Issue #590) — lihat §Full-online auth security hardening di bawah                    |
+| `AUTH_GOOGLE_CLIENT_ID`                     | bila Google    | –                                        | –        | OAuth client ID dari Google Cloud Console                                                               |
+| `AUTH_GOOGLE_CLIENT_SECRET`                 | bila Google    | –                                        | Ya       | OAuth client secret — hanya untuk token exchange server-side                                            |
+| `AUTH_GOOGLE_ALLOWED_DOMAINS`               | –              | –                                        | –        | Daftar domain email (dipisah koma) yang boleh auto-link; kosong = auto-link selalu ditolak              |
+| `AUTH_GOOGLE_REDIRECT_PATH`                 | –              | `/api/v1/auth/providers/google/callback` | –        | Path callback OAuth di bawah `APP_URL`                                                                  |
 
 ### Full-online auth security hardening (opsional, Issue #587-#593)
 
@@ -152,7 +157,28 @@ online-only ini (lihat `deployment-profiles.md`).
   `last_used_step` per factor. Reset password TIDAK menonaktifkan MFA
   (diverifikasi test integrasi). Detail lengkap: skill
   `awcms-mini-auth-online-hardening`.
-- #590-#593 (Google login, generic SSO, admin policy UI,
+- **Google OIDC login (Issue #590, selesai)** — `AUTH_GOOGLE_LOGIN_ENABLED`
+  divalidasi independen dari gate di atas (`checkGoogleOidcConfig`), tapi
+  aktivasi runtime-nya butuh KEDUANYA
+  (`isGoogleLoginRequired(env)` = gate ∧ `AUTH_GOOGLE_LOGIN_ENABLED=true`).
+  Endpoint baru: `GET /auth/providers/google/start` (redirect ke Google,
+  tombol "Continue with Google" di `/login`), `GET .../callback`
+  (redirect target Google, memvalidasi `state`/nonce/ID token lalu
+  membuat session ATAU memicu `401 MFA_REQUIRED` bila Issue #589 aktif
+  untuk identity itu), `POST .../link` (mulai alur link untuk identity
+  yang sudah login, mengembalikan `authorizationUrl` sebagai JSON, bukan
+  redirect), `POST .../unlink`. Provider account ditautkan via `sub`
+  (subject OIDC), TIDAK PERNAH via email — auto-link by email hanya
+  terjadi bila `email_verified` DAN domain-nya ada di
+  `AUTH_GOOGLE_ALLOWED_DOMAINS` (kosong = auto-link selalu ditolak,
+  fail-closed). ID token diverifikasi kriptografis penuh (signature RS256
+  via WebCrypto, issuer, audience, expiry, nonce) — tidak pernah
+  dipercaya dari query param begitu saja. `state` param membawa prefix
+  tenant id (`${tenantId}.${rawToken}`) karena redirect Google adalah
+  navigasi browser murni yang tidak bisa membawa header
+  `X-AWCMS-Mini-Tenant-ID`. Detail lengkap: skill
+  `awcms-mini-auth-online-hardening`.
+- #591-#593 (generic tenant OIDC SSO, admin policy UI,
   dokumentasi/kontrak penutup) masih backlog — belum diimplementasikan di
   repo ini.
 
@@ -393,6 +419,8 @@ AUTH_MFA_TOTP_DIGITS=6
 AUTH_MFA_CHALLENGE_TTL_SEC=300
 AUTH_MFA_RATE_LIMIT_MAX=5
 AUTH_MFA_RATE_LIMIT_WINDOW_SEC=300
+AUTH_GOOGLE_LOGIN_ENABLED=false
+AUTH_GOOGLE_REDIRECT_PATH=/api/v1/auth/providers/google/callback
 
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node

--- a/docs/awcms-mini/deployment-profiles.md
+++ b/docs/awcms-mini/deployment-profiles.md
@@ -142,9 +142,21 @@ hardening).
     (`POST /auth/mfa/totp/enroll/start` + `/enroll/verify`); identity dengan
     factor aktif akan dihentikan di `401 MFA_REQUIRED` saat login sampai
     menyelesaikan `POST /auth/mfa/totp/verify`.
-    #590-#593 (Google login, generic SSO, admin policy UI,
-    dokumentasi/kontrak penutup) masih backlog, belum diimplementasikan di
-    repo ini.
+- **Google OIDC login (Issue #590, selesai)**: set tambahan
+  `AUTH_GOOGLE_LOGIN_ENABLED=true` + `AUTH_GOOGLE_CLIENT_ID`/
+  `AUTH_GOOGLE_CLIENT_SECRET` (dari Google Cloud Console) untuk
+  mengaktifkan tombol "Continue with Google" di `/login`. Sama seperti
+  Turnstile/MFA, `AUTH_GOOGLE_LOGIN_ENABLED` divalidasi independen dari
+  gate di atas, aktivasi runtime butuh keduanya. Provider account
+  ditautkan via `sub` (subject OIDC), tidak pernah via email — auto-link
+  by email hanya aktif bila operator eksplisit mengisi
+  `AUTH_GOOGLE_ALLOWED_DOMAINS` (kosong = auto-link selalu ditolak). Bila
+  Issue #589 (MFA) juga aktif untuk identity yang login lewat Google, MFA
+  challenge tetap wajib diselesaikan sebelum session dibuat — Google
+  login tidak pernah jadi jalan pintas melewati MFA.
+  #591-#593 (generic tenant OIDC SSO, admin policy UI,
+  dokumentasi/kontrak penutup) masih backlog, belum diimplementasikan di
+  repo ini.
 
 ## Cara menjalankan tiap profil
 

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -21,6 +21,9 @@ msgstr "Password"
 msgid "auth.login.submit"
 msgstr "Sign in"
 
+msgid "auth.login.google_button"
+msgstr "Continue with Google"
+
 msgid "auth.login.generic_error"
 msgstr "Login failed. Try again."
 
@@ -151,6 +154,30 @@ msgstr "This MFA challenge is invalid, expired, or already used."
 
 msgid "error.mfa_misconfigured"
 msgstr "Multi-factor authentication is misconfigured on this server."
+
+msgid "error.google_login_disabled"
+msgstr "Google login is not enabled for this deployment."
+
+msgid "error.google_oauth_state_invalid"
+msgstr "Google sign-in could not be verified. Please try again."
+
+msgid "error.google_token_exchange_failed"
+msgstr "Google sign-in could not be completed. Please try again."
+
+msgid "error.google_id_token_invalid"
+msgstr "Google sign-in could not be verified. Please try again."
+
+msgid "error.google_account_not_linked"
+msgstr "No account is linked to this Google account."
+
+msgid "error.google_already_linked"
+msgstr "A Google account is already linked."
+
+msgid "error.google_not_linked"
+msgstr "No Google account is currently linked."
+
+msgid "error.google_misconfigured"
+msgstr "Google login is misconfigured on this server."
 
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -21,6 +21,9 @@ msgstr "Kata sandi"
 msgid "auth.login.submit"
 msgstr "Masuk"
 
+msgid "auth.login.google_button"
+msgstr "Lanjutkan dengan Google"
+
 msgid "auth.login.generic_error"
 msgstr "Login gagal. Coba lagi."
 
@@ -151,6 +154,30 @@ msgstr "Tantangan MFA ini tidak valid, kedaluwarsa, atau sudah digunakan."
 
 msgid "error.mfa_misconfigured"
 msgstr "Autentikasi multi-faktor salah konfigurasi di server ini."
+
+msgid "error.google_login_disabled"
+msgstr "Login Google tidak diaktifkan untuk deployment ini."
+
+msgid "error.google_oauth_state_invalid"
+msgstr "Login Google tidak dapat diverifikasi. Silakan coba lagi."
+
+msgid "error.google_token_exchange_failed"
+msgstr "Login Google tidak dapat diselesaikan. Silakan coba lagi."
+
+msgid "error.google_id_token_invalid"
+msgstr "Login Google tidak dapat diverifikasi. Silakan coba lagi."
+
+msgid "error.google_account_not_linked"
+msgstr "Tidak ada akun yang tertaut dengan akun Google ini."
+
+msgid "error.google_already_linked"
+msgstr "Akun Google sudah tertaut."
+
+msgid "error.google_not_linked"
+msgstr "Tidak ada akun Google yang sedang tertaut."
+
+msgid "error.google_misconfigured"
+msgstr "Login Google salah konfigurasi di server ini."
 
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -1180,6 +1180,213 @@ paths:
                 $ref: "#/components/schemas/ApiError"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/auth/providers/google/start:
+    get:
+      tags:
+        - Identity & Access
+      summary: Redirect to Google's OAuth Authorization Code endpoint (login)
+      description: >-
+        Full-online-only (Issue #590) — `403 GOOGLE_LOGIN_DISABLED` unless
+        the #587 gate AND `AUTH_GOOGLE_LOGIN_ENABLED=true` are both active.
+        Unauthenticated entry point reached from the "Continue with Google"
+        button on `/login`. Accepts `tenantId` via the
+        `X-AWCMS-Mini-Tenant-ID` header, the tenant cookie, or a `?tenantId=`
+        query param (the login page has no tenant cookie yet, and a plain
+        browser navigation can't set a custom header). Always a `login`
+        intent — see `POST .../link` for the authenticated linking flow.
+      operationId: authGoogleStart
+      security:
+        - tenantHeader: []
+      parameters:
+        - name: tenantId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Fallback tenant id when neither the header nor cookie is present.
+      responses:
+        "302":
+          description: Redirect to Google's authorization endpoint.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          description: Google login is not enabled for this deployment (`GOOGLE_LOGIN_DISABLED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/providers/google/callback:
+    get:
+      tags:
+        - Identity & Access
+      summary: Google's OAuth redirect target — completes login or link
+      description: >-
+        Full-online-only (Issue #590). A plain top-level browser
+        navigation, never a `fetch()` call — Google redirects here with
+        `code`+`state` (or `error` if the user cancelled consent).
+        Validates `state` (CSRF/replay defense) and the ID token's
+        signature, issuer, audience, expiry, and nonce cryptographically
+        before trusting any claim. For a `login`-purpose request: creates
+        the existing AWCMS-Mini session type (or, if Issue #589's MFA gate
+        is active and the identity has an active factor, returns
+        `401 MFA_REQUIRED` exactly like `POST /auth/login` — Google login
+        never bypasses MFA). For a `link`-purpose request (from
+        `POST .../link`): attaches the verified Google account to the
+        identity captured server-side at link-initiation time.
+      operationId: authGoogleCallback
+      security:
+        - tenantHeader: []
+      parameters:
+        - name: code
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: state
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: error
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Present when the user cancelled/denied consent at Google.
+      responses:
+        "302":
+          description: Login or link succeeded; redirects to `/admin`.
+        "400":
+          description: Missing or malformed `state` (`GOOGLE_OAUTH_STATE_INVALID`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: >-
+            The state/nonce/ID token could not be verified
+            (`GOOGLE_OAUTH_STATE_INVALID`/`GOOGLE_TOKEN_EXCHANGE_FAILED`/
+            `GOOGLE_ID_TOKEN_INVALID`/`GOOGLE_ACCOUNT_NOT_LINKED`), or MFA
+            must be completed first (`MFA_REQUIRED`,
+            `LoginMfaRequiredResponse`).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/ApiError"
+                  - $ref: "#/components/schemas/LoginMfaRequiredResponse"
+        "403":
+          description: >-
+            Google login is not enabled for this deployment
+            (`GOOGLE_LOGIN_DISABLED`), or the resolved identity/tenant is
+            not active (`ACCESS_DENIED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: This Google subject is already linked to a different identity (`GOOGLE_ALREADY_LINKED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/providers/google/link:
+    post:
+      tags:
+        - Identity & Access
+      summary: Start linking the caller's own identity to a Google account
+      description: >-
+        Full-online-only (Issue #590). Authenticated: creates a
+        `link`-purpose OAuth request bound to the caller's own identity
+        (captured server-side, never trusted from the callback request) and
+        returns the Google authorization URL as JSON — invoked via
+        `fetch()` from an authenticated context, so the client navigates
+        itself (`window.location = data.authorizationUrl`) rather than
+        receiving a redirect.
+      operationId: authGoogleLink
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Link-purpose OAuth request created.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/GoogleLinkStartResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Google login is not enabled for this deployment (`GOOGLE_LOGIN_DISABLED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/providers/google/unlink:
+    post:
+      tags:
+        - Identity & Access
+      summary: Unlink the caller's own Google account
+      description: >-
+        Full-online-only (Issue #590). High-risk, audited
+        (`google_account_unlinked`). Never touches local password login —
+        removing a Google link cannot lock an identity out of its own
+        account.
+      operationId: authGoogleUnlink
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Google account unlinked.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/GoogleUnlinkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Google login is not enabled for this deployment (`GOOGLE_LOGIN_DISABLED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: No Google account is currently linked (`GOOGLE_NOT_LINKED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/auth/password/forgot:
     post:
       tags:
@@ -7015,6 +7222,25 @@ components:
           description: >-
             10 fresh single-use recovery codes, shown exactly once — every
             previously issued code stops working immediately.
+    GoogleLinkStartResponse:
+      type: object
+      required:
+        - authorizationUrl
+      additionalProperties: false
+      properties:
+        authorizationUrl:
+          type: string
+          description: >-
+            Google's authorization URL — the client navigates itself here
+            (`window.location = authorizationUrl`).
+    GoogleUnlinkResponse:
+      type: object
+      required:
+        - unlinked
+      additionalProperties: false
+      properties:
+        unlinked:
+          type: boolean
     LogoutResponse:
       type: object
       required:

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -37,6 +37,7 @@ import { resolveAppBaseUrl } from "./lib/app-url";
 import { checkRateLimit } from "../src/lib/security/rate-limit";
 import {
   checkEmailConfig,
+  checkGoogleOidcConfig,
   checkMfaConfig,
   checkOnlineAuthSecurityConfig,
   checkTurnstileConfig
@@ -931,6 +932,48 @@ export function checkMfaReady(
   };
 }
 
+/**
+ * Reuses `checkGoogleOidcConfig` from `validate-env.ts` verbatim — same
+ * pattern and rationale as `checkTurnstileReady`/`checkMfaReady` above.
+ */
+export function checkGoogleOidcReady(
+  env: NodeJS.ProcessEnv = process.env
+): SecurityCheckResult {
+  const name = "Google OIDC configuration is complete when enabled";
+  const severity: CheckSeverity = "critical";
+  const results = checkGoogleOidcConfig(env);
+  const failed = results.filter((result) => result.status === "fail");
+
+  if (failed.length > 0) {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `AUTH_GOOGLE_LOGIN_ENABLED=true but config is incomplete: ${failed
+        .map((result) => result.detail)
+        .join(" ")}`
+    };
+  }
+
+  if (env.AUTH_GOOGLE_LOGIN_ENABLED !== "true") {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence:
+        'AUTH_GOOGLE_LOGIN_ENABLED is not "true" — Google OIDC config not required.'
+    };
+  }
+
+  return {
+    name,
+    severity,
+    status: "pass",
+    evidence:
+      "AUTH_GOOGLE_LOGIN_ENABLED=true and all conditional Google OIDC config check(s) pass."
+  };
+}
+
 // ---------------------------------------------------------------------------
 // 10. Errors don't leak stack traces (warning/info, best-effort)
 // ---------------------------------------------------------------------------
@@ -1174,6 +1217,7 @@ export async function runSecurityReadinessChecks(): Promise<
     checkOnlineAuthSecurityReady(),
     checkTurnstileReady(),
     checkMfaReady(),
+    checkGoogleOidcReady(),
     await checkErrorsDontLeakStackTraces(),
     await checkSecurityHeadersPresent(),
     checkLoginRateLimitImplemented()

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -147,6 +147,10 @@ import {
   isMfaEnabled
 } from "../src/lib/auth/mfa-config";
 import { resolveMfaEncryptionKey } from "../src/lib/auth/mfa-secret-crypto";
+import {
+  GOOGLE_OIDC_REQUIRED_WHEN_ENABLED,
+  isGoogleLoginEnabled
+} from "../src/lib/auth/google-oidc-config";
 
 export type EnvCheckResult = {
   name: string;
@@ -665,6 +669,44 @@ export function checkMfaConfig(
   });
 }
 
+/**
+ * Google OIDC login (Issue #590, epic: full-online auth hardening).
+ * `AUTH_GOOGLE_LOGIN_ENABLED` left unset (or anything other than `"true"`)
+ * requires nothing else — same "unset/off requires nothing" shape as
+ * `checkTurnstileConfig`/`checkMfaConfig`, and validated independently of
+ * the #587 gate for the same reason (an operator can provision Google
+ * OAuth credentials ahead of time). `AUTH_GOOGLE_ALLOWED_DOMAINS` is
+ * intentionally never required here — leaving it unset simply means
+ * auto-linking-by-email is never allowed (`isEmailDomainAllowed` fails
+ * closed), a safe default, not a misconfiguration.
+ */
+export function checkGoogleOidcConfig(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult[] {
+  if (!isGoogleLoginEnabled(env)) {
+    return [
+      {
+        name: "Google OIDC config (conditional on AUTH_GOOGLE_LOGIN_ENABLED)",
+        status: "pass",
+        detail:
+          'AUTH_GOOGLE_LOGIN_ENABLED is not "true" — Google OIDC config not required.'
+      }
+    ];
+  }
+
+  return GOOGLE_OIDC_REQUIRED_WHEN_ENABLED.map((name) => {
+    if (!isSet(env[name])) {
+      return {
+        name,
+        status: "fail",
+        detail: `AUTH_GOOGLE_LOGIN_ENABLED=true but ${name} is missing or empty.`
+      };
+    }
+
+    return { name, status: "pass", detail: `${name} is set.` };
+  });
+}
+
 export function runEnvValidation(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -677,6 +719,7 @@ export function runEnvValidation(
     ...checkTenantDomainDnsConfig(env),
     ...checkTurnstileConfig(env),
     ...checkMfaConfig(env),
+    ...checkGoogleOidcConfig(env),
     ...checkOnlineAuthSecurityConfig(env)
   ];
 }

--- a/sql/035_awcms_mini_google_oidc_schema.sql
+++ b/sql/035_awcms_mini_google_oidc_schema.sql
@@ -1,0 +1,85 @@
+-- Google OIDC login (Issue #590, epic: full-online auth hardening #587-#593).
+-- Active only when the #587 gate is active AND AUTH_GOOGLE_LOGIN_ENABLED=true
+-- (`isGoogleLoginRequired`, `src/lib/auth/google-oidc-config.ts`) — these two
+-- tables exist on every deployment (migrations always run), but stay
+-- entirely empty/unused on local/offline/LAN deployments that never enable
+-- the feature.
+--
+-- `awcms_mini_identity_provider_accounts` — links an identity to an external
+-- OIDC provider's stable subject (`sub`), NEVER by email (issue's own
+-- security note: "Account linking by provider subject (sub), not email").
+-- `provider` is a free column (not yet constrained to a fixed set) since
+-- Issue #591 (generic tenant OIDC SSO) will add more provider values on top
+-- of `google` without needing a schema change here.
+CREATE TABLE IF NOT EXISTS awcms_mini_identity_provider_accounts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  identity_id uuid NOT NULL REFERENCES awcms_mini_identities (id),
+  provider text NOT NULL,
+  provider_subject text NOT NULL,
+  linked_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- The lookup path at callback time (WHERE tenant_id = ? AND provider = ?
+-- AND provider_subject = ?) and the invariant "one provider account per
+-- (tenant, provider, subject)" share this single unique index.
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_identity_provider_accounts_subject_key
+  ON awcms_mini_identity_provider_accounts (tenant_id, provider, provider_subject);
+
+-- An identity may only link ONE account per provider (re-linking the same
+-- provider replaces, never duplicates) — the unlink/link application logic
+-- also enforces this, this index is the DB-level backstop.
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_identity_provider_accounts_identity_key
+  ON awcms_mini_identity_provider_accounts (tenant_id, identity_id, provider);
+
+ALTER TABLE awcms_mini_identity_provider_accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_identity_provider_accounts FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_identity_provider_accounts_tenant_isolation
+  ON awcms_mini_identity_provider_accounts
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- `awcms_mini_oidc_auth_requests` — the ephemeral bridge across the OAuth
+-- redirect round-trip (browser leaves this app, goes to Google, comes back)
+-- — same "ephemeral row, hash-only token, TTL, single-use" shape as
+-- `awcms_mini_mfa_challenges` (Issue #589). `state_hash` is the CSRF/replay
+-- defense (issue's own acceptance criterion: "OAuth/OIDC callback rejects
+-- invalid or missing state"); `nonce` is stored PLAINTEXT (not hashed, unlike
+-- `state`) because it must be compared against the value literally embedded
+-- in the returned ID token's `nonce` claim — it is not a bearer credential
+-- itself (possessing it grants nothing without also completing the OAuth
+-- code exchange), unlike `state`/session/reset tokens which ARE bearer
+-- credentials and are therefore always hashed at rest. `purpose` distinguishes
+-- an unauthenticated login attempt from an authenticated user linking a
+-- second (Google) login method to their existing identity; `identity_id` is
+-- only ever set for `purpose = 'link'` (the identity requesting the link,
+-- captured server-side at `start` time so `callback`/`link` never has to
+-- trust a client-supplied identity id).
+CREATE TABLE IF NOT EXISTS awcms_mini_oidc_auth_requests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  provider text NOT NULL,
+  state_hash text NOT NULL,
+  nonce text NOT NULL,
+  purpose text NOT NULL,
+  identity_id uuid REFERENCES awcms_mini_identities (id),
+  expires_at timestamptz NOT NULL,
+  consumed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_mini_oidc_auth_requests_purpose_check
+    CHECK (purpose IN ('login', 'link')),
+  CONSTRAINT awcms_mini_oidc_auth_requests_link_has_identity_check
+    CHECK (purpose <> 'link' OR identity_id IS NOT NULL)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_oidc_auth_requests_hash_key
+  ON awcms_mini_oidc_auth_requests (state_hash);
+
+ALTER TABLE awcms_mini_oidc_auth_requests ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_oidc_auth_requests FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_oidc_auth_requests_tenant_isolation
+  ON awcms_mini_oidc_auth_requests
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/src/lib/auth/google-oauth-client.ts
+++ b/src/lib/auth/google-oauth-client.ts
@@ -1,0 +1,210 @@
+/**
+ * Google OAuth/OIDC network calls (Issue #590) — authorization-code token
+ * exchange and JWKS fetch. Same timeout + circuit-breaker pattern as
+ * `../security/turnstile.ts`/`tenant-domain/infrastructure/cloudflare-dns-adapter.ts`
+ * — and the SAME fix PR #596's security review forced onto Turnstile: the
+ * circuit breaker only trips on a genuine transport-level problem with
+ * Google's endpoints (non-2xx HTTP status the caller didn't itself cause,
+ * network error, timeout), NEVER on a well-formed error response driven by
+ * attacker-controlled input (e.g. a bad/reused/expired authorization `code`
+ * — Google's token endpoint answers that with `400 {"error":"invalid_grant"}`,
+ * which is Google correctly rejecting a bad client request, not Google being
+ * unhealthy). Getting this wrong a second time, after #596, would let anyone
+ * lock out Google login for every tenant by replaying a handful of stale
+ * authorization codes.
+ */
+import { getProviderCircuitBreaker } from "../database/circuit-breaker";
+import { withTimeout } from "../integration/timeout";
+import {
+  GOOGLE_OIDC_ENDPOINTS,
+  resolveGoogleRedirectPath
+} from "./google-oidc-config";
+import { buildOAuthStateParam } from "./oauth-state-token";
+
+export type BuildAuthorizationUrlParams = {
+  clientId: string;
+  tenantId: string;
+  state: string;
+  nonce: string;
+};
+
+/** Resolves the `redirect_uri` Google is told to send the browser back to — always this deployment's own `AUTH_GOOGLE_REDIRECT_PATH` under `APP_URL`, never client-supplied (open-redirect prevention). */
+export function resolveGoogleRedirectUri(
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const appUrl = env.APP_URL ?? "http://localhost:4321";
+  return new URL(resolveGoogleRedirectPath(env), appUrl).toString();
+}
+
+/** Builds the full `https://accounts.google.com/o/oauth2/v2/auth?...` URL for `start.ts`/`link.ts` to redirect to. */
+export function buildGoogleAuthorizationUrl(
+  params: BuildAuthorizationUrlParams
+): string {
+  const authorizationUrl = new URL(GOOGLE_OIDC_ENDPOINTS.authorizationEndpoint);
+  authorizationUrl.searchParams.set("client_id", params.clientId);
+  authorizationUrl.searchParams.set("redirect_uri", resolveGoogleRedirectUri());
+  authorizationUrl.searchParams.set("response_type", "code");
+  authorizationUrl.searchParams.set("scope", "openid email profile");
+  authorizationUrl.searchParams.set(
+    "state",
+    buildOAuthStateParam(params.tenantId, params.state)
+  );
+  authorizationUrl.searchParams.set("nonce", params.nonce);
+
+  return authorizationUrl.toString();
+}
+
+const TOKEN_EXCHANGE_BREAKER_KEY = "google-oidc-token";
+const JWKS_BREAKER_KEY = "google-oidc-jwks";
+const DEFAULT_TIMEOUT_MS = 5_000;
+const JWKS_CACHE_TTL_MS = 60 * 60 * 1000;
+
+export type ExchangeCodeParams = {
+  code: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  timeoutMs?: number;
+  /** Test-only override for `GOOGLE_OIDC_ENDPOINTS.tokenEndpoint`. */
+  tokenEndpoint?: string;
+};
+
+export type ExchangeCodeResult =
+  { ok: true; idToken: string } | { ok: false; retryable: boolean };
+
+/**
+ * Authorization Code exchange (issue's own security note: "Use
+ * Authorization Code flow with state and nonce"). A non-2xx response is
+ * only ever treated as a provider-transport failure (breaker-tripping) when
+ * it's a genuine server error (5xx) — Google's own documented `400
+ * invalid_grant`/`invalid_client` responses for a bad `code` are the
+ * expected, attacker-repeatable outcome for garbage input and must never
+ * trip the shared breaker (see file header).
+ */
+export async function exchangeAuthorizationCode(
+  params: ExchangeCodeParams
+): Promise<ExchangeCodeResult> {
+  const breaker = getProviderCircuitBreaker(TOKEN_EXCHANGE_BREAKER_KEY);
+  const attemptedAt = new Date();
+
+  if (!breaker.canAttempt(attemptedAt)) {
+    return { ok: false, retryable: true };
+  }
+
+  const body = new URLSearchParams({
+    code: params.code,
+    client_id: params.clientId,
+    client_secret: params.clientSecret,
+    redirect_uri: params.redirectUri,
+    grant_type: "authorization_code"
+  });
+
+  try {
+    const response = await withTimeout(
+      fetch(params.tokenEndpoint ?? GOOGLE_OIDC_ENDPOINTS.tokenEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString()
+      }),
+      params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      "google oidc token exchange"
+    );
+
+    const rawBody = await response.text().catch(() => "");
+    let parsed: { id_token?: string } | undefined;
+
+    try {
+      parsed = rawBody
+        ? (JSON.parse(rawBody) as { id_token?: string })
+        : undefined;
+    } catch {
+      parsed = undefined;
+    }
+
+    if (response.status >= 500 || response.status === 0 || !parsed) {
+      breaker.recordFailure(attemptedAt);
+      return { ok: false, retryable: true };
+    }
+
+    if (response.status < 200 || response.status >= 300 || !parsed.id_token) {
+      // Google correctly answered a bad request (invalid_grant, expired/
+      // reused code, wrong redirect_uri, etc.) — a healthy-provider signal,
+      // not a failure of Google itself.
+      breaker.recordSuccess(attemptedAt);
+      return { ok: false, retryable: false };
+    }
+
+    breaker.recordSuccess(attemptedAt);
+    return { ok: true, idToken: parsed.id_token };
+  } catch {
+    breaker.recordFailure(attemptedAt);
+    return { ok: false, retryable: true };
+  }
+}
+
+export type GoogleJwks = { keys: Record<string, unknown>[] };
+
+let cachedJwks: { jwks: GoogleJwks; fetchedAt: number } | null = null;
+
+export type FetchJwksParams = {
+  timeoutMs?: number;
+  /** Test-only override for `GOOGLE_OIDC_ENDPOINTS.jwksUri`. */
+  jwksUri?: string;
+};
+
+export type FetchJwksResult = { ok: true; jwks: GoogleJwks } | { ok: false };
+
+/**
+ * Fetches (and caches for `JWKS_CACHE_TTL_MS`, matching standard JWKS
+ * client practice — Google's own keys rotate infrequently) Google's public
+ * signing keys. Same breaker-tripping rule as `exchangeAuthorizationCode`:
+ * only a genuine transport failure counts.
+ */
+export async function fetchGoogleJwks(
+  params: FetchJwksParams = {}
+): Promise<FetchJwksResult> {
+  const now = Date.now();
+
+  if (cachedJwks && now - cachedJwks.fetchedAt < JWKS_CACHE_TTL_MS) {
+    return { ok: true, jwks: cachedJwks.jwks };
+  }
+
+  const breaker = getProviderCircuitBreaker(JWKS_BREAKER_KEY);
+  const attemptedAt = new Date();
+
+  if (!breaker.canAttempt(attemptedAt)) {
+    return { ok: false };
+  }
+
+  try {
+    const response = await withTimeout(
+      fetch(params.jwksUri ?? GOOGLE_OIDC_ENDPOINTS.jwksUri),
+      params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      "google oidc jwks fetch"
+    );
+
+    if (response.status < 200 || response.status >= 300) {
+      breaker.recordFailure(attemptedAt);
+      return { ok: false };
+    }
+
+    const jwks = (await response.json().catch(() => null)) as GoogleJwks | null;
+
+    if (!jwks || !Array.isArray(jwks.keys)) {
+      breaker.recordFailure(attemptedAt);
+      return { ok: false };
+    }
+
+    breaker.recordSuccess(attemptedAt);
+    cachedJwks = { jwks, fetchedAt: now };
+    return { ok: true, jwks };
+  } catch {
+    breaker.recordFailure(attemptedAt);
+    return { ok: false };
+  }
+}
+
+/** Test-only: clears the in-memory JWKS cache so test files don't bleed into each other. */
+export function resetGoogleJwksCacheForTests(): void {
+  cachedJwks = null;
+}

--- a/src/lib/auth/google-oidc-config.ts
+++ b/src/lib/auth/google-oidc-config.ts
@@ -1,0 +1,84 @@
+/**
+ * Google OIDC login config gate (Issue #590, epic: full-online auth
+ * hardening). Mirrors `../security/turnstile.ts`'s `isTurnstileRequired`
+ * and `./mfa-config.ts`'s `isMfaRequired` shape exactly — `isGoogleLoginRequired`
+ * is the ONE function every Google-login endpoint and `login.astro` checks;
+ * local/offline/LAN deployments never read these env vars, never call
+ * Google, never render the button.
+ */
+import { isFullOnlineSecurityActive } from "./online-security-config";
+
+const DEFAULT_REDIRECT_PATH = "/api/v1/auth/providers/google/callback";
+
+/** Google's own, fixed OIDC endpoints — this issue is Google-specific (a generic OIDC provider is Issue #591), so these are hardcoded constants, not discovered via `.well-known/openid-configuration` at runtime (one fewer external call and failure mode per login attempt). */
+export const GOOGLE_OIDC_ENDPOINTS = {
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  jwksUri: "https://www.googleapis.com/oauth2/v3/certs",
+  /** Google's ID tokens use either form as `iss` depending on token version — both are accepted. */
+  issuers: ["https://accounts.google.com", "accounts.google.com"] as const
+};
+
+/**
+ * Env vars required only when `AUTH_GOOGLE_LOGIN_ENABLED=true`
+ * (`scripts/validate-env.ts`'s `checkGoogleOidcConfig`).
+ */
+export const GOOGLE_OIDC_REQUIRED_WHEN_ENABLED = [
+  "AUTH_GOOGLE_CLIENT_ID",
+  "AUTH_GOOGLE_CLIENT_SECRET"
+] as const;
+
+export function isGoogleLoginEnabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return env.AUTH_GOOGLE_LOGIN_ENABLED === "true";
+}
+
+/**
+ * The single boolean every Google-login endpoint and `login.astro` must
+ * check before doing anything Google/OIDC-related — true only when BOTH the
+ * full-online gate (Issue #587) and this feature's own flag agree. Matches
+ * the issue's acceptance criterion "Google login is active only when #587
+ * gate is enabled and AUTH_GOOGLE_LOGIN_ENABLED=true."
+ */
+export function isGoogleLoginRequired(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return isFullOnlineSecurityActive(env) && isGoogleLoginEnabled(env);
+}
+
+export function resolveGoogleClientId(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  return env.AUTH_GOOGLE_CLIENT_ID;
+}
+
+export function resolveGoogleClientSecret(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  return env.AUTH_GOOGLE_CLIENT_SECRET;
+}
+
+/** Comma-separated list, trimmed, lowercased, empty entries dropped. An empty result means auto-linking-by-email is never allowed (fail closed — see `google-oidc-policy.ts`'s `isEmailDomainAllowed`). */
+export function resolveGoogleAllowedDomains(
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  const raw = env.AUTH_GOOGLE_ALLOWED_DOMAINS;
+
+  if (!raw) {
+    return [];
+  }
+
+  return raw
+    .split(",")
+    .map((domain) => domain.trim().toLowerCase())
+    .filter((domain) => domain.length > 0);
+}
+
+export function resolveGoogleRedirectPath(
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const raw = env.AUTH_GOOGLE_REDIRECT_PATH?.trim();
+
+  return raw && raw.length > 0 ? raw : DEFAULT_REDIRECT_PATH;
+}

--- a/src/lib/auth/jwt-verify.ts
+++ b/src/lib/auth/jwt-verify.ts
@@ -1,0 +1,101 @@
+/**
+ * Minimal RS256 JWT verification for OIDC ID tokens (Issue #590, epic:
+ * full-online auth hardening). Deliberately dependency-free (Bun-only rule:
+ * no `jose`/`jsonwebtoken`) — signature verification itself is delegated to
+ * the platform's own WebCrypto (`crypto.subtle`, available natively in Bun),
+ * so this file only handles JWT framing (base64url, header/payload parsing)
+ * and JWKS-key selection, never hand-rolled RSA math.
+ *
+ * Scope is intentionally narrow: RS256 only (the only algorithm Google's ID
+ * tokens use), and claim *extraction* only — issuer/audience/expiry/nonce
+ * *policy* decisions live in `../../modules/identity-access/domain/
+ * google-oidc-policy.ts` (pure, testable without a network/JWKS call).
+ */
+function base64UrlDecode(segment: string): Buffer {
+  const padded = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const padLength = (4 - (padded.length % 4)) % 4;
+  return Buffer.from(padded + "=".repeat(padLength), "base64");
+}
+
+export type JwtHeader = { alg?: string; kid?: string; typ?: string };
+export type JwtPayload = Record<string, unknown>;
+
+export type ParsedJwt = {
+  header: JwtHeader;
+  payload: JwtPayload;
+  signingInput: string;
+  signature: Buffer;
+};
+
+/** Splits and base64url-decodes a compact JWT — throws on any structural malformation. Never verifies the signature (see `verifyJwtRs256`). */
+export function parseJwt(token: string): ParsedJwt {
+  const parts = token.split(".");
+
+  if (parts.length !== 3) {
+    throw new Error("Malformed JWT: expected exactly 3 dot-separated parts.");
+  }
+
+  const [headerPart, payloadPart, signaturePart] = parts;
+  const header = JSON.parse(
+    base64UrlDecode(headerPart!).toString("utf8")
+  ) as JwtHeader;
+  const payload = JSON.parse(
+    base64UrlDecode(payloadPart!).toString("utf8")
+  ) as JwtPayload;
+
+  return {
+    header,
+    payload,
+    signingInput: `${headerPart}.${payloadPart}`,
+    signature: base64UrlDecode(signaturePart!)
+  };
+}
+
+export type Jwk = {
+  kty: string;
+  kid?: string;
+  alg?: string;
+  n?: string;
+  e?: string;
+  use?: string;
+};
+
+/** Finds the JWKS entry matching `kid` — Google rotates signing keys, so the ID token's `kid` header always identifies which of several published keys was used. */
+export function findJwk(jwks: { keys: Jwk[] }, kid: string): Jwk | null {
+  return jwks.keys.find((key) => key.kid === kid) ?? null;
+}
+
+/**
+ * Verifies an RS256 signature over `signingInput` using an RSA public JWK,
+ * via WebCrypto (`crypto.subtle`) — never a hand-rolled implementation.
+ * Returns `false` (never throws) for a malformed/unusable key, so a bad JWKS
+ * response degrades to "verification failed", not a crash.
+ */
+export async function verifyJwtRs256(
+  signingInput: string,
+  signature: Buffer,
+  jwk: Jwk
+): Promise<boolean> {
+  if (jwk.kty !== "RSA") {
+    return false;
+  }
+
+  try {
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      { kty: jwk.kty, n: jwk.n, e: jwk.e, alg: "RS256", ext: true },
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      false,
+      ["verify"]
+    );
+
+    return await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      key,
+      new Uint8Array(signature),
+      new TextEncoder().encode(signingInput)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/auth/oauth-state-token.ts
+++ b/src/lib/auth/oauth-state-token.ts
@@ -1,0 +1,63 @@
+/**
+ * OAuth `state` param generation/hashing (Issue #590) — same shape as
+ * `session-token.ts`/`mfa-challenge-token.ts` (32 random bytes, base64url;
+ * sha256 hex with a `sha256:` prefix). `state` IS a bearer credential (its
+ * mere possession, embedded in the callback URL, is what the callback trusts
+ * to correlate the redirect back to the request that started it), so it is
+ * hashed at rest exactly like a session/reset/challenge token — unlike the
+ * OIDC `nonce`, which is stored plaintext (see `sql/035...`'s comment on
+ * `awcms_mini_oidc_auth_requests`).
+ */
+import { createHash, randomBytes } from "node:crypto";
+
+export function generateOAuthState(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function hashOAuthState(state: string): string {
+  return `sha256:${createHash("sha256").update(state).digest("hex")}`;
+}
+
+/** The OIDC `nonce` — plaintext (not a bearer credential; see file header). */
+export function generateOidcNonce(): string {
+  return randomBytes(24).toString("base64url");
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Google's redirect back to `callback.ts` is a plain top-level browser
+ * navigation — there is no way to attach our usual
+ * `X-AWCMS-Mini-Tenant-ID` header to it, so the tenant id must travel
+ * inside the `state` query param itself. `buildOAuthStateParam`/
+ * `parseOAuthStateParam` embed it as a `${tenantId}.${rawToken}` prefix —
+ * safe because a tenant id is not a secret, and the token portion (the
+ * actual CSRF/replay defense, always ≥32 random bytes) is unchanged and
+ * still hashed at rest exactly as if it travelled alone.
+ */
+export function buildOAuthStateParam(
+  tenantId: string,
+  rawToken: string
+): string {
+  return `${tenantId}.${rawToken}`;
+}
+
+export function parseOAuthStateParam(
+  stateParam: string
+): { tenantId: string; token: string } | null {
+  const separatorIndex = stateParam.indexOf(".");
+
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  const tenantId = stateParam.slice(0, separatorIndex);
+  const token = stateParam.slice(separatorIndex + 1);
+
+  if (!UUID_PATTERN.test(tenantId) || token.length === 0) {
+    return null;
+  }
+
+  return { tenantId, token };
+}

--- a/src/lib/auth/oauth-state-token.ts
+++ b/src/lib/auth/oauth-state-token.ts
@@ -7,6 +7,18 @@
  * hashed at rest exactly like a session/reset/challenge token — unlike the
  * OIDC `nonce`, which is stored plaintext (see `sql/035...`'s comment on
  * `awcms_mini_oidc_auth_requests`).
+ *
+ * `hashOAuthState` uses a fast hash (sha256), deliberately — same reasoning
+ * `password-reset-token.ts` documents for its own `hashResetToken`: `state`
+ * is a 256-bit CSPRNG value (`generateOAuthState`), not a user-chosen
+ * low-entropy secret, so a slow adaptive hash (bcrypt/argon2/scrypt) would
+ * only cost every callback verification for no real benefit — offline
+ * brute-forcing a 256-bit random value is infeasible regardless of hash
+ * speed. CodeQL's `js/insufficient-password-hash` query has been observed
+ * to flag this exact shape as a false positive (fast hash of a token whose
+ * value later gets compared for equality, which structurally resembles
+ * password verification) — this is the same known, accepted false-positive
+ * class `password-reset-token.ts` already documents for `hashResetToken`.
  */
 import { createHash, randomBytes } from "node:crypto";
 

--- a/src/lib/i18n/error-messages.ts
+++ b/src/lib/i18n/error-messages.ts
@@ -10,7 +10,11 @@ import type { Translator } from "./translate";
  * gate's own `TURNSTILE_REQUIRED`/`TURNSTILE_INVALID` — and Issue #589's
  * MFA/TOTP codes: `MFA_REQUIRED`/`MFA_DISABLED`/`MFA_ALREADY_ACTIVE`/
  * `MFA_NOT_ACTIVE`/`MFA_ENROLLMENT_NOT_FOUND`/`MFA_INVALID_CODE`/
- * `MFA_CHALLENGE_INVALID`/`MFA_MISCONFIGURED`) to i18n catalog keys
+ * `MFA_CHALLENGE_INVALID`/`MFA_MISCONFIGURED` — and Issue #590's Google
+ * OIDC codes: `GOOGLE_LOGIN_DISABLED`/`GOOGLE_OAUTH_STATE_INVALID`/
+ * `GOOGLE_TOKEN_EXCHANGE_FAILED`/`GOOGLE_ID_TOKEN_INVALID`/
+ * `GOOGLE_ACCOUNT_NOT_LINKED`/`GOOGLE_ALREADY_LINKED`/`GOOGLE_NOT_LINKED`/
+ * `GOOGLE_MISCONFIGURED`) to i18n catalog keys
  * under the `error.` namespace. Used both server-side (SSR error panels)
  * and to build the
  * client-string JSON blob admin pages inline for their fetch-based action
@@ -48,7 +52,15 @@ export const ERROR_CODE_KEYS: Record<string, string> = {
   MFA_ENROLLMENT_NOT_FOUND: "error.mfa_enrollment_not_found",
   MFA_INVALID_CODE: "error.mfa_invalid_code",
   MFA_CHALLENGE_INVALID: "error.mfa_challenge_invalid",
-  MFA_MISCONFIGURED: "error.mfa_misconfigured"
+  MFA_MISCONFIGURED: "error.mfa_misconfigured",
+  GOOGLE_LOGIN_DISABLED: "error.google_login_disabled",
+  GOOGLE_OAUTH_STATE_INVALID: "error.google_oauth_state_invalid",
+  GOOGLE_TOKEN_EXCHANGE_FAILED: "error.google_token_exchange_failed",
+  GOOGLE_ID_TOKEN_INVALID: "error.google_id_token_invalid",
+  GOOGLE_ACCOUNT_NOT_LINKED: "error.google_account_not_linked",
+  GOOGLE_ALREADY_LINKED: "error.google_already_linked",
+  GOOGLE_NOT_LINKED: "error.google_not_linked",
+  GOOGLE_MISCONFIGURED: "error.google_misconfigured"
 };
 
 /**

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -150,15 +150,15 @@ Astro secara default menolak (403, tanpa body) permintaan `POST`/`PUT`/`PATCH`/`
 
 CRUD ABAC policy row (`awcms_mini_abac_policies` — schema tersedia, evaluator masih pakai aturan generik bawaan, belum ada endpoint kelola policy), dan publikasi event `identity.login.succeeded`/`identity.login.failed` (doc 05, menyusul modul Observability/Logging) belum ada pada tahap ini. `/access/decision-logs` tetap `LIMIT 50` per halaman tapi kini punya keyset pagination opsional (Issue #435, `?cursor=`/`nextCursor` — lihat `src/modules/_shared/keyset-pagination.ts`).
 
-Google OIDC login, generic tenant OIDC SSO, dan admin policy UI (Issue
-#590-#592) masih backlog untuk epic full-online auth security hardening
-(#587-#593). #587 (gate bersama, lihat §Full-online-only auth security
-feature gate di bawah), #588 (Cloudflare Turnstile,
-`src/lib/security/turnstile.ts` — bukan bagian modul ini, tapi dipanggil
-dari `POST /auth/login` di modul ini via `enforceTurnstileIfRequired`),
-dan #589 (MFA/TOTP, lihat §MFA/TOTP login challenge di bawah) sudah
-selesai. Lihat skill `awcms-mini-auth-online-hardening` untuk detail
-lintas-issue.
+Generic tenant OIDC SSO dan admin policy UI (Issue #591-#592) masih
+backlog untuk epic full-online auth security hardening (#587-#593).
+#587 (gate bersama, lihat §Full-online-only auth security feature gate
+di bawah), #588 (Cloudflare Turnstile, `src/lib/security/turnstile.ts`
+— bukan bagian modul ini, tapi dipanggil dari `POST /auth/login` di
+modul ini via `enforceTurnstileIfRequired`), #589 (MFA/TOTP, lihat
+§MFA/TOTP login challenge di bawah), dan #590 (Google OIDC login, lihat
+§Google OIDC login di bawah) sudah selesai. Lihat skill
+`awcms-mini-auth-online-hardening` untuk detail lintas-issue.
 
 ## MFA/TOTP login challenge (Issue #589)
 
@@ -203,6 +203,67 @@ gate env — semuanya modul-agnostic, tinggal di `src/lib/auth/` seperti
   dua kali walau masih dalam window toleransi clock drift).
 - Detail lengkap + rasional lintas-issue: skill
   `awcms-mini-auth-online-hardening` §MFA/TOTP.
+
+## Google OIDC login (Issue #590)
+
+`src/modules/identity-access/application/google-oidc.ts` +
+`src/modules/identity-access/domain/google-oidc-policy.ts` (evaluasi
+OAuth request/claims, pure) + `src/lib/auth/jwt-verify.ts` (RS256 via
+WebCrypto `crypto.subtle`, tanpa library JWT eksternal) +
+`google-oauth-client.ts` (token exchange + JWKS fetch, timeout +
+circuit breaker) + `oauth-state-token.ts`/`google-oidc-config.ts`
+(state/nonce, gate env — modul-agnostic, sama seperti pola
+`turnstile.ts`/`mfa-config.ts`).
+
+- Gate gabungan `isGoogleLoginRequired(env)` =
+  `isFullOnlineSecurityActive(env)` (#587) ∧
+  `AUTH_GOOGLE_LOGIN_ENABLED=true` — pola persis
+  `isTurnstileRequired()`/`isMfaRequired()`.
+- **Tenant id lewat `state`, bukan header**: `GET .../callback` adalah
+  redirect target Google — navigasi browser murni yang tidak bisa
+  membawa header `X-AWCMS-Mini-Tenant-ID`. `state` yang dikirim ke
+  Google berbentuk `${tenantId}.${rawToken}` (`oauth-state-token.ts`'s
+  `buildOAuthStateParam`/`parseOAuthStateParam`) — tenant id bukan
+  secret, dan bagian token (pertahanan CSRF/replay sesungguhnya, ≥32
+  byte random) tetap di-hash at rest seperti biasa.
+- **Login vs link, dua flow berbeda**: `GET .../start` (dari tombol
+  "Continue with Google" di `/login`, tanpa session) selalu
+  `purpose='login'`. `POST .../link` (butuh session — identity diambil
+  server-side dari session, TIDAK PERNAH dipercaya dari request
+  callback) mengembalikan `authorizationUrl` sebagai JSON, bukan
+  redirect, karena dipanggil lewat `fetch()` dari konteks yang sudah
+  login. `GET .../callback` menangani KEDUA purpose berdasarkan row
+  `awcms_mini_oidc_auth_requests` yang tersimpan saat start/link.
+- **Verifikasi ID token kriptografis penuh** (bukan sekadar baca JSON):
+  signature RS256 (WebCrypto, terhadap JWKS Google yang di-cache 1 jam),
+  issuer, audience, expiry, DAN nonce — kalau salah satu gagal, hasilnya
+  generic `GOOGLE_ID_TOKEN_INVALID` (anti-enumeration, pola sama
+  `MFA_CHALLENGE_INVALID`).
+- **Provider account ditautkan via `sub`, TIDAK PERNAH via email** —
+  `awcms_mini_identity_provider_accounts` (unique per tenant+provider+subject
+  DAN per tenant+identity+provider). Auto-link by email HANYA saat
+  `email_verified=true` DAN domainnya ada di `AUTH_GOOGLE_ALLOWED_DOMAINS`
+  (kosong = auto-link selalu ditolak, fail-closed) — kalau tidak ada
+  provider account yang cocok dan auto-link tidak berlaku, login ditolak
+  `401 GOOGLE_ACCOUNT_NOT_LINKED`, TIDAK provisioning identity baru.
+- **Google login TIDAK PERNAH bypass MFA**: kalau Issue #589 aktif dan
+  identity yang berhasil verifikasi Google punya factor TOTP `active`,
+  `callback.ts` menjalankan gate MFA yang SAMA persis dengan `login.ts`
+  (challenge dibuat, `401 MFA_REQUIRED`, session baru dibuat setelah
+  `POST /auth/mfa/totp/verify`) — bukan jalur terpisah yang bisa
+  kelewatan.
+- **Token exchange/JWKS fetch**: circuit breaker HANYA trip pada
+  kegagalan transport genuine (5xx/network/timeout) — respons `400
+invalid_grant` Google terhadap `code` yang salah/bekas/kedaluwarsa
+  adalah sinyal sehat (Google benar menolak input buruk), BUKAN outage,
+  dan tidak pernah menaikkan failure count breaker (pelajaran langsung
+  dari bug circuit breaker Turnstile, PR #596 — lihat
+  `google-oauth-client.ts`).
+- `POST .../unlink`/enroll MFA: high-risk, diaudit
+  (`google_account_linked`/`google_account_unlinked`/
+  `google_login_succeeded`).
+- Detail lengkap + rasional lintas-issue: skill
+  `awcms-mini-auth-online-hardening` §Google OIDC login.
 
 ## Full-online-only auth security feature gate (Issue #587)
 

--- a/src/modules/identity-access/application/google-oidc.ts
+++ b/src/modules/identity-access/application/google-oidc.ts
@@ -1,0 +1,562 @@
+/**
+ * Google OIDC application logic (Issue #590, epic: full-online auth
+ * hardening). Reuses this module's own #589 conventions:
+ * `oauth-state-token.ts` mirrors `mfa-challenge-token.ts`'s shape, and
+ * `consumeOAuthRequest` uses the exact `SELECT ... FOR UPDATE` +
+ * compare-and-swap pattern PR #597's security review forced onto
+ * `verifyMfaChallenge` — a bearer `state` token has the same "must not be
+ * redeemable twice under a concurrency race" requirement a TOTP code does.
+ */
+import {
+  findJwk,
+  parseJwt,
+  verifyJwtRs256
+} from "../../../lib/auth/jwt-verify";
+import {
+  exchangeAuthorizationCode,
+  fetchGoogleJwks,
+  resolveGoogleRedirectUri,
+  type GoogleJwks
+} from "../../../lib/auth/google-oauth-client";
+import {
+  GOOGLE_OIDC_ENDPOINTS,
+  resolveGoogleAllowedDomains,
+  resolveGoogleClientId,
+  resolveGoogleClientSecret
+} from "../../../lib/auth/google-oidc-config";
+import {
+  generateOAuthState,
+  generateOidcNonce,
+  hashOAuthState,
+  parseOAuthStateParam
+} from "../../../lib/auth/oauth-state-token";
+import {
+  evaluateOAuthRequest,
+  isEmailDomainAllowed,
+  validateIdTokenClaims,
+  type IdTokenClaims,
+  type OAuthRequestDenyReason
+} from "../domain/google-oidc-policy";
+import { withTenant } from "../../../lib/database/tenant-context";
+import {
+  isMfaRequired,
+  resolveChallengeTtlSec
+} from "../../../lib/auth/mfa-config";
+import { createMfaChallenge, findActiveMfaFactor } from "./mfa";
+
+export type OAuthPurpose = "login" | "link";
+
+export async function createOAuthRequest(
+  tx: Bun.SQL,
+  tenantId: string,
+  purpose: OAuthPurpose,
+  identityId: string | null,
+  ttlSec: number,
+  now: Date
+): Promise<{ state: string; nonce: string; expiresAt: Date }> {
+  const state = generateOAuthState();
+  const stateHash = hashOAuthState(state);
+  const nonce = generateOidcNonce();
+  const expiresAt = new Date(now.getTime() + ttlSec * 1000);
+
+  await tx`
+    INSERT INTO awcms_mini_oidc_auth_requests
+      (tenant_id, provider, state_hash, nonce, purpose, identity_id, expires_at)
+    VALUES (${tenantId}, 'google', ${stateHash}, ${nonce}, ${purpose}, ${identityId}, ${expiresAt})
+  `;
+
+  return { state, nonce, expiresAt };
+}
+
+export type ConsumeOAuthRequestResult =
+  | {
+      ok: true;
+      purpose: OAuthPurpose;
+      identityId: string | null;
+      nonce: string;
+    }
+  | { ok: false; reason: OAuthRequestDenyReason };
+
+/**
+ * Looks up and single-use-consumes an OAuth request by its raw `state`
+ * value. `FOR UPDATE` + a CAS `UPDATE ... WHERE consumed_at IS NULL` (not a
+ * blind SET) — the same fix PR #597 applied to `verifyMfaChallenge` —
+ * closes the race where two concurrent callback requests carrying the same
+ * `state` (e.g. a doubled browser redirect, or an attacker replaying an
+ * intercepted callback URL) could otherwise both read "not yet consumed"
+ * before either commits.
+ */
+export async function consumeOAuthRequest(
+  tx: Bun.SQL,
+  tenantId: string,
+  rawState: string,
+  now: Date
+): Promise<ConsumeOAuthRequestResult> {
+  const stateHash = hashOAuthState(rawState);
+
+  const rows = (await tx`
+    SELECT id, purpose, identity_id, nonce, expires_at, consumed_at
+    FROM awcms_mini_oidc_auth_requests
+    WHERE tenant_id = ${tenantId} AND provider = 'google' AND state_hash = ${stateHash}
+    FOR UPDATE
+  `) as {
+    id: string;
+    purpose: OAuthPurpose;
+    identity_id: string | null;
+    nonce: string;
+    expires_at: Date;
+    consumed_at: Date | null;
+  }[];
+  const row = rows[0];
+
+  const evaluation = evaluateOAuthRequest(
+    row
+      ? {
+          expiresAt: new Date(row.expires_at),
+          consumedAt: row.consumed_at
+        }
+      : null,
+    now
+  );
+
+  if (evaluation.outcome === "invalid") {
+    return { ok: false, reason: evaluation.reason };
+  }
+
+  const consumedRows = (await tx`
+    UPDATE awcms_mini_oidc_auth_requests
+    SET consumed_at = ${now}
+    WHERE id = ${row!.id} AND consumed_at IS NULL
+    RETURNING id
+  `) as { id: string }[];
+
+  if (consumedRows.length === 0) {
+    return { ok: false, reason: "already_used" };
+  }
+
+  return {
+    ok: true,
+    purpose: row!.purpose,
+    identityId: row!.identity_id,
+    nonce: row!.nonce
+  };
+}
+
+export type VerifyIdTokenResult =
+  | { ok: true; subject: string; email: string | null; emailVerified: boolean }
+  | { ok: false; code: "GOOGLE_ID_TOKEN_INVALID" | "GOOGLE_MISCONFIGURED" };
+
+/**
+ * Full ID token verification pipeline: parse -> fetch/select the matching
+ * JWKS key -> verify the RS256 signature (cryptographic proof this token
+ * really came from Google, not just well-formed JSON — issue's own security
+ * note: "Do not trust query parameters alone; validate ID token
+ * cryptographically") -> validate claims (issuer/audience/expiry/nonce, via
+ * the pure `validateIdTokenClaims`). Every failure mode collapses to the
+ * same generic `GOOGLE_ID_TOKEN_INVALID` (anti-enumeration, matches this
+ * module's `MFA_CHALLENGE_INVALID`/`completePasswordReset` convention) —
+ * the specific reason is for internal audit logging only, never returned.
+ */
+export async function verifyGoogleIdToken(
+  idToken: string,
+  expectedClientId: string,
+  expectedNonce: string,
+  nowSec: number
+): Promise<VerifyIdTokenResult> {
+  let parsed;
+
+  try {
+    parsed = parseJwt(idToken);
+  } catch {
+    return { ok: false, code: "GOOGLE_ID_TOKEN_INVALID" };
+  }
+
+  if (parsed.header.alg !== "RS256" || !parsed.header.kid) {
+    return { ok: false, code: "GOOGLE_ID_TOKEN_INVALID" };
+  }
+
+  const jwksResult = await fetchGoogleJwks();
+
+  if (!jwksResult.ok) {
+    return { ok: false, code: "GOOGLE_MISCONFIGURED" };
+  }
+
+  const jwk = findJwk(
+    jwksResult.jwks as GoogleJwks & { keys: never[] },
+    parsed.header.kid
+  );
+
+  if (!jwk) {
+    return { ok: false, code: "GOOGLE_ID_TOKEN_INVALID" };
+  }
+
+  const signatureValid = await verifyJwtRs256(
+    parsed.signingInput,
+    parsed.signature,
+    jwk
+  );
+
+  if (!signatureValid) {
+    return { ok: false, code: "GOOGLE_ID_TOKEN_INVALID" };
+  }
+
+  const claimsValidation = validateIdTokenClaims(
+    parsed.payload as IdTokenClaims,
+    {
+      expectedIssuers: GOOGLE_OIDC_ENDPOINTS.issuers,
+      expectedAudience: expectedClientId,
+      expectedNonce,
+      nowSec
+    }
+  );
+
+  if (claimsValidation.outcome === "invalid") {
+    return { ok: false, code: "GOOGLE_ID_TOKEN_INVALID" };
+  }
+
+  const email =
+    typeof parsed.payload.email === "string" ? parsed.payload.email : null;
+  const emailVerified = parsed.payload.email_verified === true;
+
+  return {
+    ok: true,
+    subject: claimsValidation.subject,
+    email,
+    emailVerified
+  };
+}
+
+/** Used by `callback.ts` to find an existing account after ID token verification succeeds. */
+export async function findIdentityByProviderSubject(
+  tx: Bun.SQL,
+  tenantId: string,
+  subject: string
+): Promise<string | null> {
+  const rows = (await tx`
+    SELECT identity_id FROM awcms_mini_identity_provider_accounts
+    WHERE tenant_id = ${tenantId} AND provider = 'google' AND provider_subject = ${subject}
+  `) as { identity_id: string }[];
+
+  return rows[0]?.identity_id ?? null;
+}
+
+export type AutoLinkResult = { ok: true; identityId: string } | { ok: false };
+
+/**
+ * Auto-link-by-email (issue's own acceptance criterion: "requires verified
+ * email and allowed domain policy"). Only ever runs when no provider
+ * account already exists for this `subject` — `callback.ts` tries
+ * `findIdentityByProviderSubject` first. Requires: `emailVerified` true,
+ * the email's domain in the configured allow-list
+ * (`isEmailDomainAllowed` — fail-closed on an empty list), a tenant-active
+ * identity whose `login_identifier` exactly equals `email`, and that
+ * identity's `tenant_user` membership active — the same eligibility
+ * checks `requestPasswordReset` already applies before treating an
+ * identifier as "real."
+ */
+export async function autoLinkByEmail(
+  tx: Bun.SQL,
+  tenantId: string,
+  email: string,
+  emailVerified: boolean,
+  allowedDomains: readonly string[],
+  subject: string,
+  now: Date
+): Promise<AutoLinkResult> {
+  if (!emailVerified || !isEmailDomainAllowed(email, allowedDomains)) {
+    return { ok: false };
+  }
+
+  const tenantRows = (await tx`
+    SELECT status FROM awcms_mini_tenants WHERE id = ${tenantId}
+  `) as { status: string }[];
+
+  if (tenantRows[0]?.status !== "active") {
+    return { ok: false };
+  }
+
+  const identityRows = (await tx`
+    SELECT id, status FROM awcms_mini_identities
+    WHERE tenant_id = ${tenantId} AND login_identifier = ${email}
+  `) as { id: string; status: string }[];
+  const identity = identityRows[0];
+
+  if (!identity || identity.status !== "active") {
+    return { ok: false };
+  }
+
+  const tenantUserRows = (await tx`
+    SELECT status FROM awcms_mini_tenant_users
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identity.id}
+  `) as { status: string }[];
+
+  if (tenantUserRows[0]?.status !== "active") {
+    return { ok: false };
+  }
+
+  // Compare-and-swap-free INSERT is safe here because both unique indexes
+  // on `awcms_mini_identity_provider_accounts` (subject-scoped and
+  // identity-scoped) enforce the invariant at the DB level — a concurrent
+  // duplicate insert throws a unique-violation rather than silently
+  // double-linking.
+  await tx`
+    INSERT INTO awcms_mini_identity_provider_accounts
+      (tenant_id, identity_id, provider, provider_subject, linked_at, created_at, updated_at)
+    VALUES (${tenantId}, ${identity.id}, 'google', ${subject}, ${now}, ${now}, ${now})
+  `;
+
+  return { ok: true, identityId: identity.id };
+}
+
+export type LinkProviderAccountResult =
+  { ok: true } | { ok: false; code: "GOOGLE_ALREADY_LINKED" };
+
+/**
+ * Explicit link (authenticated user choosing to attach Google as an
+ * additional login method). Rejects if this identity already has a Google
+ * account linked, or if this specific Google subject is already linked to
+ * a DIFFERENT identity in this tenant (both enforced by the unique indexes;
+ * checked here first only to return a clean, specific error code instead
+ * of a raw constraint-violation exception).
+ */
+export async function linkProviderAccount(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string,
+  subject: string,
+  now: Date
+): Promise<LinkProviderAccountResult> {
+  const existingRows = (await tx`
+    SELECT identity_id FROM awcms_mini_identity_provider_accounts
+    WHERE tenant_id = ${tenantId} AND provider = 'google'
+      AND (identity_id = ${identityId} OR provider_subject = ${subject})
+  `) as { identity_id: string }[];
+
+  if (existingRows.length > 0) {
+    return { ok: false, code: "GOOGLE_ALREADY_LINKED" };
+  }
+
+  await tx`
+    INSERT INTO awcms_mini_identity_provider_accounts
+      (tenant_id, identity_id, provider, provider_subject, linked_at, created_at, updated_at)
+    VALUES (${tenantId}, ${identityId}, 'google', ${subject}, ${now}, ${now}, ${now})
+  `;
+
+  return { ok: true };
+}
+
+export type UnlinkProviderAccountResult =
+  { ok: true } | { ok: false; code: "GOOGLE_NOT_LINKED" };
+
+export async function unlinkProviderAccount(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string
+): Promise<UnlinkProviderAccountResult> {
+  const deletedRows = (await tx`
+    DELETE FROM awcms_mini_identity_provider_accounts
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId} AND provider = 'google'
+    RETURNING id
+  `) as { id: string }[];
+
+  if (deletedRows.length === 0) {
+    return { ok: false, code: "GOOGLE_NOT_LINKED" };
+  }
+
+  return { ok: true };
+}
+
+export type GoogleOAuthErrorCode =
+  | "GOOGLE_OAUTH_STATE_INVALID"
+  | "GOOGLE_TOKEN_EXCHANGE_FAILED"
+  | "GOOGLE_ID_TOKEN_INVALID"
+  | "GOOGLE_ACCOUNT_NOT_LINKED"
+  | "GOOGLE_ALREADY_LINKED"
+  | "GOOGLE_MISCONFIGURED"
+  | "ACCESS_DENIED";
+
+export type CompleteGoogleOAuthResult =
+  | { outcome: "session_ready"; tenantId: string; identityId: string }
+  | {
+      outcome: "mfa_required";
+      tenantId: string;
+      identityId: string;
+      challengeToken: string;
+      challengeExpiresAt: Date;
+    }
+  | { outcome: "linked"; tenantId: string; identityId: string }
+  | { outcome: "error"; code: GoogleOAuthErrorCode };
+
+/**
+ * The single orchestrator both `callback.ts` (GET, Google's own redirect
+ * target) and the eventual client-driven completion path call — deliberately
+ * NOT a `tx`-scoped function like every other function in this file: it
+ * spans MULTIPLE transactions with external HTTP calls (token exchange,
+ * JWKS fetch) in between, and those calls must never happen inside a DB
+ * transaction (ADR-0006). Takes the raw `sql` client and opens/closes
+ * `withTenant` transactions itself, exactly as an endpoint normally would —
+ * centralized here (rather than duplicated per endpoint) because this
+ * specific sequencing (verify state -> exchange code -> verify ID token ->
+ * resolve identity -> MFA gate) is complex enough that duplicating it would
+ * risk the two call sites silently diverging on a security-relevant step.
+ *
+ * Session/cookie creation and audit logging remain the CALLING endpoint's
+ * responsibility (matches this module's existing convention — `login.ts`,
+ * `mfa/totp/verify.ts` — of owning their own cookies/audit calls), so this
+ * function only ever returns identity/challenge identifiers, never sets a
+ * cookie or writes an audit row itself.
+ */
+export async function completeGoogleOAuthCallback(
+  sql: Bun.SQL,
+  rawStateParam: string,
+  code: string | null,
+  env: NodeJS.ProcessEnv,
+  now: Date
+): Promise<CompleteGoogleOAuthResult> {
+  const parsedState = parseOAuthStateParam(rawStateParam);
+
+  if (!parsedState) {
+    return { outcome: "error", code: "GOOGLE_OAUTH_STATE_INVALID" };
+  }
+
+  const { tenantId, token } = parsedState;
+
+  const consumeResult = await withTenant(sql, tenantId, (tx) =>
+    consumeOAuthRequest(tx, tenantId, token, now)
+  );
+
+  if (!consumeResult.ok) {
+    return { outcome: "error", code: "GOOGLE_OAUTH_STATE_INVALID" };
+  }
+
+  if (!code) {
+    return { outcome: "error", code: "GOOGLE_OAUTH_STATE_INVALID" };
+  }
+
+  const clientId = resolveGoogleClientId(env);
+  const clientSecret = resolveGoogleClientSecret(env);
+
+  if (!clientId || !clientSecret) {
+    return { outcome: "error", code: "GOOGLE_MISCONFIGURED" };
+  }
+
+  const exchangeResult = await exchangeAuthorizationCode({
+    code,
+    clientId,
+    clientSecret,
+    redirectUri: resolveGoogleRedirectUri(env)
+  });
+
+  if (!exchangeResult.ok) {
+    return { outcome: "error", code: "GOOGLE_TOKEN_EXCHANGE_FAILED" };
+  }
+
+  const verifyResult = await verifyGoogleIdToken(
+    exchangeResult.idToken,
+    clientId,
+    consumeResult.nonce,
+    Math.floor(now.getTime() / 1000)
+  );
+
+  if (!verifyResult.ok) {
+    return { outcome: "error", code: verifyResult.code };
+  }
+
+  return withTenant(sql, tenantId, async (tx) => {
+    if (consumeResult.purpose === "link") {
+      // `identityId` was captured server-side at `start`/`link`-initiation
+      // time from an authenticated session — never trusted from this
+      // callback request itself. The DB CHECK constraint on
+      // `awcms_mini_oidc_auth_requests` guarantees a `link`-purpose row
+      // always has one, but this is re-checked here rather than asserted,
+      // since a `null` here indicates a schema/data invariant violation
+      // that must fail closed, not crash.
+      const linkIdentityId = consumeResult.identityId;
+
+      if (!linkIdentityId) {
+        return { outcome: "error", code: "GOOGLE_OAUTH_STATE_INVALID" };
+      }
+
+      const linkResult = await linkProviderAccount(
+        tx,
+        tenantId,
+        linkIdentityId,
+        verifyResult.subject,
+        now
+      );
+
+      if (!linkResult.ok) {
+        return { outcome: "error", code: linkResult.code };
+      }
+
+      return {
+        outcome: "linked",
+        tenantId,
+        identityId: linkIdentityId
+      };
+    }
+
+    let identityId = await findIdentityByProviderSubject(
+      tx,
+      tenantId,
+      verifyResult.subject
+    );
+
+    if (!identityId) {
+      const autoLink = await autoLinkByEmail(
+        tx,
+        tenantId,
+        verifyResult.email ?? "",
+        verifyResult.emailVerified,
+        resolveGoogleAllowedDomains(env),
+        verifyResult.subject,
+        now
+      );
+
+      if (!autoLink.ok) {
+        return { outcome: "error", code: "GOOGLE_ACCOUNT_NOT_LINKED" };
+      }
+
+      identityId = autoLink.identityId;
+    }
+
+    const identityRows = (await tx`
+      SELECT status FROM awcms_mini_identities WHERE id = ${identityId}
+    `) as { status: string }[];
+    const tenantUserRows = (await tx`
+      SELECT status FROM awcms_mini_tenant_users
+      WHERE tenant_id = ${tenantId} AND identity_id = ${identityId}
+    `) as { status: string }[];
+
+    if (
+      identityRows[0]?.status !== "active" ||
+      tenantUserRows[0]?.status !== "active"
+    ) {
+      return { outcome: "error", code: "ACCESS_DENIED" };
+    }
+
+    if (isMfaRequired(env)) {
+      const factor = await findActiveMfaFactor(tx, tenantId, identityId);
+
+      if (factor) {
+        const challenge = await createMfaChallenge(
+          tx,
+          tenantId,
+          identityId,
+          resolveChallengeTtlSec(env),
+          now
+        );
+
+        return {
+          outcome: "mfa_required",
+          tenantId,
+          identityId,
+          challengeToken: challenge.token,
+          challengeExpiresAt: challenge.expiresAt
+        };
+      }
+    }
+
+    return { outcome: "session_ready", tenantId, identityId };
+  });
+}

--- a/src/modules/identity-access/domain/google-oidc-policy.ts
+++ b/src/modules/identity-access/domain/google-oidc-policy.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure Google OIDC decision logic (Issue #590) — same "pure decision, DB/
+ * network does the fetching" shape as `mfa-policy.ts`'s
+ * `evaluateMfaChallenge` and `password-reset-policy.ts`'s
+ * `evaluatePasswordResetToken`. Nothing here makes a network call or reads
+ * `process.env` directly — callers pass in already-resolved config/claims.
+ */
+export type OAuthRequestSnapshot = {
+  expiresAt: Date;
+  consumedAt: Date | null;
+};
+
+export type OAuthRequestDenyReason = "not_found" | "already_used" | "expired";
+
+export type OAuthRequestEvaluation =
+  { outcome: "valid" } | { outcome: "invalid"; reason: OAuthRequestDenyReason };
+
+export function evaluateOAuthRequest(
+  row: OAuthRequestSnapshot | null,
+  now: Date
+): OAuthRequestEvaluation {
+  if (!row) {
+    return { outcome: "invalid", reason: "not_found" };
+  }
+
+  if (row.consumedAt !== null) {
+    return { outcome: "invalid", reason: "already_used" };
+  }
+
+  if (row.expiresAt.getTime() <= now.getTime()) {
+    return { outcome: "invalid", reason: "expired" };
+  }
+
+  return { outcome: "valid" };
+}
+
+export type IdTokenClaims = {
+  iss?: unknown;
+  aud?: unknown;
+  exp?: unknown;
+  nonce?: unknown;
+  sub?: unknown;
+};
+
+export type IdTokenValidationOptions = {
+  expectedIssuers: readonly string[];
+  expectedAudience: string;
+  expectedNonce: string;
+  /** Seconds; Unix time, matching the JWT `exp` claim's own unit. */
+  nowSec: number;
+};
+
+export type IdTokenDenyReason =
+  | "missing_subject"
+  | "issuer_mismatch"
+  | "audience_mismatch"
+  | "expired"
+  | "nonce_mismatch";
+
+export type IdTokenValidation =
+  | { outcome: "valid"; subject: string }
+  | { outcome: "invalid"; reason: IdTokenDenyReason };
+
+/**
+ * Validates the claims of an ALREADY signature-verified ID token (signature
+ * verification itself is `../../../lib/auth/jwt-verify.ts`'s job — this
+ * function trusts its caller already confirmed the token is authentically
+ * from Google before calling this). Matches the issue's acceptance
+ * criterion: "ID token validation checks issuer, audience, expiration, and
+ * nonce."
+ */
+export function validateIdTokenClaims(
+  claims: IdTokenClaims,
+  options: IdTokenValidationOptions
+): IdTokenValidation {
+  if (typeof claims.sub !== "string" || claims.sub.length === 0) {
+    return { outcome: "invalid", reason: "missing_subject" };
+  }
+
+  if (
+    typeof claims.iss !== "string" ||
+    !options.expectedIssuers.includes(claims.iss)
+  ) {
+    return { outcome: "invalid", reason: "issuer_mismatch" };
+  }
+
+  if (claims.aud !== options.expectedAudience) {
+    return { outcome: "invalid", reason: "audience_mismatch" };
+  }
+
+  if (typeof claims.exp !== "number" || claims.exp <= options.nowSec) {
+    return { outcome: "invalid", reason: "expired" };
+  }
+
+  if (claims.nonce !== options.expectedNonce) {
+    return { outcome: "invalid", reason: "nonce_mismatch" };
+  }
+
+  return { outcome: "valid", subject: claims.sub };
+}
+
+/**
+ * Auto-linking-by-email guardrail (issue's own acceptance criterion:
+ * "Auto-linking by email... requires verified email and allowed domain
+ * policy"). Fail-closed by construction: an empty `allowedDomains` list
+ * (the default — `AUTH_GOOGLE_ALLOWED_DOMAINS` unset) means auto-linking is
+ * NEVER allowed, not "allow any domain."
+ */
+export function isEmailDomainAllowed(
+  email: string,
+  allowedDomains: readonly string[]
+): boolean {
+  if (allowedDomains.length === 0) {
+    return false;
+  }
+
+  const atIndex = email.lastIndexOf("@");
+
+  if (atIndex === -1) {
+    return false;
+  }
+
+  const domain = email.slice(atIndex + 1).toLowerCase();
+
+  return allowedDomains.includes(domain);
+}

--- a/src/pages/api/v1/auth/providers/google/callback.ts
+++ b/src/pages/api/v1/auth/providers/google/callback.ts
@@ -1,0 +1,174 @@
+import type { APIRoute } from "astro";
+import { fail } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  generateSessionToken,
+  hashSessionToken
+} from "../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../lib/auth/ssr-session";
+import { isGoogleLoginRequired } from "../../../../../../lib/auth/google-oidc-config";
+import { completeGoogleOAuthCallback } from "../../../../../../modules/identity-access/application/google-oidc";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+
+const SESSION_TTL_MIN = Number(process.env.AUTH_SESSION_TTL_MIN ?? 120);
+
+/**
+ * `GET /api/v1/auth/providers/google/callback` (Issue #590) — Google's own
+ * redirect target, a plain top-level browser navigation (never a `fetch()`
+ * call), so error responses here are necessarily raw JSON shown in the
+ * browser rather than a styled page — the same tradeoff `password/reset.ts`
+ * accepts today for a repo with no dedicated reset-password UI page yet.
+ * A follow-up issue could add a proper `/login` error redirect; out of
+ * scope for #590's own endpoint-focused acceptance criteria.
+ */
+export const GET: APIRoute = async ({ cookies, url, locals }) => {
+  if (!isGoogleLoginRequired()) {
+    return fail(
+      403,
+      "GOOGLE_LOGIN_DISABLED",
+      "Google login is not enabled for this deployment."
+    );
+  }
+
+  const providerError = url.searchParams.get("error");
+
+  if (providerError) {
+    return fail(
+      401,
+      "GOOGLE_OAUTH_STATE_INVALID",
+      "Google sign-in was cancelled or denied."
+    );
+  }
+
+  const state = url.searchParams.get("state");
+  const code = url.searchParams.get("code");
+
+  if (!state) {
+    return fail(
+      400,
+      "GOOGLE_OAUTH_STATE_INVALID",
+      "Missing or invalid state parameter."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const now = new Date();
+
+  const result = await completeGoogleOAuthCallback(
+    sql,
+    state,
+    code,
+    process.env,
+    now
+  );
+
+  if (result.outcome === "error") {
+    const status =
+      result.code === "GOOGLE_MISCONFIGURED"
+        ? 500
+        : result.code === "GOOGLE_ALREADY_LINKED"
+          ? 409
+          : result.code === "ACCESS_DENIED"
+            ? 403
+            : 401;
+
+    return fail(
+      status,
+      result.code,
+      "Google sign-in could not be completed. Please try again."
+    );
+  }
+
+  if (result.outcome === "mfa_required") {
+    await withTenant(sql, result.tenantId, (tx) =>
+      recordAuditEvent(tx, {
+        tenantId: result.tenantId,
+        moduleKey: "identity_access",
+        action: "mfa_challenge_issued",
+        resourceType: "identity",
+        resourceId: result.identityId,
+        severity: "info",
+        message: "Google sign-in verified; MFA challenge issued.",
+        correlationId: locals.correlationId
+      })
+    );
+
+    return fail(
+      401,
+      "MFA_REQUIRED",
+      "Multi-factor authentication is required to complete sign-in.",
+      {},
+      {
+        mfaChallengeToken: result.challengeToken,
+        expiresAt: result.challengeExpiresAt.toISOString()
+      }
+    );
+  }
+
+  if (result.outcome === "linked") {
+    await withTenant(sql, result.tenantId, (tx) =>
+      recordAuditEvent(tx, {
+        tenantId: result.tenantId,
+        moduleKey: "identity_access",
+        action: "google_account_linked",
+        resourceType: "identity",
+        resourceId: result.identityId,
+        severity: "warning",
+        message: "Google account linked.",
+        correlationId: locals.correlationId
+      })
+    );
+
+    return new Response(null, {
+      status: 302,
+      headers: { Location: "/admin" }
+    });
+  }
+
+  const token = generateSessionToken();
+  const tokenHash = hashSessionToken(token);
+  const expiresAt = new Date(now.getTime() + SESSION_TTL_MIN * 60_000);
+
+  await withTenant(sql, result.tenantId, async (tx) => {
+    await tx`
+      UPDATE awcms_mini_identities
+      SET failed_login_count = 0, last_login_at = ${now}
+      WHERE id = ${result.identityId}
+    `;
+
+    await tx`
+      INSERT INTO awcms_mini_sessions (tenant_id, identity_id, token_hash, expires_at)
+      VALUES (${result.tenantId}, ${result.identityId}, ${tokenHash}, ${expiresAt})
+    `;
+
+    await recordAuditEvent(tx, {
+      tenantId: result.tenantId,
+      moduleKey: "identity_access",
+      action: "google_login_succeeded",
+      resourceType: "identity",
+      resourceId: result.identityId,
+      severity: "info",
+      message: "Google sign-in succeeded; session created.",
+      correlationId: locals.correlationId
+    });
+  });
+
+  const cookieOptions = {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: SESSION_TTL_MIN * 60,
+    secure: process.env.AUTH_COOKIE_SECURE === "true"
+  };
+  cookies.set(SESSION_COOKIE_NAME, token, cookieOptions);
+  cookies.set(TENANT_COOKIE_NAME, result.tenantId, cookieOptions);
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: "/admin" }
+  });
+};

--- a/src/pages/api/v1/auth/providers/google/link.ts
+++ b/src/pages/api/v1/auth/providers/google/link.ts
@@ -1,0 +1,100 @@
+import type { APIRoute } from "astro";
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../lib/auth/ssr-session";
+import {
+  extractBearerToken,
+  resolveActiveSession
+} from "../../../../../../modules/identity-access/application/session-lookup";
+import {
+  isGoogleLoginRequired,
+  resolveGoogleClientId
+} from "../../../../../../lib/auth/google-oidc-config";
+import { createOAuthRequest } from "../../../../../../modules/identity-access/application/google-oidc";
+import { buildGoogleAuthorizationUrl } from "../../../../../../lib/auth/google-oauth-client";
+
+const OAUTH_REQUEST_TTL_SEC = 600;
+
+/**
+ * `POST /api/v1/auth/providers/google/link` (Issue #590) — authenticated:
+ * starts a link-purpose OAuth request for the CALLER's own identity
+ * (captured server-side here, never trusted from the eventual callback
+ * request) and returns the Google authorization URL as JSON for the client
+ * to navigate to (`window.location = data.data.authorizationUrl`) — a
+ * POST-returning-JSON shape rather than a redirect, since this is invoked
+ * via `fetch()` from an already-authenticated context (unlike
+ * `GET .../start`, reached from a plain `<a href>` on the unauthenticated
+ * login page).
+ */
+export const POST: APIRoute = async ({ request, cookies }) => {
+  if (!isGoogleLoginRequired()) {
+    return fail(
+      403,
+      "GOOGLE_LOGIN_DISABLED",
+      "Google login is not enabled for this deployment."
+    );
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token =
+    extractBearerToken(request.headers.get("authorization")) ??
+    cookies.get(SESSION_COOKIE_NAME)?.value ??
+    null;
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const clientId = resolveGoogleClientId();
+
+  if (!clientId) {
+    return fail(
+      500,
+      "GOOGLE_MISCONFIGURED",
+      "Google login is misconfigured on this server."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const session = await resolveActiveSession(tx, tenantId, tokenHash, now);
+
+    if (!session) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const { state, nonce } = await createOAuthRequest(
+      tx,
+      tenantId,
+      "link",
+      session.identity_id,
+      OAUTH_REQUEST_TTL_SEC,
+      now
+    );
+
+    const authorizationUrl = buildGoogleAuthorizationUrl({
+      clientId,
+      tenantId,
+      state,
+      nonce
+    });
+
+    return ok({ authorizationUrl });
+  });
+};

--- a/src/pages/api/v1/auth/providers/google/start.ts
+++ b/src/pages/api/v1/auth/providers/google/start.ts
@@ -1,0 +1,77 @@
+import type { APIRoute } from "astro";
+import { fail } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { TENANT_COOKIE_NAME } from "../../../../../../lib/auth/ssr-session";
+import {
+  isGoogleLoginRequired,
+  resolveGoogleClientId
+} from "../../../../../../lib/auth/google-oidc-config";
+import { createOAuthRequest } from "../../../../../../modules/identity-access/application/google-oidc";
+import { buildGoogleAuthorizationUrl } from "../../../../../../lib/auth/google-oauth-client";
+
+const OAUTH_REQUEST_TTL_SEC = 600;
+
+/**
+ * `GET /api/v1/auth/providers/google/start` (Issue #590) — unauthenticated
+ * entry point reached from the "Continue with Google" button on
+ * `login.astro`. Always `purpose = "login"` — linking an ALREADY
+ * authenticated identity's Google account is a separate, POST-initiated
+ * flow (`POST .../link`), since that one needs the caller's session to
+ * know which identity to attach to, and a plain `<a href>`/redirect can't
+ * carry an `Authorization` header the way a `fetch()` call can.
+ *
+ * Tenant resolution accepts a `?tenantId=` query param as a fallback after
+ * the header/cookie, specifically because `login.astro` has no tenant
+ * cookie yet pre-login (the user types their Tenant ID into a plain text
+ * field) and a top-level navigation can't set the
+ * `X-AWCMS-Mini-Tenant-ID` header every other endpoint relies on instead.
+ */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  if (!isGoogleLoginRequired()) {
+    return fail(
+      403,
+      "GOOGLE_LOGIN_DISABLED",
+      "Google login is not enabled for this deployment."
+    );
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    url.searchParams.get("tenantId") ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const clientId = resolveGoogleClientId();
+
+  if (!clientId) {
+    return fail(
+      500,
+      "GOOGLE_MISCONFIGURED",
+      "Google login is misconfigured on this server."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const now = new Date();
+
+  const { state, nonce } = await withTenant(sql, tenantId, (tx) =>
+    createOAuthRequest(tx, tenantId, "login", null, OAUTH_REQUEST_TTL_SEC, now)
+  );
+
+  const authorizationUrl = buildGoogleAuthorizationUrl({
+    clientId,
+    tenantId,
+    state,
+    nonce
+  });
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: authorizationUrl }
+  });
+};

--- a/src/pages/api/v1/auth/providers/google/start.ts
+++ b/src/pages/api/v1/auth/providers/google/start.ts
@@ -4,6 +4,10 @@ import { getDatabaseClient } from "../../../../../../lib/database/client";
 import { withTenant } from "../../../../../../lib/database/tenant-context";
 import { TENANT_COOKIE_NAME } from "../../../../../../lib/auth/ssr-session";
 import {
+  checkRateLimit,
+  resolveClientIp
+} from "../../../../../../lib/security/rate-limit";
+import {
   isGoogleLoginRequired,
   resolveGoogleClientId
 } from "../../../../../../lib/auth/google-oidc-config";
@@ -11,6 +15,12 @@ import { createOAuthRequest } from "../../../../../../modules/identity-access/ap
 import { buildGoogleAuthorizationUrl } from "../../../../../../lib/auth/google-oauth-client";
 
 const OAUTH_REQUEST_TTL_SEC = 600;
+const RATE_LIMIT_MAX_ATTEMPTS = Number(
+  process.env.AUTH_LOGIN_RATE_LIMIT_MAX ?? 20
+);
+const RATE_LIMIT_WINDOW_SEC = Number(
+  process.env.AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC ?? 60
+);
 
 /**
  * `GET /api/v1/auth/providers/google/start` (Issue #590) — unauthenticated
@@ -26,8 +36,31 @@ const OAUTH_REQUEST_TTL_SEC = 600;
  * cookie yet pre-login (the user types their Tenant ID into a plain text
  * field) and a top-level navigation can't set the
  * `X-AWCMS-Mini-Tenant-ID` header every other endpoint relies on instead.
+ *
+ * Rate-limited (same shape as `login.ts`) AND — critically — the tenant's
+ * existence/status is checked via a plain `SELECT` BEFORE ever inserting
+ * into `awcms_mini_oidc_auth_requests`. Security review of this PR found
+ * that inserting directly with an unauthenticated, caller-supplied
+ * `tenantId` let a nonexistent tenant id trip a foreign-key violation,
+ * which `withTenant`'s catch-all treats as an infrastructure failure and
+ * records against the single, APPLICATION-WIDE database circuit breaker
+ * (`getDatabaseCircuitBreaker()` — shared across every tenant and every
+ * endpoint, unlike the per-provider breakers Turnstile/Google's own token
+ * exchange use). An unauthenticated caller could open that breaker with 5
+ * garbage tenant ids and take down the entire deployment for 30 seconds
+ * at a time, repeatedly — a strictly worse blast radius than the #596
+ * Turnstile bug this epic already fixed once. A `SELECT` never throws for
+ * a missing row, so checking first (and returning a plain `403
+ * ACCESS_DENIED` without ever attempting the insert) closes this off
+ * completely, mirroring how `login.ts` itself already resolves tenant
+ * status via `SELECT` before any write.
  */
-export const GET: APIRoute = async ({ request, cookies, url }) => {
+export const GET: APIRoute = async ({
+  request,
+  cookies,
+  url,
+  clientAddress
+}) => {
   if (!isGoogleLoginRequired()) {
     return fail(
       403,
@@ -46,6 +79,26 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
     return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
   }
 
+  const clientIp = resolveClientIp(request, clientAddress);
+  const rateLimit = checkRateLimit(
+    `${clientIp}:${tenantId}:google-oauth-start`,
+    {
+      maxAttempts: RATE_LIMIT_MAX_ATTEMPTS,
+      windowMs: RATE_LIMIT_WINDOW_SEC * 1000
+    }
+  );
+
+  if (!rateLimit.allowed) {
+    return fail(
+      429,
+      "RATE_LIMITED",
+      "Too many requests from this source. Try again later.",
+      {},
+      undefined,
+      { "retry-after": String(rateLimit.retryAfterSec) }
+    );
+  }
+
   const clientId = resolveGoogleClientId();
 
   if (!clientId) {
@@ -59,15 +112,36 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
   const sql = getDatabaseClient();
   const now = new Date();
 
-  const { state, nonce } = await withTenant(sql, tenantId, (tx) =>
-    createOAuthRequest(tx, tenantId, "login", null, OAUTH_REQUEST_TTL_SEC, now)
-  );
+  const result = await withTenant(sql, tenantId, async (tx) => {
+    const tenantRows = (await tx`
+      SELECT status FROM awcms_mini_tenants WHERE id = ${tenantId}
+    `) as { status: string }[];
+
+    if (tenantRows[0]?.status !== "active") {
+      return { ok: false as const };
+    }
+
+    const { state, nonce } = await createOAuthRequest(
+      tx,
+      tenantId,
+      "login",
+      null,
+      OAUTH_REQUEST_TTL_SEC,
+      now
+    );
+
+    return { ok: true as const, state, nonce };
+  });
+
+  if (!result.ok) {
+    return fail(403, "ACCESS_DENIED", "Tenant is not active.");
+  }
 
   const authorizationUrl = buildGoogleAuthorizationUrl({
     clientId,
     tenantId,
-    state,
-    nonce
+    state: result.state,
+    nonce: result.nonce
   });
 
   return new Response(null, {

--- a/src/pages/api/v1/auth/providers/google/unlink.ts
+++ b/src/pages/api/v1/auth/providers/google/unlink.ts
@@ -1,0 +1,90 @@
+import type { APIRoute } from "astro";
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../lib/auth/ssr-session";
+import {
+  extractBearerToken,
+  resolveActiveSession
+} from "../../../../../../modules/identity-access/application/session-lookup";
+import { isGoogleLoginRequired } from "../../../../../../lib/auth/google-oidc-config";
+import { unlinkProviderAccount } from "../../../../../../modules/identity-access/application/google-oidc";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+
+/**
+ * `POST /api/v1/auth/providers/google/unlink` (Issue #590) — high-risk,
+ * self-service action: authenticated identity removes its own linked
+ * Google account. Local password login is never affected (issue's own
+ * out-of-scope note: "Removing or disabling local password login" is out
+ * of scope) — unlinking Google never touches `password_hash`.
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  if (!isGoogleLoginRequired()) {
+    return fail(
+      403,
+      "GOOGLE_LOGIN_DISABLED",
+      "Google login is not enabled for this deployment."
+    );
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token =
+    extractBearerToken(request.headers.get("authorization")) ??
+    cookies.get(SESSION_COOKIE_NAME)?.value ??
+    null;
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const session = await resolveActiveSession(tx, tenantId, tokenHash, now);
+
+    if (!session) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const result = await unlinkProviderAccount(
+      tx,
+      tenantId,
+      session.identity_id
+    );
+
+    if (!result.ok) {
+      return fail(
+        409,
+        result.code,
+        "No Google account is currently linked for this identity."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      moduleKey: "identity_access",
+      action: "google_account_unlinked",
+      resourceType: "identity",
+      resourceId: session.identity_id,
+      severity: "warning",
+      message: "Google account unlinked.",
+      correlationId: locals.correlationId
+    });
+
+    return ok({ unlinked: true });
+  });
+};

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -20,11 +20,19 @@
  * docs: embedded in every public Turnstile widget) — only
  * `TURNSTILE_SECRET_KEY` (server-side verification only, never sent here)
  * needs the redaction discipline `src/lib/security/turnstile.ts` applies.
+ *
+ * Google OIDC login (Issue #590) — the "Continue with Google" button only
+ * renders when `isGoogleLoginRequired()` is true. It's a plain button (not
+ * an `<a href>`) because the destination URL needs the Tenant ID field's
+ * CURRENT value at click time (`GET /auth/providers/google/start
+ * ?tenantId=...` — see that endpoint's own comment for why a query param
+ * fallback exists there pre-login).
  */
 import "../styles/tokens.css";
 import { createTranslator } from "../lib/i18n/translate";
 import { buildClientErrorMessages } from "../lib/i18n/error-messages";
 import { isTurnstileRequired } from "../lib/security/turnstile";
+import { isGoogleLoginRequired } from "../lib/auth/google-oidc-config";
 
 const locale = Astro.locals.locale;
 const t = await createTranslator(locale);
@@ -32,6 +40,7 @@ const turnstileActive = isTurnstileRequired();
 const turnstileSiteKey = turnstileActive
   ? process.env.TURNSTILE_SITE_KEY
   : null;
+const googleLoginActive = isGoogleLoginRequired();
 
 const clientStrings = {
   genericError: t("auth.login.generic_error"),
@@ -97,6 +106,14 @@ const clientStrings = {
         <button type="submit" id="login-submit">
           {t("auth.login.submit")}
         </button>
+
+        {
+          googleLoginActive && (
+            <button type="button" id="google-login-button">
+              {t("auth.login.google_button")}
+            </button>
+          )
+        }
       </form>
     </main>
 
@@ -205,6 +222,29 @@ const clientStrings = {
           unlock();
         }
       });
+
+      // Google OIDC login (Issue #590) — the destination needs the Tenant
+      // ID field's CURRENT value, read at click time, as a `?tenantId=`
+      // query param (this page has no tenant cookie yet pre-login, and a
+      // plain navigation can't carry the `X-AWCMS-Mini-Tenant-ID` header
+      // every fetch-based call on this page uses instead).
+      const googleButton = document.getElementById(
+        "google-login-button"
+      ) as HTMLButtonElement | null;
+
+      googleButton?.addEventListener("click", () => {
+        const tenantId = String(
+          (document.getElementById("tenant-id") as HTMLInputElement | null)
+            ?.value ?? ""
+        ).trim();
+
+        if (!tenantId) {
+          showError(strings.genericError);
+          return;
+        }
+
+        window.location.href = `/api/v1/auth/providers/google/start?tenantId=${encodeURIComponent(tenantId)}`;
+      });
     </script>
   </body>
 </html>
@@ -264,6 +304,13 @@ const clientStrings = {
   .login-form button:disabled {
     cursor: not-allowed;
     opacity: 0.75;
+  }
+
+  #google-login-button {
+    margin-top: var(--sp-2);
+    background: var(--color-surface);
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
   }
 
   .login-form input {

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -237,7 +237,8 @@ describe("database migration runner helpers", () => {
       "031_awcms_mini_tenant_domain_schema.sql",
       "032_awcms_mini_tenant_domain_permissions.sql",
       "033_awcms_mini_tenant_domain_lookup_function.sql",
-      "034_awcms_mini_mfa_totp_schema.sql"
+      "034_awcms_mini_mfa_totp_schema.sql",
+      "035_awcms_mini_google_oidc_schema.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/google-oidc-flow.integration.test.ts
+++ b/tests/integration/google-oidc-flow.integration.test.ts
@@ -40,7 +40,11 @@ import { POST as googleLink } from "../../src/pages/api/v1/auth/providers/google
 import { POST as googleUnlink } from "../../src/pages/api/v1/auth/providers/google/unlink";
 import { GOOGLE_OIDC_ENDPOINTS } from "../../src/lib/auth/google-oidc-config";
 import { resetGoogleJwksCacheForTests } from "../../src/lib/auth/google-oauth-client";
-import { resetProviderCircuitBreakersForTests } from "../../src/lib/database/circuit-breaker";
+import {
+  getDatabaseCircuitBreaker,
+  resetDatabaseCircuitBreakerForTests,
+  resetProviderCircuitBreakersForTests
+} from "../../src/lib/database/circuit-breaker";
 
 const OWNER_LOGIN = "owner@example.com";
 const OWNER_PASSWORD = "integration-test-owner-password";
@@ -215,6 +219,38 @@ suite("Google OIDC login flow (Issue #590)", () => {
 
   beforeEach(async () => {
     await resetDatabase();
+    resetDatabaseCircuitBreakerForTests();
+  });
+
+  test("start rejects a nonexistent tenant WITHOUT tripping the shared database circuit breaker", async () => {
+    // Security review of this PR found that inserting into
+    // awcms_mini_oidc_auth_requests with an unauthenticated, unvalidated
+    // tenantId let a nonexistent tenant trip a foreign-key violation,
+    // which withTenant's catch-all records against the single,
+    // APPLICATION-WIDE database circuit breaker — shared across every
+    // tenant and every endpoint, not scoped to this feature. Five bogus
+    // requests would have opened it and taken down the entire deployment
+    // for 30 seconds at a time, repeatedly, from an unauthenticated
+    // caller. Fixed by checking tenant existence/status via a plain
+    // SELECT (which never throws for a missing row) before ever
+    // attempting the insert.
+    await withEnvOverride(FULL_ONLINE_GOOGLE_ENV, async () => {
+      const bogusTenantId = "00000000-0000-0000-0000-000000000000";
+
+      for (let i = 0; i < 10; i += 1) {
+        const start = await invoke<{ error: { code: string } }>(googleStart, {
+          method: "GET",
+          path: `/api/v1/auth/providers/google/start?tenantId=${bogusTenantId}`
+        });
+        expect(start.status).toBe(403);
+        expect(start.body.error.code).toBe("ACCESS_DENIED");
+      }
+
+      // The shared database breaker must still be closed (i.e. usable) —
+      // if the bug were present, 5 consecutive FK-violation exceptions
+      // would have opened it.
+      expect(getDatabaseCircuitBreaker().canAttempt(new Date())).toBe(true);
+    });
   });
 
   test("disabled mode (default): start/link/unlink all report disabled", async () => {
@@ -408,6 +444,50 @@ suite("Google OIDC login flow (Issue #590)", () => {
           );
           expect(replay.status).toBe(401);
           expect(replay.body.error.code).toBe("GOOGLE_OAUTH_STATE_INVALID");
+        });
+      }
+    );
+  });
+
+  test("concurrent callback requests with the same state only succeed once (race-safe single-use)", async () => {
+    // `consumeOAuthRequest` uses SELECT ... FOR UPDATE + a compare-and-swap
+    // UPDATE ... WHERE consumed_at IS NULL RETURNING id (PR #597's fix for
+    // the equivalent MFA challenge race, reapplied here) — without it,
+    // concurrent requests carrying the same state could all read
+    // "not yet consumed" before any commits and all succeed.
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(
+      { ...FULL_ONLINE_GOOGLE_ENV, AUTH_GOOGLE_ALLOWED_DOMAINS: "example.com" },
+      async () => {
+        const { state, nonce } = await startGoogleLogin(owner.tenantId);
+        const idToken = signGoogleIdToken({
+          iss: "https://accounts.google.com",
+          aud: GOOGLE_CLIENT_ID,
+          sub: "google-subject-concurrent-replay",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        await withStubbedGoogle({ idToken }, async () => {
+          const callOnce = () =>
+            invoke<{ data?: { token: string } }>(googleCallback, {
+              method: "GET",
+              path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+            });
+
+          const results = await Promise.all([
+            callOnce(),
+            callOnce(),
+            callOnce(),
+            callOnce(),
+            callOnce()
+          ]);
+
+          const succeeded = results.filter((result) => result.status === 302);
+          expect(succeeded).toHaveLength(1);
         });
       }
     );

--- a/tests/integration/google-oidc-flow.integration.test.ts
+++ b/tests/integration/google-oidc-flow.integration.test.ts
@@ -1,0 +1,774 @@
+/**
+ * Integration tests for the Google OIDC login/link/unlink flow (Issue #590,
+ * epic: full-online auth hardening) across the real route handlers against
+ * a real PostgreSQL — start -> (stubbed Google) -> callback -> session,
+ * invalid state/nonce/issuer/audience rejection, auto-link-by-email, link,
+ * unlink, and MFA integration. The pure JWT/JWKS/policy logic is already
+ * covered by `tests/unit/jwt-verify.test.ts`/`google-oidc-policy.test.ts`/
+ * `google-oauth-client.test.ts`; this file proves the endpoints are wired
+ * correctly end to end, mirroring `mfa-flow.integration.test.ts`'s shape
+ * for the #589 feature this epic shares a gate with.
+ *
+ * Google's own token/JWKS endpoints are stubbed via a temporary
+ * `globalThis.fetch` override (same pattern
+ * `turnstile-gate.integration.test.ts`'s `withStubbedSiteverify` uses) —
+ * there is no test-only URL override hook on the production code path
+ * (`callback.ts` always calls Google's real, hardcoded endpoints), so
+ * intercepting the global fetch is the only way to exercise this endpoint
+ * end to end without a live Google account.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { GET as googleStart } from "../../src/pages/api/v1/auth/providers/google/start";
+import { GET as googleCallback } from "../../src/pages/api/v1/auth/providers/google/callback";
+import { POST as googleLink } from "../../src/pages/api/v1/auth/providers/google/link";
+import { POST as googleUnlink } from "../../src/pages/api/v1/auth/providers/google/unlink";
+import { GOOGLE_OIDC_ENDPOINTS } from "../../src/lib/auth/google-oidc-config";
+import { resetGoogleJwksCacheForTests } from "../../src/lib/auth/google-oauth-client";
+import { resetProviderCircuitBreakersForTests } from "../../src/lib/database/circuit-breaker";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+const GOOGLE_CLIENT_ID = "test-client-id.apps.googleusercontent.com";
+
+const FULL_ONLINE_GOOGLE_ENV: Record<string, string> = {
+  AUTH_ONLINE_SECURITY_ENABLED: "true",
+  AUTH_ONLINE_SECURITY_PROFILE: "full_online",
+  AUTH_GOOGLE_LOGIN_ENABLED: "true",
+  AUTH_GOOGLE_CLIENT_ID: GOOGLE_CLIENT_ID,
+  AUTH_GOOGLE_CLIENT_SECRET: "test-client-secret"
+};
+
+function base64Url(input: Buffer | string): string {
+  const buffer = typeof input === "string" ? Buffer.from(input) : input;
+  return buffer
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+const { publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY } =
+  generateKeyPairSync("rsa", { modulusLength: 2048 });
+const TEST_JWK = {
+  ...(TEST_PUBLIC_KEY.export({ format: "jwk" }) as Record<string, unknown>),
+  kid: "test-key-1"
+};
+
+function signGoogleIdToken(claims: Record<string, unknown>): string {
+  const header = { alg: "RS256", typ: "JWT", kid: "test-key-1" };
+  const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(claims))}`;
+  const signature = cryptoSign(
+    "RSA-SHA256",
+    Buffer.from(signingInput),
+    TEST_PRIVATE_KEY
+  );
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+type StubGoogleOptions = {
+  /** Overrides the ID token returned by the (stubbed) token exchange — build via `signGoogleIdToken`. */
+  idToken?: string;
+  /** Simulate the token endpoint itself failing (5xx) rather than returning a token. */
+  tokenEndpointFails?: boolean;
+};
+
+async function withStubbedGoogle<T>(
+  options: StubGoogleOptions,
+  fn: () => Promise<T>
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    if (url.startsWith(GOOGLE_OIDC_ENDPOINTS.tokenEndpoint)) {
+      if (options.tokenEndpointFails) {
+        return new Response("upstream error", { status: 500 });
+      }
+      return Response.json({ id_token: options.idToken ?? "" });
+    }
+
+    if (url.startsWith(GOOGLE_OIDC_ENDPOINTS.jwksUri)) {
+      return Response.json({ keys: [TEST_JWK] });
+    }
+
+    return originalFetch(input as never);
+  }) as typeof fetch;
+
+  resetGoogleJwksCacheForTests();
+  resetProviderCircuitBreakersForTests();
+
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+    resetGoogleJwksCacheForTests();
+    resetProviderCircuitBreakersForTests();
+  }
+}
+
+async function withEnvOverride<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+
+  for (const key of Object.keys(overrides)) {
+    previous[key] = process.env[key];
+    const value = overrides[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(overrides)) {
+      const value = previous[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function bootstrapTenant(tenantCode = "acme") {
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: `Tenant ${tenantCode}`,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "Head Office",
+      ownerLoginIdentifier: OWNER_LOGIN,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId };
+}
+
+async function loginAndGetToken(tenantId: string): Promise<string> {
+  const result = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(result.status).toBe(200);
+  return result.body.data.token;
+}
+
+/** Calls `start.ts` and extracts `state`/`nonce` from the 302 redirect's Location query params. */
+async function startGoogleLogin(
+  tenantId: string
+): Promise<{ state: string; nonce: string }> {
+  const result = await invoke(googleStart, {
+    method: "GET",
+    path: `/api/v1/auth/providers/google/start?tenantId=${tenantId}`
+  });
+  expect(result.status).toBe(302);
+
+  const location = new URL(result.response.headers.get("location")!);
+  return {
+    state: location.searchParams.get("state")!,
+    nonce: location.searchParams.get("nonce")!
+  };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("Google OIDC login flow (Issue #590)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("disabled mode (default): start/link/unlink all report disabled", async () => {
+    const owner = await bootstrapTenant();
+    const token = await loginAndGetToken(owner.tenantId);
+
+    const start = await invoke(googleStart, {
+      method: "GET",
+      path: `/api/v1/auth/providers/google/start?tenantId=${owner.tenantId}`
+    });
+    expect(start.status).toBe(403);
+
+    const link = await invoke<{ error: { code: string } }>(googleLink, {
+      method: "POST",
+      path: "/api/v1/auth/providers/google/link",
+      headers: {
+        "content-type": "application/json",
+        "x-awcms-mini-tenant-id": owner.tenantId,
+        authorization: `Bearer ${token}`
+      }
+    });
+    expect(link.status).toBe(403);
+    expect(link.body.error.code).toBe("GOOGLE_LOGIN_DISABLED");
+  });
+
+  test("login with no linked account and no auto-link policy configured is rejected, not silently provisioned", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_GOOGLE_ENV, async () => {
+      const { state, nonce } = await startGoogleLogin(owner.tenantId);
+
+      const idToken = signGoogleIdToken({
+        iss: "https://accounts.google.com",
+        aud: GOOGLE_CLIENT_ID,
+        sub: "google-subject-owner",
+        email: "owner@example.com",
+        email_verified: true,
+        nonce,
+        exp: Math.floor(Date.now() / 1000) + 3600
+      });
+
+      await withStubbedGoogle({ idToken }, async () => {
+        const callback = await invoke<{ error: { code: string } }>(
+          googleCallback,
+          {
+            method: "GET",
+            path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+          }
+        );
+
+        // No existing provider account and no auto-link-eligible policy
+        // configured (AUTH_GOOGLE_ALLOWED_DOMAINS unset) — must reject,
+        // not silently create an account.
+        expect(callback.status).toBe(401);
+        expect(callback.body.error.code).toBe("GOOGLE_ACCOUNT_NOT_LINKED");
+      });
+    });
+  });
+
+  test("full login flow with auto-link-by-email: verified email + allowed domain links to the existing identity", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(
+      { ...FULL_ONLINE_GOOGLE_ENV, AUTH_GOOGLE_ALLOWED_DOMAINS: "example.com" },
+      async () => {
+        const { state, nonce } = await startGoogleLogin(owner.tenantId);
+
+        const idToken = signGoogleIdToken({
+          iss: "https://accounts.google.com",
+          aud: GOOGLE_CLIENT_ID,
+          sub: "google-subject-owner",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        await withStubbedGoogle({ idToken }, async () => {
+          const callback = await invoke<{ data: { token: string } }>(
+            googleCallback,
+            {
+              method: "GET",
+              path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+            }
+          );
+
+          expect(callback.status).toBe(302);
+          expect(callback.response.headers.get("location")).toBe("/admin");
+        });
+
+        // A second login with the SAME Google subject now finds the
+        // linked provider account directly (no auto-link needed).
+        const second = await startGoogleLogin(owner.tenantId);
+        const secondIdToken = signGoogleIdToken({
+          iss: "https://accounts.google.com",
+          aud: GOOGLE_CLIENT_ID,
+          sub: "google-subject-owner",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce: second.nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        await withStubbedGoogle({ idToken: secondIdToken }, async () => {
+          const callback = await invoke(googleCallback, {
+            method: "GET",
+            path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(second.state)}`
+          });
+          expect(callback.status).toBe(302);
+        });
+      }
+    );
+  });
+
+  test("auto-link rejects an unverified email even with an allowed domain", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(
+      { ...FULL_ONLINE_GOOGLE_ENV, AUTH_GOOGLE_ALLOWED_DOMAINS: "example.com" },
+      async () => {
+        const { state, nonce } = await startGoogleLogin(owner.tenantId);
+        const idToken = signGoogleIdToken({
+          iss: "https://accounts.google.com",
+          aud: GOOGLE_CLIENT_ID,
+          sub: "google-subject-unverified",
+          email: OWNER_LOGIN,
+          email_verified: false,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        await withStubbedGoogle({ idToken }, async () => {
+          const callback = await invoke<{ error: { code: string } }>(
+            googleCallback,
+            {
+              method: "GET",
+              path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+            }
+          );
+          expect(callback.status).toBe(401);
+          expect(callback.body.error.code).toBe("GOOGLE_ACCOUNT_NOT_LINKED");
+        });
+      }
+    );
+  });
+
+  test("rejects a missing/invalid state parameter", async () => {
+    await withEnvOverride(FULL_ONLINE_GOOGLE_ENV, async () => {
+      const callback = await invoke<{ error: { code: string } }>(
+        googleCallback,
+        {
+          method: "GET",
+          path: `/api/v1/auth/providers/google/callback?code=some-code&state=garbage-not-a-valid-state`
+        }
+      );
+      expect(callback.status).toBe(401);
+      expect(callback.body.error.code).toBe("GOOGLE_OAUTH_STATE_INVALID");
+    });
+  });
+
+  test("rejects a replayed state (single-use)", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(
+      { ...FULL_ONLINE_GOOGLE_ENV, AUTH_GOOGLE_ALLOWED_DOMAINS: "example.com" },
+      async () => {
+        const { state, nonce } = await startGoogleLogin(owner.tenantId);
+        const idToken = signGoogleIdToken({
+          iss: "https://accounts.google.com",
+          aud: GOOGLE_CLIENT_ID,
+          sub: "google-subject-replay",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        await withStubbedGoogle({ idToken }, async () => {
+          const first = await invoke(googleCallback, {
+            method: "GET",
+            path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+          });
+          expect(first.status).toBe(302);
+
+          const replay = await invoke<{ error: { code: string } }>(
+            googleCallback,
+            {
+              method: "GET",
+              path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+            }
+          );
+          expect(replay.status).toBe(401);
+          expect(replay.body.error.code).toBe("GOOGLE_OAUTH_STATE_INVALID");
+        });
+      }
+    );
+  });
+
+  test("rejects an ID token with the wrong nonce", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(
+      { ...FULL_ONLINE_GOOGLE_ENV, AUTH_GOOGLE_ALLOWED_DOMAINS: "example.com" },
+      async () => {
+        const { state } = await startGoogleLogin(owner.tenantId);
+        const idToken = signGoogleIdToken({
+          iss: "https://accounts.google.com",
+          aud: GOOGLE_CLIENT_ID,
+          sub: "google-subject-wrong-nonce",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce: "wrong-nonce-value",
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        await withStubbedGoogle({ idToken }, async () => {
+          const callback = await invoke<{ error: { code: string } }>(
+            googleCallback,
+            {
+              method: "GET",
+              path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+            }
+          );
+          expect(callback.status).toBe(401);
+          expect(callback.body.error.code).toBe("GOOGLE_ID_TOKEN_INVALID");
+        });
+      }
+    );
+  });
+
+  test("rejects an ID token with the wrong audience", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(
+      { ...FULL_ONLINE_GOOGLE_ENV, AUTH_GOOGLE_ALLOWED_DOMAINS: "example.com" },
+      async () => {
+        const { state, nonce } = await startGoogleLogin(owner.tenantId);
+        const idToken = signGoogleIdToken({
+          iss: "https://accounts.google.com",
+          aud: "some-other-client-id",
+          sub: "google-subject-wrong-aud",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        await withStubbedGoogle({ idToken }, async () => {
+          const callback = await invoke<{ error: { code: string } }>(
+            googleCallback,
+            {
+              method: "GET",
+              path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+            }
+          );
+          expect(callback.status).toBe(401);
+          expect(callback.body.error.code).toBe("GOOGLE_ID_TOKEN_INVALID");
+        });
+      }
+    );
+  });
+
+  test("rejects an ID token with the wrong issuer", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(
+      { ...FULL_ONLINE_GOOGLE_ENV, AUTH_GOOGLE_ALLOWED_DOMAINS: "example.com" },
+      async () => {
+        const { state, nonce } = await startGoogleLogin(owner.tenantId);
+        const idToken = signGoogleIdToken({
+          iss: "https://evil.example.com",
+          aud: GOOGLE_CLIENT_ID,
+          sub: "google-subject-wrong-iss",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        await withStubbedGoogle({ idToken }, async () => {
+          const callback = await invoke<{ error: { code: string } }>(
+            googleCallback,
+            {
+              method: "GET",
+              path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+            }
+          );
+          expect(callback.status).toBe(401);
+          expect(callback.body.error.code).toBe("GOOGLE_ID_TOKEN_INVALID");
+        });
+      }
+    );
+  });
+
+  test("link: authenticated identity can link, then subsequent Google login uses that link", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_GOOGLE_ENV, async () => {
+      const token = await loginAndGetToken(owner.tenantId);
+
+      const linkStart = await invoke<{ data: { authorizationUrl: string } }>(
+        googleLink,
+        {
+          method: "POST",
+          path: "/api/v1/auth/providers/google/link",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId,
+            authorization: `Bearer ${token}`
+          }
+        }
+      );
+      expect(linkStart.status).toBe(200);
+
+      const location = new URL(linkStart.body.data.authorizationUrl);
+      const state = location.searchParams.get("state")!;
+      const nonce = location.searchParams.get("nonce")!;
+
+      const idToken = signGoogleIdToken({
+        iss: "https://accounts.google.com",
+        aud: GOOGLE_CLIENT_ID,
+        sub: "google-subject-link-me",
+        email: "unrelated@example.com",
+        email_verified: true,
+        nonce,
+        exp: Math.floor(Date.now() / 1000) + 3600
+      });
+
+      await withStubbedGoogle({ idToken }, async () => {
+        const callback = await invoke(googleCallback, {
+          method: "GET",
+          path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+        });
+        expect(callback.status).toBe(302);
+        expect(callback.response.headers.get("location")).toBe("/admin");
+      });
+
+      // A fresh login flow with the SAME Google subject now finds the
+      // linked account directly.
+      const { state: loginState, nonce: loginNonce } = await startGoogleLogin(
+        owner.tenantId
+      );
+      const loginIdToken = signGoogleIdToken({
+        iss: "https://accounts.google.com",
+        aud: GOOGLE_CLIENT_ID,
+        sub: "google-subject-link-me",
+        email: "unrelated@example.com",
+        email_verified: true,
+        nonce: loginNonce,
+        exp: Math.floor(Date.now() / 1000) + 3600
+      });
+
+      await withStubbedGoogle({ idToken: loginIdToken }, async () => {
+        const callback = await invoke<{ data: { token: string } }>(
+          googleCallback,
+          {
+            method: "GET",
+            path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(loginState)}`
+          }
+        );
+        expect(callback.status).toBe(302);
+      });
+    });
+  });
+
+  test("link rejects a Google subject already linked to a different identity", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_GOOGLE_ENV, async () => {
+      const admin = getAdminSql();
+      const other = await admin`
+        SELECT id FROM awcms_mini_identities
+        WHERE tenant_id = ${owner.tenantId} AND login_identifier = ${OWNER_LOGIN}
+      `;
+      await admin`
+        INSERT INTO awcms_mini_identity_provider_accounts
+          (tenant_id, identity_id, provider, provider_subject)
+        VALUES (${owner.tenantId}, ${(other[0] as { id: string }).id}, 'google', 'already-taken-subject')
+      `;
+
+      const token = await loginAndGetToken(owner.tenantId);
+      const linkStart = await invoke<{ data: { authorizationUrl: string } }>(
+        googleLink,
+        {
+          method: "POST",
+          path: "/api/v1/auth/providers/google/link",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId,
+            authorization: `Bearer ${token}`
+          }
+        }
+      );
+      const location = new URL(linkStart.body.data.authorizationUrl);
+      const state = location.searchParams.get("state")!;
+      const nonce = location.searchParams.get("nonce")!;
+
+      const idToken = signGoogleIdToken({
+        iss: "https://accounts.google.com",
+        aud: GOOGLE_CLIENT_ID,
+        sub: "already-taken-subject",
+        email: "someone@example.com",
+        email_verified: true,
+        nonce,
+        exp: Math.floor(Date.now() / 1000) + 3600
+      });
+
+      await withStubbedGoogle({ idToken }, async () => {
+        const callback = await invoke<{ error: { code: string } }>(
+          googleCallback,
+          {
+            method: "GET",
+            path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+          }
+        );
+        expect(callback.status).toBe(409);
+        expect(callback.body.error.code).toBe("GOOGLE_ALREADY_LINKED");
+      });
+    });
+  });
+
+  test("unlink: removes a linked account; unlinking again is a conflict", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(FULL_ONLINE_GOOGLE_ENV, async () => {
+      const admin = getAdminSql();
+      const identityRows = await admin`
+        SELECT id FROM awcms_mini_identities
+        WHERE tenant_id = ${owner.tenantId} AND login_identifier = ${OWNER_LOGIN}
+      `;
+      await admin`
+        INSERT INTO awcms_mini_identity_provider_accounts
+          (tenant_id, identity_id, provider, provider_subject)
+        VALUES (${owner.tenantId}, ${(identityRows[0] as { id: string }).id}, 'google', 'subject-to-unlink')
+      `;
+
+      const token = await loginAndGetToken(owner.tenantId);
+
+      const unlink = await invoke<{ data: { unlinked: boolean } }>(
+        googleUnlink,
+        {
+          method: "POST",
+          path: "/api/v1/auth/providers/google/unlink",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId,
+            authorization: `Bearer ${token}`
+          }
+        }
+      );
+      expect(unlink.status).toBe(200);
+      expect(unlink.body.data.unlinked).toBe(true);
+
+      const again = await invoke<{ error: { code: string } }>(googleUnlink, {
+        method: "POST",
+        path: "/api/v1/auth/providers/google/unlink",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId,
+          authorization: `Bearer ${token}`
+        }
+      });
+      expect(again.status).toBe(409);
+      expect(again.body.error.code).toBe("GOOGLE_NOT_LINKED");
+    });
+  });
+
+  test("MFA integration: Google login for an MFA-enrolled identity stops at MFA_REQUIRED, not a session", async () => {
+    const owner = await bootstrapTenant();
+    const mfaKey = Buffer.alloc(32, 7).toString("base64");
+
+    await withEnvOverride(
+      {
+        ...FULL_ONLINE_GOOGLE_ENV,
+        AUTH_GOOGLE_ALLOWED_DOMAINS: "example.com",
+        AUTH_MFA_ENABLED: "true",
+        AUTH_MFA_SECRET_ENCRYPTION_KEY: mfaKey
+      },
+      async () => {
+        const token = await loginAndGetToken(owner.tenantId);
+
+        const { POST: enrollStart } =
+          await import("../../src/pages/api/v1/auth/mfa/totp/enroll/start");
+        const { POST: enrollVerify } =
+          await import("../../src/pages/api/v1/auth/mfa/totp/enroll/verify");
+        const { generateTotpCode, base32Decode } =
+          await import("../../src/lib/auth/totp");
+
+        const start = await invoke<{ data: { secret: string } }>(enrollStart, {
+          method: "POST",
+          path: "/api/v1/auth/mfa/totp/enroll/start",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId,
+            authorization: `Bearer ${token}`
+          }
+        });
+        const code = generateTotpCode(
+          base32Decode(start.body.data.secret),
+          Date.now(),
+          { periodSec: 30, digits: 6 }
+        );
+        const verify = await invoke(enrollVerify, {
+          method: "POST",
+          path: "/api/v1/auth/mfa/totp/enroll/verify",
+          headers: {
+            "content-type": "application/json",
+            "x-awcms-mini-tenant-id": owner.tenantId,
+            authorization: `Bearer ${token}`
+          },
+          body: { code }
+        });
+        expect(verify.status).toBe(200);
+
+        const { state, nonce } = await startGoogleLogin(owner.tenantId);
+        const idToken = signGoogleIdToken({
+          iss: "https://accounts.google.com",
+          aud: GOOGLE_CLIENT_ID,
+          sub: "google-subject-mfa-owner",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        await withStubbedGoogle({ idToken }, async () => {
+          const callback = await invoke<{
+            error: { code: string; details?: { mfaChallengeToken?: string } };
+          }>(googleCallback, {
+            method: "GET",
+            path: `/api/v1/auth/providers/google/callback?code=some-code&state=${encodeURIComponent(state)}`
+          });
+
+          expect(callback.status).toBe(401);
+          expect(callback.body.error.code).toBe("MFA_REQUIRED");
+          expect(typeof callback.body.error.details?.mfaChallengeToken).toBe(
+            "string"
+          );
+        });
+      }
+    );
+  });
+
+  test("user cancelling Google consent is rejected cleanly", async () => {
+    await withEnvOverride(FULL_ONLINE_GOOGLE_ENV, async () => {
+      const callback = await invoke<{ error: { code: string } }>(
+        googleCallback,
+        {
+          method: "GET",
+          path: "/api/v1/auth/providers/google/callback?error=access_denied"
+        }
+      );
+      expect(callback.status).toBe(401);
+      expect(callback.body.error.code).toBe("GOOGLE_OAUTH_STATE_INVALID");
+    });
+  });
+});

--- a/tests/integration/google-oidc-schema.integration.test.ts
+++ b/tests/integration/google-oidc-schema.integration.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Integration tests for the Google OIDC foundation schema/RLS (Issue #590,
+ * epic: full-online auth hardening) against a real PostgreSQL — migration
+ * 035's two new tables. Same pattern `mfa-schema.integration.test.ts` (#589)
+ * and `blog-content-schema.integration.test.ts` (#537) used: exercise
+ * constraints and RLS enforcement directly via `withTenant`/raw admin SQL,
+ * independent of the endpoint-level flow covered by
+ * `google-oidc-flow.integration.test.ts`.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+
+const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const PROFILE_A = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+const PROFILE_B = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+const IDENTITY_A = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+const IDENTITY_B = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+const IDENTITY_A2 = "99999999-9999-9999-9999-999999999999";
+
+async function seedFixtures(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES
+      (${TENANT_A}, 'tenant-a', 'Tenant A', 'Tenant A Legal', 'active', 'en', 'light'),
+      (${TENANT_B}, 'tenant-b', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+  `;
+  await admin`
+    INSERT INTO awcms_mini_profiles (id, tenant_id, profile_type, display_name)
+    VALUES
+      (${PROFILE_A}, ${TENANT_A}, 'person', 'Owner A'),
+      (${PROFILE_B}, ${TENANT_B}, 'person', 'Owner B')
+  `;
+  await admin`
+    INSERT INTO awcms_mini_identities
+      (id, tenant_id, profile_id, login_identifier, password_hash)
+    VALUES
+      (${IDENTITY_A}, ${TENANT_A}, ${PROFILE_A}, 'owner-a@example.com', 'hash'),
+      (${IDENTITY_A2}, ${TENANT_A}, ${PROFILE_A}, 'owner-a2@example.com', 'hash'),
+      (${IDENTITY_B}, ${TENANT_B}, ${PROFILE_B}, 'owner-b@example.com', 'hash')
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("Google OIDC schema — RLS isolation and constraints (Issue #590)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedFixtures();
+  });
+
+  test("provider accounts: tenant A cannot see tenant B's linked account (RLS isolation)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_identity_provider_accounts
+        (tenant_id, identity_id, provider, provider_subject)
+      VALUES
+        (${TENANT_A}, ${IDENTITY_A}, 'google', 'subject-a'),
+        (${TENANT_B}, ${IDENTITY_B}, 'google', 'subject-b')
+    `;
+
+    const sql = getDatabaseClient();
+    const rows = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT identity_id FROM awcms_mini_identity_provider_accounts`
+    );
+
+    expect(rows).toHaveLength(1);
+    expect((rows as { identity_id: string }[])[0]?.identity_id).toBe(
+      IDENTITY_A
+    );
+  });
+
+  test("querying provider accounts without a tenant GUC set returns no rows (fail-closed)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_identity_provider_accounts
+        (tenant_id, identity_id, provider, provider_subject)
+      VALUES (${TENANT_A}, ${IDENTITY_A}, 'google', 'subject-a')
+    `;
+
+    const sql = getDatabaseClient();
+    const rows =
+      await sql`SELECT identity_id FROM awcms_mini_identity_provider_accounts`;
+    expect(rows).toHaveLength(0);
+  });
+
+  test("one identity can only link one account per provider (identity-scoped unique index)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_identity_provider_accounts
+        (tenant_id, identity_id, provider, provider_subject)
+      VALUES (${TENANT_A}, ${IDENTITY_A}, 'google', 'subject-a')
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_identity_provider_accounts
+          (tenant_id, identity_id, provider, provider_subject)
+        VALUES (${TENANT_A}, ${IDENTITY_A}, 'google', 'a-different-subject')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("one provider subject can only be linked to one identity (subject-scoped unique index)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_identity_provider_accounts
+        (tenant_id, identity_id, provider, provider_subject)
+      VALUES (${TENANT_A}, ${IDENTITY_A}, 'google', 'shared-subject')
+    `;
+
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_identity_provider_accounts
+          (tenant_id, identity_id, provider, provider_subject)
+        VALUES (${TENANT_A}, ${IDENTITY_A2}, 'google', 'shared-subject')
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("oidc auth requests: tenant A cannot see tenant B's request (RLS isolation)", async () => {
+    const admin = getAdminSql();
+    const future = new Date(Date.now() + 10 * 60_000);
+    await admin`
+      INSERT INTO awcms_mini_oidc_auth_requests
+        (tenant_id, provider, state_hash, nonce, purpose, expires_at)
+      VALUES
+        (${TENANT_A}, 'google', 'sha256:aaa', 'nonce-a', 'login', ${future}),
+        (${TENANT_B}, 'google', 'sha256:bbb', 'nonce-b', 'login', ${future})
+    `;
+
+    const sql = getDatabaseClient();
+    const rows = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT state_hash FROM awcms_mini_oidc_auth_requests`
+    );
+
+    expect(rows).toHaveLength(1);
+    expect((rows as { state_hash: string }[])[0]?.state_hash).toBe(
+      "sha256:aaa"
+    );
+  });
+
+  test("oidc auth requests rejects an unknown purpose", async () => {
+    const admin = getAdminSql();
+    const future = new Date(Date.now() + 10 * 60_000);
+    let didThrow = false;
+
+    try {
+      await admin`
+        INSERT INTO awcms_mini_oidc_auth_requests
+          (tenant_id, provider, state_hash, nonce, purpose, expires_at)
+        VALUES (${TENANT_A}, 'google', 'sha256:aaa', 'nonce-a', 'bogus', ${future})
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("oidc auth requests rejects a link-purpose row with no identity_id", async () => {
+    const admin = getAdminSql();
+    const future = new Date(Date.now() + 10 * 60_000);
+    let didThrow = false;
+
+    try {
+      await admin`
+        INSERT INTO awcms_mini_oidc_auth_requests
+          (tenant_id, provider, state_hash, nonce, purpose, identity_id, expires_at)
+        VALUES (${TENANT_A}, 'google', 'sha256:aaa', 'nonce-a', 'link', NULL, ${future})
+      `;
+    } catch {
+      didThrow = true;
+    }
+
+    expect(didThrow).toBe(true);
+  });
+
+  test("oidc auth requests accepts a link-purpose row WITH an identity_id", async () => {
+    const admin = getAdminSql();
+    const future = new Date(Date.now() + 10 * 60_000);
+
+    const rows = await admin`
+      INSERT INTO awcms_mini_oidc_auth_requests
+        (tenant_id, provider, state_hash, nonce, purpose, identity_id, expires_at)
+      VALUES (${TENANT_A}, 'google', 'sha256:aaa', 'nonce-a', 'link', ${IDENTITY_A}, ${future})
+      RETURNING id
+    `;
+
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/tests/security-readiness.test.ts
+++ b/tests/security-readiness.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   checkAbacDefaultDeny,
   checkEmailProviderConfigReady,
+  checkGoogleOidcReady,
   checkLoginLockoutImplemented,
   checkLoginRateLimitImplemented,
   checkOnlineAuthSecurityReady,
@@ -270,6 +271,35 @@ describe("checkMfaReady", () => {
     const result = checkMfaReady({
       AUTH_MFA_ENABLED: "true",
       AUTH_MFA_SECRET_ENCRYPTION_KEY: validKey
+    } as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("pass");
+  });
+});
+
+describe("checkGoogleOidcReady", () => {
+  test("is critical/pass (informational, not a failure) when Google login is not enabled", () => {
+    const result = checkGoogleOidcReady({} as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when AUTH_GOOGLE_LOGIN_ENABLED=true but the client id/secret are missing", () => {
+    const result = checkGoogleOidcReady({
+      AUTH_GOOGLE_LOGIN_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.severity).toBe("critical");
+    expect(result.status).toBe("fail");
+  });
+
+  test("passes when AUTH_GOOGLE_LOGIN_ENABLED=true and both client id/secret are set", () => {
+    const result = checkGoogleOidcReady({
+      AUTH_GOOGLE_LOGIN_ENABLED: "true",
+      AUTH_GOOGLE_CLIENT_ID: "client-abc",
+      AUTH_GOOGLE_CLIENT_SECRET: "a-real-secret"
     } as NodeJS.ProcessEnv);
 
     expect(result.severity).toBe("critical");

--- a/tests/unit/google-oauth-client.test.ts
+++ b/tests/unit/google-oauth-client.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  buildGoogleAuthorizationUrl,
+  exchangeAuthorizationCode,
+  fetchGoogleJwks,
+  resetGoogleJwksCacheForTests,
+  resolveGoogleRedirectUri
+} from "../../src/lib/auth/google-oauth-client";
+import { resetProviderCircuitBreakersForTests } from "../../src/lib/database/circuit-breaker";
+
+describe("resolveGoogleRedirectUri/buildGoogleAuthorizationUrl", () => {
+  test("resolveGoogleRedirectUri combines APP_URL with the redirect path", () => {
+    expect(
+      resolveGoogleRedirectUri({
+        APP_URL: "https://awcms-mini.example.com"
+      } as NodeJS.ProcessEnv)
+    ).toBe(
+      "https://awcms-mini.example.com/api/v1/auth/providers/google/callback"
+    );
+  });
+
+  test("buildGoogleAuthorizationUrl includes every required query param", () => {
+    const url = new URL(
+      buildGoogleAuthorizationUrl({
+        clientId: "client-abc",
+        tenantId: "11111111-1111-1111-1111-111111111111",
+        state: "raw-state-value",
+        nonce: "raw-nonce-value"
+      })
+    );
+
+    expect(url.origin + url.pathname).toBe(
+      "https://accounts.google.com/o/oauth2/v2/auth"
+    );
+    expect(url.searchParams.get("client_id")).toBe("client-abc");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("scope")).toBe("openid email profile");
+    expect(url.searchParams.get("state")).toBe(
+      "11111111-1111-1111-1111-111111111111.raw-state-value"
+    );
+    expect(url.searchParams.get("nonce")).toBe("raw-nonce-value");
+  });
+});
+
+describe("exchangeAuthorizationCode", () => {
+  beforeEach(() => {
+    resetProviderCircuitBreakersForTests();
+  });
+
+  afterEach(() => {
+    resetProviderCircuitBreakersForTests();
+  });
+
+  test("succeeds when Google returns an id_token", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ id_token: "a-real-id-token" });
+      }
+    });
+
+    const result = await exchangeAuthorizationCode({
+      code: "good-code",
+      clientId: "client-abc",
+      clientSecret: "secret-abc",
+      redirectUri: "https://app.example.com/callback",
+      tokenEndpoint: `http://127.0.0.1:${server.port}`
+    });
+
+    expect(result).toEqual({ ok: true, idToken: "a-real-id-token" });
+  });
+
+  test("fails cleanly (not retryable) on a 400 invalid_grant — Google correctly rejecting a bad code", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+          headers: { "content-type": "application/json" }
+        });
+      }
+    });
+
+    const result = await exchangeAuthorizationCode({
+      code: "bad-or-reused-code",
+      clientId: "client-abc",
+      clientSecret: "secret-abc",
+      redirectUri: "https://app.example.com/callback",
+      tokenEndpoint: `http://127.0.0.1:${server.port}`
+    });
+
+    expect(result).toEqual({ ok: false, retryable: false });
+  });
+
+  test("never trips the circuit breaker on repeated invalid_grant responses (client-input-driven, not a provider outage)", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+          headers: { "content-type": "application/json" }
+        });
+      }
+    });
+
+    const params = {
+      code: "bad-code",
+      clientId: "client-abc",
+      clientSecret: "secret-abc",
+      redirectUri: "https://app.example.com/callback",
+      tokenEndpoint: `http://127.0.0.1:${server.port}`
+    };
+
+    for (let i = 0; i < 10; i += 1) {
+      await exchangeAuthorizationCode(params);
+    }
+
+    // If this were incorrectly tripping the breaker, the 11th call would
+    // come back retryable:true without ever reaching the fake server —
+    // instead it must still reach it and get the same clean 400 result.
+    const result = await exchangeAuthorizationCode(params);
+    expect(result).toEqual({ ok: false, retryable: false });
+  });
+
+  test("opens the circuit breaker after consecutive genuine provider failures (5xx)", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("upstream error", { status: 500 });
+      }
+    });
+
+    const params = {
+      code: "some-code",
+      clientId: "client-abc",
+      clientSecret: "secret-abc",
+      redirectUri: "https://app.example.com/callback",
+      tokenEndpoint: `http://127.0.0.1:${server.port}`
+    };
+
+    for (let i = 0; i < 5; i += 1) {
+      await exchangeAuthorizationCode(params);
+    }
+
+    const sixth = await exchangeAuthorizationCode(params);
+    expect(sixth).toEqual({ ok: false, retryable: true });
+  });
+
+  test("times out a wedged token endpoint instead of hanging forever", async () => {
+    using server = Bun.serve({
+      port: 0,
+      async fetch() {
+        await Bun.sleep(500);
+        return Response.json({ id_token: "too-late" });
+      }
+    });
+
+    const result = await exchangeAuthorizationCode({
+      code: "some-code",
+      clientId: "client-abc",
+      clientSecret: "secret-abc",
+      redirectUri: "https://app.example.com/callback",
+      tokenEndpoint: `http://127.0.0.1:${server.port}`,
+      timeoutMs: 20
+    });
+
+    expect(result).toEqual({ ok: false, retryable: true });
+  });
+});
+
+describe("fetchGoogleJwks", () => {
+  beforeEach(() => {
+    resetProviderCircuitBreakersForTests();
+    resetGoogleJwksCacheForTests();
+  });
+
+  afterEach(() => {
+    resetProviderCircuitBreakersForTests();
+    resetGoogleJwksCacheForTests();
+  });
+
+  test("succeeds and caches the result across calls", async () => {
+    let callCount = 0;
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        callCount += 1;
+        return Response.json({ keys: [{ kty: "RSA", kid: "k1" }] });
+      }
+    });
+
+    const first = await fetchGoogleJwks({
+      jwksUri: `http://127.0.0.1:${server.port}`
+    });
+    const second = await fetchGoogleJwks({
+      jwksUri: `http://127.0.0.1:${server.port}`
+    });
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(callCount).toBe(1);
+  });
+
+  test("fails cleanly on a malformed JWKS response", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ notKeys: [] });
+      }
+    });
+
+    const result = await fetchGoogleJwks({
+      jwksUri: `http://127.0.0.1:${server.port}`
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("opens the circuit breaker after consecutive failures", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("upstream error", { status: 500 });
+      }
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      resetGoogleJwksCacheForTests();
+      await fetchGoogleJwks({ jwksUri: `http://127.0.0.1:${server.port}` });
+    }
+
+    resetGoogleJwksCacheForTests();
+    const sixth = await fetchGoogleJwks({
+      jwksUri: `http://127.0.0.1:${server.port}`
+    });
+    expect(sixth.ok).toBe(false);
+  });
+});

--- a/tests/unit/google-oidc-config.test.ts
+++ b/tests/unit/google-oidc-config.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isGoogleLoginEnabled,
+  isGoogleLoginRequired,
+  resolveGoogleAllowedDomains,
+  resolveGoogleClientId,
+  resolveGoogleClientSecret,
+  resolveGoogleRedirectPath
+} from "../../src/lib/auth/google-oidc-config";
+
+const FULL_ONLINE_ENV = {
+  AUTH_ONLINE_SECURITY_ENABLED: "true",
+  AUTH_ONLINE_SECURITY_PROFILE: "full_online"
+} as const;
+
+describe("isGoogleLoginEnabled", () => {
+  test("false when unset", () => {
+    expect(isGoogleLoginEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  test('true only for the literal string "true"', () => {
+    expect(
+      isGoogleLoginEnabled({
+        AUTH_GOOGLE_LOGIN_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+    expect(
+      isGoogleLoginEnabled({
+        AUTH_GOOGLE_LOGIN_ENABLED: "TRUE"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+});
+
+describe("isGoogleLoginRequired — the shared gate login/callback/link/unlink all check", () => {
+  test("false when the full-online gate (#587) is off, even if AUTH_GOOGLE_LOGIN_ENABLED=true", () => {
+    expect(
+      isGoogleLoginRequired({
+        AUTH_GOOGLE_LOGIN_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("false when AUTH_GOOGLE_LOGIN_ENABLED is not set, even if the full-online gate is on", () => {
+    expect(
+      isGoogleLoginRequired({ ...FULL_ONLINE_ENV } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("true only when both the full-online gate and AUTH_GOOGLE_LOGIN_ENABLED agree", () => {
+    expect(
+      isGoogleLoginRequired({
+        ...FULL_ONLINE_ENV,
+        AUTH_GOOGLE_LOGIN_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+});
+
+describe("resolveGoogleClientId/resolveGoogleClientSecret", () => {
+  test("returns undefined when unset", () => {
+    expect(resolveGoogleClientId({} as NodeJS.ProcessEnv)).toBeUndefined();
+    expect(resolveGoogleClientSecret({} as NodeJS.ProcessEnv)).toBeUndefined();
+  });
+
+  test("returns the configured value", () => {
+    expect(
+      resolveGoogleClientId({
+        AUTH_GOOGLE_CLIENT_ID: "client-abc"
+      } as NodeJS.ProcessEnv)
+    ).toBe("client-abc");
+    expect(
+      resolveGoogleClientSecret({
+        AUTH_GOOGLE_CLIENT_SECRET: "secret-abc"
+      } as NodeJS.ProcessEnv)
+    ).toBe("secret-abc");
+  });
+});
+
+describe("resolveGoogleAllowedDomains", () => {
+  test("empty array when unset — auto-linking-by-email is fail-closed", () => {
+    expect(resolveGoogleAllowedDomains({} as NodeJS.ProcessEnv)).toEqual([]);
+  });
+
+  test("parses a comma-separated list, trimmed and lowercased", () => {
+    expect(
+      resolveGoogleAllowedDomains({
+        AUTH_GOOGLE_ALLOWED_DOMAINS: " Example.com, other.ORG ,"
+      } as NodeJS.ProcessEnv)
+    ).toEqual(["example.com", "other.org"]);
+  });
+
+  test("drops empty entries from stray commas", () => {
+    expect(
+      resolveGoogleAllowedDomains({
+        AUTH_GOOGLE_ALLOWED_DOMAINS: "example.com,,other.org"
+      } as NodeJS.ProcessEnv)
+    ).toEqual(["example.com", "other.org"]);
+  });
+});
+
+describe("resolveGoogleRedirectPath", () => {
+  test("defaults to the standard callback path", () => {
+    expect(resolveGoogleRedirectPath({} as NodeJS.ProcessEnv)).toBe(
+      "/api/v1/auth/providers/google/callback"
+    );
+  });
+
+  test("uses a trimmed override", () => {
+    expect(
+      resolveGoogleRedirectPath({
+        AUTH_GOOGLE_REDIRECT_PATH: "  /custom/callback  "
+      } as NodeJS.ProcessEnv)
+    ).toBe("/custom/callback");
+  });
+
+  test("falls back to the default for an empty/whitespace-only override", () => {
+    expect(
+      resolveGoogleRedirectPath({
+        AUTH_GOOGLE_REDIRECT_PATH: "   "
+      } as NodeJS.ProcessEnv)
+    ).toBe("/api/v1/auth/providers/google/callback");
+  });
+});

--- a/tests/unit/google-oidc-policy.test.ts
+++ b/tests/unit/google-oidc-policy.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluateOAuthRequest,
+  isEmailDomainAllowed,
+  validateIdTokenClaims
+} from "../../src/modules/identity-access/domain/google-oidc-policy";
+
+const NOW = new Date("2026-01-01T00:00:00Z");
+const FUTURE = new Date(NOW.getTime() + 60_000);
+const PAST = new Date(NOW.getTime() - 60_000);
+
+describe("evaluateOAuthRequest", () => {
+  test("invalid: not_found when there is no row", () => {
+    expect(evaluateOAuthRequest(null, NOW)).toEqual({
+      outcome: "invalid",
+      reason: "not_found"
+    });
+  });
+
+  test("invalid: already_used when consumedAt is set", () => {
+    const result = evaluateOAuthRequest(
+      { expiresAt: FUTURE, consumedAt: PAST },
+      NOW
+    );
+    expect(result).toEqual({ outcome: "invalid", reason: "already_used" });
+  });
+
+  test("invalid: expired when expiresAt is in the past", () => {
+    const result = evaluateOAuthRequest(
+      { expiresAt: PAST, consumedAt: null },
+      NOW
+    );
+    expect(result).toEqual({ outcome: "invalid", reason: "expired" });
+  });
+
+  test("valid when none of the deny conditions apply", () => {
+    const result = evaluateOAuthRequest(
+      { expiresAt: FUTURE, consumedAt: null },
+      NOW
+    );
+    expect(result).toEqual({ outcome: "valid" });
+  });
+
+  test("already_used takes priority over expired", () => {
+    const result = evaluateOAuthRequest(
+      { expiresAt: PAST, consumedAt: PAST },
+      NOW
+    );
+    expect(result).toEqual({ outcome: "invalid", reason: "already_used" });
+  });
+});
+
+const BASE_OPTIONS = {
+  expectedIssuers: ["https://accounts.google.com", "accounts.google.com"],
+  expectedAudience: "client-abc",
+  expectedNonce: "nonce-123",
+  nowSec: 1_700_000_000
+};
+
+describe("validateIdTokenClaims", () => {
+  test("valid: all claims correct", () => {
+    const result = validateIdTokenClaims(
+      {
+        sub: "user-123",
+        iss: "https://accounts.google.com",
+        aud: "client-abc",
+        exp: BASE_OPTIONS.nowSec + 3600,
+        nonce: "nonce-123"
+      },
+      BASE_OPTIONS
+    );
+    expect(result).toEqual({ outcome: "valid", subject: "user-123" });
+  });
+
+  test("accepts the alternate issuer form", () => {
+    const result = validateIdTokenClaims(
+      {
+        sub: "user-123",
+        iss: "accounts.google.com",
+        aud: "client-abc",
+        exp: BASE_OPTIONS.nowSec + 3600,
+        nonce: "nonce-123"
+      },
+      BASE_OPTIONS
+    );
+    expect(result.outcome).toBe("valid");
+  });
+
+  test("invalid: missing_subject when sub is absent or empty", () => {
+    expect(
+      validateIdTokenClaims(
+        {
+          iss: "https://accounts.google.com",
+          aud: "client-abc",
+          exp: BASE_OPTIONS.nowSec + 3600,
+          nonce: "nonce-123"
+        },
+        BASE_OPTIONS
+      )
+    ).toEqual({ outcome: "invalid", reason: "missing_subject" });
+  });
+
+  test("invalid: issuer_mismatch for an unrecognized issuer", () => {
+    expect(
+      validateIdTokenClaims(
+        {
+          sub: "user-123",
+          iss: "https://evil.example.com",
+          aud: "client-abc",
+          exp: BASE_OPTIONS.nowSec + 3600,
+          nonce: "nonce-123"
+        },
+        BASE_OPTIONS
+      )
+    ).toEqual({ outcome: "invalid", reason: "issuer_mismatch" });
+  });
+
+  test("invalid: audience_mismatch when aud doesn't match our client id", () => {
+    expect(
+      validateIdTokenClaims(
+        {
+          sub: "user-123",
+          iss: "https://accounts.google.com",
+          aud: "someone-elses-client-id",
+          exp: BASE_OPTIONS.nowSec + 3600,
+          nonce: "nonce-123"
+        },
+        BASE_OPTIONS
+      )
+    ).toEqual({ outcome: "invalid", reason: "audience_mismatch" });
+  });
+
+  test("invalid: expired when exp is in the past", () => {
+    expect(
+      validateIdTokenClaims(
+        {
+          sub: "user-123",
+          iss: "https://accounts.google.com",
+          aud: "client-abc",
+          exp: BASE_OPTIONS.nowSec - 1,
+          nonce: "nonce-123"
+        },
+        BASE_OPTIONS
+      )
+    ).toEqual({ outcome: "invalid", reason: "expired" });
+  });
+
+  test("invalid: nonce_mismatch when nonce doesn't match the stored request", () => {
+    expect(
+      validateIdTokenClaims(
+        {
+          sub: "user-123",
+          iss: "https://accounts.google.com",
+          aud: "client-abc",
+          exp: BASE_OPTIONS.nowSec + 3600,
+          nonce: "wrong-nonce"
+        },
+        BASE_OPTIONS
+      )
+    ).toEqual({ outcome: "invalid", reason: "nonce_mismatch" });
+  });
+});
+
+describe("isEmailDomainAllowed", () => {
+  test("fails closed when allowedDomains is empty (the default, unset config)", () => {
+    expect(isEmailDomainAllowed("user@example.com", [])).toBe(false);
+  });
+
+  test("true when the email's domain is in the list", () => {
+    expect(
+      isEmailDomainAllowed("user@example.com", ["example.com", "other.org"])
+    ).toBe(true);
+  });
+
+  test("false when the domain isn't in the list", () => {
+    expect(isEmailDomainAllowed("user@evil.com", ["example.com"])).toBe(false);
+  });
+
+  test("comparison is case-insensitive on the domain", () => {
+    expect(isEmailDomainAllowed("user@Example.COM", ["example.com"])).toBe(
+      true
+    );
+  });
+
+  test("false for a malformed email with no @", () => {
+    expect(isEmailDomainAllowed("not-an-email", ["example.com"])).toBe(false);
+  });
+});

--- a/tests/unit/jwt-verify.test.ts
+++ b/tests/unit/jwt-verify.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+
+import {
+  findJwk,
+  parseJwt,
+  verifyJwtRs256,
+  type Jwk
+} from "../../src/lib/auth/jwt-verify";
+
+function base64Url(input: Buffer | string): string {
+  const buffer = typeof input === "string" ? Buffer.from(input) : input;
+  return buffer
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** Builds a real, correctly-signed RS256 JWT from a fresh keypair — the same construction Google's own ID tokens use, so `parseJwt`/`verifyJwtRs256` are tested against a genuine signature, not a mock. */
+function buildSignedJwt(
+  payload: Record<string, unknown>,
+  kid = "test-key-1"
+): { token: string; jwk: Jwk } {
+  const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048
+  });
+  const jwk = { ...(publicKey.export({ format: "jwk" }) as Jwk), kid };
+
+  const header = { alg: "RS256", typ: "JWT", kid };
+  const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(payload))}`;
+  const signature = cryptoSign(
+    "RSA-SHA256",
+    Buffer.from(signingInput),
+    privateKey
+  );
+  const token = `${signingInput}.${base64Url(signature)}`;
+
+  return { token, jwk };
+}
+
+describe("parseJwt", () => {
+  test("parses a well-formed JWT into header/payload/signingInput/signature", () => {
+    const { token } = buildSignedJwt({ sub: "user-123", aud: "client-abc" });
+    const parsed = parseJwt(token);
+
+    expect(parsed.header.alg).toBe("RS256");
+    expect(parsed.header.kid).toBe("test-key-1");
+    expect(parsed.payload.sub).toBe("user-123");
+    expect(parsed.signingInput).toBe(token.split(".").slice(0, 2).join("."));
+    expect(parsed.signature.length).toBeGreaterThan(0);
+  });
+
+  test("throws on a token with the wrong number of segments", () => {
+    expect(() => parseJwt("only.two")).toThrow();
+    expect(() => parseJwt("a.b.c.d")).toThrow();
+  });
+
+  test("throws on a token whose header/payload isn't valid base64url JSON", () => {
+    expect(() => parseJwt("not-json.not-json.sig")).toThrow();
+  });
+});
+
+describe("findJwk", () => {
+  const keys: Jwk[] = [
+    { kty: "RSA", kid: "key-a", n: "a", e: "AQAB" },
+    { kty: "RSA", kid: "key-b", n: "b", e: "AQAB" }
+  ];
+
+  test("finds the matching key by kid", () => {
+    expect(findJwk({ keys }, "key-b")).toEqual(keys[1]!);
+  });
+
+  test("returns null when no key matches", () => {
+    expect(findJwk({ keys }, "key-c")).toBeNull();
+  });
+});
+
+describe("verifyJwtRs256", () => {
+  test("verifies a genuinely signed token against its own public JWK", async () => {
+    const { token, jwk } = buildSignedJwt({ sub: "user-123" });
+    const parsed = parseJwt(token);
+
+    const valid = await verifyJwtRs256(
+      parsed.signingInput,
+      parsed.signature,
+      jwk
+    );
+    expect(valid).toBe(true);
+  });
+
+  test("rejects a token verified against a DIFFERENT key's JWK", async () => {
+    const { token } = buildSignedJwt({ sub: "user-123" });
+    const { jwk: otherJwk } = buildSignedJwt({ sub: "someone-else" });
+    const parsed = parseJwt(token);
+
+    const valid = await verifyJwtRs256(
+      parsed.signingInput,
+      parsed.signature,
+      otherJwk
+    );
+    expect(valid).toBe(false);
+  });
+
+  test("rejects a tampered payload (signature no longer matches)", async () => {
+    const { token, jwk } = buildSignedJwt({ sub: "user-123", admin: false });
+    const parsed = parseJwt(token);
+
+    // Tamper: flip a claim in the payload without re-signing.
+    const tamperedPayloadB64 = base64Url(
+      JSON.stringify({ ...parsed.payload, admin: true })
+    );
+    const tamperedSigningInput = `${token.split(".")[0]}.${tamperedPayloadB64}`;
+
+    const valid = await verifyJwtRs256(
+      tamperedSigningInput,
+      parsed.signature,
+      jwk
+    );
+    expect(valid).toBe(false);
+  });
+
+  test("returns false (never throws) for a non-RSA key type", async () => {
+    const { token } = buildSignedJwt({ sub: "user-123" });
+    const parsed = parseJwt(token);
+
+    const valid = await verifyJwtRs256(parsed.signingInput, parsed.signature, {
+      kty: "EC"
+    } as Jwk);
+    expect(valid).toBe(false);
+  });
+
+  test("returns false (never throws) for a malformed JWK", async () => {
+    const { token } = buildSignedJwt({ sub: "user-123" });
+    const parsed = parseJwt(token);
+
+    const valid = await verifyJwtRs256(parsed.signingInput, parsed.signature, {
+      kty: "RSA",
+      n: "not-valid-base64url!!!",
+      e: "AQAB"
+    });
+    expect(valid).toBe(false);
+  });
+});

--- a/tests/unit/oauth-state-token.test.ts
+++ b/tests/unit/oauth-state-token.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildOAuthStateParam,
+  generateOAuthState,
+  generateOidcNonce,
+  hashOAuthState,
+  parseOAuthStateParam
+} from "../../src/lib/auth/oauth-state-token";
+
+const TENANT_ID = "11111111-1111-1111-1111-111111111111";
+
+describe("generateOAuthState/hashOAuthState", () => {
+  test("generates a base64url token and a stable sha256 hash", () => {
+    const state = generateOAuthState();
+    expect(state).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const hash = hashOAuthState(state);
+    expect(hash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(hashOAuthState(state)).toBe(hash);
+  });
+
+  test("different tokens hash differently", () => {
+    const a = generateOAuthState();
+    const b = generateOAuthState();
+    expect(hashOAuthState(a)).not.toBe(hashOAuthState(b));
+  });
+});
+
+describe("generateOidcNonce", () => {
+  test("generates a base64url nonce, distinct across calls", () => {
+    const a = generateOidcNonce();
+    const b = generateOidcNonce();
+    expect(a).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("buildOAuthStateParam/parseOAuthStateParam", () => {
+  test("round-trips a tenant id and raw token", () => {
+    const rawToken = generateOAuthState();
+    const stateParam = buildOAuthStateParam(TENANT_ID, rawToken);
+    const parsed = parseOAuthStateParam(stateParam);
+
+    expect(parsed).toEqual({ tenantId: TENANT_ID, token: rawToken });
+  });
+
+  test("returns null when there's no separator", () => {
+    expect(parseOAuthStateParam("no-separator-here")).toBeNull();
+  });
+
+  test("returns null when the tenant id prefix isn't a valid UUID", () => {
+    expect(parseOAuthStateParam("not-a-uuid.some-token")).toBeNull();
+  });
+
+  test("returns null when the token portion is empty", () => {
+    expect(parseOAuthStateParam(`${TENANT_ID}.`)).toBeNull();
+  });
+
+  test("tolerates a token portion that itself contains dots (base64url never produces one, but defensive)", () => {
+    const parsed = parseOAuthStateParam(`${TENANT_ID}.abc.def`);
+    expect(parsed).toEqual({ tenantId: TENANT_ID, token: "abc.def" });
+  });
+});

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   checkEmailConfig,
+  checkGoogleOidcConfig,
   checkOnlineAuthSecurityConfig,
   checkPublicRoutingConfig,
   checkR2Config,
@@ -566,6 +567,61 @@ describe("checkMfaConfig", () => {
 
     for (const result of results) {
       expect(result.detail).not.toContain(VALID_MFA_KEY_BASE64);
+    }
+  });
+});
+
+describe("checkGoogleOidcConfig", () => {
+  test("passes (single check) when AUTH_GOOGLE_LOGIN_ENABLED is not set", () => {
+    const results = checkGoogleOidcConfig({} as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("passes when AUTH_GOOGLE_LOGIN_ENABLED=false", () => {
+    const results = checkGoogleOidcConfig({
+      AUTH_GOOGLE_LOGIN_ENABLED: "false"
+    } as NodeJS.ProcessEnv);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("pass");
+  });
+
+  test("fails and names each missing var when AUTH_GOOGLE_LOGIN_ENABLED=true", () => {
+    const results = checkGoogleOidcConfig({
+      AUTH_GOOGLE_LOGIN_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    const failedNames = results
+      .filter((result) => result.status === "fail")
+      .map((result) => result.name)
+      .sort();
+
+    expect(failedNames).toEqual(
+      ["AUTH_GOOGLE_CLIENT_ID", "AUTH_GOOGLE_CLIENT_SECRET"].sort()
+    );
+  });
+
+  test("all pass when AUTH_GOOGLE_LOGIN_ENABLED=true and both vars are set", () => {
+    const results = checkGoogleOidcConfig({
+      AUTH_GOOGLE_LOGIN_ENABLED: "true",
+      AUTH_GOOGLE_CLIENT_ID: "client-abc",
+      AUTH_GOOGLE_CLIENT_SECRET: "a-real-secret"
+    } as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("never includes the configured secret in any result detail", () => {
+    const results = checkGoogleOidcConfig({
+      AUTH_GOOGLE_LOGIN_ENABLED: "true",
+      AUTH_GOOGLE_CLIENT_ID: "client-abc",
+      AUTH_GOOGLE_CLIENT_SECRET: "super-secret-google-value"
+    } as NodeJS.ProcessEnv);
+
+    for (const result of results) {
+      expect(result.detail).not.toContain("super-secret-google-value");
     }
   });
 });


### PR DESCRIPTION
## Summary

- Adds Google OIDC login (Issue #590, epic #587-#593) as an additive full-online authentication option, gated by the shared full-online security gate (#587) combined with a new `AUTH_GOOGLE_LOGIN_ENABLED` flag. Every local/offline/LAN deployment is unaffected — no external call, no button rendered, no new tables used.
- New tables (migration 035, tenant-scoped, RLS `ENABLE`+`FORCE`): `awcms_mini_identity_provider_accounts` (links by Google's stable `sub`, never by email), `awcms_mini_oidc_auth_requests` (ephemeral state/nonce bridge across the OAuth redirect round-trip, single-use via the same `SELECT ... FOR UPDATE` + compare-and-swap pattern PR #597's security review established for MFA).
- 4 new endpoints: `GET /auth/providers/google/start` (unauthenticated, redirects to Google; reached from a new conditional "Continue with Google" button on `/login`), `GET .../callback` (Google's redirect target — validates `state`/nonce and cryptographically verifies the ID token's RS256 signature, issuer, audience, expiry, and nonce before trusting any claim; creates the existing session type, or returns `401 MFA_REQUIRED` exactly like `POST /auth/login` if Issue #589's MFA gate is active for the identity — Google login never bypasses MFA), `POST .../link` (authenticated, returns an authorization URL as JSON for the client to navigate to), `POST .../unlink` (authenticated, high-risk, audited).
- RS256 signature verification uses the platform's own WebCrypto (`crypto.subtle`) — no JWT library dependency. Token exchange and JWKS fetch are timeout-bounded and circuit-breaker gated, with the breaker only tripping on genuine transport failures (5xx/network/timeout) — a `400 invalid_grant` for a bad/reused code is Google correctly rejecting attacker-controlled input, not an outage, and must never trip the breaker (the same class of bug found and fixed in Turnstile's PR #596).
- Auto-linking by email is fail-closed: requires both a verified email and the domain to be explicitly listed in a new `AUTH_GOOGLE_ALLOWED_DOMAINS` env var (default unset — never auto-links). Without an existing link or eligible auto-link, login is rejected, never silently provisioning a new account.
- New env vars, error codes, OpenAPI updates for all 4 endpoints, and docs/skill updates.

Closes #590

## Test plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run check:docs`
- [x] `bun run api:spec:check`
- [x] `bun run build`
- [x] `bun test` with real Postgres — 1396 pass, 0 fail (includes: JWT verification tested against a real self-signed RS256 keypair, `verifyJwtRs256` tamper/wrong-key rejection; token-exchange/JWKS-fetch circuit breaker tests proving `invalid_grant` never trips the breaker while genuine 5xx does; domain-policy tests for state/claims validation and fail-closed auto-link domain matching; RLS/constraint integration tests for both new tables; end-to-end integration tests covering start→callback→session, wrong state/nonce/issuer/audience rejection, replayed-state rejection, auto-link-by-email, explicit link/unlink, and MFA integration)
- [x] Live `bun run config:validate`: default (disabled) passes with 15 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)