### PR TITLE
feat(auth): add generic tenant OIDC SSO provider for full-online deployments

### DIFF
--- a/.changeset/auth-tenant-oidc-sso-full-online.md
+++ b/.changeset/auth-tenant-oidc-sso-full-online.md
@@ -1,0 +1,81 @@
+---
+"awcms-mini": minor
+---
+
+Add generic tenant OIDC SSO provider for full-online deployments (Issue
+#591, epic #587-#593) — generalizes Issue #590's Google-specific login
+into a tenant-configurable OIDC provider model (Okta, Azure AD, Keycloak,
+etc.), without changing Google's own code/tables. `isSsoRequired(env)`
+combines the shared `isFullOnlineSecurityActive(env)` gate (#587) with a
+new `AUTH_SSO_ENABLED` flag, following the same pattern as Turnstile
+(#588), MFA/TOTP (#589), and Google login (#590).
+
+New tables (migration 036, tenant-scoped, RLS `ENABLE`+`FORCE`):
+`awcms_mini_auth_providers` (per-tenant OIDC provider config — issuer,
+client id, client secret encrypted at rest with a dedicated
+`AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY` or referenced by environment
+variable name, exactly one via a CHECK constraint, never returned
+plaintext by any endpoint; scopes; allowed email domains; enabled flag;
+soft delete) and `awcms_mini_tenant_auth_policies` (one row per tenant —
+`password_login_enabled`, `sso_enabled`, `sso_required`,
+`auto_link_verified_email`, allowed email domains, break-glass identity
+ids, and `mfa_required` reserved for future #589 compatibility). The
+existing `awcms_mini_identity_provider_accounts`/
+`awcms_mini_oidc_auth_requests` tables (migration 035) are reused as-is
+for the generic flow — they were already designed provider-agnostic
+specifically for this.
+
+New endpoints: `GET /api/v1/auth/sso/{providerKey}/start|callback`,
+`POST /api/v1/auth/sso/{providerKey}/link|unlink` (same shape as Google's
+own endpoints — unauthenticated tenant existence is `SELECT`ed before any
+INSERT, applying PR #598's lesson from day one). Also new — admin CRUD,
+in scope for this issue unlike #590: `/api/v1/identity/sso/providers`
+(`/{id}`) and `/api/v1/identity/sso/policy`, protected by ABAC
+(`identity_access.sso_providers.*`/`sso_policy.*`, migration 037), never
+gated by the runtime SSO flag itself (credentials can be provisioned
+ahead of time, same allowance Turnstile/Google's own config checks
+grant).
+
+Unlike Google (hardcoded OAuth endpoints), a tenant-configured provider's
+`.well-known/openid-configuration` and JWKS are discovered per provider,
+cached, and bounded by `AUTH_SSO_DISCOVERY_TIMEOUT_MS` — circuit breakers
+are keyed per provider (`sso-oidc-discovery:<key>`/`sso-oidc-jwks:<key>`/
+`sso-oidc-token:<key>`) so one tenant's unhealthy provider never affects
+another tenant or provider, and only trip on genuine transport failures
+(5xx/network/timeout), never a well-formed 4xx from the provider
+correctly rejecting a bad/reused authorization code.
+
+Break-glass enforcement is the headline security behavior: a tenant
+policy that would set `sso_required=true` or `password_login_enabled=false`
+is rejected (`409 BREAK_GLASS_REQUIRED`) unless at least one configured
+break-glass identity currently resolves to an `active` identity with an
+`active` tenant membership — checked at the point the policy is SAVED
+(against a fresh DB read), not merely at login time, so a provider outage
+can never lock an operator out of their own tenant. `login.ts` enforces
+`password_login_enabled=false` only when `isSsoRequired(env)` is active;
+every deployment that never enables this feature runs zero extra queries
+and has zero behavior change.
+
+Auto-linking by email is fail-closed on two independent layers: the
+provider's own allowed-domain list (mirrors Google's
+`AUTH_GOOGLE_ALLOWED_DOMAINS`, per tenant/provider) AND the tenant
+policy's `auto_link_verified_email` master switch, which defaults to
+`false`.
+
+New env vars: `AUTH_SSO_ENABLED` (default `false`),
+`AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY` (base64, 32-byte AES-256 key,
+required and validated when enabled — a separate key from MFA's own),
+`AUTH_SSO_DISCOVERY_TIMEOUT_MS` (default `5000`).
+
+New error codes `SSO_DISABLED`/`SSO_PROVIDER_NOT_FOUND`/
+`SSO_PROVIDER_DISABLED`/`SSO_PROVIDER_UNAVAILABLE`/
+`SSO_OAUTH_STATE_INVALID`/`SSO_TOKEN_EXCHANGE_FAILED`/
+`SSO_ID_TOKEN_INVALID`/`SSO_ACCOUNT_NOT_LINKED`/`SSO_ALREADY_LINKED`/
+`SSO_NOT_LINKED`/`SSO_MISCONFIGURED`/`SSO_PROVIDER_KEY_CONFLICT`/
+`BREAK_GLASS_REQUIRED`/`PASSWORD_LOGIN_DISABLED` with i18n strings
+(`en`/`id`). OpenAPI spec updated for all 11 new endpoints and their
+schemas.
+
+Docs updated: `.env.example`, `docs/awcms-mini/18_configuration_env_reference.md`,
+`docs/awcms-mini/deployment-profiles.md`, `src/modules/identity-access/README.md`,
+skill `awcms-mini-auth-online-hardening`.

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -29,15 +29,15 @@ keputusan desain yang mengikat semua issue di epic ini sekaligus.
 
 ## Status per issue (jangan bangun ulang yang sudah ada)
 
-| Issue | Scope                                                  | Status                                             |
-| ----- | ------------------------------------------------------ | -------------------------------------------------- |
-| #587  | Gate bersama `AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE` | **Selesai** — lihat §Gate bersama di bawah         |
-| #588  | Cloudflare Turnstile untuk form auth publik            | **Selesai** — lihat §Cloudflare Turnstile di bawah |
-| #589  | MFA/TOTP login challenge                               | **Selesai** — lihat §MFA/TOTP di bawah             |
-| #590  | Google OIDC login                                      | **Selesai** — lihat §Google OIDC login di bawah    |
-| #591  | Generic tenant OIDC SSO provider                       | Belum dikerjakan                                   |
-| #592  | Admin UI kebijakan auth security online                | Belum dikerjakan (depends #587 selesai + #591)     |
-| #593  | Docs/kontrak/readiness penutup epic                    | Belum dikerjakan (finalisasi setelah #588-592)     |
+| Issue | Scope                                                  | Status                                                         |
+| ----- | ------------------------------------------------------ | -------------------------------------------------------------- |
+| #587  | Gate bersama `AUTH_ONLINE_SECURITY_ENABLED`/`_PROFILE` | **Selesai** — lihat §Gate bersama di bawah                     |
+| #588  | Cloudflare Turnstile untuk form auth publik            | **Selesai** — lihat §Cloudflare Turnstile di bawah             |
+| #589  | MFA/TOTP login challenge                               | **Selesai** — lihat §MFA/TOTP di bawah                         |
+| #590  | Google OIDC login                                      | **Selesai** — lihat §Google OIDC login di bawah                |
+| #591  | Generic tenant OIDC SSO provider                       | **Selesai** — lihat §Generic tenant OIDC SSO provider di bawah |
+| #592  | Admin UI kebijakan auth security online                | Belum dikerjakan (depends #587 selesai + #591 selesai)         |
+| #593  | Docs/kontrak/readiness penutup epic                    | Belum dikerjakan (finalisasi setelah #588-592)                 |
 
 ## Yang sudah ada — pakai ulang, jangan re-derive
 
@@ -337,6 +337,111 @@ WHERE id = tenantId` (aman, tidak pernah throw untuk baris kosong)
   `_account_not_linked`/`_already_linked`/`_not_linked`/`_misconfigured`
   (`error-messages.ts`, `i18n/en.po`+`id.po`).
 
+### Generic tenant OIDC SSO provider (Issue #591, `src/modules/identity-access/application/tenant-sso.ts`)
+
+Generalizes #590's Google-specific login into a tenant-CONFIGURED
+provider model, WITHOUT touching Google's own code/tables — a deliberate
+PARALLEL implementation, not a refactor of `google-oidc.ts`:
+
+- **Reuses `awcms_mini_oidc_auth_requests`/`awcms_mini_identity_provider_accounts`
+  (migration 035) as-is** — both were already generic (`provider text`,
+  no CHECK constraining it to `'google'`) specifically so this issue
+  wouldn't need a schema change to them. Generic SSO stores
+  `provider = <providerKey>` in the exact same rows Google's own flow
+  stores `provider = 'google'` in. New tables (migration 036) are only
+  `awcms_mini_auth_providers` (tenant-configured provider config: `provider_key`,
+  `issuer_url`, `client_id`, client secret — encrypted at rest
+  (`AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY`, AES-256-GCM, SEPARATE key from
+  MFA's own `AUTH_MFA_SECRET_ENCRYPTION_KEY`) OR an env-var-name
+  reference, exactly one via CHECK constraint, NEVER returned plaintext
+  by any endpoint; `scopes`, `allowed_email_domains` jsonb, `enabled`,
+  soft delete) and `awcms_mini_tenant_auth_policies` (one row per
+  tenant: `password_login_enabled`, `sso_enabled`, `sso_required`,
+  `auto_link_verified_email`, `allowed_email_domains` jsonb,
+  `break_glass_identity_ids` jsonb, `mfa_required` reserved for future
+  #589 compatibility, not yet enforced). Both RLS `ENABLE`+`FORCE`.
+- Gate gabungan `isSsoRequired(env)` (`src/lib/auth/sso-config.ts`) =
+  `isFullOnlineSecurityActive(env)` (#587) ∧ `AUTH_SSO_ENABLED=true` —
+  same shape as every other feature's gate in this epic.
+- **OIDC discovery is unavoidable here** (unlike Google's hardcoded
+  endpoint constants) — `discoverOidcConfiguration`/`fetchProviderJwks`
+  (`src/lib/auth/generic-oidc-client.ts`) fetch
+  `.well-known/openid-configuration` + JWKS from each provider's own
+  `issuer_url`, cached 1h, bounded by `AUTH_SSO_DISCOVERY_TIMEOUT_MS`
+  (issue's own acceptance criterion: "OIDC discovery and JWKS fetches
+  have bounded timeout"). Circuit breakers are keyed PER PROVIDER
+  (`sso-oidc-discovery:<providerKey>`/`sso-oidc-jwks:<providerKey>`/
+  `sso-oidc-token:<providerKey>`) — a slow/unhealthy provider on one
+  tenant must never affect another tenant's or provider's login. Same
+  PR #596/#598 rule applied from day one: only a genuine transport
+  failure (5xx/network/timeout) trips the breaker, never a well-formed
+  4xx (bad/reused/expired `code`) — the provider correctly rejecting
+  attacker-controlled input is a healthy-provider signal.
+- **Endpoints mirror Google's own shape exactly**: `GET
+/auth/sso/{providerKey}/start` (unauthenticated, tenant resolved from
+  header/cookie/`?tenantId=`, tenant existence/status `SELECT`ed BEFORE
+  any INSERT into the reused `awcms_mini_oidc_auth_requests` — applying
+  PR #598's fix from the very first version of this endpoint, not as an
+  afterthought), `GET .../callback` (re-checks `provider.enabled` again
+  at callback time — an admin may have disabled the provider between
+  `start` and the user completing the flow at the external provider),
+  `POST .../link`/`.../unlink` (identical session/audit shape to
+  Google's).
+- **Admin CRUD is IN SCOPE for #591** (unlike #590 which had none) —
+  `identity_access.sso_providers.{read,create,update,delete}` and
+  `identity_access.sso_policy.{read,update}` (migration 037 permission
+  seed) protect `/api/v1/identity/sso/providers`(`/{id}`) and
+  `/api/v1/identity/sso/policy`. Deliberately NOT gated by
+  `isSsoRequired()` — an admin may configure a provider ahead of
+  flipping the deployment-level gate on, same allowance
+  `checkGoogleOidcConfig`/`checkTurnstileConfig` already grant for their
+  own credentials; no network/provider call happens in the CRUD path
+  itself. Admin UI pages for this API are Issue #592, not this issue —
+  "minimal UI... unless needed for verification" in the issue's own
+  scope note was read as "API only", since the API itself IS the
+  verification surface (curl/fetch), full UI is explicitly tracked
+  separately.
+- **Break-glass enforcement is at POLICY-SAVE time, not just login
+  time** (issue's own acceptance criterion) — `saveTenantAuthPolicy`
+  (`tenant-auth-policy.ts`) re-reads `break_glass_identity_ids` from the
+  request against a FRESH DB query (`countEligibleBreakGlassIdentities`)
+  confirming each id is a currently `active` identity with an `active`
+  `awcms_mini_tenant_users` membership — a request that would leave
+  `sso_required=true` or `password_login_enabled=false` with zero
+  eligible break-glass identities is rejected `409
+BREAK_GLASS_REQUIRED` and never persisted. `login.ts` itself only
+  enforces `password_login_enabled=false` when `isSsoRequired(env)` is
+  ALSO active (`isPasswordLoginDisabledForIdentity`) — every
+  local/offline/LAN deployment that never flips the #591 gate on runs
+  zero extra queries and has zero behavior change, exactly like every
+  other feature in this epic.
+- **Auto-link by email, two independent fail-closed layers** (domain:
+  `tenant-sso-policy.ts`'s `isAutoLinkAllowedForProvider`): the
+  PROVIDER's own `allowed_email_domains` (mirrors
+  `AUTH_GOOGLE_ALLOWED_DOMAINS`, per-tenant-per-provider instead of a
+  deployment env var) AND the tenant POLICY's `auto_link_verified_email`
+  master switch, which must be explicitly `true` — unlike Google (whose
+  auto-link only needed the domain allow-list to be non-empty), generic
+  SSO requires the tenant to opt in twice: enable the provider's own
+  domain list AND flip the policy's master switch.
+- `google-oidc-policy.ts`'s `evaluateOAuthRequest`/`validateIdTokenClaims`
+  are reused VERBATIM here (imported directly, not copied) — both were
+  already pure and provider-agnostic. `oauth-state-token.ts`'s
+  `buildOAuthStateParam`/`parseOAuthStateParam`/`generateOAuthState`/
+  `hashOAuthState`/`generateOidcNonce` are reused the same way. What is
+  NOT reused: `google-oidc.ts`'s own `createOAuthRequest`/
+  `consumeOAuthRequest`/`findIdentityByProviderSubject`/
+  `linkProviderAccount`/`unlinkProviderAccount` all hardcode
+  `provider = 'google'` in their SQL — `tenant-sso.ts` has its own small
+  parameterized duplicates of these instead of refactoring Google's
+  (keeps the already-tested Google flow untouched).
+- Error code i18n: `error.sso_disabled`/`_provider_not_found`/
+  `_provider_disabled`/`_provider_unavailable`/`_oauth_state_invalid`/
+  `_token_exchange_failed`/`_id_token_invalid`/`_account_not_linked`/
+  `_already_linked`/`_not_linked`/`_misconfigured`/
+  `_provider_key_conflict`, plus `break_glass_required`/
+  `password_login_disabled` (`error-messages.ts`, `i18n/en.po`+`id.po`).
+
 ## Aturan lintas-issue yang wajib diikuti (#588-#593)
 
 1. **Setiap fitur (#588-#592) WAJIB memanggil `isFullOnlineSecurityActive(env)`
@@ -357,10 +462,12 @@ WHERE id = tenantId` (aman, tidak pernah throw untuk baris kosong)
    pernah menjadikan `APP_ENV=production` sebagai proxy untuk
    `isFullOnlineSecurityActive`.
 4. **Login password lokal tidak pernah dihapus/dinonaktifkan secara
-   default** oleh fitur mana pun di epic ini — `sso_required`/kebijakan
-   serupa (#591) hanya boleh aktif kalau ada break-glass local
-   owner/account valid, dicek server-side sebelum kebijakan itu bisa
-   disimpan.
+   default** oleh fitur mana pun di epic ini — `sso_required`/
+   `password_login_enabled=false` (#591, `awcms_mini_tenant_auth_policies`)
+   hanya boleh aktif kalau ada break-glass local owner/account valid,
+   dicek server-side (`saveTenantAuthPolicy`) sebelum kebijakan itu bisa
+   disimpan — sudah diimplementasikan konkret, lihat §Generic tenant
+   OIDC SSO provider di atas.
 5. **Kredensial provider (Google client secret, OIDC client secret,
    Turnstile secret key, TOTP seed, recovery code) tidak pernah
    disimpan plaintext** — dari environment variable/secret manager, atau
@@ -375,8 +482,10 @@ WHERE id = tenantId` (aman, tidak pernah throw untuk baris kosong)
    email** — auto-link by email wajib mensyaratkan email terverifikasi +
    kebijakan allowed-domain eksplisit, tidak pernah linking implisit
    murni dari kecocokan string email. Sudah diimplementasikan konkret di
-   #590 (`isEmailDomainAllowed`, fail-closed) — #591 (generic tenant OIDC
-   SSO) WAJIB reuse pola yang sama, jangan re-derive.
+   #590 (`isEmailDomainAllowed`, fail-closed) DAN #591 (generic tenant
+   OIDC SSO, `isAutoLinkAllowedForProvider` — dua lapis: domain allow-list
+   PER PROVIDER ditambah master switch `auto_link_verified_email` per
+   tenant policy).
 8. **Semua panggilan provider eksternal (OIDC discovery/JWKS, Turnstile
    siteverify, Google token exchange) wajib timeout-bounded DAN circuit
    breaker-nya hanya boleh trip pada kegagalan transport genuine** — pola
@@ -399,20 +508,24 @@ WHERE id = tenantId` (aman, tidak pernah throw untuk baris kosong)
    `SELECT` (aman, tidak throw untuk baris kosong) sebelum write
    ber-FK di endpoint yang bisa dijangkau tanpa autentikasi.
 9. **Tabel baru yang tenant-scoped (`awcms_mini_identity_provider_accounts`,
-   `awcms_mini_oidc_auth_requests` — #590; `awcms_mini_tenant_auth_policies`
-   dst. untuk #591-#592; `awcms_mini_identity_mfa_factors` dkk. — #589)
-   wajib RLS `ENABLE` + `FORCE`** — pola sama seperti setiap migration
-   sejak 013 (`awcms-mini-new-migration`).
+   `awcms_mini_oidc_auth_requests` — #590; `awcms_mini_auth_providers`,
+   `awcms_mini_tenant_auth_policies` — #591; `awcms_mini_identity_mfa_factors`
+   dkk. — #589) wajib RLS `ENABLE` + `FORCE`** — pola sama seperti setiap
+   migration sejak 013 (`awcms-mini-new-migration`).
 10. **MFA reset password tidak boleh jadi bypass MFA** — reset password
     yang berhasil tidak otomatis menonaktifkan MFA milik identity itu.
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Dua fitur (#591-#592) plus dokumentasi/kontrak penutup (#593) masih
-backlog per 2026-07-09 — gate bersama (#587), Cloudflare Turnstile
-(#588), MFA/TOTP (#589), dan Google OIDC login (#590) sudah ada di repo
-ini. Jangan asumsikan `awcms_mini_auth_providers`,
-`awcms_mini_tenant_auth_policies`, atau endpoint
-`/api/v1/auth/sso/*`/admin policy UI sudah ada — cek langsung sebelum
-membangun di atasnya. `/api/v1/auth/providers/google/*` SUDAH ada
-(#590) — jangan bangun ulang.
+Admin policy UI (#592) plus dokumentasi/kontrak penutup epic (#593)
+masih backlog per 2026-07-09 — gate bersama (#587), Cloudflare Turnstile
+(#588), MFA/TOTP (#589), Google OIDC login (#590), DAN generic tenant
+OIDC SSO provider (#591, termasuk admin CRUD API-nya) sudah ada di repo
+ini. `awcms_mini_auth_providers`/`awcms_mini_tenant_auth_policies`
+(migration 036), endpoint `/api/v1/auth/sso/*`, dan admin CRUD API
+`/api/v1/identity/sso/providers`/`/api/v1/identity/sso/policy` SUDAH
+ada — jangan bangun ulang. Yang BELUM ada: admin UI PAGES untuk
+kebijakan ini (Issue #592 — admin CRUD API dari #591 belum punya
+halaman `/admin/*` yang mengonsumsinya). `/api/v1/auth/providers/google/*`
+SUDAH ada (#590) — jangan bangun ulang, dan #591 sengaja TIDAK
+mengubah/menggantinya (lihat §Generic tenant OIDC SSO provider di atas).

--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,25 @@ AUTH_GOOGLE_LOGIN_ENABLED=false
 # AUTH_GOOGLE_ALLOWED_DOMAINS=
 AUTH_GOOGLE_REDIRECT_PATH=/api/v1/auth/providers/google/callback
 
+# Generic tenant OIDC SSO (Issue #591) — GET /auth/sso/{providerKey}/start,
+# /callback, POST .../link, .../unlink, plus admin CRUD at
+# /api/v1/identity/sso/providers and /api/v1/identity/sso/policy. Only active
+# when the full-online gate above is ALSO on (isSsoRequired() = full-online
+# gate AND AUTH_SSO_ENABLED=true). Independent of the gate for
+# config:validate purposes, same as Turnstile/MFA/Google above. Per-tenant
+# provider issuer/client id/secret/scopes/allowed domains are tenant-scoped
+# DATA (awcms_mini_auth_providers), configured via the admin API — not env
+# vars. AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY encrypts provider client secrets
+# at rest (AES-256-GCM) when a tenant stores one directly rather than
+# referencing an environment variable — must be a base64-encoded 32-byte
+# key, e.g. `openssl rand -base64 32`; never a real value in git; must be a
+# DIFFERENT key from AUTH_MFA_SECRET_ENCRYPTION_KEY (separate blast radius
+# per secret class). AUTH_SSO_DISCOVERY_TIMEOUT_MS bounds every
+# `.well-known/openid-configuration`/JWKS/token-exchange call.
+AUTH_SSO_ENABLED=false
+# AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY=
+AUTH_SSO_DISCOVERY_TIMEOUT_MS=5000
+
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node
 AWCMS_MINI_SYNC_ENABLED=false

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -95,6 +95,9 @@ Legenda: Wajib = perlu untuk boot; Sensitif = jangan bocor ke log/response.
 | `AUTH_GOOGLE_CLIENT_SECRET`                 | bila Google    | –                                        | Ya       | OAuth client secret — hanya untuk token exchange server-side                                            |
 | `AUTH_GOOGLE_ALLOWED_DOMAINS`               | –              | –                                        | –        | Daftar domain email (dipisah koma) yang boleh auto-link; kosong = auto-link selalu ditolak              |
 | `AUTH_GOOGLE_REDIRECT_PATH`                 | –              | `/api/v1/auth/providers/google/callback` | –        | Path callback OAuth di bawah `APP_URL`                                                                  |
+| `AUTH_SSO_ENABLED`                          | –              | `false`                                  | –        | Generic tenant OIDC SSO (Issue #591) — lihat §Full-online auth security hardening di bawah              |
+| `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY`        | bila SSO       | –                                        | Ya       | Key AES-256-GCM (base64, 32 byte) untuk enkripsi-at-rest client secret provider — beda dari key MFA     |
+| `AUTH_SSO_DISCOVERY_TIMEOUT_MS`             | –              | `5000`                                   | –        | Timeout discovery/JWKS/token-exchange OIDC provider tenant (ms)                                         |
 
 ### Full-online auth security hardening (opsional, Issue #587-#593)
 
@@ -178,9 +181,47 @@ online-only ini (lihat `deployment-profiles.md`).
   navigasi browser murni yang tidak bisa membawa header
   `X-AWCMS-Mini-Tenant-ID`. Detail lengkap: skill
   `awcms-mini-auth-online-hardening`.
-- #591-#593 (generic tenant OIDC SSO, admin policy UI,
-  dokumentasi/kontrak penutup) masih backlog — belum diimplementasikan di
-  repo ini.
+- **Generic tenant OIDC SSO (Issue #591, selesai)** — `AUTH_SSO_ENABLED`
+  divalidasi independen dari gate di atas (`checkSsoConfig`), tapi aktivasi
+  runtime-nya butuh KEDUANYA (`isSsoRequired(env)` = gate ∧
+  `AUTH_SSO_ENABLED=true`). Menggeneralisasi Google OIDC login (#590) tanpa
+  mengubahnya — provider Google tetap berjalan lewat `google-oidc.ts`-nya
+  sendiri; SSO generik ini adalah jalur PARALEL untuk provider
+  tenant-configured (Okta, Azure AD, Keycloak, dst.), memakai ulang tabel
+  `awcms_mini_oidc_auth_requests`/`awcms_mini_identity_provider_accounts`
+  (migration 035, sudah generik `provider text` sejak awal) dengan
+  `provider = <providerKey>`. Schema baru (migration 036):
+  `awcms_mini_auth_providers` (per tenant: `provider_key`, `issuer_url`,
+  `client_id`, client secret terenkripsi AES-256-GCM ATAU env-var
+  reference — persis salah satu, tidak pernah keduanya, dan tidak pernah
+  plaintext di response API manapun; `scopes`, `allowed_email_domains`
+  jsonb, `enabled`, soft delete) dan `awcms_mini_tenant_auth_policies`
+  (satu baris per tenant: `password_login_enabled`, `sso_enabled`,
+  `sso_required`, `auto_link_verified_email`, `allowed_email_domains`
+  jsonb, `break_glass_identity_ids` jsonb, `mfa_required` — reserved untuk
+  kompatibilitas #589 di masa depan, belum ditegakkan). Endpoint baru:
+  `GET /auth/sso/{providerKey}/start|callback`,
+  `POST /auth/sso/{providerKey}/link|unlink` (pola identik Google), plus
+  admin CRUD `identity_access.sso_providers.*`/`sso_policy.*` di
+  `/api/v1/identity/sso/providers`/`/api/v1/identity/sso/policy`
+  (dilindungi ABAC, migration 037). OIDC discovery
+  (`.well-known/openid-configuration`) dan JWKS di-fetch per provider (beda
+  dari Google yang hardcode endpoint) — timeout `AUTH_SSO_DISCOVERY_TIMEOUT_MS`,
+  circuit breaker PER PROVIDER KEY (`sso-oidc-discovery:<key>`/
+  `sso-oidc-jwks:<key>`/`sso-oidc-token:<key>`), hanya trip pada kegagalan
+  transport genuine (bukan respons 4xx valid dari provider). **Break-glass
+  enforcement**: `sso_required=true` atau `password_login_enabled=false`
+  tidak bisa disimpan (`PATCH .../policy` → `409 BREAK_GLASS_REQUIRED`)
+  kecuali minimal satu `break_glass_identity_ids` adalah identity yang saat
+  ini `active` DENGAN tenant_user membership `active` — dicek ulang dari DB
+  di titik SAVE, bukan hanya di titik login. `login.ts` menegakkan
+  `password_login_enabled=false` HANYA saat `isSsoRequired(env)` aktif
+  (deployment offline/LAN yang tidak pernah menyalakan gate ini tidak
+  pernah menjalankan query tambahan ini maupun berubah perilaku). Detail
+  lengkap: skill `awcms-mini-auth-online-hardening`,
+  `src/modules/identity-access/README.md`.
+- #592-#593 (admin policy UI, dokumentasi/kontrak penutup) masih backlog —
+  belum diimplementasikan di repo ini.
 
 ### Sync & node
 
@@ -421,6 +462,8 @@ AUTH_MFA_RATE_LIMIT_MAX=5
 AUTH_MFA_RATE_LIMIT_WINDOW_SEC=300
 AUTH_GOOGLE_LOGIN_ENABLED=false
 AUTH_GOOGLE_REDIRECT_PATH=/api/v1/auth/providers/google/callback
+AUTH_SSO_ENABLED=false
+AUTH_SSO_DISCOVERY_TIMEOUT_MS=5000
 
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node

--- a/docs/awcms-mini/deployment-profiles.md
+++ b/docs/awcms-mini/deployment-profiles.md
@@ -154,9 +154,24 @@ hardening).
   Issue #589 (MFA) juga aktif untuk identity yang login lewat Google, MFA
   challenge tetap wajib diselesaikan sebelum session dibuat — Google
   login tidak pernah jadi jalan pintas melewati MFA.
-  #591-#593 (generic tenant OIDC SSO, admin policy UI,
-  dokumentasi/kontrak penutup) masih backlog, belum diimplementasikan di
-  repo ini.
+- **Generic tenant OIDC SSO (Issue #591, selesai)**: set tambahan
+  `AUTH_SSO_ENABLED=true` + `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY` (base64,
+  32 byte AES-256 key, beda dari key MFA) untuk mengaktifkan
+  `GET/POST /api/v1/auth/sso/{providerKey}/*`. Sama seperti fitur lain,
+  `AUTH_SSO_ENABLED` divalidasi independen dari gate di atas, aktivasi
+  runtime butuh keduanya. Berbeda dari Google (endpoint hardcoded), setiap
+  provider (Okta, Azure AD, Keycloak, dst.) dikonfigurasi PER TENANT lewat
+  admin API `/api/v1/identity/sso/providers` (issuer/client
+  id/secret/scopes/allowed domains) — bukan env var deployment-wide;
+  admin CRUD ini reachable regardless of gate ini (operator boleh
+  provisioning provider lebih dulu). `sso_required=true`/
+  `password_login_enabled=false` (`/api/v1/identity/sso/policy`) hanya
+  bisa disimpan bila minimal satu break-glass local owner tetap tersedia
+  — dicek di titik SAVE, bukan hanya login, supaya outage provider tidak
+  pernah mengunci operator keluar dari akunnya sendiri. MFA (#589) tetap
+  ditegakkan sama seperti Google. #592-#593 (admin UI kebijakan,
+  dokumentasi/kontrak penutup epic) masih backlog, belum diimplementasikan
+  di repo ini.
 
 ## Cara menjalankan tiap profil
 

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -179,6 +179,48 @@ msgstr "No Google account is currently linked."
 msgid "error.google_misconfigured"
 msgstr "Google login is misconfigured on this server."
 
+msgid "error.sso_disabled"
+msgstr "Tenant OIDC SSO is not enabled for this deployment."
+
+msgid "error.sso_provider_not_found"
+msgstr "No enabled SSO provider matches this key."
+
+msgid "error.sso_provider_disabled"
+msgstr "This SSO provider is disabled."
+
+msgid "error.sso_provider_unavailable"
+msgstr "The SSO provider could not be reached. Try again later."
+
+msgid "error.sso_oauth_state_invalid"
+msgstr "SSO sign-in could not be verified. Please try again."
+
+msgid "error.sso_token_exchange_failed"
+msgstr "SSO sign-in could not be completed. Please try again."
+
+msgid "error.sso_id_token_invalid"
+msgstr "SSO sign-in could not be verified. Please try again."
+
+msgid "error.sso_account_not_linked"
+msgstr "No account is linked to this SSO identity."
+
+msgid "error.sso_already_linked"
+msgstr "An SSO account is already linked."
+
+msgid "error.sso_not_linked"
+msgstr "No SSO account is currently linked."
+
+msgid "error.sso_misconfigured"
+msgstr "Tenant OIDC SSO is misconfigured on this server."
+
+msgid "error.sso_provider_key_conflict"
+msgstr "A provider already exists for this provider key."
+
+msgid "error.break_glass_required"
+msgstr "This change requires at least one currently-active break-glass identity."
+
+msgid "error.password_login_disabled"
+msgstr "Password login is disabled for this account. Use single sign-on instead."
+
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"
 msgstr "No role"

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -179,6 +179,48 @@ msgstr "Tidak ada akun Google yang sedang tertaut."
 msgid "error.google_misconfigured"
 msgstr "Login Google salah konfigurasi di server ini."
 
+msgid "error.sso_disabled"
+msgstr "SSO OIDC tenant tidak diaktifkan untuk deployment ini."
+
+msgid "error.sso_provider_not_found"
+msgstr "Tidak ada provider SSO aktif yang cocok dengan kunci ini."
+
+msgid "error.sso_provider_disabled"
+msgstr "Provider SSO ini dinonaktifkan."
+
+msgid "error.sso_provider_unavailable"
+msgstr "Provider SSO tidak dapat dihubungi. Coba lagi nanti."
+
+msgid "error.sso_oauth_state_invalid"
+msgstr "Login SSO tidak dapat diverifikasi. Silakan coba lagi."
+
+msgid "error.sso_token_exchange_failed"
+msgstr "Login SSO tidak dapat diselesaikan. Silakan coba lagi."
+
+msgid "error.sso_id_token_invalid"
+msgstr "Login SSO tidak dapat diverifikasi. Silakan coba lagi."
+
+msgid "error.sso_account_not_linked"
+msgstr "Tidak ada akun yang tertaut ke identitas SSO ini."
+
+msgid "error.sso_already_linked"
+msgstr "Akun SSO sudah tertaut."
+
+msgid "error.sso_not_linked"
+msgstr "Tidak ada akun SSO yang sedang tertaut."
+
+msgid "error.sso_misconfigured"
+msgstr "SSO OIDC tenant salah konfigurasi di server ini."
+
+msgid "error.sso_provider_key_conflict"
+msgstr "Provider dengan kunci ini sudah ada."
+
+msgid "error.break_glass_required"
+msgstr "Perubahan ini membutuhkan minimal satu identitas break-glass yang masih aktif."
+
+msgid "error.password_login_disabled"
+msgstr "Login password dinonaktifkan untuk akun ini. Gunakan single sign-on."
+
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"
 msgstr "Tanpa role"

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -1387,6 +1387,622 @@ paths:
                 $ref: "#/components/schemas/ApiError"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/auth/sso/{providerKey}/start:
+    get:
+      tags:
+        - Identity & Access
+      summary: Redirect to a tenant-configured OIDC provider's authorization endpoint (login)
+      description: >-
+        Full-online-only (Issue #591) — `403 SSO_DISABLED` unless the #587
+        gate AND `AUTH_SSO_ENABLED=true` are both active. Generalizes Issue
+        #590's Google login to a tenant-configured provider
+        (`awcms_mini_auth_providers`); Google's own
+        `/auth/providers/google/*` endpoints are unaffected. `providerKey`
+        must resolve to an `enabled` provider for this tenant, else `404
+        SSO_PROVIDER_NOT_FOUND`. Tenant resolved from the
+        `X-AWCMS-Mini-Tenant-ID` header, the tenant cookie, or a
+        `?tenantId=` query param fallback, same as Google's own `start`.
+      operationId: authSsoStart
+      security:
+        - tenantHeader: []
+      parameters:
+        - name: providerKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: tenantId
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Fallback tenant id when neither the header nor cookie is present.
+      responses:
+        "302":
+          description: Redirect to the provider's authorization endpoint.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          description: Tenant OIDC SSO is not enabled for this deployment (`SSO_DISABLED`), or the tenant is not active (`ACCESS_DENIED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: No enabled SSO provider matches this key (`SSO_PROVIDER_NOT_FOUND`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          description: Too many requests from this source (`RATE_LIMITED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: The SSO provider's discovery endpoint could not be reached (`SSO_PROVIDER_UNAVAILABLE`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/sso/{providerKey}/callback:
+    get:
+      tags:
+        - Identity & Access
+      summary: Tenant OIDC provider's redirect target — completes login or link
+      description: >-
+        Full-online-only (Issue #591). A plain top-level browser
+        navigation, never a `fetch()` call — the provider redirects here
+        with `code`+`state` (or `error` if the user cancelled consent).
+        Validates `state` (CSRF/replay defense) and the ID token's
+        signature, issuer, audience, expiry, and nonce cryptographically
+        before trusting any claim — same verification depth as Issue #590's
+        Google callback. For a `login`-purpose request: creates the
+        existing AWCMS-Mini session type (or, if Issue #589's MFA gate is
+        active and the identity has an active factor, returns `401
+        MFA_REQUIRED` exactly like `POST /auth/login`/Google login — SSO
+        login never bypasses MFA). For a `link`-purpose request (from
+        `POST .../link`): attaches the verified provider account to the
+        identity captured server-side at link-initiation time.
+      operationId: authSsoCallback
+      security:
+        - tenantHeader: []
+      parameters:
+        - name: providerKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: code
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: state
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: error
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Present when the user cancelled/denied consent at the provider.
+      responses:
+        "302":
+          description: Login or link succeeded; redirects to `/admin`.
+        "400":
+          description: Missing or malformed `state` (`SSO_OAUTH_STATE_INVALID`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: >-
+            The state/nonce/ID token could not be verified
+            (`SSO_OAUTH_STATE_INVALID`/`SSO_TOKEN_EXCHANGE_FAILED`/
+            `SSO_ID_TOKEN_INVALID`/`SSO_ACCOUNT_NOT_LINKED`), or MFA must
+            be completed first (`MFA_REQUIRED`, `LoginMfaRequiredResponse`).
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/ApiError"
+                  - $ref: "#/components/schemas/LoginMfaRequiredResponse"
+        "403":
+          description: >-
+            Tenant OIDC SSO is not enabled for this deployment
+            (`SSO_DISABLED`), this provider is disabled
+            (`SSO_PROVIDER_DISABLED`), or the resolved identity/tenant is
+            not active (`ACCESS_DENIED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: This provider subject is already linked to a different identity (`SSO_ALREADY_LINKED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: The SSO provider could not be reached (`SSO_PROVIDER_UNAVAILABLE`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/sso/{providerKey}/link:
+    post:
+      tags:
+        - Identity & Access
+      summary: Start linking the caller's own identity to a tenant-configured OIDC provider account
+      description: >-
+        Full-online-only (Issue #591). Authenticated: creates a
+        `link`-purpose OAuth request bound to the caller's own identity
+        (captured server-side, never trusted from the callback request) and
+        returns the provider's authorization URL as JSON — same shape as
+        Issue #590's Google `link`.
+      operationId: authSsoLink
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: providerKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Link-purpose OAuth request created.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/SsoLinkStartResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Tenant OIDC SSO is not enabled for this deployment (`SSO_DISABLED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: No enabled SSO provider matches this key (`SSO_PROVIDER_NOT_FOUND`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: The SSO provider's discovery endpoint could not be reached (`SSO_PROVIDER_UNAVAILABLE`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/auth/sso/{providerKey}/unlink:
+    post:
+      tags:
+        - Identity & Access
+      summary: Unlink the caller's own tenant-configured OIDC provider account
+      description: >-
+        Full-online-only (Issue #591). High-risk, audited
+        (`sso_account_unlinked`). Never touches local password login —
+        unlinking a provider cannot lock an identity out of its own
+        account (that guarantee is the tenant policy's `sso_required` +
+        break-glass enforcement's job instead).
+      operationId: authSsoUnlink
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: providerKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: SSO account unlinked.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/SsoUnlinkResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: Tenant OIDC SSO is not enabled for this deployment (`SSO_DISABLED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: No SSO account is currently linked (`SSO_NOT_LINKED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/identity/sso/providers:
+    get:
+      tags:
+        - Identity & Access
+      summary: List this tenant's configured OIDC SSO providers
+      description: >-
+        Admin CRUD (Issue #591), protected by ABAC
+        (`identity_access.sso_providers.read`). Never returns a provider's
+        client secret plaintext — see `AuthProviderView`'s `secretSource`.
+      operationId: identitySsoProvidersList
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: SSO providers listed.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AuthProviderListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      tags:
+        - Identity & Access
+      summary: Add a tenant OIDC SSO provider
+      description: >-
+        Admin CRUD (Issue #591), protected by ABAC
+        (`identity_access.sso_providers.create`). High-risk: audited
+        (`sso_provider_created`). Exactly one of `clientSecret`/
+        `clientSecretEnvVar` must be provided; the secret is encrypted at
+        rest (AES-256-GCM, `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY`) or stored
+        as an environment variable name reference — never plaintext.
+      operationId: identitySsoProvidersCreate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAuthProviderRequest"
+      responses:
+        "200":
+          description: SSO provider created.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AuthProviderView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A provider already exists for this `providerKey` (`SSO_PROVIDER_KEY_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          description: >-
+            Internal error, or `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY` is not
+            configured on this server (`SSO_MISCONFIGURED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/identity/sso/providers/{id}:
+    get:
+      tags:
+        - Identity & Access
+      summary: Read one tenant OIDC SSO provider
+      operationId: identitySsoProvidersGet
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: SSO provider found.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AuthProviderView"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    patch:
+      tags:
+        - Identity & Access
+      summary: Update a tenant OIDC SSO provider
+      description: >-
+        Admin CRUD (Issue #591), protected by ABAC
+        (`identity_access.sso_providers.update`). Partial update;
+        high-risk, audited (`sso_provider_updated`).
+      operationId: identitySsoProvidersUpdate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAuthProviderRequest"
+      responses:
+        "200":
+          description: SSO provider updated.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AuthProviderView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          description: >-
+            Internal error, or `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY` is not
+            configured on this server (`SSO_MISCONFIGURED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    delete:
+      tags:
+        - Identity & Access
+      summary: Soft-delete a tenant OIDC SSO provider
+      description: >-
+        Admin CRUD (Issue #591), protected by ABAC
+        (`identity_access.sso_providers.delete`). High-risk, audited
+        (`sso_provider_deleted`).
+      operationId: identitySsoProvidersDelete
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+                  minLength: 1
+      responses:
+        "200":
+          description: SSO provider deleted.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        type: object
+                        additionalProperties: false
+                        required:
+                          - id
+                          - deleted
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                          deleted:
+                            type: boolean
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/identity/sso/policy:
+    get:
+      tags:
+        - Identity & Access
+      summary: Read this tenant's authentication policy
+      description: >-
+        Admin CRUD (Issue #591), protected by ABAC
+        (`identity_access.sso_policy.read`). Falls back to the safe default
+        (password login enabled, SSO disabled) when never configured.
+      operationId: identitySsoPolicyGet
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Tenant authentication policy.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/TenantAuthPolicyView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    patch:
+      tags:
+        - Identity & Access
+      summary: Update this tenant's authentication policy
+      description: >-
+        Admin CRUD (Issue #591), protected by ABAC
+        (`identity_access.sso_policy.update`). High-risk, audited
+        (`sso_policy_updated`). Server-side break-glass enforcement:
+        `sso_required=true` or `password_login_enabled=false` is rejected
+        (`409 BREAK_GLASS_REQUIRED`) unless at least one currently-active
+        break-glass identity with an active tenant membership is
+        configured.
+      operationId: identitySsoPolicyUpdate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateTenantAuthPolicyRequest"
+      responses:
+        "200":
+          description: Tenant authentication policy updated.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/TenantAuthPolicyView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: Break-glass requirement not satisfied (`BREAK_GLASS_REQUIRED`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/v1/auth/password/forgot:
     post:
       tags:
@@ -7241,6 +7857,217 @@ components:
       properties:
         unlinked:
           type: boolean
+    SsoLinkStartResponse:
+      type: object
+      required:
+        - authorizationUrl
+      additionalProperties: false
+      properties:
+        authorizationUrl:
+          type: string
+          description: >-
+            The tenant-configured provider's authorization URL — the
+            client navigates itself here
+            (`window.location = authorizationUrl`).
+    SsoUnlinkResponse:
+      type: object
+      required:
+        - unlinked
+      additionalProperties: false
+      properties:
+        unlinked:
+          type: boolean
+    AuthProviderView:
+      type: object
+      required:
+        - id
+        - providerKey
+        - providerType
+        - displayName
+        - issuerUrl
+        - clientId
+        - secretSource
+        - clientSecretEnvVar
+        - scopes
+        - allowedEmailDomains
+        - enabled
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        providerKey:
+          type: string
+        providerType:
+          type: string
+          enum: [oidc]
+        displayName:
+          type: string
+        issuerUrl:
+          type: string
+        clientId:
+          type: string
+        secretSource:
+          type: string
+          enum: [encrypted, env]
+          description: >-
+            Never the secret itself — `encrypted` means a client secret is
+            stored encrypted at rest (AES-256-GCM); `env` means the secret
+            is read from the named environment variable
+            (`clientSecretEnvVar`) at OAuth-call time.
+        clientSecretEnvVar:
+          type: string
+          nullable: true
+          description: The environment variable NAME (never a secret value) when `secretSource` is `env`.
+        scopes:
+          type: string
+        allowedEmailDomains:
+          type: array
+          items:
+            type: string
+        enabled:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    AuthProviderListResponse:
+      type: object
+      required:
+        - providers
+      additionalProperties: false
+      properties:
+        providers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuthProviderView"
+    CreateAuthProviderRequest:
+      type: object
+      required:
+        - providerKey
+        - displayName
+        - issuerUrl
+        - clientId
+      additionalProperties: false
+      properties:
+        providerKey:
+          type: string
+          pattern: "^[a-z0-9][a-z0-9_-]*$"
+        displayName:
+          type: string
+          maxLength: 120
+        issuerUrl:
+          type: string
+          description: Must be an `https://` URL.
+        clientId:
+          type: string
+          maxLength: 255
+        clientSecret:
+          type: string
+          description: Plaintext secret, encrypted at rest immediately — never returned by any endpoint. Exactly one of `clientSecret`/`clientSecretEnvVar` must be provided.
+        clientSecretEnvVar:
+          type: string
+          description: Name of an environment variable holding the secret. Exactly one of `clientSecret`/`clientSecretEnvVar` must be provided.
+        scopes:
+          type: string
+          default: "openid email profile"
+        allowedEmailDomains:
+          type: array
+          items:
+            type: string
+        enabled:
+          type: boolean
+          default: false
+    UpdateAuthProviderRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        displayName:
+          type: string
+          maxLength: 120
+        issuerUrl:
+          type: string
+        clientId:
+          type: string
+          maxLength: 255
+        clientSecret:
+          type: string
+        clientSecretEnvVar:
+          type: string
+        scopes:
+          type: string
+        allowedEmailDomains:
+          type: array
+          items:
+            type: string
+        enabled:
+          type: boolean
+    TenantAuthPolicyView:
+      type: object
+      required:
+        - tenantId
+        - passwordLoginEnabled
+        - ssoEnabled
+        - ssoRequired
+        - autoLinkVerifiedEmail
+        - allowedEmailDomains
+        - breakGlassIdentityIds
+        - mfaRequired
+        - updatedAt
+      additionalProperties: false
+      properties:
+        tenantId:
+          type: string
+          format: uuid
+        passwordLoginEnabled:
+          type: boolean
+        ssoEnabled:
+          type: boolean
+        ssoRequired:
+          type: boolean
+        autoLinkVerifiedEmail:
+          type: boolean
+        allowedEmailDomains:
+          type: array
+          items:
+            type: string
+        breakGlassIdentityIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        mfaRequired:
+          type: boolean
+          description: Reserved for future compatibility with Issue #589's MFA policy — not yet enforced.
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+    UpdateTenantAuthPolicyRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        passwordLoginEnabled:
+          type: boolean
+        ssoEnabled:
+          type: boolean
+        ssoRequired:
+          type: boolean
+        autoLinkVerifiedEmail:
+          type: boolean
+        allowedEmailDomains:
+          type: array
+          items:
+            type: string
+        breakGlassIdentityIds:
+          type: array
+          items:
+            type: string
+            format: uuid
     LogoutResponse:
       type: object
       required:

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -40,6 +40,7 @@ import {
   checkGoogleOidcConfig,
   checkMfaConfig,
   checkOnlineAuthSecurityConfig,
+  checkSsoConfig,
   checkTurnstileConfig
 } from "./validate-env";
 
@@ -974,6 +975,49 @@ export function checkGoogleOidcReady(
   };
 }
 
+/**
+ * Reuses `checkSsoConfig` from `validate-env.ts` verbatim — same pattern
+ * and rationale as `checkTurnstileReady`/`checkMfaReady`/
+ * `checkGoogleOidcReady` above (Issue #591, epic: full-online auth
+ * hardening).
+ */
+export function checkSsoReady(
+  env: NodeJS.ProcessEnv = process.env
+): SecurityCheckResult {
+  const name = "Tenant OIDC SSO configuration is complete when enabled";
+  const severity: CheckSeverity = "critical";
+  const results = checkSsoConfig(env);
+  const failed = results.filter((result) => result.status === "fail");
+
+  if (failed.length > 0) {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `AUTH_SSO_ENABLED=true but config is incomplete: ${failed
+        .map((result) => result.detail)
+        .join(" ")}`
+    };
+  }
+
+  if (env.AUTH_SSO_ENABLED !== "true") {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence: 'AUTH_SSO_ENABLED is not "true" — SSO config not required.'
+    };
+  }
+
+  return {
+    name,
+    severity,
+    status: "pass",
+    evidence:
+      "AUTH_SSO_ENABLED=true and all conditional SSO config check(s) pass."
+  };
+}
+
 // ---------------------------------------------------------------------------
 // 10. Errors don't leak stack traces (warning/info, best-effort)
 // ---------------------------------------------------------------------------
@@ -1218,6 +1262,7 @@ export async function runSecurityReadinessChecks(): Promise<
     checkTurnstileReady(),
     checkMfaReady(),
     checkGoogleOidcReady(),
+    checkSsoReady(),
     await checkErrorsDontLeakStackTraces(),
     await checkSecurityHeadersPresent(),
     checkLoginRateLimitImplemented()

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -151,6 +151,11 @@ import {
   GOOGLE_OIDC_REQUIRED_WHEN_ENABLED,
   isGoogleLoginEnabled
 } from "../src/lib/auth/google-oidc-config";
+import {
+  isSsoEnabled,
+  SSO_REQUIRED_WHEN_ENABLED
+} from "../src/lib/auth/sso-config";
+import { resolveSsoEncryptionKey } from "../src/lib/auth/sso-credential-crypto";
 
 export type EnvCheckResult = {
   name: string;
@@ -707,6 +712,61 @@ export function checkGoogleOidcConfig(
   });
 }
 
+/**
+ * Generic tenant OIDC SSO (Issue #591, epic: full-online auth hardening).
+ * `AUTH_SSO_ENABLED` left unset (or anything other than `"true"`) requires
+ * nothing else — same "unset/off requires nothing" shape as
+ * `checkTurnstileConfig`/`checkMfaConfig`/`checkGoogleOidcConfig`, validated
+ * independently of the #587 gate for the same reason (an operator can
+ * provision the credential encryption key ahead of time). Per-provider
+ * issuer/client id/secret are tenant-configured DATA
+ * (`awcms_mini_auth_providers`, migration 036), not deployment-level env
+ * vars, so unlike Google OIDC there is nothing provider-specific to check
+ * here — only the shared encryption key, checked for validity (decodes as
+ * base64 to exactly 32 bytes) the same way `checkMfaConfig` validates
+ * `AUTH_MFA_SECRET_ENCRYPTION_KEY`, so a deployment that passes
+ * `config:validate` never later hits the `SSO_MISCONFIGURED` fail-closed
+ * path due to a malformed key.
+ */
+export function checkSsoConfig(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult[] {
+  if (!isSsoEnabled(env)) {
+    return [
+      {
+        name: "SSO config (conditional on AUTH_SSO_ENABLED)",
+        status: "pass",
+        detail: 'AUTH_SSO_ENABLED is not "true" — SSO config not required.'
+      }
+    ];
+  }
+
+  const encryptionKeyWellFormed = resolveSsoEncryptionKey(env) !== null;
+
+  return SSO_REQUIRED_WHEN_ENABLED.map((name) => {
+    if (!isSet(env[name])) {
+      return {
+        name,
+        status: "fail",
+        detail: `AUTH_SSO_ENABLED=true but ${name} is missing or empty.`
+      };
+    }
+
+    if (
+      name === "AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY" &&
+      !encryptionKeyWellFormed
+    ) {
+      return {
+        name,
+        status: "fail",
+        detail: `${name} must be a base64-encoded 32-byte (AES-256) key, e.g. from "openssl rand -base64 32".`
+      };
+    }
+
+    return { name, status: "pass", detail: `${name} is set.` };
+  });
+}
+
 export function runEnvValidation(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -720,6 +780,7 @@ export function runEnvValidation(
     ...checkTurnstileConfig(env),
     ...checkMfaConfig(env),
     ...checkGoogleOidcConfig(env),
+    ...checkSsoConfig(env),
     ...checkOnlineAuthSecurityConfig(env)
   ];
 }

--- a/sql/036_awcms_mini_tenant_oidc_sso_schema.sql
+++ b/sql/036_awcms_mini_tenant_oidc_sso_schema.sql
@@ -1,0 +1,132 @@
+-- Generic tenant OIDC SSO provider (Issue #591, epic: full-online auth
+-- hardening #587-#593). Active only when the #587 gate is active AND
+-- AUTH_SSO_ENABLED=true (`isSsoRequired`, `src/lib/auth/sso-config.ts`) —
+-- these tables exist on every deployment (migrations always run), but stay
+-- entirely empty/unused on local/offline/LAN deployments that never enable
+-- the feature.
+--
+-- This issue generalizes Issue #590's Google-specific login into a
+-- tenant-configurable OIDC provider model. It deliberately does NOT touch
+-- `awcms_mini_identity_provider_accounts` or `awcms_mini_oidc_auth_requests`
+-- (migration 035) — both were already designed generic: `provider` is a
+-- free-text column there specifically "since Issue #591 ... will add more
+-- provider values on top of `google` without needing a schema change here"
+-- (035's own comment). Generic SSO reuses both tables verbatim, storing
+-- `provider = <provider_key>` for a tenant-configured provider exactly as
+-- `google-oidc.ts` stores `provider = 'google'` — this migration only adds
+-- the two NEW tables the generic flow needs on top of that reused pair.
+--
+-- `awcms_mini_auth_providers` — one tenant-configured OIDC identity
+-- provider (Okta, Azure AD, Keycloak, etc.). `provider_key` is the stable
+-- slug used everywhere else this issue touches `awcms_mini_identity_provider_accounts.provider`
+-- /`awcms_mini_oidc_auth_requests.provider`, and in the `/api/v1/auth/sso/{providerKey}/...`
+-- URL path itself. Client secret is NEVER stored plaintext (issue's own
+-- acceptance criterion): either `client_secret_ciphertext` (AES-256-GCM via
+-- `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY`, same at-rest encryption pattern as
+-- Issue #589's `mfa-secret-crypto.ts`) or `client_secret_env_var` (the NAME
+-- of an environment variable holding the secret, resolved at OAuth-call
+-- time, never persisted) — exactly one of the two must be set, enforced by
+-- the CHECK constraint below. `allowed_email_domains` (jsonb array, not a
+-- native Postgres array — this repo's established convention for flexible
+-- list-shaped columns, see `awcms_mini_module_settings.settings` and doc 04
+-- "JSONB per-locale") is this provider's own auto-link-by-email allow-list,
+-- mirroring Issue #590's `AUTH_GOOGLE_ALLOWED_DOMAINS` env var but per
+-- tenant/provider instead of deployment-wide. Soft delete
+-- (`deleted_at`/`deleted_by`/`delete_reason`) since a provider config is
+-- tenant master data, not an append-only/posted record.
+CREATE TABLE IF NOT EXISTS awcms_mini_auth_providers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  provider_key text NOT NULL,
+  provider_type text NOT NULL DEFAULT 'oidc',
+  display_name text NOT NULL,
+  issuer_url text NOT NULL,
+  client_id text NOT NULL,
+  client_secret_ciphertext text,
+  client_secret_env_var text,
+  scopes text NOT NULL DEFAULT 'openid email profile',
+  allowed_email_domains jsonb NOT NULL DEFAULT '[]'::jsonb,
+  enabled boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  updated_by uuid,
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_mini_auth_providers_provider_type_check
+    CHECK (provider_type IN ('oidc')),
+  CONSTRAINT awcms_mini_auth_providers_provider_key_format_check
+    CHECK (provider_key ~ '^[a-z0-9][a-z0-9_-]*$'),
+  CONSTRAINT awcms_mini_auth_providers_secret_source_check
+    CHECK (
+      (client_secret_ciphertext IS NOT NULL AND client_secret_env_var IS NULL)
+      OR (client_secret_ciphertext IS NULL AND client_secret_env_var IS NOT NULL)
+    )
+);
+
+-- `provider_key` doubles as the `/api/v1/auth/sso/{providerKey}/...` path
+-- segment and the value stored into the reused
+-- `awcms_mini_identity_provider_accounts.provider`/
+-- `awcms_mini_oidc_auth_requests.provider` columns — must be unique per
+-- tenant among non-deleted providers (an archived provider's slug may be
+-- reused, same convention as `awcms_mini_tenant_domains`' hostname dedup).
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_auth_providers_key_active
+  ON awcms_mini_auth_providers (tenant_id, provider_key)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_awcms_mini_auth_providers_tenant
+  ON awcms_mini_auth_providers (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_awcms_mini_auth_providers_tenant_created
+  ON awcms_mini_auth_providers (tenant_id, created_at DESC)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE awcms_mini_auth_providers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_auth_providers FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_auth_providers_tenant_isolation
+  ON awcms_mini_auth_providers
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- `awcms_mini_tenant_auth_policies` — one row per tenant (unique index
+-- below), same "one row per tenant, upsert, no `id` in the URL" shape as
+-- `awcms_mini_blog_settings` (migration 029). `break_glass_identity_ids`
+-- (jsonb array of identity ids) is the safe model the issue asks for:
+-- "sso_required=true cannot be enabled unless at least one break-glass
+-- local owner remains available" is enforced in the application layer
+-- (`tenant-auth-policy.ts`'s `saveTenantAuthPolicy`) at the point the
+-- policy is SAVED, not merely at login time — a DB CHECK constraint alone
+-- cannot express "at least one of these ids is a currently-active identity
+-- with an active tenant_user membership," which requires cross-table
+-- validation. `mfa_required` is added now (default `false`, never read by
+-- any endpoint yet) purely for forward compatibility with Issue #589's
+-- per-identity MFA opt-in model, per this issue's own scope note — a
+-- future issue may centralize "require MFA tenant-wide" here instead of
+-- leaving it purely opt-in per identity; wiring that enforcement is
+-- explicitly out of scope for #591.
+CREATE TABLE IF NOT EXISTS awcms_mini_tenant_auth_policies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  password_login_enabled boolean NOT NULL DEFAULT true,
+  sso_enabled boolean NOT NULL DEFAULT false,
+  sso_required boolean NOT NULL DEFAULT false,
+  auto_link_verified_email boolean NOT NULL DEFAULT false,
+  allowed_email_domains jsonb NOT NULL DEFAULT '[]'::jsonb,
+  break_glass_identity_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+  mfa_required boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by uuid,
+  CONSTRAINT awcms_mini_tenant_auth_policies_login_method_check
+    CHECK (password_login_enabled OR sso_enabled)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_tenant_auth_policies_tenant_key
+  ON awcms_mini_tenant_auth_policies (tenant_id);
+
+ALTER TABLE awcms_mini_tenant_auth_policies ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_tenant_auth_policies FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_tenant_auth_policies_tenant_isolation
+  ON awcms_mini_tenant_auth_policies
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/sql/037_awcms_mini_tenant_oidc_sso_permissions.sql
+++ b/sql/037_awcms_mini_tenant_oidc_sso_permissions.sql
@@ -1,0 +1,18 @@
+-- Issue #591 (epic: full-online auth hardening #587-#593) — permission
+-- catalog seed for the admin CRUD endpoints over the new
+-- `awcms_mini_auth_providers`/`awcms_mini_tenant_auth_policies` tables
+-- (migration 036). Same shape as `sql/032_awcms_mini_tenant_domain_permissions.sql` —
+-- extends the global ABAC permission catalog only under the existing
+-- `identity_access` module_key (already used by migration 005's
+-- `user_management`/`access_control` activity codes), no
+-- roles/access-assignments wired here (tenant admins grant these via the
+-- existing role management UI, out of scope for this migration).
+INSERT INTO awcms_mini_permissions (module_key, activity_code, action, description)
+VALUES
+  ('identity_access', 'sso_providers', 'read', 'Read tenant OIDC SSO provider configuration'),
+  ('identity_access', 'sso_providers', 'create', 'Add a tenant OIDC SSO provider'),
+  ('identity_access', 'sso_providers', 'update', 'Update a tenant OIDC SSO provider'),
+  ('identity_access', 'sso_providers', 'delete', 'Soft delete a tenant OIDC SSO provider'),
+  ('identity_access', 'sso_policy', 'read', 'Read tenant authentication policy (password/SSO/break-glass)'),
+  ('identity_access', 'sso_policy', 'update', 'Update tenant authentication policy (password/SSO/break-glass)')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/lib/auth/generic-oidc-client.ts
+++ b/src/lib/auth/generic-oidc-client.ts
@@ -1,0 +1,258 @@
+/**
+ * Generic tenant OIDC provider network calls (Issue #591, epic: full-online
+ * auth hardening) — `.well-known/openid-configuration` discovery, JWKS
+ * fetch, and authorization-code token exchange for a TENANT-CONFIGURED
+ * issuer (unlike Issue #590's Google login, whose endpoints are hardcoded
+ * constants — see `google-oidc-config.ts`'s own comment on why: here the
+ * issuer is arbitrary, so discovery is unavoidable).
+ *
+ * Same timeout + circuit-breaker pattern as `google-oauth-client.ts`/
+ * `../security/turnstile.ts`, and the SAME rule PR #596/#598's security
+ * reviews forced onto every provider call in this epic: the circuit
+ * breaker only trips on a genuine transport-level failure (non-2xx the
+ * caller didn't cause, network error, timeout), NEVER on a well-formed
+ * error response driven by attacker-controlled input (a bad/reused/expired
+ * authorization `code` answered with `400 invalid_grant` is the provider
+ * correctly rejecting a bad request, not the provider being unhealthy).
+ * Breakers are keyed PER PROVIDER (`sso-oidc-discovery:<providerKey>` etc.)
+ * — a slow/unhealthy tenant-configured provider must never affect any
+ * other tenant's or provider's login, unlike the single application-wide
+ * database circuit breaker.
+ */
+import { getProviderCircuitBreaker } from "../database/circuit-breaker";
+import { withTimeout } from "../integration/timeout";
+import { resolveSsoDiscoveryTimeoutMs } from "./sso-config";
+
+export type OidcDiscoveryDocument = {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  jwks_uri: string;
+};
+
+export type DiscoverOidcResult =
+  { ok: true; document: OidcDiscoveryDocument } | { ok: false };
+
+const DISCOVERY_CACHE_TTL_MS = 60 * 60 * 1000;
+
+const discoveryCache = new Map<
+  string,
+  { document: OidcDiscoveryDocument; fetchedAt: number }
+>();
+
+function normalizeIssuerUrl(issuerUrl: string): string {
+  return issuerUrl.endsWith("/") ? issuerUrl.slice(0, -1) : issuerUrl;
+}
+
+/**
+ * Fetches (and caches for `DISCOVERY_CACHE_TTL_MS`, same rationale as
+ * `google-oauth-client.ts`'s JWKS cache — a provider's discovery document
+ * changes rarely) a tenant-configured provider's
+ * `.well-known/openid-configuration`. `providerKey` scopes the circuit
+ * breaker AND the cache key so one misconfigured/unhealthy tenant provider
+ * never affects another tenant's identically-issued provider (e.g. two
+ * tenants both pointing at the same Okta org).
+ */
+export async function discoverOidcConfiguration(
+  providerKey: string,
+  issuerUrl: string,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<DiscoverOidcResult> {
+  const normalizedIssuer = normalizeIssuerUrl(issuerUrl);
+  const cached = discoveryCache.get(providerKey);
+  const now = Date.now();
+
+  if (cached && now - cached.fetchedAt < DISCOVERY_CACHE_TTL_MS) {
+    return { ok: true, document: cached.document };
+  }
+
+  const breaker = getProviderCircuitBreaker(
+    `sso-oidc-discovery:${providerKey}`
+  );
+  const attemptedAt = new Date();
+
+  if (!breaker.canAttempt(attemptedAt)) {
+    return { ok: false };
+  }
+
+  try {
+    const response = await withTimeout(
+      fetch(`${normalizedIssuer}/.well-known/openid-configuration`),
+      resolveSsoDiscoveryTimeoutMs(env),
+      `oidc discovery (${providerKey})`
+    );
+
+    if (response.status < 200 || response.status >= 300) {
+      breaker.recordFailure(attemptedAt);
+      return { ok: false };
+    }
+
+    const document = (await response
+      .json()
+      .catch(() => null)) as Partial<OidcDiscoveryDocument> | null;
+
+    if (
+      !document ||
+      typeof document.authorization_endpoint !== "string" ||
+      typeof document.token_endpoint !== "string" ||
+      typeof document.jwks_uri !== "string" ||
+      typeof document.issuer !== "string"
+    ) {
+      breaker.recordFailure(attemptedAt);
+      return { ok: false };
+    }
+
+    breaker.recordSuccess(attemptedAt);
+    const resolved = document as OidcDiscoveryDocument;
+    discoveryCache.set(providerKey, { document: resolved, fetchedAt: now });
+    return { ok: true, document: resolved };
+  } catch {
+    breaker.recordFailure(attemptedAt);
+    return { ok: false };
+  }
+}
+
+export type GenericJwks = { keys: Record<string, unknown>[] };
+
+const jwksCache = new Map<string, { jwks: GenericJwks; fetchedAt: number }>();
+const JWKS_CACHE_TTL_MS = 60 * 60 * 1000;
+
+export type FetchJwksResult = { ok: true; jwks: GenericJwks } | { ok: false };
+
+/** Same breaker-tripping rule as `discoverOidcConfiguration`/`exchangeAuthorizationCode` — only a genuine transport failure counts. */
+export async function fetchProviderJwks(
+  providerKey: string,
+  jwksUri: string,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<FetchJwksResult> {
+  const cached = jwksCache.get(providerKey);
+  const now = Date.now();
+
+  if (cached && now - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
+    return { ok: true, jwks: cached.jwks };
+  }
+
+  const breaker = getProviderCircuitBreaker(`sso-oidc-jwks:${providerKey}`);
+  const attemptedAt = new Date();
+
+  if (!breaker.canAttempt(attemptedAt)) {
+    return { ok: false };
+  }
+
+  try {
+    const response = await withTimeout(
+      fetch(jwksUri),
+      resolveSsoDiscoveryTimeoutMs(env),
+      `oidc jwks fetch (${providerKey})`
+    );
+
+    if (response.status < 200 || response.status >= 300) {
+      breaker.recordFailure(attemptedAt);
+      return { ok: false };
+    }
+
+    const jwks = (await response
+      .json()
+      .catch(() => null)) as GenericJwks | null;
+
+    if (!jwks || !Array.isArray(jwks.keys)) {
+      breaker.recordFailure(attemptedAt);
+      return { ok: false };
+    }
+
+    breaker.recordSuccess(attemptedAt);
+    jwksCache.set(providerKey, { jwks, fetchedAt: now });
+    return { ok: true, jwks };
+  } catch {
+    breaker.recordFailure(attemptedAt);
+    return { ok: false };
+  }
+}
+
+export type ExchangeCodeParams = {
+  providerKey: string;
+  tokenEndpoint: string;
+  code: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  timeoutMs?: number;
+};
+
+export type ExchangeCodeResult =
+  { ok: true; idToken: string } | { ok: false; retryable: boolean };
+
+/**
+ * Authorization Code exchange against a tenant-configured provider's own
+ * `token_endpoint` (resolved via `discoverOidcConfiguration`). Mirrors
+ * `google-oauth-client.ts`'s `exchangeAuthorizationCode` exactly, including
+ * its breaker-tripping rule: a genuine 5xx/network/timeout records failure;
+ * a well-formed 4xx (bad/reused/expired `code`) records SUCCESS (the
+ * provider is healthy — it just correctly rejected attacker-controlled
+ * input) and returns a non-retryable failure.
+ */
+export async function exchangeAuthorizationCode(
+  params: ExchangeCodeParams
+): Promise<ExchangeCodeResult> {
+  const breaker = getProviderCircuitBreaker(
+    `sso-oidc-token:${params.providerKey}`
+  );
+  const attemptedAt = new Date();
+
+  if (!breaker.canAttempt(attemptedAt)) {
+    return { ok: false, retryable: true };
+  }
+
+  const body = new URLSearchParams({
+    code: params.code,
+    client_id: params.clientId,
+    client_secret: params.clientSecret,
+    redirect_uri: params.redirectUri,
+    grant_type: "authorization_code"
+  });
+
+  try {
+    const response = await withTimeout(
+      fetch(params.tokenEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString()
+      }),
+      params.timeoutMs ?? resolveSsoDiscoveryTimeoutMs(),
+      `oidc token exchange (${params.providerKey})`
+    );
+
+    const rawBody = await response.text().catch(() => "");
+    let parsed: { id_token?: string } | undefined;
+
+    try {
+      parsed = rawBody
+        ? (JSON.parse(rawBody) as { id_token?: string })
+        : undefined;
+    } catch {
+      parsed = undefined;
+    }
+
+    if (response.status >= 500 || response.status === 0 || !parsed) {
+      breaker.recordFailure(attemptedAt);
+      return { ok: false, retryable: true };
+    }
+
+    if (response.status < 200 || response.status >= 300 || !parsed.id_token) {
+      breaker.recordSuccess(attemptedAt);
+      return { ok: false, retryable: false };
+    }
+
+    breaker.recordSuccess(attemptedAt);
+    return { ok: true, idToken: parsed.id_token };
+  } catch {
+    breaker.recordFailure(attemptedAt);
+    return { ok: false, retryable: true };
+  }
+}
+
+/** Test-only: clears the in-memory discovery/JWKS caches so test files don't bleed into each other. */
+export function resetGenericOidcCachesForTests(): void {
+  discoveryCache.clear();
+  jwksCache.clear();
+}

--- a/src/lib/auth/sso-config.ts
+++ b/src/lib/auth/sso-config.ts
@@ -1,0 +1,75 @@
+/**
+ * Generic tenant OIDC SSO config gate (Issue #591, epic: full-online auth
+ * hardening). Mirrors `./google-oidc-config.ts`'s `isGoogleLoginRequired`/
+ * `./mfa-config.ts`'s `isMfaRequired`/`../security/turnstile.ts`'s
+ * `isTurnstileRequired` shape exactly — `isSsoRequired` is the ONE function
+ * every generic-SSO endpoint checks; local/offline/LAN deployments never
+ * read these env vars, never fetch OIDC discovery/JWKS, never call any
+ * tenant-configured provider.
+ *
+ * Unlike Google login (Issue #590), the provider's own issuer/client
+ * id/secret/scopes/allowed domains are tenant-configured DATA
+ * (`awcms_mini_auth_providers`, migration 036), not deployment-wide env
+ * vars — this file only owns the three deployment-level knobs from the
+ * issue's own §Environment variables: the master enable flag, the at-rest
+ * credential encryption key, and the discovery/JWKS fetch timeout.
+ */
+import { isFullOnlineSecurityActive } from "./online-security-config";
+
+export function isSsoEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.AUTH_SSO_ENABLED === "true";
+}
+
+/**
+ * The single boolean every generic-SSO endpoint and admin provider/policy
+ * endpoint must check before doing anything online/provider-related — true
+ * only when BOTH the full-online gate (Issue #587) and this feature's own
+ * flag agree. Matches the issue's acceptance criterion "SSO is active only
+ * when #587 gate is enabled and AUTH_SSO_ENABLED=true."
+ */
+export function isSsoRequired(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isFullOnlineSecurityActive(env) && isSsoEnabled(env);
+}
+
+/**
+ * Env vars required only when `AUTH_SSO_ENABLED=true`
+ * (`scripts/validate-env.ts`'s `checkSsoConfig`). Only the credential
+ * encryption key is deployment-level required — per-provider issuer/client
+ * id/secret are tenant-configured DATA (`awcms_mini_auth_providers`), whose
+ * presence/validity is checked at provider-create/OAuth-call time, not at
+ * deployment boot.
+ */
+export const SSO_REQUIRED_WHEN_ENABLED = [
+  "AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY"
+] as const;
+
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 5_000;
+
+/**
+ * Bounded timeout for OIDC discovery (`.well-known/openid-configuration`)
+ * and JWKS fetches (issue's own acceptance criterion: "OIDC discovery and
+ * JWKS fetches have bounded timeout"). Falls back to 5000ms for an unset or
+ * non-numeric value — never throws, never blocks indefinitely.
+ */
+export function resolveSsoDiscoveryTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const raw = Number(env.AUTH_SSO_DISCOVERY_TIMEOUT_MS);
+
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_DISCOVERY_TIMEOUT_MS;
+}
+
+const DEFAULT_REDIRECT_PATH_PREFIX = "/api/v1/auth/sso";
+
+/** Resolves this deployment's own callback redirect URI for a given provider key — always this deployment's own path under `APP_URL`, never client-supplied (open-redirect prevention), same convention as `google-oauth-client.ts`'s `resolveGoogleRedirectUri`. */
+export function resolveSsoRedirectUri(
+  providerKey: string,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const appUrl = env.APP_URL ?? "http://localhost:4321";
+
+  return new URL(
+    `${DEFAULT_REDIRECT_PATH_PREFIX}/${providerKey}/callback`,
+    appUrl
+  ).toString();
+}

--- a/src/lib/auth/sso-credential-crypto.ts
+++ b/src/lib/auth/sso-credential-crypto.ts
@@ -1,0 +1,88 @@
+/**
+ * Encryption-at-rest for generic tenant OIDC SSO client secrets (Issue
+ * #591). Identical shape and rationale to Issue #589's
+ * `mfa-secret-crypto.ts` (AES-256-GCM, versioned `v1:<iv>:<tag>:<ciphertext>`
+ * format, fail-closed key resolution) — a SEPARATE key
+ * (`AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY`) from MFA's own
+ * `AUTH_MFA_SECRET_ENCRYPTION_KEY`, deliberately: rotating/compromising one
+ * secret class must never affect the other, and each key's blast radius
+ * stays scoped to the one column it protects
+ * (`awcms_mini_auth_providers.client_secret_ciphertext`).
+ *
+ * Unlike a TOTP seed, an OIDC client secret is only ever needed at
+ * token-exchange time (never a per-request HMAC-style comparison), but it
+ * still must be recoverable in full (not hashed) — the provider's own
+ * token endpoint expects the literal secret value.
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_BYTE_LENGTH = 32;
+const IV_BYTE_LENGTH = 12;
+const FORMAT_VERSION = "v1";
+
+/**
+ * Decodes and validates `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY` from env.
+ * Returns `null` — never throws — if unset or not exactly 32 bytes once
+ * base64-decoded, so every caller can fail closed (treat "no usable key" as
+ * "cannot encrypt/decrypt this provider's secret") rather than crash.
+ */
+export function resolveSsoEncryptionKey(
+  env: NodeJS.ProcessEnv = process.env
+): Buffer | null {
+  const raw = env.AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY;
+
+  if (!raw) {
+    return null;
+  }
+
+  let key: Buffer;
+
+  try {
+    key = Buffer.from(raw, "base64");
+  } catch {
+    return null;
+  }
+
+  return key.length === KEY_BYTE_LENGTH ? key : null;
+}
+
+/** `v1:<iv-base64>:<authTag-base64>:<ciphertext-base64>` — versioned so the format can evolve without breaking already-encrypted rows. */
+export function encryptSsoClientSecret(plaintext: string, key: Buffer): string {
+  const iv = randomBytes(IV_BYTE_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(Buffer.from(plaintext, "utf8")),
+    cipher.final()
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return [
+    FORMAT_VERSION,
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    ciphertext.toString("base64")
+  ].join(":");
+}
+
+/** Throws if `encoded` is malformed, the tag doesn't authenticate, or the version is unrecognized — callers must treat any throw as "cannot decrypt", never as "empty secret". */
+export function decryptSsoClientSecret(encoded: string, key: Buffer): string {
+  const parts = encoded.split(":");
+
+  if (parts.length !== 4 || parts[0] !== FORMAT_VERSION) {
+    throw new Error("Unrecognized SSO client secret ciphertext format.");
+  }
+
+  const [, ivPart, tagPart, ciphertextPart] = parts;
+  const iv = Buffer.from(ivPart!, "base64");
+  const authTag = Buffer.from(tagPart!, "base64");
+  const ciphertext = Buffer.from(ciphertextPart!, "base64");
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final()
+  ]).toString("utf8");
+}

--- a/src/lib/i18n/error-messages.ts
+++ b/src/lib/i18n/error-messages.ts
@@ -14,7 +14,13 @@ import type { Translator } from "./translate";
  * OIDC codes: `GOOGLE_LOGIN_DISABLED`/`GOOGLE_OAUTH_STATE_INVALID`/
  * `GOOGLE_TOKEN_EXCHANGE_FAILED`/`GOOGLE_ID_TOKEN_INVALID`/
  * `GOOGLE_ACCOUNT_NOT_LINKED`/`GOOGLE_ALREADY_LINKED`/`GOOGLE_NOT_LINKED`/
- * `GOOGLE_MISCONFIGURED`) to i18n catalog keys
+ * `GOOGLE_MISCONFIGURED` — and Issue #591's generic tenant OIDC SSO codes:
+ * `SSO_DISABLED`/`SSO_PROVIDER_NOT_FOUND`/`SSO_PROVIDER_DISABLED`/
+ * `SSO_PROVIDER_UNAVAILABLE`/`SSO_OAUTH_STATE_INVALID`/
+ * `SSO_TOKEN_EXCHANGE_FAILED`/`SSO_ID_TOKEN_INVALID`/
+ * `SSO_ACCOUNT_NOT_LINKED`/`SSO_ALREADY_LINKED`/`SSO_NOT_LINKED`/
+ * `SSO_MISCONFIGURED`/`SSO_PROVIDER_KEY_CONFLICT`/`BREAK_GLASS_REQUIRED`/
+ * `PASSWORD_LOGIN_DISABLED`) to i18n catalog keys
  * under the `error.` namespace. Used both server-side (SSR error panels)
  * and to build the
  * client-string JSON blob admin pages inline for their fetch-based action
@@ -60,7 +66,21 @@ export const ERROR_CODE_KEYS: Record<string, string> = {
   GOOGLE_ACCOUNT_NOT_LINKED: "error.google_account_not_linked",
   GOOGLE_ALREADY_LINKED: "error.google_already_linked",
   GOOGLE_NOT_LINKED: "error.google_not_linked",
-  GOOGLE_MISCONFIGURED: "error.google_misconfigured"
+  GOOGLE_MISCONFIGURED: "error.google_misconfigured",
+  SSO_DISABLED: "error.sso_disabled",
+  SSO_PROVIDER_NOT_FOUND: "error.sso_provider_not_found",
+  SSO_PROVIDER_DISABLED: "error.sso_provider_disabled",
+  SSO_PROVIDER_UNAVAILABLE: "error.sso_provider_unavailable",
+  SSO_OAUTH_STATE_INVALID: "error.sso_oauth_state_invalid",
+  SSO_TOKEN_EXCHANGE_FAILED: "error.sso_token_exchange_failed",
+  SSO_ID_TOKEN_INVALID: "error.sso_id_token_invalid",
+  SSO_ACCOUNT_NOT_LINKED: "error.sso_account_not_linked",
+  SSO_ALREADY_LINKED: "error.sso_already_linked",
+  SSO_NOT_LINKED: "error.sso_not_linked",
+  SSO_MISCONFIGURED: "error.sso_misconfigured",
+  SSO_PROVIDER_KEY_CONFLICT: "error.sso_provider_key_conflict",
+  BREAK_GLASS_REQUIRED: "error.break_glass_required",
+  PASSWORD_LOGIN_DISABLED: "error.password_login_disabled"
 };
 
 /**

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -150,14 +150,17 @@ Astro secara default menolak (403, tanpa body) permintaan `POST`/`PUT`/`PATCH`/`
 
 CRUD ABAC policy row (`awcms_mini_abac_policies` — schema tersedia, evaluator masih pakai aturan generik bawaan, belum ada endpoint kelola policy), dan publikasi event `identity.login.succeeded`/`identity.login.failed` (doc 05, menyusul modul Observability/Logging) belum ada pada tahap ini. `/access/decision-logs` tetap `LIMIT 50` per halaman tapi kini punya keyset pagination opsional (Issue #435, `?cursor=`/`nextCursor` — lihat `src/modules/_shared/keyset-pagination.ts`).
 
-Generic tenant OIDC SSO dan admin policy UI (Issue #591-#592) masih
-backlog untuk epic full-online auth security hardening (#587-#593).
-#587 (gate bersama, lihat §Full-online-only auth security feature gate
-di bawah), #588 (Cloudflare Turnstile, `src/lib/security/turnstile.ts`
-— bukan bagian modul ini, tapi dipanggil dari `POST /auth/login` di
-modul ini via `enforceTurnstileIfRequired`), #589 (MFA/TOTP, lihat
-§MFA/TOTP login challenge di bawah), dan #590 (Google OIDC login, lihat
-§Google OIDC login di bawah) sudah selesai. Lihat skill
+Admin policy UI (Issue #592, minimal UI verifikasi terpisah dari admin
+CRUD API yang sudah ada — lihat §Generic tenant OIDC SSO provider di
+bawah) masih backlog untuk epic full-online auth security hardening
+(#587-#593). #587 (gate bersama, lihat §Full-online-only auth security
+feature gate di bawah), #588 (Cloudflare Turnstile,
+`src/lib/security/turnstile.ts` — bukan bagian modul ini, tapi
+dipanggil dari `POST /auth/login` di modul ini via
+`enforceTurnstileIfRequired`), #589 (MFA/TOTP, lihat §MFA/TOTP login
+challenge di bawah), #590 (Google OIDC login, lihat §Google OIDC login
+di bawah), dan #591 (generic tenant OIDC SSO provider, lihat §Generic
+tenant OIDC SSO provider di bawah) sudah selesai. Lihat skill
 `awcms-mini-auth-online-hardening` untuk detail lintas-issue.
 
 ## MFA/TOTP login challenge (Issue #589)
@@ -264,6 +267,88 @@ invalid_grant` Google terhadap `code` yang salah/bekas/kedaluwarsa
   `google_login_succeeded`).
 - Detail lengkap + rasional lintas-issue: skill
   `awcms-mini-auth-online-hardening` §Google OIDC login.
+
+## Generic tenant OIDC SSO provider (Issue #591)
+
+`src/modules/identity-access/application/tenant-sso.ts` +
+`auth-provider-directory.ts` + `tenant-auth-policy.ts` +
+`src/modules/identity-access/domain/tenant-sso-policy.ts` (break-glass
+evaluation, auto-link domain resolution, admin input validation, pure)
+
+- `src/lib/auth/sso-config.ts`/`sso-credential-crypto.ts`/
+  `generic-oidc-client.ts` (gate env, AES-256-GCM client-secret
+  encryption, discovery/JWKS/token-exchange with per-provider circuit
+  breaker — module-agnostic, same shape as `google-oidc-config.ts`/
+  `mfa-secret-crypto.ts`/`google-oauth-client.ts`).
+
+* Gate gabungan `isSsoRequired(env)` = `isFullOnlineSecurityActive(env)`
+  (#587) ∧ `AUTH_SSO_ENABLED=true` — pola persis
+  `isTurnstileRequired()`/`isMfaRequired()`/`isGoogleLoginRequired()`.
+* **Menggeneralisasi Google OIDC (#590) tanpa mengubahnya**: jalur ini
+  adalah PARALEL terhadap `google-oidc.ts`, bukan pengganti — Google
+  login tetap berjalan lewat kode/tabelnya sendiri persis seperti
+  sebelumnya. SSO generik memakai ulang `awcms_mini_oidc_auth_requests`/
+  `awcms_mini_identity_provider_accounts` (migration 035, sudah generik
+  `provider text` sejak awal — lihat komentar migration itu) dengan
+  `provider = <providerKey>` alih-alih `'google'`.
+* **Skema baru (migration 036)**: `awcms_mini_auth_providers` (tenant
+  master data — `provider_key`, `provider_type='oidc'`, `issuer_url`,
+  `client_id`, client secret terenkripsi AES-256-GCM ATAU nama env var
+  referensi — persis salah satu lewat CHECK constraint, TIDAK PERNAH
+  dikembalikan plaintext oleh endpoint manapun, `scopes`,
+  `allowed_email_domains` jsonb, `enabled`, soft delete) dan
+  `awcms_mini_tenant_auth_policies` (satu baris per tenant —
+  `password_login_enabled`, `sso_enabled`, `sso_required`,
+  `auto_link_verified_email`, `allowed_email_domains` jsonb,
+  `break_glass_identity_ids` jsonb, `mfa_required` reserved untuk
+  kompatibilitas #589 di masa depan, belum ditegakkan). Keduanya RLS
+  `ENABLE`+`FORCE`.
+* **Endpoint login/link generik** — pola identik Google: `GET
+/auth/sso/{providerKey}/start` (unauthenticated, tenant dari
+  header/cookie/`?tenantId=`, tenant di-`SELECT` sebelum INSERT apa pun
+  — pola yang sama PR #598 paksakan ke Google `start.ts` untuk
+  menghindari trip circuit breaker database aplikasi-lebar),
+  `GET .../callback` (redirect target provider, validasi
+  `state`/nonce/ID token kriptografis penuh, MFA gate #589 SAMA persis
+  dengan `login.ts`/Google), `POST .../link` (butuh session, kembalikan
+  `authorizationUrl` sebagai JSON), `POST .../unlink` (high-risk,
+  diaudit `sso_account_unlinked`).
+* **Admin CRUD API** (bukan admin UI — itu Issue #592) dilindungi ABAC
+  (migration 037): `identity_access.sso_providers.{read,create,update,delete}`
+  di `/api/v1/identity/sso/providers`(`/{id}`), dan
+  `identity_access.sso_policy.{read,update}` di
+  `/api/v1/identity/sso/policy`. Semua mutation high-risk: diaudit
+  (`sso_provider_created`/`_updated`/`_deleted`, `sso_policy_updated`).
+* **OIDC discovery per-provider** (beda dari Google yang endpoint-nya
+  hardcoded konstan): `.well-known/openid-configuration` + JWKS
+  di-fetch dari `issuer_url` masing-masing provider, di-cache 1 jam,
+  timeout `AUTH_SSO_DISCOVERY_TIMEOUT_MS` (default 5000ms), circuit
+  breaker PER PROVIDER KEY (`sso-oidc-discovery:<key>`/
+  `sso-oidc-jwks:<key>`/`sso-oidc-token:<key>`) — provider satu tenant
+  yang tidak sehat tidak pernah memengaruhi tenant/provider lain. Hanya
+  kegagalan transport genuine (5xx/network/timeout) yang trip breaker;
+  respons 4xx valid dari provider (`invalid_grant`, dst.) TIDAK —
+  pelajaran yang sama dari PR #596/#598 diterapkan sejak awal di sini.
+* **Break-glass enforcement, di titik SAVE bukan hanya login**:
+  `PATCH /api/v1/identity/sso/policy` menolak (`409
+BREAK_GLASS_REQUIRED`) permintaan yang membuat `sso_required=true`
+  atau `password_login_enabled=false` TANPA minimal satu
+  `break_glass_identity_ids` yang saat ini `active` DENGAN tenant_user
+  membership `active` — dicek ulang dari DB (`saveTenantAuthPolicy`,
+  bukan dipercaya dari body request), bukan sekadar validasi bentuk
+  array. `login.ts` menegakkan `password_login_enabled=false` HANYA
+  ketika `isSsoRequired(env)` aktif — deployment offline/LAN yang tidak
+  pernah menyalakan gate #587/#591 tidak pernah menjalankan query
+  tambahan ini maupun mengalami perubahan perilaku login.
+* **Auto-link by email**, dua lapis fail-closed: `provider.allowed_email_domains`
+  (mirip `AUTH_GOOGLE_ALLOWED_DOMAINS`, per provider) DAN
+  `policy.auto_link_verified_email` sebagai master switch — kalau
+  `false` (default), tidak pernah auto-link, identity harus
+  `POST .../link` eksplisit dari sesi yang sudah login. Provider account
+  selalu ditautkan via `sub` (subject OIDC), TIDAK PERNAH via email
+  semata.
+* Detail lengkap + rasional lintas-issue: skill
+  `awcms-mini-auth-online-hardening` §Generic tenant OIDC SSO provider.
 
 ## Full-online-only auth security feature gate (Issue #587)
 

--- a/src/modules/identity-access/application/auth-provider-directory.ts
+++ b/src/modules/identity-access/application/auth-provider-directory.ts
@@ -1,0 +1,290 @@
+/**
+ * Admin CRUD for tenant-configured generic OIDC SSO providers (Issue #591,
+ * epic: full-online auth hardening). `awcms_mini_auth_providers` (migration
+ * 036) is tenant master data — same soft-delete shape as
+ * `blog-page-directory.ts`. The client secret is NEVER returned by any
+ * function here (issue's own acceptance criterion: "Provider credentials
+ * are not returned plaintext by any API") — `toProviderView` only ever
+ * exposes whether a secret is configured and, for the env-referenced case,
+ * the environment variable NAME (not a secret itself). The column list is
+ * repeated literally at each query site (not factored into a shared
+ * `sql.unsafe()` fragment) — same convention `tenant-domain-directory.ts`
+ * documents (every query stays a single self-contained tagged template).
+ */
+import {
+  encryptSsoClientSecret,
+  resolveSsoEncryptionKey
+} from "../../../lib/auth/sso-credential-crypto";
+import type {
+  CreateAuthProviderInput,
+  UpdateAuthProviderInput
+} from "../domain/tenant-sso-policy";
+
+export type AuthProviderView = {
+  id: string;
+  providerKey: string;
+  providerType: string;
+  displayName: string;
+  issuerUrl: string;
+  clientId: string;
+  secretSource: "encrypted" | "env";
+  clientSecretEnvVar: string | null;
+  scopes: string;
+  allowedEmailDomains: string[];
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AuthProviderRow = {
+  id: string;
+  provider_key: string;
+  provider_type: string;
+  display_name: string;
+  issuer_url: string;
+  client_id: string;
+  client_secret_ciphertext: string | null;
+  client_secret_env_var: string | null;
+  scopes: string;
+  allowed_email_domains: unknown;
+  enabled: boolean;
+  created_at: Date;
+  updated_at: Date;
+};
+
+function toProviderView(row: AuthProviderRow): AuthProviderView {
+  return {
+    id: row.id,
+    providerKey: row.provider_key,
+    providerType: row.provider_type,
+    displayName: row.display_name,
+    issuerUrl: row.issuer_url,
+    clientId: row.client_id,
+    secretSource: row.client_secret_ciphertext !== null ? "encrypted" : "env",
+    clientSecretEnvVar: row.client_secret_env_var,
+    scopes: row.scopes,
+    allowedEmailDomains: Array.isArray(row.allowed_email_domains)
+      ? (row.allowed_email_domains as string[])
+      : [],
+    enabled: row.enabled,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString()
+  };
+}
+
+export async function listAuthProviders(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<AuthProviderView[]> {
+  const rows = (await tx`
+    SELECT id, provider_key, provider_type, display_name, issuer_url, client_id,
+           client_secret_ciphertext, client_secret_env_var, scopes,
+           allowed_email_domains, enabled, created_at, updated_at
+    FROM awcms_mini_auth_providers
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+    ORDER BY created_at DESC
+  `) as AuthProviderRow[];
+
+  return rows.map(toProviderView);
+}
+
+export async function fetchAuthProviderById(
+  tx: Bun.SQL,
+  tenantId: string,
+  providerId: string
+): Promise<AuthProviderView | null> {
+  const rows = (await tx`
+    SELECT id, provider_key, provider_type, display_name, issuer_url, client_id,
+           client_secret_ciphertext, client_secret_env_var, scopes,
+           allowed_email_domains, enabled, created_at, updated_at
+    FROM awcms_mini_auth_providers
+    WHERE tenant_id = ${tenantId} AND id = ${providerId} AND deleted_at IS NULL
+  `) as AuthProviderRow[];
+
+  return rows[0] ? toProviderView(rows[0]) : null;
+}
+
+/**
+ * Loads the raw row (including the secret material) for OAuth-time use only
+ * — `tenant-sso.ts`'s `resolveProviderClientSecret` is the sole consumer
+ * that ever needs the ciphertext/env-var-name, and it never leaves that
+ * function as plaintext beyond the in-memory token-exchange call itself.
+ */
+export async function fetchAuthProviderRowByKey(
+  tx: Bun.SQL,
+  tenantId: string,
+  providerKey: string
+): Promise<AuthProviderRow | null> {
+  const rows = (await tx`
+    SELECT id, provider_key, provider_type, display_name, issuer_url, client_id,
+           client_secret_ciphertext, client_secret_env_var, scopes,
+           allowed_email_domains, enabled, created_at, updated_at
+    FROM awcms_mini_auth_providers
+    WHERE tenant_id = ${tenantId} AND provider_key = ${providerKey} AND deleted_at IS NULL
+  `) as AuthProviderRow[];
+
+  return rows[0] ?? null;
+}
+
+export type CreateAuthProviderResult =
+  | { outcome: "created"; provider: AuthProviderView }
+  | { outcome: "duplicate_key" }
+  | { outcome: "misconfigured" };
+
+export async function createAuthProvider(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  input: CreateAuthProviderInput,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<CreateAuthProviderResult> {
+  const existingRows = await tx`
+    SELECT id FROM awcms_mini_auth_providers
+    WHERE tenant_id = ${tenantId} AND provider_key = ${input.providerKey} AND deleted_at IS NULL
+  `;
+
+  if (existingRows.length > 0) {
+    return { outcome: "duplicate_key" };
+  }
+
+  let clientSecretCiphertext: string | null = null;
+
+  if (input.clientSecret) {
+    const key = resolveSsoEncryptionKey(env);
+
+    if (!key) {
+      return { outcome: "misconfigured" };
+    }
+
+    clientSecretCiphertext = encryptSsoClientSecret(input.clientSecret, key);
+  }
+
+  const rows = (await tx`
+    INSERT INTO awcms_mini_auth_providers
+      (tenant_id, provider_key, display_name, issuer_url, client_id,
+       client_secret_ciphertext, client_secret_env_var, scopes,
+       allowed_email_domains, enabled, created_by, updated_by)
+    VALUES (
+      ${tenantId}, ${input.providerKey}, ${input.displayName}, ${input.issuerUrl},
+      ${input.clientId}, ${clientSecretCiphertext}, ${input.clientSecretEnvVar},
+      ${input.scopes}, ${input.allowedEmailDomains},
+      ${input.enabled}, ${actorTenantUserId}, ${actorTenantUserId}
+    )
+    RETURNING id, provider_key, provider_type, display_name, issuer_url, client_id,
+              client_secret_ciphertext, client_secret_env_var, scopes,
+              allowed_email_domains, enabled, created_at, updated_at
+  `) as AuthProviderRow[];
+
+  return { outcome: "created", provider: toProviderView(rows[0]!) };
+}
+
+export type UpdateAuthProviderResult =
+  | { outcome: "updated"; provider: AuthProviderView }
+  | { outcome: "not_found" }
+  | { outcome: "misconfigured" };
+
+export async function updateAuthProvider(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  providerId: string,
+  input: UpdateAuthProviderInput,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<UpdateAuthProviderResult> {
+  const existing = await fetchAuthProviderRowByKeyOrId(
+    tx,
+    tenantId,
+    providerId
+  );
+
+  if (!existing) {
+    return { outcome: "not_found" };
+  }
+
+  let clientSecretCiphertext = existing.client_secret_ciphertext;
+  let clientSecretEnvVar = existing.client_secret_env_var;
+
+  if (
+    input.clientSecret !== undefined ||
+    input.clientSecretEnvVar !== undefined
+  ) {
+    if (input.clientSecret) {
+      const key = resolveSsoEncryptionKey(env);
+
+      if (!key) {
+        return { outcome: "misconfigured" };
+      }
+
+      clientSecretCiphertext = encryptSsoClientSecret(input.clientSecret, key);
+      clientSecretEnvVar = null;
+    } else if (input.clientSecretEnvVar) {
+      clientSecretCiphertext = null;
+      clientSecretEnvVar = input.clientSecretEnvVar;
+    }
+  }
+
+  const displayName = input.displayName ?? existing.display_name;
+  const issuerUrl = input.issuerUrl ?? existing.issuer_url;
+  const clientId = input.clientId ?? existing.client_id;
+  const scopes = input.scopes ?? existing.scopes;
+  const allowedEmailDomains =
+    input.allowedEmailDomains ??
+    (Array.isArray(existing.allowed_email_domains)
+      ? (existing.allowed_email_domains as string[])
+      : []);
+  const enabled = input.enabled ?? existing.enabled;
+
+  const rows = (await tx`
+    UPDATE awcms_mini_auth_providers
+    SET display_name = ${displayName},
+        issuer_url = ${issuerUrl},
+        client_id = ${clientId},
+        client_secret_ciphertext = ${clientSecretCiphertext},
+        client_secret_env_var = ${clientSecretEnvVar},
+        scopes = ${scopes},
+        allowed_email_domains = ${allowedEmailDomains},
+        enabled = ${enabled},
+        updated_at = now(),
+        updated_by = ${actorTenantUserId}
+    WHERE tenant_id = ${tenantId} AND id = ${providerId} AND deleted_at IS NULL
+    RETURNING id, provider_key, provider_type, display_name, issuer_url, client_id,
+              client_secret_ciphertext, client_secret_env_var, scopes,
+              allowed_email_domains, enabled, created_at, updated_at
+  `) as AuthProviderRow[];
+
+  return { outcome: "updated", provider: toProviderView(rows[0]!) };
+}
+
+/** Internal helper: fetches the raw row by primary key id (used only to read the pre-update state in `updateAuthProvider`). */
+async function fetchAuthProviderRowByKeyOrId(
+  tx: Bun.SQL,
+  tenantId: string,
+  providerId: string
+): Promise<AuthProviderRow | null> {
+  const rows = (await tx`
+    SELECT id, provider_key, provider_type, display_name, issuer_url, client_id,
+           client_secret_ciphertext, client_secret_env_var, scopes,
+           allowed_email_domains, enabled, created_at, updated_at
+    FROM awcms_mini_auth_providers
+    WHERE tenant_id = ${tenantId} AND id = ${providerId} AND deleted_at IS NULL
+  `) as AuthProviderRow[];
+
+  return rows[0] ?? null;
+}
+
+export async function softDeleteAuthProvider(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  providerId: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_mini_auth_providers
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason}
+    WHERE tenant_id = ${tenantId} AND id = ${providerId} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}

--- a/src/modules/identity-access/application/tenant-auth-policy.ts
+++ b/src/modules/identity-access/application/tenant-auth-policy.ts
@@ -1,0 +1,234 @@
+/**
+ * Tenant authentication policy CRUD (Issue #591, epic: full-online auth
+ * hardening) over `awcms_mini_tenant_auth_policies` (migration 036) — same
+ * "one row per tenant, upsert, no `id` in the URL" shape as
+ * `blog-settings-directory.ts`. `saveTenantAuthPolicy` is the ONE place
+ * that enforces the issue's own acceptance criterion "`sso_required=true`
+ * cannot be enabled unless at least one break-glass local owner remains
+ * available" — checked here, at save time, against a fresh DB read of the
+ * candidate break-glass identities' current status, never trusted from the
+ * request body alone.
+ */
+import {
+  evaluateBreakGlassRequirement,
+  type UpdateTenantAuthPolicyInput
+} from "../domain/tenant-sso-policy";
+
+export type TenantAuthPolicyView = {
+  tenantId: string;
+  passwordLoginEnabled: boolean;
+  ssoEnabled: boolean;
+  ssoRequired: boolean;
+  autoLinkVerifiedEmail: boolean;
+  allowedEmailDomains: string[];
+  breakGlassIdentityIds: string[];
+  mfaRequired: boolean;
+  updatedAt: string | null;
+};
+
+const DEFAULT_POLICY_VIEW: Omit<TenantAuthPolicyView, "tenantId"> = {
+  passwordLoginEnabled: true,
+  ssoEnabled: false,
+  ssoRequired: false,
+  autoLinkVerifiedEmail: false,
+  allowedEmailDomains: [],
+  breakGlassIdentityIds: [],
+  mfaRequired: false,
+  updatedAt: null
+};
+
+type TenantAuthPolicyRow = {
+  password_login_enabled: boolean;
+  sso_enabled: boolean;
+  sso_required: boolean;
+  auto_link_verified_email: boolean;
+  allowed_email_domains: unknown;
+  break_glass_identity_ids: unknown;
+  mfa_required: boolean;
+  updated_at: Date;
+};
+
+function toArray(value: unknown): string[] {
+  return Array.isArray(value) ? (value as string[]) : [];
+}
+
+/** Returns the tenant's policy, or the safe backward-compatible default (password login enabled, SSO disabled) when no row has ever been saved — every deployment that never touches this endpoint behaves exactly as it did before this issue. */
+export async function getTenantAuthPolicy(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<TenantAuthPolicyView> {
+  const rows = (await tx`
+    SELECT password_login_enabled, sso_enabled, sso_required,
+           auto_link_verified_email, allowed_email_domains,
+           break_glass_identity_ids, mfa_required, updated_at
+    FROM awcms_mini_tenant_auth_policies
+    WHERE tenant_id = ${tenantId}
+  `) as TenantAuthPolicyRow[];
+  const row = rows[0];
+
+  if (!row) {
+    return { tenantId, ...DEFAULT_POLICY_VIEW };
+  }
+
+  return {
+    tenantId,
+    passwordLoginEnabled: row.password_login_enabled,
+    ssoEnabled: row.sso_enabled,
+    ssoRequired: row.sso_required,
+    autoLinkVerifiedEmail: row.auto_link_verified_email,
+    allowedEmailDomains: toArray(row.allowed_email_domains),
+    breakGlassIdentityIds: toArray(row.break_glass_identity_ids),
+    mfaRequired: row.mfa_required,
+    updatedAt: row.updated_at.toISOString()
+  };
+}
+
+/**
+ * Counts how many of `breakGlassIdentityIds` currently resolve to an
+ * identity that can actually still complete a local password login in this
+ * tenant: the identity exists, belongs to this tenant, `status = 'active'`,
+ * and has an `active` `awcms_mini_tenant_users` membership. Every identity
+ * row always has a `password_hash` (NOT NULL, migration 004 — there is no
+ * "SSO-only identity" model in this schema), so this is a sufficient
+ * eligibility check without inspecting `password_hash` itself.
+ */
+async function countEligibleBreakGlassIdentities(
+  tx: Bun.SQL,
+  tenantId: string,
+  breakGlassIdentityIds: string[]
+): Promise<number> {
+  if (breakGlassIdentityIds.length === 0) {
+    return 0;
+  }
+
+  const rows = (await tx`
+    SELECT i.id
+    FROM awcms_mini_identities i
+    JOIN awcms_mini_tenant_users tu
+      ON tu.tenant_id = i.tenant_id AND tu.identity_id = i.id
+    WHERE i.tenant_id = ${tenantId}
+      AND i.id = ANY(${tx.array(breakGlassIdentityIds, "uuid")})
+      AND i.status = 'active'
+      AND tu.status = 'active'
+  `) as { id: string }[];
+
+  return rows.length;
+}
+
+export type SaveTenantAuthPolicyResult =
+  | { outcome: "saved"; policy: TenantAuthPolicyView }
+  | { outcome: "break_glass_required" };
+
+export async function saveTenantAuthPolicy(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  input: UpdateTenantAuthPolicyInput
+): Promise<SaveTenantAuthPolicyResult> {
+  const current = await getTenantAuthPolicy(tx, tenantId);
+
+  const passwordLoginEnabled =
+    input.passwordLoginEnabled ?? current.passwordLoginEnabled;
+  const ssoEnabled = input.ssoEnabled ?? current.ssoEnabled;
+  const ssoRequired = input.ssoRequired ?? current.ssoRequired;
+  const autoLinkVerifiedEmail =
+    input.autoLinkVerifiedEmail ?? current.autoLinkVerifiedEmail;
+  const allowedEmailDomains =
+    input.allowedEmailDomains ?? current.allowedEmailDomains;
+  const breakGlassIdentityIds =
+    input.breakGlassIdentityIds ?? current.breakGlassIdentityIds;
+
+  const eligibleBreakGlassCount = await countEligibleBreakGlassIdentities(
+    tx,
+    tenantId,
+    breakGlassIdentityIds
+  );
+
+  const breakGlassEvaluation = evaluateBreakGlassRequirement({
+    passwordLoginEnabled,
+    ssoRequired,
+    breakGlassIdentityIds,
+    eligibleBreakGlassCount
+  });
+
+  if (breakGlassEvaluation.outcome === "invalid") {
+    return { outcome: "break_glass_required" };
+  }
+
+  const rows = (await tx`
+    INSERT INTO awcms_mini_tenant_auth_policies
+      (tenant_id, password_login_enabled, sso_enabled, sso_required,
+       auto_link_verified_email, allowed_email_domains,
+       break_glass_identity_ids, updated_by)
+    VALUES (
+      ${tenantId}, ${passwordLoginEnabled}, ${ssoEnabled}, ${ssoRequired},
+      ${autoLinkVerifiedEmail}, ${allowedEmailDomains},
+      ${breakGlassIdentityIds}, ${actorTenantUserId}
+    )
+    ON CONFLICT (tenant_id) DO UPDATE SET
+      password_login_enabled = ${passwordLoginEnabled},
+      sso_enabled = ${ssoEnabled},
+      sso_required = ${ssoRequired},
+      auto_link_verified_email = ${autoLinkVerifiedEmail},
+      allowed_email_domains = ${allowedEmailDomains},
+      break_glass_identity_ids = ${breakGlassIdentityIds},
+      updated_at = now(),
+      updated_by = ${actorTenantUserId}
+    RETURNING password_login_enabled, sso_enabled, sso_required,
+              auto_link_verified_email, allowed_email_domains,
+              break_glass_identity_ids, mfa_required, updated_at
+  `) as TenantAuthPolicyRow[];
+  const row = rows[0]!;
+
+  return {
+    outcome: "saved",
+    policy: {
+      tenantId,
+      passwordLoginEnabled: row.password_login_enabled,
+      ssoEnabled: row.sso_enabled,
+      ssoRequired: row.sso_required,
+      autoLinkVerifiedEmail: row.auto_link_verified_email,
+      allowedEmailDomains: toArray(row.allowed_email_domains),
+      breakGlassIdentityIds: toArray(row.break_glass_identity_ids),
+      mfaRequired: row.mfa_required,
+      updatedAt: row.updated_at.toISOString()
+    }
+  };
+}
+
+/**
+ * Login-time enforcement (issue's own acceptance criterion: "Existing
+ * password login remains available unless tenant policy explicitly
+ * restricts it and break-glass is valid"). Returns `true` only when
+ * password login should be REJECTED for this specific identity: the
+ * tenant's policy has `password_login_enabled = false` AND this identity is
+ * not one of the configured break-glass identities. Deliberately a single
+ * cheap read (no join/eligibility re-check — an identity already listed as
+ * break-glass is trusted here; `saveTenantAuthPolicy` is what guarantees
+ * the list contains at least one currently-eligible identity at save time).
+ * Callers (`login.ts`) must gate this behind `isSsoRequired(env)` — a
+ * deployment that never enables the #591 feature must never run this extra
+ * query or change login behavior at all.
+ */
+export async function isPasswordLoginDisabledForIdentity(
+  tx: Bun.SQL,
+  tenantId: string,
+  identityId: string
+): Promise<boolean> {
+  const rows = (await tx`
+    SELECT password_login_enabled, break_glass_identity_ids
+    FROM awcms_mini_tenant_auth_policies
+    WHERE tenant_id = ${tenantId}
+  `) as {
+    password_login_enabled: boolean;
+    break_glass_identity_ids: unknown;
+  }[];
+  const row = rows[0];
+
+  if (!row || row.password_login_enabled) {
+    return false;
+  }
+
+  const breakGlassIds = toArray(row.break_glass_identity_ids);
+  return !breakGlassIds.includes(identityId);
+}

--- a/src/modules/identity-access/application/tenant-sso.ts
+++ b/src/modules/identity-access/application/tenant-sso.ts
@@ -1,0 +1,637 @@
+/**
+ * Generic tenant OIDC SSO application logic (Issue #591, epic: full-online
+ * auth hardening) — the same orchestration shape as Issue #590's
+ * `google-oidc.ts`, generalized to a TENANT-CONFIGURED provider
+ * (`awcms_mini_auth_providers`, migration 036) instead of Google's hardcoded
+ * endpoints. Deliberately does not import from `google-oidc.ts` (its
+ * `createOAuthRequest`/`consumeOAuthRequest`/etc. all hardcode
+ * `provider = 'google'`) — this file duplicates that small amount of logic,
+ * parameterized by `providerKey`, against the SAME reused tables
+ * (`awcms_mini_oidc_auth_requests`, `awcms_mini_identity_provider_accounts`
+ * — both already provider-agnostic since migration 035, see that
+ * migration's own comment). This keeps the existing, already-tested Google
+ * login flow completely untouched while giving the generic flow its own
+ * small, easily-audited implementation.
+ *
+ * Reuses `google-oidc-policy.ts`'s `evaluateOAuthRequest` and
+ * `validateIdTokenClaims` verbatim — both are already pure and
+ * provider-agnostic (they operate on generic snapshots/claims, no Google
+ * constant baked in), exactly the kind of shared logic the epic's own
+ * skill doc calls out as safe to reuse rather than re-derive.
+ */
+import {
+  findJwk,
+  parseJwt,
+  verifyJwtRs256
+} from "../../../lib/auth/jwt-verify";
+import {
+  discoverOidcConfiguration,
+  exchangeAuthorizationCode,
+  fetchProviderJwks
+} from "../../../lib/auth/generic-oidc-client";
+import {
+  resolveSsoDiscoveryTimeoutMs,
+  resolveSsoRedirectUri
+} from "../../../lib/auth/sso-config";
+import {
+  decryptSsoClientSecret,
+  resolveSsoEncryptionKey
+} from "../../../lib/auth/sso-credential-crypto";
+import {
+  buildOAuthStateParam,
+  generateOAuthState,
+  generateOidcNonce,
+  hashOAuthState,
+  parseOAuthStateParam
+} from "../../../lib/auth/oauth-state-token";
+import {
+  evaluateOAuthRequest,
+  validateIdTokenClaims,
+  type IdTokenClaims,
+  type OAuthRequestDenyReason
+} from "../domain/google-oidc-policy";
+import { isAutoLinkAllowedForProvider } from "../domain/tenant-sso-policy";
+import { withTenant } from "../../../lib/database/tenant-context";
+import {
+  isMfaRequired,
+  resolveChallengeTtlSec
+} from "../../../lib/auth/mfa-config";
+import { createMfaChallenge, findActiveMfaFactor } from "./mfa";
+import {
+  fetchAuthProviderRowByKey,
+  type AuthProviderRow
+} from "./auth-provider-directory";
+import { getTenantAuthPolicy } from "./tenant-auth-policy";
+
+export type SsoOAuthPurpose = "login" | "link";
+
+export async function createSsoOAuthRequest(
+  tx: Bun.SQL,
+  tenantId: string,
+  providerKey: string,
+  purpose: SsoOAuthPurpose,
+  identityId: string | null,
+  ttlSec: number,
+  now: Date
+): Promise<{ state: string; nonce: string; expiresAt: Date }> {
+  const state = generateOAuthState();
+  const stateHash = hashOAuthState(state);
+  const nonce = generateOidcNonce();
+  const expiresAt = new Date(now.getTime() + ttlSec * 1000);
+
+  await tx`
+    INSERT INTO awcms_mini_oidc_auth_requests
+      (tenant_id, provider, state_hash, nonce, purpose, identity_id, expires_at)
+    VALUES (${tenantId}, ${providerKey}, ${stateHash}, ${nonce}, ${purpose}, ${identityId}, ${expiresAt})
+  `;
+
+  return { state, nonce, expiresAt };
+}
+
+export type ConsumeSsoOAuthRequestResult =
+  | {
+      ok: true;
+      purpose: SsoOAuthPurpose;
+      identityId: string | null;
+      nonce: string;
+    }
+  | { ok: false; reason: OAuthRequestDenyReason };
+
+/** Same `SELECT ... FOR UPDATE` + compare-and-swap single-use pattern as `google-oidc.ts`'s `consumeOAuthRequest` (PR #597's fix, reused here from day one rather than re-introducing the race). */
+export async function consumeSsoOAuthRequest(
+  tx: Bun.SQL,
+  tenantId: string,
+  providerKey: string,
+  rawState: string,
+  now: Date
+): Promise<ConsumeSsoOAuthRequestResult> {
+  const stateHash = hashOAuthState(rawState);
+
+  const rows = (await tx`
+    SELECT id, purpose, identity_id, nonce, expires_at, consumed_at
+    FROM awcms_mini_oidc_auth_requests
+    WHERE tenant_id = ${tenantId} AND provider = ${providerKey} AND state_hash = ${stateHash}
+    FOR UPDATE
+  `) as {
+    id: string;
+    purpose: SsoOAuthPurpose;
+    identity_id: string | null;
+    nonce: string;
+    expires_at: Date;
+    consumed_at: Date | null;
+  }[];
+  const row = rows[0];
+
+  const evaluation = evaluateOAuthRequest(
+    row
+      ? { expiresAt: new Date(row.expires_at), consumedAt: row.consumed_at }
+      : null,
+    now
+  );
+
+  if (evaluation.outcome === "invalid") {
+    return { ok: false, reason: evaluation.reason };
+  }
+
+  const consumedRows = (await tx`
+    UPDATE awcms_mini_oidc_auth_requests
+    SET consumed_at = ${now}
+    WHERE id = ${row!.id} AND consumed_at IS NULL
+    RETURNING id
+  `) as { id: string }[];
+
+  if (consumedRows.length === 0) {
+    return { ok: false, reason: "already_used" };
+  }
+
+  return {
+    ok: true,
+    purpose: row!.purpose,
+    identityId: row!.identity_id,
+    nonce: row!.nonce
+  };
+}
+
+/** Resolves a provider's client secret in plaintext, in memory only, for the token-exchange call this request makes — never persisted, logged, or returned. `null` means misconfigured (env var referenced but unset, or ciphertext present but the encryption key is unavailable/wrong). */
+export function resolveProviderClientSecret(
+  provider: AuthProviderRow,
+  env: NodeJS.ProcessEnv = process.env
+): string | null {
+  if (provider.client_secret_env_var) {
+    const value = env[provider.client_secret_env_var];
+    return value && value.length > 0 ? value : null;
+  }
+
+  if (provider.client_secret_ciphertext) {
+    const key = resolveSsoEncryptionKey(env);
+
+    if (!key) {
+      return null;
+    }
+
+    try {
+      return decryptSsoClientSecret(provider.client_secret_ciphertext, key);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export type BuildAuthorizationUrlResult =
+  | { ok: true; authorizationUrl: string }
+  | { ok: false; code: "SSO_PROVIDER_UNAVAILABLE" };
+
+/** Discovers the provider's `authorization_endpoint` and builds the full redirect URL — the one step of the flow that needs a live provider call before the browser ever leaves this app. */
+export async function buildSsoAuthorizationUrl(
+  provider: AuthProviderRow,
+  tenantId: string,
+  state: string,
+  nonce: string,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<BuildAuthorizationUrlResult> {
+  const discovery = await discoverOidcConfiguration(
+    provider.provider_key,
+    provider.issuer_url,
+    env
+  );
+
+  if (!discovery.ok) {
+    return { ok: false, code: "SSO_PROVIDER_UNAVAILABLE" };
+  }
+
+  const url = new URL(discovery.document.authorization_endpoint);
+  url.searchParams.set("client_id", provider.client_id);
+  url.searchParams.set(
+    "redirect_uri",
+    resolveSsoRedirectUri(provider.provider_key, env)
+  );
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", provider.scopes);
+  url.searchParams.set("state", buildOAuthStateParam(tenantId, state));
+  url.searchParams.set("nonce", nonce);
+
+  return { ok: true, authorizationUrl: url.toString() };
+}
+
+export type VerifyIdTokenResult =
+  | { ok: true; subject: string; email: string | null; emailVerified: boolean }
+  | { ok: false; code: "SSO_ID_TOKEN_INVALID" | "SSO_PROVIDER_UNAVAILABLE" };
+
+/** Full ID token verification pipeline against a tenant-configured provider — same cryptographic approach as `google-oidc.ts`'s `verifyGoogleIdToken` (RS256 via WebCrypto, then issuer/audience/expiry/nonce claim validation), except the JWKS URI/issuer come from `discoverOidcConfiguration` rather than a hardcoded constant. */
+export async function verifyTenantOidcIdToken(
+  provider: AuthProviderRow,
+  idToken: string,
+  expectedNonce: string,
+  nowSec: number,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<VerifyIdTokenResult> {
+  const discovery = await discoverOidcConfiguration(
+    provider.provider_key,
+    provider.issuer_url,
+    env
+  );
+
+  if (!discovery.ok) {
+    return { ok: false, code: "SSO_PROVIDER_UNAVAILABLE" };
+  }
+
+  let parsed;
+
+  try {
+    parsed = parseJwt(idToken);
+  } catch {
+    return { ok: false, code: "SSO_ID_TOKEN_INVALID" };
+  }
+
+  if (parsed.header.alg !== "RS256" || !parsed.header.kid) {
+    return { ok: false, code: "SSO_ID_TOKEN_INVALID" };
+  }
+
+  const jwksResult = await fetchProviderJwks(
+    provider.provider_key,
+    discovery.document.jwks_uri,
+    env
+  );
+
+  if (!jwksResult.ok) {
+    return { ok: false, code: "SSO_PROVIDER_UNAVAILABLE" };
+  }
+
+  const jwk = findJwk(jwksResult.jwks as { keys: never[] }, parsed.header.kid);
+
+  if (!jwk) {
+    return { ok: false, code: "SSO_ID_TOKEN_INVALID" };
+  }
+
+  const signatureValid = await verifyJwtRs256(
+    parsed.signingInput,
+    parsed.signature,
+    jwk
+  );
+
+  if (!signatureValid) {
+    return { ok: false, code: "SSO_ID_TOKEN_INVALID" };
+  }
+
+  const claimsValidation = validateIdTokenClaims(
+    parsed.payload as IdTokenClaims,
+    {
+      expectedIssuers: [discovery.document.issuer],
+      expectedAudience: provider.client_id,
+      expectedNonce,
+      nowSec
+    }
+  );
+
+  if (claimsValidation.outcome === "invalid") {
+    return { ok: false, code: "SSO_ID_TOKEN_INVALID" };
+  }
+
+  const email =
+    typeof parsed.payload.email === "string" ? parsed.payload.email : null;
+  const emailVerified = parsed.payload.email_verified === true;
+
+  return {
+    ok: true,
+    subject: claimsValidation.subject,
+    email,
+    emailVerified
+  };
+}
+
+export async function findIdentityByProviderSubject(
+  tx: Bun.SQL,
+  tenantId: string,
+  providerKey: string,
+  subject: string
+): Promise<string | null> {
+  const rows = (await tx`
+    SELECT identity_id FROM awcms_mini_identity_provider_accounts
+    WHERE tenant_id = ${tenantId} AND provider = ${providerKey} AND provider_subject = ${subject}
+  `) as { identity_id: string }[];
+
+  return rows[0]?.identity_id ?? null;
+}
+
+export type AutoLinkResult = { ok: true; identityId: string } | { ok: false };
+
+/** Auto-link-by-email for a tenant-configured provider — `isAutoLinkAllowedForProvider` (domain layer) combines the tenant policy's master switch/domain list with this specific provider's own domain list, both fail-closed. */
+export async function autoLinkByEmailForProvider(
+  tx: Bun.SQL,
+  tenantId: string,
+  providerKey: string,
+  provider: AuthProviderRow,
+  email: string,
+  emailVerified: boolean,
+  subject: string,
+  now: Date
+): Promise<AutoLinkResult> {
+  const policy = await getTenantAuthPolicy(tx, tenantId);
+  const providerAllowedDomains = Array.isArray(provider.allowed_email_domains)
+    ? (provider.allowed_email_domains as string[])
+    : [];
+  const atIndex = email.lastIndexOf("@");
+  const domain = atIndex === -1 ? null : email.slice(atIndex + 1).toLowerCase();
+  const isProviderDomainAllowed =
+    domain !== null && providerAllowedDomains.includes(domain);
+
+  const allowed = isAutoLinkAllowedForProvider(
+    policy.autoLinkVerifiedEmail,
+    emailVerified,
+    isProviderDomainAllowed,
+    policy.allowedEmailDomains,
+    domain
+  );
+
+  if (!allowed) {
+    return { ok: false };
+  }
+
+  const tenantRows = (await tx`
+    SELECT status FROM awcms_mini_tenants WHERE id = ${tenantId}
+  `) as { status: string }[];
+
+  if (tenantRows[0]?.status !== "active") {
+    return { ok: false };
+  }
+
+  const identityRows = (await tx`
+    SELECT id, status FROM awcms_mini_identities
+    WHERE tenant_id = ${tenantId} AND login_identifier = ${email}
+  `) as { id: string; status: string }[];
+  const identity = identityRows[0];
+
+  if (!identity || identity.status !== "active") {
+    return { ok: false };
+  }
+
+  const tenantUserRows = (await tx`
+    SELECT status FROM awcms_mini_tenant_users
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identity.id}
+  `) as { status: string }[];
+
+  if (tenantUserRows[0]?.status !== "active") {
+    return { ok: false };
+  }
+
+  await tx`
+    INSERT INTO awcms_mini_identity_provider_accounts
+      (tenant_id, identity_id, provider, provider_subject, linked_at, created_at, updated_at)
+    VALUES (${tenantId}, ${identity.id}, ${providerKey}, ${subject}, ${now}, ${now}, ${now})
+  `;
+
+  return { ok: true, identityId: identity.id };
+}
+
+export type LinkProviderAccountResult =
+  { ok: true } | { ok: false; code: "SSO_ALREADY_LINKED" };
+
+export async function linkProviderAccount(
+  tx: Bun.SQL,
+  tenantId: string,
+  providerKey: string,
+  identityId: string,
+  subject: string,
+  now: Date
+): Promise<LinkProviderAccountResult> {
+  const existingRows = (await tx`
+    SELECT identity_id FROM awcms_mini_identity_provider_accounts
+    WHERE tenant_id = ${tenantId} AND provider = ${providerKey}
+      AND (identity_id = ${identityId} OR provider_subject = ${subject})
+  `) as { identity_id: string }[];
+
+  if (existingRows.length > 0) {
+    return { ok: false, code: "SSO_ALREADY_LINKED" };
+  }
+
+  await tx`
+    INSERT INTO awcms_mini_identity_provider_accounts
+      (tenant_id, identity_id, provider, provider_subject, linked_at, created_at, updated_at)
+    VALUES (${tenantId}, ${identityId}, ${providerKey}, ${subject}, ${now}, ${now}, ${now})
+  `;
+
+  return { ok: true };
+}
+
+export type UnlinkProviderAccountResult =
+  { ok: true } | { ok: false; code: "SSO_NOT_LINKED" };
+
+export async function unlinkProviderAccount(
+  tx: Bun.SQL,
+  tenantId: string,
+  providerKey: string,
+  identityId: string
+): Promise<UnlinkProviderAccountResult> {
+  const deletedRows = (await tx`
+    DELETE FROM awcms_mini_identity_provider_accounts
+    WHERE tenant_id = ${tenantId} AND identity_id = ${identityId} AND provider = ${providerKey}
+    RETURNING id
+  `) as { id: string }[];
+
+  if (deletedRows.length === 0) {
+    return { ok: false, code: "SSO_NOT_LINKED" };
+  }
+
+  return { ok: true };
+}
+
+export type SsoOAuthErrorCode =
+  | "SSO_OAUTH_STATE_INVALID"
+  | "SSO_TOKEN_EXCHANGE_FAILED"
+  | "SSO_ID_TOKEN_INVALID"
+  | "SSO_ACCOUNT_NOT_LINKED"
+  | "SSO_ALREADY_LINKED"
+  | "SSO_PROVIDER_DISABLED"
+  | "SSO_PROVIDER_UNAVAILABLE"
+  | "ACCESS_DENIED";
+
+export type CompleteSsoOAuthResult =
+  | { outcome: "session_ready"; tenantId: string; identityId: string }
+  | {
+      outcome: "mfa_required";
+      tenantId: string;
+      identityId: string;
+      challengeToken: string;
+      challengeExpiresAt: Date;
+    }
+  | { outcome: "linked"; tenantId: string; identityId: string }
+  | { outcome: "error"; code: SsoOAuthErrorCode };
+
+/**
+ * The single orchestrator `callback.ts` calls — same "spans multiple
+ * transactions with external HTTP calls in between, never inside a single
+ * DB transaction (ADR-0006)" shape as `google-oidc.ts`'s
+ * `completeGoogleOAuthCallback`. Re-checks `provider.enabled` here (not just
+ * at `start` time) — an admin may have disabled the provider between the
+ * user starting the flow and completing it at the external provider.
+ */
+export async function completeTenantSsoCallback(
+  sql: Bun.SQL,
+  providerKey: string,
+  rawStateParam: string,
+  code: string | null,
+  env: NodeJS.ProcessEnv,
+  now: Date
+): Promise<CompleteSsoOAuthResult> {
+  const parsedState = parseOAuthStateParam(rawStateParam);
+
+  if (!parsedState) {
+    return { outcome: "error", code: "SSO_OAUTH_STATE_INVALID" };
+  }
+
+  const { tenantId, token } = parsedState;
+
+  const consumeResult = await withTenant(sql, tenantId, (tx) =>
+    consumeSsoOAuthRequest(tx, tenantId, providerKey, token, now)
+  );
+
+  if (!consumeResult.ok) {
+    return { outcome: "error", code: "SSO_OAUTH_STATE_INVALID" };
+  }
+
+  if (!code) {
+    return { outcome: "error", code: "SSO_OAUTH_STATE_INVALID" };
+  }
+
+  const provider = await withTenant(sql, tenantId, (tx) =>
+    fetchAuthProviderRowByKey(tx, tenantId, providerKey)
+  );
+
+  if (!provider || !provider.enabled) {
+    return { outcome: "error", code: "SSO_PROVIDER_DISABLED" };
+  }
+
+  const clientSecret = resolveProviderClientSecret(provider, env);
+
+  if (!clientSecret) {
+    return { outcome: "error", code: "SSO_PROVIDER_UNAVAILABLE" };
+  }
+
+  const discovery = await discoverOidcConfiguration(
+    providerKey,
+    provider.issuer_url,
+    env
+  );
+
+  if (!discovery.ok) {
+    return { outcome: "error", code: "SSO_PROVIDER_UNAVAILABLE" };
+  }
+
+  const exchangeResult = await exchangeAuthorizationCode({
+    providerKey,
+    tokenEndpoint: discovery.document.token_endpoint,
+    code,
+    clientId: provider.client_id,
+    clientSecret,
+    redirectUri: resolveSsoRedirectUri(providerKey, env),
+    timeoutMs: resolveSsoDiscoveryTimeoutMs(env)
+  });
+
+  if (!exchangeResult.ok) {
+    return { outcome: "error", code: "SSO_TOKEN_EXCHANGE_FAILED" };
+  }
+
+  const verifyResult = await verifyTenantOidcIdToken(
+    provider,
+    exchangeResult.idToken,
+    consumeResult.nonce,
+    Math.floor(now.getTime() / 1000),
+    env
+  );
+
+  if (!verifyResult.ok) {
+    return { outcome: "error", code: verifyResult.code };
+  }
+
+  return withTenant(sql, tenantId, async (tx) => {
+    if (consumeResult.purpose === "link") {
+      const linkIdentityId = consumeResult.identityId;
+
+      if (!linkIdentityId) {
+        return { outcome: "error", code: "SSO_OAUTH_STATE_INVALID" };
+      }
+
+      const linkResult = await linkProviderAccount(
+        tx,
+        tenantId,
+        providerKey,
+        linkIdentityId,
+        verifyResult.subject,
+        now
+      );
+
+      if (!linkResult.ok) {
+        return { outcome: "error", code: linkResult.code };
+      }
+
+      return { outcome: "linked", tenantId, identityId: linkIdentityId };
+    }
+
+    let identityId = await findIdentityByProviderSubject(
+      tx,
+      tenantId,
+      providerKey,
+      verifyResult.subject
+    );
+
+    if (!identityId) {
+      const autoLink = await autoLinkByEmailForProvider(
+        tx,
+        tenantId,
+        providerKey,
+        provider,
+        verifyResult.email ?? "",
+        verifyResult.emailVerified,
+        verifyResult.subject,
+        now
+      );
+
+      if (!autoLink.ok) {
+        return { outcome: "error", code: "SSO_ACCOUNT_NOT_LINKED" };
+      }
+
+      identityId = autoLink.identityId;
+    }
+
+    const identityRows = (await tx`
+      SELECT status FROM awcms_mini_identities WHERE id = ${identityId}
+    `) as { status: string }[];
+    const tenantUserRows = (await tx`
+      SELECT status FROM awcms_mini_tenant_users
+      WHERE tenant_id = ${tenantId} AND identity_id = ${identityId}
+    `) as { status: string }[];
+
+    if (
+      identityRows[0]?.status !== "active" ||
+      tenantUserRows[0]?.status !== "active"
+    ) {
+      return { outcome: "error", code: "ACCESS_DENIED" };
+    }
+
+    if (isMfaRequired(env)) {
+      const factor = await findActiveMfaFactor(tx, tenantId, identityId);
+
+      if (factor) {
+        const challenge = await createMfaChallenge(
+          tx,
+          tenantId,
+          identityId,
+          resolveChallengeTtlSec(env),
+          now
+        );
+
+        return {
+          outcome: "mfa_required",
+          tenantId,
+          identityId,
+          challengeToken: challenge.token,
+          challengeExpiresAt: challenge.expiresAt
+        };
+      }
+    }
+
+    return { outcome: "session_ready", tenantId, identityId };
+  });
+}

--- a/src/modules/identity-access/domain/login-policy.ts
+++ b/src/modules/identity-access/domain/login-policy.ts
@@ -30,10 +30,23 @@ export type LoginAttemptInput = {
   passwordMatches: boolean;
   maxFailedAttempts: number;
   lockoutMinutes: number;
+  /**
+   * Issue #591 (epic: full-online auth hardening) — `true` when the
+   * tenant's `awcms_mini_tenant_auth_policies.password_login_enabled` is
+   * `false` AND this identity is not one of the tenant's configured
+   * break-glass identities. Callers must only ever compute this when
+   * `isSsoRequired(env)` is active (`login.ts`) — every local/offline/LAN
+   * deployment leaves this `false` and this check is a complete no-op,
+   * preserving today's login behavior exactly.
+   */
+  passwordLoginDisabled?: boolean;
 };
 
 export type LoginDenyReason =
-  "tenant_inactive" | "locked" | "invalid_credentials";
+  | "tenant_inactive"
+  | "locked"
+  | "password_login_disabled"
+  | "invalid_credentials";
 
 export type LoginAttemptResult =
   | { outcome: "allow" }
@@ -57,6 +70,10 @@ export function evaluateLoginAttempt(
       isAccountLocked(input.identity.lockedUntil, input.now))
   ) {
     return { outcome: "deny", reason: "locked" };
+  }
+
+  if (input.identity && input.passwordLoginDisabled) {
+    return { outcome: "deny", reason: "password_login_disabled" };
   }
 
   const isValid =

--- a/src/modules/identity-access/domain/tenant-sso-policy.ts
+++ b/src/modules/identity-access/domain/tenant-sso-policy.ts
@@ -1,0 +1,470 @@
+/**
+ * Pure generic tenant OIDC SSO decision logic (Issue #591, epic: full-online
+ * auth hardening) — same "pure decision, DB/network does the fetching"
+ * shape as `google-oidc-policy.ts`'s `evaluateOAuthRequest`/
+ * `validateIdTokenClaims`/`isEmailDomainAllowed` (all of which this issue's
+ * application layer reuses verbatim for the generic flow — see
+ * `tenant-sso.ts`'s imports — since they were already provider-agnostic).
+ * This file only adds the decisions that are NEW to #591: break-glass
+ * enforcement at policy-save time, and per-provider+per-policy auto-link
+ * domain resolution, plus input validation for the admin CRUD endpoints.
+ */
+
+export type ValidationError = { field: string; message: string };
+
+const PROVIDER_KEY_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// ---------------------------------------------------------------------------
+// Break-glass enforcement (issue's own acceptance criterion:
+// "sso_required=true cannot be enabled unless at least one break-glass
+// local owner remains available"). Applied at the point the tenant policy
+// is SAVED (`tenant-auth-policy.ts`'s `saveTenantAuthPolicy`), not merely at
+// login time — an admin must not even be able to persist a policy that
+// would lock everyone out if the configured SSO provider has an outage.
+// ---------------------------------------------------------------------------
+
+export type BreakGlassRequirementInput = {
+  passwordLoginEnabled: boolean;
+  ssoRequired: boolean;
+  breakGlassIdentityIds: string[];
+  /**
+   * Count of ids in `breakGlassIdentityIds` that the caller has confirmed,
+   * via a fresh DB lookup, resolve to a currently `active` identity with an
+   * `active` tenant_user membership in THIS tenant — i.e. an identity that
+   * can actually still complete a local password login today.
+   */
+  eligibleBreakGlassCount: number;
+};
+
+export type BreakGlassRequirementResult =
+  { outcome: "ok" } | { outcome: "invalid"; reason: "break_glass_required" };
+
+/**
+ * A tenant policy requires at least one eligible break-glass local owner
+ * whenever it would otherwise be possible for every identity to be locked
+ * out of local password login: `sso_required=true` (SSO login mandatory)
+ * OR `password_login_enabled=false` (password login switched off entirely).
+ * If neither restrictive setting is requested, no break-glass identity is
+ * required at all (the default, fully backward-compatible shape).
+ */
+export function evaluateBreakGlassRequirement(
+  input: BreakGlassRequirementInput
+): BreakGlassRequirementResult {
+  const requiresBreakGlass = input.ssoRequired || !input.passwordLoginEnabled;
+
+  if (!requiresBreakGlass) {
+    return { outcome: "ok" };
+  }
+
+  if (input.eligibleBreakGlassCount < 1) {
+    return { outcome: "invalid", reason: "break_glass_required" };
+  }
+
+  return { outcome: "ok" };
+}
+
+// ---------------------------------------------------------------------------
+// Auto-link-by-email domain resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Auto-linking-by-email guardrail for the generic SSO flow. Two independent
+ * fail-closed layers, both must agree:
+ *  1. `policy.auto_link_verified_email` is the master switch — `false`
+ *     (the default) means auto-link never happens regardless of any domain
+ *     list, matching Issue #590's own opt-in shape.
+ *  2. The email's domain must be in the PROVIDER's own
+ *     `allowed_email_domains` (mirrors Issue #590's
+ *     `AUTH_GOOGLE_ALLOWED_DOMAINS`, fail-closed on an empty list — reused
+ *     as-is via `google-oidc-policy.ts`'s `isEmailDomainAllowed`), AND if
+ *     the TENANT POLICY's own `allowed_email_domains` is non-empty, the
+ *     domain must additionally appear there too (a tenant-wide restriction
+ *     layered defense-in-depth on top of any individual provider's own,
+ *     possibly broader, list).
+ */
+export function isAutoLinkAllowedForProvider(
+  autoLinkVerifiedEmail: boolean,
+  emailVerified: boolean,
+  isProviderDomainAllowed: boolean,
+  policyAllowedDomains: readonly string[],
+  domain: string | null
+): boolean {
+  if (
+    !autoLinkVerifiedEmail ||
+    !emailVerified ||
+    !isProviderDomainAllowed ||
+    domain === null
+  ) {
+    return false;
+  }
+
+  if (policyAllowedDomains.length === 0) {
+    return true;
+  }
+
+  return policyAllowedDomains.includes(domain);
+}
+
+// ---------------------------------------------------------------------------
+// Admin CRUD input validation
+// ---------------------------------------------------------------------------
+
+function validateBoundedString(
+  value: unknown,
+  field: string,
+  maxLength: number
+): { valid: true; value: string } | { valid: false; message: string } {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return { valid: false, message: `${field} is required.` };
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length > maxLength) {
+    return {
+      valid: false,
+      message: `${field} must be at most ${maxLength} characters.`
+    };
+  }
+
+  return { valid: true, value: trimmed };
+}
+
+function validateEmailDomainList(
+  value: unknown,
+  field: string
+): { valid: true; value: string[] } | { valid: false; message: string } {
+  if (value === undefined) {
+    return { valid: true, value: [] };
+  }
+
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string")
+  ) {
+    return { valid: false, message: `${field} must be an array of strings.` };
+  }
+
+  return {
+    valid: true,
+    value: value
+      .map((domain) => domain.trim().toLowerCase())
+      .filter((domain) => domain.length > 0)
+  };
+}
+
+function validateIssuerUrl(
+  value: unknown
+): { valid: true; value: string } | { valid: false; message: string } {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return { valid: false, message: "issuerUrl is required." };
+  }
+
+  try {
+    const parsed = new URL(value.trim());
+
+    if (parsed.protocol !== "https:") {
+      return { valid: false, message: "issuerUrl must use https." };
+    }
+  } catch {
+    return { valid: false, message: "issuerUrl must be a valid URL." };
+  }
+
+  return { valid: true, value: value.trim() };
+}
+
+export type CreateAuthProviderInput = {
+  providerKey: string;
+  displayName: string;
+  issuerUrl: string;
+  clientId: string;
+  clientSecret: string | null;
+  clientSecretEnvVar: string | null;
+  scopes: string;
+  allowedEmailDomains: string[];
+  enabled: boolean;
+};
+
+export type CreateAuthProviderValidationResult =
+  | { valid: true; value: CreateAuthProviderInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** Validates the admin `POST /api/v1/identity/sso/providers` body. Exactly one of `clientSecret`/`clientSecretEnvVar` must be provided — mirrors the DB CHECK constraint on `awcms_mini_auth_providers`, checked here first so a bad request gets a clean `400`, not a raw constraint-violation error. */
+export function validateCreateAuthProviderInput(
+  body: unknown
+): CreateAuthProviderValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+
+  let providerKey = "";
+  if (
+    typeof record.providerKey !== "string" ||
+    !PROVIDER_KEY_PATTERN.test(record.providerKey)
+  ) {
+    errors.push({
+      field: "providerKey",
+      message: "providerKey is required and must match ^[a-z0-9][a-z0-9_-]*$."
+    });
+  } else {
+    providerKey = record.providerKey;
+  }
+
+  const displayNameResult = validateBoundedString(
+    record.displayName,
+    "displayName",
+    120
+  );
+  if (!displayNameResult.valid) {
+    errors.push({ field: "displayName", message: displayNameResult.message });
+  }
+
+  const issuerUrlResult = validateIssuerUrl(record.issuerUrl);
+  if (!issuerUrlResult.valid) {
+    errors.push({ field: "issuerUrl", message: issuerUrlResult.message });
+  }
+
+  const clientIdResult = validateBoundedString(
+    record.clientId,
+    "clientId",
+    255
+  );
+  if (!clientIdResult.valid) {
+    errors.push({ field: "clientId", message: clientIdResult.message });
+  }
+
+  const hasSecret =
+    typeof record.clientSecret === "string" && record.clientSecret.length > 0;
+  const hasSecretEnvVar =
+    typeof record.clientSecretEnvVar === "string" &&
+    record.clientSecretEnvVar.trim().length > 0;
+
+  if (hasSecret === hasSecretEnvVar) {
+    errors.push({
+      field: "clientSecret",
+      message:
+        "Exactly one of clientSecret or clientSecretEnvVar must be provided."
+    });
+  }
+
+  const scopes =
+    typeof record.scopes === "string" && record.scopes.trim().length > 0
+      ? record.scopes.trim()
+      : "openid email profile";
+
+  const allowedDomainsResult = validateEmailDomainList(
+    record.allowedEmailDomains,
+    "allowedEmailDomains"
+  );
+  if (!allowedDomainsResult.valid) {
+    errors.push({
+      field: "allowedEmailDomains",
+      message: allowedDomainsResult.message
+    });
+  }
+
+  const enabled = record.enabled === true;
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      providerKey,
+      displayName: (displayNameResult as { valid: true; value: string }).value,
+      issuerUrl: (issuerUrlResult as { valid: true; value: string }).value,
+      clientId: (clientIdResult as { valid: true; value: string }).value,
+      clientSecret: hasSecret ? (record.clientSecret as string) : null,
+      clientSecretEnvVar: hasSecretEnvVar
+        ? (record.clientSecretEnvVar as string).trim()
+        : null,
+      scopes,
+      allowedEmailDomains: (
+        allowedDomainsResult as { valid: true; value: string[] }
+      ).value,
+      enabled
+    }
+  };
+}
+
+export type UpdateAuthProviderInput = Partial<
+  Omit<CreateAuthProviderInput, "providerKey">
+>;
+
+export type UpdateAuthProviderValidationResult =
+  | { valid: true; value: UpdateAuthProviderInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** Validates the admin `PATCH /api/v1/identity/sso/providers/{id}` body — every field optional (partial update), same convention as `validateUpdateBlogSettingsInput`. */
+export function validateUpdateAuthProviderInput(
+  body: unknown
+): UpdateAuthProviderValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+  const value: UpdateAuthProviderInput = {};
+
+  if (record.displayName !== undefined) {
+    const result = validateBoundedString(
+      record.displayName,
+      "displayName",
+      120
+    );
+    if (!result.valid) {
+      errors.push({ field: "displayName", message: result.message });
+    } else {
+      value.displayName = result.value;
+    }
+  }
+
+  if (record.issuerUrl !== undefined) {
+    const result = validateIssuerUrl(record.issuerUrl);
+    if (!result.valid) {
+      errors.push({ field: "issuerUrl", message: result.message });
+    } else {
+      value.issuerUrl = result.value;
+    }
+  }
+
+  if (record.clientId !== undefined) {
+    const result = validateBoundedString(record.clientId, "clientId", 255);
+    if (!result.valid) {
+      errors.push({ field: "clientId", message: result.message });
+    } else {
+      value.clientId = result.value;
+    }
+  }
+
+  const hasSecret =
+    typeof record.clientSecret === "string" && record.clientSecret.length > 0;
+  const hasSecretEnvVar =
+    typeof record.clientSecretEnvVar === "string" &&
+    record.clientSecretEnvVar.trim().length > 0;
+
+  if (hasSecret || hasSecretEnvVar) {
+    if (hasSecret && hasSecretEnvVar) {
+      errors.push({
+        field: "clientSecret",
+        message:
+          "Only one of clientSecret or clientSecretEnvVar may be set at a time."
+      });
+    } else {
+      value.clientSecret = hasSecret ? (record.clientSecret as string) : null;
+      value.clientSecretEnvVar = hasSecretEnvVar
+        ? (record.clientSecretEnvVar as string).trim()
+        : null;
+    }
+  }
+
+  if (record.scopes !== undefined) {
+    const result = validateBoundedString(record.scopes, "scopes", 500);
+    if (!result.valid) {
+      errors.push({ field: "scopes", message: result.message });
+    } else {
+      value.scopes = result.value;
+    }
+  }
+
+  if (record.allowedEmailDomains !== undefined) {
+    const result = validateEmailDomainList(
+      record.allowedEmailDomains,
+      "allowedEmailDomains"
+    );
+    if (!result.valid) {
+      errors.push({ field: "allowedEmailDomains", message: result.message });
+    } else {
+      value.allowedEmailDomains = result.value;
+    }
+  }
+
+  if (record.enabled !== undefined) {
+    if (typeof record.enabled !== "boolean") {
+      errors.push({ field: "enabled", message: "enabled must be a boolean." });
+    } else {
+      value.enabled = record.enabled;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}
+
+export type UpdateTenantAuthPolicyInput = {
+  passwordLoginEnabled?: boolean;
+  ssoEnabled?: boolean;
+  ssoRequired?: boolean;
+  autoLinkVerifiedEmail?: boolean;
+  allowedEmailDomains?: string[];
+  breakGlassIdentityIds?: string[];
+};
+
+export type UpdateTenantAuthPolicyValidationResult =
+  | { valid: true; value: UpdateTenantAuthPolicyInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** Validates the admin `PATCH /api/v1/identity/sso/policy` body. Break-glass AVAILABILITY (not just shape) is enforced separately by `tenant-auth-policy.ts`'s `saveTenantAuthPolicy`, which needs a DB read this pure function cannot perform. */
+export function validateUpdateTenantAuthPolicyInput(
+  body: unknown
+): UpdateTenantAuthPolicyValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+  const value: UpdateTenantAuthPolicyInput = {};
+
+  const booleanFields = [
+    "passwordLoginEnabled",
+    "ssoEnabled",
+    "ssoRequired",
+    "autoLinkVerifiedEmail"
+  ] as const;
+
+  for (const field of booleanFields) {
+    if (record[field] !== undefined) {
+      if (typeof record[field] !== "boolean") {
+        errors.push({ field, message: `${field} must be a boolean.` });
+      } else {
+        value[field] = record[field] as boolean;
+      }
+    }
+  }
+
+  if (record.allowedEmailDomains !== undefined) {
+    const result = validateEmailDomainList(
+      record.allowedEmailDomains,
+      "allowedEmailDomains"
+    );
+    if (!result.valid) {
+      errors.push({ field: "allowedEmailDomains", message: result.message });
+    } else {
+      value.allowedEmailDomains = result.value;
+    }
+  }
+
+  if (record.breakGlassIdentityIds !== undefined) {
+    if (
+      !Array.isArray(record.breakGlassIdentityIds) ||
+      !record.breakGlassIdentityIds.every(
+        (id) => typeof id === "string" && UUID_PATTERN.test(id)
+      )
+    ) {
+      errors.push({
+        field: "breakGlassIdentityIds",
+        message: "breakGlassIdentityIds must be an array of identity UUIDs."
+      });
+    } else {
+      value.breakGlassIdentityIds = [
+        ...new Set(record.breakGlassIdentityIds as string[])
+      ];
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/pages/api/v1/auth/login.ts
+++ b/src/pages/api/v1/auth/login.ts
@@ -26,6 +26,8 @@ import {
   findActiveMfaFactor
 } from "../../../../modules/identity-access/application/mfa";
 import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import { isSsoRequired } from "../../../../lib/auth/sso-config";
+import { isPasswordLoginDisabledForIdentity } from "../../../../modules/identity-access/application/tenant-auth-policy";
 
 const MAX_FAILED_ATTEMPTS = Number(process.env.AUTH_LOGIN_MAX_ATTEMPTS ?? 5);
 const LOCKOUT_MINUTES = 15;
@@ -163,6 +165,16 @@ export const POST: APIRoute = async ({
         null;
     }
 
+    // Full-online-only (Issue #587/#591): a no-op on every local/offline/LAN
+    // deployment (isSsoRequired() is false there) and on every tenant that
+    // has never configured a restrictive auth policy — only then is the
+    // extra read even attempted, preserving today's login behavior exactly
+    // everywhere else.
+    const passwordLoginDisabled =
+      identityRow && isSsoRequired()
+        ? await isPasswordLoginDisabledForIdentity(tx, tenantId, identityRow.id)
+        : false;
+
     const result = evaluateLoginAttempt({
       now,
       tenantStatus,
@@ -176,7 +188,8 @@ export const POST: APIRoute = async ({
       tenantUserStatus,
       passwordMatches,
       maxFailedAttempts: MAX_FAILED_ATTEMPTS,
-      lockoutMinutes: LOCKOUT_MINUTES
+      lockoutMinutes: LOCKOUT_MINUTES,
+      passwordLoginDisabled
     });
 
     if (result.outcome === "deny") {
@@ -198,6 +211,14 @@ export const POST: APIRoute = async ({
           401,
           "AUTH_INVALID_CREDENTIALS",
           "Account is temporarily locked."
+        );
+      }
+
+      if (result.reason === "password_login_disabled") {
+        return fail(
+          403,
+          "PASSWORD_LOGIN_DISABLED",
+          "Password login is disabled for this account. Use single sign-on instead."
         );
       }
 

--- a/src/pages/api/v1/auth/sso/[providerKey]/callback.ts
+++ b/src/pages/api/v1/auth/sso/[providerKey]/callback.ts
@@ -1,0 +1,184 @@
+import type { APIRoute } from "astro";
+import { fail } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  generateSessionToken,
+  hashSessionToken
+} from "../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../lib/auth/ssr-session";
+import { isSsoRequired } from "../../../../../../lib/auth/sso-config";
+import { completeTenantSsoCallback } from "../../../../../../modules/identity-access/application/tenant-sso";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+
+const SESSION_TTL_MIN = Number(process.env.AUTH_SESSION_TTL_MIN ?? 120);
+
+/**
+ * `GET /api/v1/auth/sso/{providerKey}/callback` (Issue #591) — the
+ * tenant-configured provider's own redirect target, same shape as Issue
+ * #590's `providers/google/callback.ts`: plain top-level browser
+ * navigation, raw JSON error responses (no dedicated error page yet, same
+ * accepted trade-off), `state`/nonce/ID token validated cryptographically
+ * before trusting any claim, MFA gate always checked before session
+ * creation.
+ */
+export const GET: APIRoute = async ({ cookies, url, params, locals }) => {
+  if (!isSsoRequired()) {
+    return fail(
+      403,
+      "SSO_DISABLED",
+      "Tenant OIDC SSO is not enabled for this deployment."
+    );
+  }
+
+  const providerKey = params.providerKey;
+
+  if (!providerKey) {
+    return fail(400, "VALIDATION_ERROR", "providerKey is required.");
+  }
+
+  const providerError = url.searchParams.get("error");
+
+  if (providerError) {
+    return fail(
+      401,
+      "SSO_OAUTH_STATE_INVALID",
+      "SSO sign-in was cancelled or denied."
+    );
+  }
+
+  const state = url.searchParams.get("state");
+  const code = url.searchParams.get("code");
+
+  if (!state) {
+    return fail(
+      400,
+      "SSO_OAUTH_STATE_INVALID",
+      "Missing or invalid state parameter."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const now = new Date();
+
+  const result = await completeTenantSsoCallback(
+    sql,
+    providerKey,
+    state,
+    code,
+    process.env,
+    now
+  );
+
+  if (result.outcome === "error") {
+    const status =
+      result.code === "SSO_PROVIDER_UNAVAILABLE"
+        ? 502
+        : result.code === "SSO_ALREADY_LINKED"
+          ? 409
+          : result.code === "ACCESS_DENIED" ||
+              result.code === "SSO_PROVIDER_DISABLED"
+            ? 403
+            : 401;
+
+    return fail(
+      status,
+      result.code,
+      "SSO sign-in could not be completed. Please try again."
+    );
+  }
+
+  if (result.outcome === "mfa_required") {
+    await withTenant(sql, result.tenantId, (tx) =>
+      recordAuditEvent(tx, {
+        tenantId: result.tenantId,
+        moduleKey: "identity_access",
+        action: "mfa_challenge_issued",
+        resourceType: "identity",
+        resourceId: result.identityId,
+        severity: "info",
+        message: "SSO sign-in verified; MFA challenge issued.",
+        correlationId: locals.correlationId
+      })
+    );
+
+    return fail(
+      401,
+      "MFA_REQUIRED",
+      "Multi-factor authentication is required to complete sign-in.",
+      {},
+      {
+        mfaChallengeToken: result.challengeToken,
+        expiresAt: result.challengeExpiresAt.toISOString()
+      }
+    );
+  }
+
+  if (result.outcome === "linked") {
+    await withTenant(sql, result.tenantId, (tx) =>
+      recordAuditEvent(tx, {
+        tenantId: result.tenantId,
+        moduleKey: "identity_access",
+        action: "sso_account_linked",
+        resourceType: "identity",
+        resourceId: result.identityId,
+        severity: "warning",
+        message: `SSO account linked (provider: ${providerKey}).`,
+        attributes: { providerKey },
+        correlationId: locals.correlationId
+      })
+    );
+
+    return new Response(null, {
+      status: 302,
+      headers: { Location: "/admin" }
+    });
+  }
+
+  const token = generateSessionToken();
+  const tokenHash = hashSessionToken(token);
+  const expiresAt = new Date(now.getTime() + SESSION_TTL_MIN * 60_000);
+
+  await withTenant(sql, result.tenantId, async (tx) => {
+    await tx`
+      UPDATE awcms_mini_identities
+      SET failed_login_count = 0, last_login_at = ${now}
+      WHERE id = ${result.identityId}
+    `;
+
+    await tx`
+      INSERT INTO awcms_mini_sessions (tenant_id, identity_id, token_hash, expires_at)
+      VALUES (${result.tenantId}, ${result.identityId}, ${tokenHash}, ${expiresAt})
+    `;
+
+    await recordAuditEvent(tx, {
+      tenantId: result.tenantId,
+      moduleKey: "identity_access",
+      action: "sso_login_succeeded",
+      resourceType: "identity",
+      resourceId: result.identityId,
+      severity: "info",
+      message: `SSO sign-in succeeded; session created (provider: ${providerKey}).`,
+      attributes: { providerKey },
+      correlationId: locals.correlationId
+    });
+  });
+
+  const cookieOptions = {
+    httpOnly: true,
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: SESSION_TTL_MIN * 60,
+    secure: process.env.AUTH_COOKIE_SECURE === "true"
+  };
+  cookies.set(SESSION_COOKIE_NAME, token, cookieOptions);
+  cookies.set(TENANT_COOKIE_NAME, result.tenantId, cookieOptions);
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: "/admin" }
+  });
+};

--- a/src/pages/api/v1/auth/sso/[providerKey]/link.ts
+++ b/src/pages/api/v1/auth/sso/[providerKey]/link.ts
@@ -1,0 +1,111 @@
+import type { APIRoute } from "astro";
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../lib/auth/ssr-session";
+import {
+  extractBearerToken,
+  resolveActiveSession
+} from "../../../../../../modules/identity-access/application/session-lookup";
+import { isSsoRequired } from "../../../../../../lib/auth/sso-config";
+import {
+  buildSsoAuthorizationUrl,
+  createSsoOAuthRequest
+} from "../../../../../../modules/identity-access/application/tenant-sso";
+import { fetchAuthProviderRowByKey } from "../../../../../../modules/identity-access/application/auth-provider-directory";
+
+const OAUTH_REQUEST_TTL_SEC = 600;
+
+/**
+ * `POST /api/v1/auth/sso/{providerKey}/link` (Issue #591) — authenticated,
+ * same shape as Issue #590's `providers/google/link.ts`: starts a
+ * `link`-purpose OAuth request for the CALLER's own identity (captured
+ * server-side, never trusted from the eventual callback) and returns the
+ * provider's authorization URL as JSON.
+ */
+export const POST: APIRoute = async ({ request, cookies, params }) => {
+  if (!isSsoRequired()) {
+    return fail(
+      403,
+      "SSO_DISABLED",
+      "Tenant OIDC SSO is not enabled for this deployment."
+    );
+  }
+
+  const providerKey = params.providerKey;
+
+  if (!providerKey) {
+    return fail(400, "VALIDATION_ERROR", "providerKey is required.");
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token =
+    extractBearerToken(request.headers.get("authorization")) ??
+    cookies.get(SESSION_COOKIE_NAME)?.value ??
+    null;
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const session = await resolveActiveSession(tx, tenantId, tokenHash, now);
+
+    if (!session) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const provider = await fetchAuthProviderRowByKey(tx, tenantId, providerKey);
+
+    if (!provider || !provider.enabled) {
+      return fail(
+        404,
+        "SSO_PROVIDER_NOT_FOUND",
+        "No enabled SSO provider matches this key."
+      );
+    }
+
+    const { state, nonce } = await createSsoOAuthRequest(
+      tx,
+      tenantId,
+      providerKey,
+      "link",
+      session.identity_id,
+      OAUTH_REQUEST_TTL_SEC,
+      now
+    );
+
+    const authorizationResult = await buildSsoAuthorizationUrl(
+      provider,
+      tenantId,
+      state,
+      nonce
+    );
+
+    if (!authorizationResult.ok) {
+      return fail(
+        502,
+        authorizationResult.code,
+        "The SSO provider could not be reached. Try again later."
+      );
+    }
+
+    return ok({ authorizationUrl: authorizationResult.authorizationUrl });
+  });
+};

--- a/src/pages/api/v1/auth/sso/[providerKey]/start.ts
+++ b/src/pages/api/v1/auth/sso/[providerKey]/start.ts
@@ -1,0 +1,148 @@
+import type { APIRoute } from "astro";
+import { fail } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { TENANT_COOKIE_NAME } from "../../../../../../lib/auth/ssr-session";
+import {
+  checkRateLimit,
+  resolveClientIp
+} from "../../../../../../lib/security/rate-limit";
+import { isSsoRequired } from "../../../../../../lib/auth/sso-config";
+import {
+  buildSsoAuthorizationUrl,
+  createSsoOAuthRequest
+} from "../../../../../../modules/identity-access/application/tenant-sso";
+import { fetchAuthProviderRowByKey } from "../../../../../../modules/identity-access/application/auth-provider-directory";
+
+const OAUTH_REQUEST_TTL_SEC = 600;
+const RATE_LIMIT_MAX_ATTEMPTS = Number(
+  process.env.AUTH_LOGIN_RATE_LIMIT_MAX ?? 20
+);
+const RATE_LIMIT_WINDOW_SEC = Number(
+  process.env.AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC ?? 60
+);
+
+/**
+ * `GET /api/v1/auth/sso/{providerKey}/start` (Issue #591) — unauthenticated
+ * entry point, same shape as Issue #590's `providers/google/start.ts`:
+ * `tenantId` resolved from header/cookie/`?tenantId=` query param fallback
+ * (a plain browser navigation to a tenant-configured provider has no
+ * tenant cookie yet either), tenant existence/status checked via a plain
+ * `SELECT` BEFORE any INSERT (PR #598's fix, applied here from day one to
+ * avoid re-introducing the shared-database-circuit-breaker DoS it found).
+ * `404 SSO_PROVIDER_NOT_FOUND` (not the gate's own `403`) once the gate is
+ * confirmed active but the provider key doesn't resolve to an enabled
+ * provider for this tenant — avoids leaking a distinct signal for "gate
+ * off" vs "provider key wrong" beyond what's already unavoidable.
+ */
+export const GET: APIRoute = async ({
+  request,
+  cookies,
+  url,
+  params,
+  clientAddress
+}) => {
+  if (!isSsoRequired()) {
+    return fail(
+      403,
+      "SSO_DISABLED",
+      "Tenant OIDC SSO is not enabled for this deployment."
+    );
+  }
+
+  const providerKey = params.providerKey;
+
+  if (!providerKey) {
+    return fail(400, "VALIDATION_ERROR", "providerKey is required.");
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    url.searchParams.get("tenantId") ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const clientIp = resolveClientIp(request, clientAddress);
+  const rateLimit = checkRateLimit(`${clientIp}:${tenantId}:sso-start`, {
+    maxAttempts: RATE_LIMIT_MAX_ATTEMPTS,
+    windowMs: RATE_LIMIT_WINDOW_SEC * 1000
+  });
+
+  if (!rateLimit.allowed) {
+    return fail(
+      429,
+      "RATE_LIMITED",
+      "Too many requests from this source. Try again later.",
+      {},
+      undefined,
+      { "retry-after": String(rateLimit.retryAfterSec) }
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const now = new Date();
+
+  const result = await withTenant(sql, tenantId, async (tx) => {
+    const tenantRows = (await tx`
+      SELECT status FROM awcms_mini_tenants WHERE id = ${tenantId}
+    `) as { status: string }[];
+
+    if (tenantRows[0]?.status !== "active") {
+      return { outcome: "denied" as const };
+    }
+
+    const provider = await fetchAuthProviderRowByKey(tx, tenantId, providerKey);
+
+    if (!provider || !provider.enabled) {
+      return { outcome: "not_found" as const };
+    }
+
+    const { state, nonce } = await createSsoOAuthRequest(
+      tx,
+      tenantId,
+      providerKey,
+      "login",
+      null,
+      OAUTH_REQUEST_TTL_SEC,
+      now
+    );
+
+    return { outcome: "ready" as const, provider, state, nonce };
+  });
+
+  if (result.outcome === "denied") {
+    return fail(403, "ACCESS_DENIED", "Tenant is not active.");
+  }
+
+  if (result.outcome === "not_found") {
+    return fail(
+      404,
+      "SSO_PROVIDER_NOT_FOUND",
+      "No enabled SSO provider matches this key."
+    );
+  }
+
+  const authorizationResult = await buildSsoAuthorizationUrl(
+    result.provider,
+    tenantId,
+    result.state,
+    result.nonce
+  );
+
+  if (!authorizationResult.ok) {
+    return fail(
+      502,
+      authorizationResult.code,
+      "The SSO provider could not be reached. Try again later."
+    );
+  }
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: authorizationResult.authorizationUrl }
+  });
+};

--- a/src/pages/api/v1/auth/sso/[providerKey]/unlink.ts
+++ b/src/pages/api/v1/auth/sso/[providerKey]/unlink.ts
@@ -1,0 +1,99 @@
+import type { APIRoute } from "astro";
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  SESSION_COOKIE_NAME,
+  TENANT_COOKIE_NAME
+} from "../../../../../../lib/auth/ssr-session";
+import {
+  extractBearerToken,
+  resolveActiveSession
+} from "../../../../../../modules/identity-access/application/session-lookup";
+import { isSsoRequired } from "../../../../../../lib/auth/sso-config";
+import { unlinkProviderAccount } from "../../../../../../modules/identity-access/application/tenant-sso";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+
+/**
+ * `POST /api/v1/auth/sso/{providerKey}/unlink` (Issue #591) — high-risk,
+ * self-service action, same shape as Issue #590's
+ * `providers/google/unlink.ts`. Never touches local password login —
+ * unlinking a provider cannot lock an identity out of its own account
+ * (that guarantee is the tenant policy's `sso_required` + break-glass
+ * enforcement's job instead, checked at policy-save time).
+ */
+export const POST: APIRoute = async ({ request, cookies, params, locals }) => {
+  if (!isSsoRequired()) {
+    return fail(
+      403,
+      "SSO_DISABLED",
+      "Tenant OIDC SSO is not enabled for this deployment."
+    );
+  }
+
+  const providerKey = params.providerKey;
+
+  if (!providerKey) {
+    return fail(400, "VALIDATION_ERROR", "providerKey is required.");
+  }
+
+  const tenantId =
+    request.headers.get("x-awcms-mini-tenant-id") ??
+    cookies.get(TENANT_COOKIE_NAME)?.value ??
+    null;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token =
+    extractBearerToken(request.headers.get("authorization")) ??
+    cookies.get(SESSION_COOKIE_NAME)?.value ??
+    null;
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const session = await resolveActiveSession(tx, tenantId, tokenHash, now);
+
+    if (!session) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const result = await unlinkProviderAccount(
+      tx,
+      tenantId,
+      providerKey,
+      session.identity_id
+    );
+
+    if (!result.ok) {
+      return fail(
+        409,
+        result.code,
+        "No SSO account is currently linked for this identity and provider."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      moduleKey: "identity_access",
+      action: "sso_account_unlinked",
+      resourceType: "identity",
+      resourceId: session.identity_id,
+      severity: "warning",
+      message: `SSO account unlinked (provider: ${providerKey}).`,
+      attributes: { providerKey },
+      correlationId: locals.correlationId
+    });
+
+    return ok({ unlinked: true });
+  });
+};

--- a/src/pages/api/v1/identity/sso/policy/index.ts
+++ b/src/pages/api/v1/identity/sso/policy/index.ts
@@ -1,0 +1,148 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  getTenantAuthPolicy,
+  saveTenantAuthPolicy
+} from "../../../../../../modules/identity-access/application/tenant-auth-policy";
+import { validateUpdateTenantAuthPolicyInput } from "../../../../../../modules/identity-access/domain/tenant-sso-policy";
+
+const READ_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "sso_policy",
+  action: "read" as const
+};
+
+const UPDATE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "sso_policy",
+  action: "update" as const
+};
+
+/** `GET /api/v1/identity/sso/policy` (Issue #591) — this tenant's authentication policy, falling back to the safe default (password login enabled, SSO disabled) when never configured. */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const policy = await getTenantAuthPolicy(tx, tenantId);
+
+    return ok(policy);
+  });
+};
+
+/**
+ * `PATCH /api/v1/identity/sso/policy` (Issue #591) — partial-update upsert,
+ * no `id` (one row per tenant, same convention as `PATCH /api/v1/blog/settings`).
+ * High-risk admin action: audited. Server-side break-glass enforcement
+ * (issue's own acceptance criterion) happens inside `saveTenantAuthPolicy`
+ * — a request that would leave the tenant with `sso_required=true` (or
+ * `password_login_enabled=false`) and no currently-eligible break-glass
+ * identity is rejected with `409 BREAK_GLASS_REQUIRED`, never silently
+ * saved.
+ */
+export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const validation = validateUpdateTenantAuthPolicyInput(
+    await request.json().catch(() => null)
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Tenant authentication policy update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      UPDATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const result = await saveTenantAuthPolicy(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      input
+    );
+
+    if (result.outcome === "break_glass_required") {
+      return fail(
+        409,
+        "BREAK_GLASS_REQUIRED",
+        "sso_required=true or password_login_enabled=false requires at least one currently-active break-glass identity with an active tenant membership."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "identity_access",
+      action: "sso_policy_updated",
+      resourceType: "tenant_auth_policy",
+      resourceId: tenantId,
+      severity: "warning",
+      message: "Tenant authentication policy updated.",
+      correlationId
+    });
+
+    return ok(result.policy);
+  });
+};

--- a/src/pages/api/v1/identity/sso/providers/[id].ts
+++ b/src/pages/api/v1/identity/sso/providers/[id].ts
@@ -1,0 +1,245 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  fetchAuthProviderById,
+  softDeleteAuthProvider,
+  updateAuthProvider
+} from "../../../../../../modules/identity-access/application/auth-provider-directory";
+import { validateUpdateAuthProviderInput } from "../../../../../../modules/identity-access/domain/tenant-sso-policy";
+
+const READ_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "sso_providers",
+  action: "read" as const
+};
+
+const UPDATE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "sso_providers",
+  action: "update" as const
+};
+
+const DELETE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "sso_providers",
+  action: "delete" as const
+};
+
+/** `GET /api/v1/identity/sso/providers/{id}` (Issue #591). */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const providerId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!providerId) {
+    return fail(400, "VALIDATION_ERROR", "Provider id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const provider = await fetchAuthProviderById(tx, tenantId, providerId);
+
+    if (!provider) {
+      return fail(404, "RESOURCE_NOT_FOUND", "SSO provider not found.");
+    }
+
+    return ok(provider);
+  });
+};
+
+/** `PATCH /api/v1/identity/sso/providers/{id}` (Issue #591) — partial update. High-risk admin action: audited. */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const providerId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!providerId) {
+    return fail(400, "VALIDATION_ERROR", "Provider id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const validation = validateUpdateAuthProviderInput(
+    await request.json().catch(() => null)
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "SSO provider update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      UPDATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const result = await updateAuthProvider(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      providerId,
+      input
+    );
+
+    if (result.outcome === "not_found") {
+      return fail(404, "RESOURCE_NOT_FOUND", "SSO provider not found.");
+    }
+
+    if (result.outcome === "misconfigured") {
+      return fail(
+        500,
+        "SSO_MISCONFIGURED",
+        "AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY is not configured on this server."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "identity_access",
+      action: "sso_provider_updated",
+      resourceType: "auth_provider",
+      resourceId: providerId,
+      severity: "warning",
+      message: `Tenant OIDC SSO provider updated: ${result.provider.providerKey}.`,
+      correlationId
+    });
+
+    return ok(result.provider);
+  });
+};
+
+/** `DELETE /api/v1/identity/sso/providers/{id}` (Issue #591) — soft delete. `reason` required, same convention as `blog/pages/{id}`. */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const providerId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!providerId) {
+    return fail(400, "VALIDATION_ERROR", "Provider id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    reason?: unknown;
+  } | null;
+  const reason = typeof body?.reason === "string" ? body.reason.trim() : "";
+
+  if (reason.length === 0) {
+    return fail(400, "VALIDATION_ERROR", "reason is required.", {}, [
+      { field: "reason", message: "reason is required." }
+    ]);
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DELETE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const deleted = await softDeleteAuthProvider(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      providerId,
+      reason
+    );
+
+    if (!deleted) {
+      return fail(404, "RESOURCE_NOT_FOUND", "SSO provider not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "identity_access",
+      action: "sso_provider_deleted",
+      resourceType: "auth_provider",
+      resourceId: providerId,
+      severity: "warning",
+      message: "Tenant OIDC SSO provider deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    return ok({ id: providerId, deleted: true });
+  });
+};

--- a/src/pages/api/v1/identity/sso/providers/index.ts
+++ b/src/pages/api/v1/identity/sso/providers/index.ts
@@ -1,0 +1,156 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  createAuthProvider,
+  listAuthProviders
+} from "../../../../../../modules/identity-access/application/auth-provider-directory";
+import { validateCreateAuthProviderInput } from "../../../../../../modules/identity-access/domain/tenant-sso-policy";
+
+const READ_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "sso_providers",
+  action: "read" as const
+};
+
+const CREATE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "sso_providers",
+  action: "create" as const
+};
+
+/**
+ * `GET /api/v1/identity/sso/providers` (Issue #591) — admin CRUD, protected
+ * by ABAC (`identity_access.sso_providers.read`, migration 037).
+ * Deliberately NOT gated by `isSsoRequired()` — an admin may configure a
+ * provider ahead of enabling the deployment-level #587/`AUTH_SSO_ENABLED`
+ * gate, same "credentials can be provisioned ahead of time" allowance
+ * Issue #588/#590's own `checkTurnstileConfig`/`checkGoogleOidcConfig`
+ * already grant. No network/provider call happens in this file — pure CRUD
+ * over `awcms_mini_auth_providers`.
+ */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const providers = await listAuthProviders(tx, tenantId);
+
+    return ok({ providers });
+  });
+};
+
+/** `POST /api/v1/identity/sso/providers` (Issue #591) — creates a tenant OIDC SSO provider. High-risk admin action: audited. Not idempotency-gated (a retry duplicating a create is caught by the `(tenant_id, provider_key)` partial unique index and reported as `409 SSO_PROVIDER_KEY_CONFLICT`, same convention as `POST /api/v1/blog/pages`). */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const validation = validateCreateAuthProviderInput(
+    await request.json().catch(() => null)
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "SSO provider input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CREATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const result = await createAuthProvider(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      input
+    );
+
+    if (result.outcome === "duplicate_key") {
+      return fail(
+        409,
+        "SSO_PROVIDER_KEY_CONFLICT",
+        `A provider already exists for providerKey "${input.providerKey}".`
+      );
+    }
+
+    if (result.outcome === "misconfigured") {
+      return fail(
+        500,
+        "SSO_MISCONFIGURED",
+        "AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY is not configured on this server."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "identity_access",
+      action: "sso_provider_created",
+      resourceType: "auth_provider",
+      resourceId: result.provider.id,
+      severity: "warning",
+      message: `Tenant OIDC SSO provider created: ${result.provider.providerKey}.`,
+      correlationId
+    });
+
+    return ok(result.provider);
+  });
+};

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -238,7 +238,9 @@ describe("database migration runner helpers", () => {
       "032_awcms_mini_tenant_domain_permissions.sql",
       "033_awcms_mini_tenant_domain_lookup_function.sql",
       "034_awcms_mini_mfa_totp_schema.sql",
-      "035_awcms_mini_google_oidc_schema.sql"
+      "035_awcms_mini_google_oidc_schema.sql",
+      "036_awcms_mini_tenant_oidc_sso_schema.sql",
+      "037_awcms_mini_tenant_oidc_sso_permissions.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/tenant-sso-flow.integration.test.ts
+++ b/tests/integration/tenant-sso-flow.integration.test.ts
@@ -1,0 +1,819 @@
+/**
+ * Integration tests for the generic tenant OIDC SSO flow (Issue #591, epic:
+ * full-online auth hardening) across the real route handlers against a
+ * real PostgreSQL — gate behavior, admin CRUD + ABAC, break-glass
+ * enforcement (both at policy-save time and at login time), start/callback/
+ * link/unlink, auto-link-by-email, and the tenant-existence-check-before-
+ * insert regression (PR #598's lesson, applied here from day one). Mirrors
+ * `google-oidc-flow.integration.test.ts`'s shape for the #590 feature this
+ * epic shares infrastructure with.
+ *
+ * The tenant-configured provider's discovery/token/JWKS endpoints are
+ * stubbed via a temporary `globalThis.fetch` override (same pattern
+ * `google-oidc-flow.integration.test.ts`'s `withStubbedGoogle` uses) —
+ * there is no test-only URL override on `discoverOidcConfiguration`, so
+ * intercepting the global fetch is the way to exercise this end to end.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { generateKeyPairSync, sign as cryptoSign } from "node:crypto";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { GET as ssoStart } from "../../src/pages/api/v1/auth/sso/[providerKey]/start";
+import { GET as ssoCallback } from "../../src/pages/api/v1/auth/sso/[providerKey]/callback";
+import { POST as ssoLink } from "../../src/pages/api/v1/auth/sso/[providerKey]/link";
+import { POST as ssoUnlink } from "../../src/pages/api/v1/auth/sso/[providerKey]/unlink";
+import {
+  GET as listProviders,
+  POST as createProvider
+} from "../../src/pages/api/v1/identity/sso/providers/index";
+import {
+  GET as getPolicy,
+  PATCH as updatePolicy
+} from "../../src/pages/api/v1/identity/sso/policy/index";
+import { resetGenericOidcCachesForTests } from "../../src/lib/auth/generic-oidc-client";
+import {
+  getDatabaseCircuitBreaker,
+  resetDatabaseCircuitBreakerForTests,
+  resetProviderCircuitBreakersForTests
+} from "../../src/lib/database/circuit-breaker";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+const OKTA_ISSUER = "https://acme.okta.example.com";
+const OKTA_CLIENT_ID = "test-okta-client-id";
+
+const FULL_ONLINE_SSO_ENV: Record<string, string> = {
+  AUTH_ONLINE_SECURITY_ENABLED: "true",
+  AUTH_ONLINE_SECURITY_PROFILE: "full_online",
+  AUTH_SSO_ENABLED: "true"
+};
+
+function base64Url(input: Buffer | string): string {
+  const buffer = typeof input === "string" ? Buffer.from(input) : input;
+  return buffer
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+const { publicKey: TEST_PUBLIC_KEY, privateKey: TEST_PRIVATE_KEY } =
+  generateKeyPairSync("rsa", { modulusLength: 2048 });
+const TEST_JWK = {
+  ...(TEST_PUBLIC_KEY.export({ format: "jwk" }) as Record<string, unknown>),
+  kid: "test-key-1"
+};
+
+function signIdToken(claims: Record<string, unknown>): string {
+  const header = { alg: "RS256", typ: "JWT", kid: "test-key-1" };
+  const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(claims))}`;
+  const signature = cryptoSign(
+    "RSA-SHA256",
+    Buffer.from(signingInput),
+    TEST_PRIVATE_KEY
+  );
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+type StubOktaOptions = {
+  idToken?: string;
+  tokenEndpointFails?: boolean;
+  discoveryFails?: boolean;
+};
+
+async function withStubbedOkta<T>(
+  options: StubOktaOptions,
+  fn: () => Promise<T>
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  const tokenEndpoint = `${OKTA_ISSUER}/oauth2/v1/token`;
+  const jwksUri = `${OKTA_ISSUER}/oauth2/v1/keys`;
+  const authorizationEndpoint = `${OKTA_ISSUER}/oauth2/v1/authorize`;
+
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    if (url === `${OKTA_ISSUER}/.well-known/openid-configuration`) {
+      if (options.discoveryFails) {
+        return new Response("upstream error", { status: 500 });
+      }
+      return Response.json({
+        issuer: OKTA_ISSUER,
+        authorization_endpoint: authorizationEndpoint,
+        token_endpoint: tokenEndpoint,
+        jwks_uri: jwksUri
+      });
+    }
+
+    if (url === tokenEndpoint) {
+      if (options.tokenEndpointFails) {
+        return new Response("upstream error", { status: 500 });
+      }
+      return Response.json({ id_token: options.idToken ?? "" });
+    }
+
+    if (url === jwksUri) {
+      return Response.json({ keys: [TEST_JWK] });
+    }
+
+    return originalFetch(input as never);
+  }) as typeof fetch;
+
+  resetGenericOidcCachesForTests();
+  resetProviderCircuitBreakersForTests();
+
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+    resetGenericOidcCachesForTests();
+    resetProviderCircuitBreakersForTests();
+  }
+}
+
+async function withEnvOverride<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+
+  for (const key of Object.keys(overrides)) {
+    previous[key] = process.env[key];
+    const value = overrides[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(overrides)) {
+      const value = previous[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+type Bootstrap = { tenantId: string; token: string };
+
+async function bootstrapTenant(tenantCode = "acme"): Promise<Bootstrap> {
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: `Tenant ${tenantCode}`,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "Head Office",
+      ownerLoginIdentifier: OWNER_LOGIN,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId, token: login.body.data.token };
+}
+
+function authHeaders(owner: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": owner.tenantId,
+    authorization: `Bearer ${owner.token}`
+  };
+}
+
+async function createOktaProvider(
+  owner: Bootstrap,
+  overrides: Record<string, unknown> = {}
+): Promise<{ id: string }> {
+  const result = await invoke<{ data: { id: string } }>(createProvider, {
+    method: "POST",
+    path: "/api/v1/identity/sso/providers",
+    headers: authHeaders(owner),
+    body: {
+      providerKey: "okta",
+      displayName: "Okta",
+      issuerUrl: OKTA_ISSUER,
+      clientId: OKTA_CLIENT_ID,
+      clientSecretEnvVar: "OKTA_TEST_CLIENT_SECRET",
+      enabled: true,
+      ...overrides
+    }
+  });
+  expect(result.status).toBe(200);
+  return { id: result.body.data.id };
+}
+
+/** Calls `start.ts` and extracts `state`/`nonce` from the 302 redirect's Location query params. */
+async function startSsoLogin(
+  tenantId: string
+): Promise<{ state: string; nonce: string }> {
+  const result = await invoke(ssoStart, {
+    method: "GET",
+    path: `/api/v1/auth/sso/okta/start?tenantId=${tenantId}`,
+    params: { providerKey: "okta" }
+  });
+  expect(result.status).toBe(302);
+
+  const location = new URL(result.response.headers.get("location")!);
+  return {
+    state: location.searchParams.get("state")!,
+    nonce: location.searchParams.get("nonce")!
+  };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("Generic tenant OIDC SSO flow (Issue #591)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    resetDatabaseCircuitBreakerForTests();
+    process.env.OKTA_TEST_CLIENT_SECRET = "okta-test-client-secret";
+    process.env.AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY = Buffer.alloc(
+      32,
+      3
+    ).toString("base64");
+  });
+
+  test("start rejects a nonexistent tenant WITHOUT tripping the shared database circuit breaker", async () => {
+    await withEnvOverride(FULL_ONLINE_SSO_ENV, async () => {
+      const bogusTenantId = "00000000-0000-0000-0000-000000000000";
+
+      for (let i = 0; i < 10; i += 1) {
+        const start = await invoke<{ error: { code: string } }>(ssoStart, {
+          method: "GET",
+          path: `/api/v1/auth/sso/okta/start?tenantId=${bogusTenantId}`,
+          params: { providerKey: "okta" }
+        });
+        expect(start.status).toBe(403);
+        expect(start.body.error.code).toBe("ACCESS_DENIED");
+      }
+
+      expect(getDatabaseCircuitBreaker().canAttempt(new Date())).toBe(true);
+    });
+  });
+
+  test("disabled mode (default): start/link/unlink all report SSO_DISABLED", async () => {
+    const owner = await bootstrapTenant();
+
+    const start = await invoke<{ error: { code: string } }>(ssoStart, {
+      method: "GET",
+      path: `/api/v1/auth/sso/okta/start?tenantId=${owner.tenantId}`,
+      params: { providerKey: "okta" }
+    });
+    expect(start.status).toBe(403);
+    expect(start.body.error.code).toBe("SSO_DISABLED");
+
+    const link = await invoke<{ error: { code: string } }>(ssoLink, {
+      method: "POST",
+      path: "/api/v1/auth/sso/okta/link",
+      headers: authHeaders(owner),
+      params: { providerKey: "okta" }
+    });
+    expect(link.status).toBe(403);
+    expect(link.body.error.code).toBe("SSO_DISABLED");
+
+    const unlink = await invoke<{ error: { code: string } }>(ssoUnlink, {
+      method: "POST",
+      path: "/api/v1/auth/sso/okta/unlink",
+      headers: authHeaders(owner),
+      params: { providerKey: "okta" }
+    });
+    expect(unlink.status).toBe(403);
+    expect(unlink.body.error.code).toBe("SSO_DISABLED");
+  });
+
+  test("admin CRUD is reachable even when the SSO gate is off — credentials can be provisioned ahead of time", async () => {
+    const owner = await bootstrapTenant();
+
+    const created = await createOktaProvider(owner);
+    expect(created.id).toBeTruthy();
+
+    const list = await invoke<{
+      data: { providers: { providerKey: string }[] };
+    }>(listProviders, {
+      method: "GET",
+      path: "/api/v1/identity/sso/providers",
+      headers: authHeaders(owner)
+    });
+    expect(list.status).toBe(200);
+    expect(list.body.data.providers).toHaveLength(1);
+    expect(list.body.data.providers[0]?.providerKey).toBe("okta");
+  });
+
+  test("admin CRUD never returns the client secret plaintext", async () => {
+    const owner = await bootstrapTenant();
+    await createOktaProvider(owner, {
+      clientSecretEnvVar: undefined,
+      clientSecret: "super-secret-value"
+    });
+
+    const list = await invoke<{
+      data: { providers: Record<string, unknown>[] };
+    }>(listProviders, {
+      method: "GET",
+      path: "/api/v1/identity/sso/providers",
+      headers: authHeaders(owner)
+    });
+    expect(list.status).toBe(200);
+
+    const raw = JSON.stringify(list.body);
+    expect(raw).not.toContain("super-secret-value");
+    expect(list.body.data.providers[0]).not.toHaveProperty("clientSecret");
+    expect(list.body.data.providers[0]).not.toHaveProperty(
+      "clientSecretCiphertext"
+    );
+  });
+
+  test("ABAC: an identity with no role/permission is denied admin provider access (default deny)", async () => {
+    const owner = await bootstrapTenant();
+    const admin = getAdminSql();
+
+    const profileRows = await admin`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${owner.tenantId}, 'person', 'No Role User') RETURNING id
+    `;
+    const password = "integration-test-norole-password";
+    const passwordHash = await Bun.password.hash(password);
+    await admin`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${owner.tenantId}, ${(profileRows[0] as { id: string }).id}, 'norole@example.com', ${passwordHash})
+    `;
+    const identityRows = await admin`
+      SELECT id FROM awcms_mini_identities WHERE login_identifier = 'norole@example.com'
+    `;
+    await admin`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${owner.tenantId}, ${(identityRows[0] as { id: string }).id})
+    `;
+
+    const login = await invoke<{ data: { token: string } }>(authLogin, {
+      method: "POST",
+      path: "/api/v1/auth/login",
+      headers: {
+        "content-type": "application/json",
+        "x-awcms-mini-tenant-id": owner.tenantId
+      },
+      body: { loginIdentifier: "norole@example.com", password },
+      cookies: createCookieJar()
+    });
+    expect(login.status).toBe(200);
+
+    const list = await invoke<{ error: { code: string } }>(listProviders, {
+      method: "GET",
+      path: "/api/v1/identity/sso/providers",
+      headers: {
+        "content-type": "application/json",
+        "x-awcms-mini-tenant-id": owner.tenantId,
+        authorization: `Bearer ${login.body.data.token}`
+      }
+    });
+    expect(list.status).toBe(403);
+    expect(list.body.error.code).toBe("ACCESS_DENIED");
+  });
+
+  test("full login flow with auto-link-by-email: verified email + allowed domain (provider AND policy) links to the existing identity", async () => {
+    const owner = await bootstrapTenant();
+    await createOktaProvider(owner, { allowedEmailDomains: ["example.com"] });
+
+    const patchPolicy = await invoke(updatePolicy, {
+      method: "PATCH",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(owner),
+      body: { autoLinkVerifiedEmail: true }
+    });
+    expect(patchPolicy.status).toBe(200);
+
+    await withEnvOverride(FULL_ONLINE_SSO_ENV, async () => {
+      const options: StubOktaOptions = {};
+
+      await withStubbedOkta(options, async () => {
+        const { state, nonce } = await startSsoLogin(owner.tenantId);
+        options.idToken = signIdToken({
+          iss: OKTA_ISSUER,
+          aud: OKTA_CLIENT_ID,
+          sub: "okta-subject-owner",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        const callback = await invoke<{ data: { token: string } }>(
+          ssoCallback,
+          {
+            method: "GET",
+            path: `/api/v1/auth/sso/okta/callback?code=some-code&state=${encodeURIComponent(state)}`,
+            params: { providerKey: "okta" }
+          }
+        );
+        expect(callback.status).toBe(302);
+        expect(callback.response.headers.get("location")).toBe("/admin");
+      });
+    });
+  });
+
+  test("login with no linked account and auto-link disabled is rejected, not silently provisioned", async () => {
+    const owner = await bootstrapTenant();
+    await createOktaProvider(owner, { allowedEmailDomains: ["example.com"] });
+    // auto_link_verified_email left at its default (false).
+
+    await withEnvOverride(FULL_ONLINE_SSO_ENV, async () => {
+      const options: StubOktaOptions = {};
+
+      await withStubbedOkta(options, async () => {
+        const { state, nonce } = await startSsoLogin(owner.tenantId);
+        options.idToken = signIdToken({
+          iss: OKTA_ISSUER,
+          aud: OKTA_CLIENT_ID,
+          sub: "okta-subject-owner",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        const callback = await invoke<{ error: { code: string } }>(
+          ssoCallback,
+          {
+            method: "GET",
+            path: `/api/v1/auth/sso/okta/callback?code=some-code&state=${encodeURIComponent(state)}`,
+            params: { providerKey: "okta" }
+          }
+        );
+        expect(callback.status).toBe(401);
+        expect(callback.body.error.code).toBe("SSO_ACCOUNT_NOT_LINKED");
+      });
+    });
+  });
+
+  test("link then subsequent login uses the linked account; unlink then removes it", async () => {
+    const owner = await bootstrapTenant();
+    await createOktaProvider(owner);
+
+    await withEnvOverride(FULL_ONLINE_SSO_ENV, async () => {
+      const options: StubOktaOptions = {};
+
+      await withStubbedOkta(options, async () => {
+        const linkStart = await invoke<{ data: { authorizationUrl: string } }>(
+          ssoLink,
+          {
+            method: "POST",
+            path: "/api/v1/auth/sso/okta/link",
+            headers: authHeaders(owner),
+            params: { providerKey: "okta" }
+          }
+        );
+        expect(linkStart.status).toBe(200);
+
+        const location = new URL(linkStart.body.data.authorizationUrl);
+        const state = location.searchParams.get("state")!;
+        const nonce = location.searchParams.get("nonce")!;
+
+        options.idToken = signIdToken({
+          iss: OKTA_ISSUER,
+          aud: OKTA_CLIENT_ID,
+          sub: "okta-subject-link-me",
+          email: "unrelated@example.com",
+          email_verified: true,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        const callback = await invoke(ssoCallback, {
+          method: "GET",
+          path: `/api/v1/auth/sso/okta/callback?code=some-code&state=${encodeURIComponent(state)}`,
+          params: { providerKey: "okta" }
+        });
+        expect(callback.status).toBe(302);
+      });
+
+      const unlink = await invoke<{ data: { unlinked: boolean } }>(ssoUnlink, {
+        method: "POST",
+        path: "/api/v1/auth/sso/okta/unlink",
+        headers: authHeaders(owner),
+        params: { providerKey: "okta" }
+      });
+      expect(unlink.status).toBe(200);
+      expect(unlink.body.data.unlinked).toBe(true);
+
+      const again = await invoke<{ error: { code: string } }>(ssoUnlink, {
+        method: "POST",
+        path: "/api/v1/auth/sso/okta/unlink",
+        headers: authHeaders(owner),
+        params: { providerKey: "okta" }
+      });
+      expect(again.status).toBe(409);
+      expect(again.body.error.code).toBe("SSO_NOT_LINKED");
+    });
+  });
+
+  test("break-glass enforcement: PATCH policy rejects sso_required=true with no eligible break-glass identity, accepts once one is provided", async () => {
+    const owner = await bootstrapTenant();
+    await createOktaProvider(owner);
+
+    const rejected = await invoke<{ error: { code: string } }>(updatePolicy, {
+      method: "PATCH",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(owner),
+      body: { ssoEnabled: true, ssoRequired: true }
+    });
+    expect(rejected.status).toBe(409);
+    expect(rejected.body.error.code).toBe("BREAK_GLASS_REQUIRED");
+
+    // Confirm the rejected policy was NOT persisted.
+    const unchanged = await invoke<{ data: { ssoRequired: boolean } }>(
+      getPolicy,
+      {
+        method: "GET",
+        path: "/api/v1/identity/sso/policy",
+        headers: authHeaders(owner)
+      }
+    );
+    expect(unchanged.body.data.ssoRequired).toBe(false);
+
+    const admin = getAdminSql();
+    const ownerIdentityRows = await admin`
+      SELECT id FROM awcms_mini_identities
+      WHERE tenant_id = ${owner.tenantId} AND login_identifier = ${OWNER_LOGIN}
+    `;
+    const ownerIdentityId = (ownerIdentityRows[0] as { id: string }).id;
+
+    const accepted = await invoke<{ data: { ssoRequired: boolean } }>(
+      updatePolicy,
+      {
+        method: "PATCH",
+        path: "/api/v1/identity/sso/policy",
+        headers: authHeaders(owner),
+        body: {
+          ssoEnabled: true,
+          ssoRequired: true,
+          breakGlassIdentityIds: [ownerIdentityId]
+        }
+      }
+    );
+    expect(accepted.status).toBe(200);
+    expect(accepted.body.data.ssoRequired).toBe(true);
+  });
+
+  test("break-glass enforcement also rejects password_login_enabled=false without an eligible break-glass identity", async () => {
+    const owner = await bootstrapTenant();
+
+    const rejected = await invoke<{ error: { code: string } }>(updatePolicy, {
+      method: "PATCH",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(owner),
+      body: { ssoEnabled: true, passwordLoginEnabled: false }
+    });
+    expect(rejected.status).toBe(409);
+    expect(rejected.body.error.code).toBe("BREAK_GLASS_REQUIRED");
+  });
+
+  test("login enforcement: password_login_enabled=false blocks a non-break-glass identity but not the break-glass owner, only when the SSO gate is active", async () => {
+    const owner = await bootstrapTenant();
+    const admin = getAdminSql();
+
+    const ownerIdentityRows = await admin`
+      SELECT id FROM awcms_mini_identities
+      WHERE tenant_id = ${owner.tenantId} AND login_identifier = ${OWNER_LOGIN}
+    `;
+    const ownerIdentityId = (ownerIdentityRows[0] as { id: string }).id;
+
+    const otherPassword = "integration-test-other-password";
+    const otherPasswordHash = await Bun.password.hash(otherPassword);
+    const profileRows = await admin`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${owner.tenantId}, 'person', 'Other User') RETURNING id
+    `;
+    await admin`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${owner.tenantId}, ${(profileRows[0] as { id: string }).id}, 'other@example.com', ${otherPasswordHash})
+    `;
+    const otherIdentityRows = await admin`
+      SELECT id FROM awcms_mini_identities WHERE login_identifier = 'other@example.com'
+    `;
+    await admin`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${owner.tenantId}, ${(otherIdentityRows[0] as { id: string }).id})
+    `;
+
+    const patch = await invoke<{ data: { passwordLoginEnabled: boolean } }>(
+      updatePolicy,
+      {
+        method: "PATCH",
+        path: "/api/v1/identity/sso/policy",
+        headers: authHeaders(owner),
+        body: {
+          ssoEnabled: true,
+          passwordLoginEnabled: false,
+          breakGlassIdentityIds: [ownerIdentityId]
+        }
+      }
+    );
+    expect(patch.status).toBe(200);
+    expect(patch.body.data.passwordLoginEnabled).toBe(false);
+
+    // Gate INACTIVE (default env): policy is stored but not enforced yet —
+    // both identities can still log in with their password, exactly like
+    // before this issue, on every deployment that never flips the #591 gate.
+    const otherLoginGateOff = await invoke<{ data: { token: string } }>(
+      authLogin,
+      {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: "other@example.com", password: otherPassword },
+        cookies: createCookieJar()
+      }
+    );
+    expect(otherLoginGateOff.status).toBe(200);
+
+    await withEnvOverride(FULL_ONLINE_SSO_ENV, async () => {
+      // Gate ACTIVE: the non-break-glass identity is now blocked...
+      const otherLogin = await invoke<{ error: { code: string } }>(authLogin, {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: {
+          loginIdentifier: "other@example.com",
+          password: otherPassword
+        },
+        cookies: createCookieJar()
+      });
+      expect(otherLogin.status).toBe(403);
+      expect(otherLogin.body.error.code).toBe("PASSWORD_LOGIN_DISABLED");
+
+      // ...but the break-glass owner identity can still log in with password.
+      const ownerLogin = await invoke<{ data: { token: string } }>(authLogin, {
+        method: "POST",
+        path: "/api/v1/auth/login",
+        headers: {
+          "content-type": "application/json",
+          "x-awcms-mini-tenant-id": owner.tenantId
+        },
+        body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+        cookies: createCookieJar()
+      });
+      expect(ownerLogin.status).toBe(200);
+    });
+  });
+
+  test("rejects an ID token with the wrong issuer", async () => {
+    const owner = await bootstrapTenant();
+    await createOktaProvider(owner, { allowedEmailDomains: ["example.com"] });
+    await invoke(updatePolicy, {
+      method: "PATCH",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(owner),
+      body: { autoLinkVerifiedEmail: true }
+    });
+
+    await withEnvOverride(FULL_ONLINE_SSO_ENV, async () => {
+      const options: StubOktaOptions = {};
+
+      await withStubbedOkta(options, async () => {
+        const { state, nonce } = await startSsoLogin(owner.tenantId);
+        options.idToken = signIdToken({
+          iss: "https://evil.example.com",
+          aud: OKTA_CLIENT_ID,
+          sub: "okta-subject-wrong-iss",
+          email: OWNER_LOGIN,
+          email_verified: true,
+          nonce,
+          exp: Math.floor(Date.now() / 1000) + 3600
+        });
+
+        const callback = await invoke<{ error: { code: string } }>(
+          ssoCallback,
+          {
+            method: "GET",
+            path: `/api/v1/auth/sso/okta/callback?code=some-code&state=${encodeURIComponent(state)}`,
+            params: { providerKey: "okta" }
+          }
+        );
+        expect(callback.status).toBe(401);
+        expect(callback.body.error.code).toBe("SSO_ID_TOKEN_INVALID");
+      });
+    });
+  });
+
+  test("MFA integration: SSO login for an MFA-enrolled identity stops at MFA_REQUIRED, not a session", async () => {
+    const owner = await bootstrapTenant();
+    await createOktaProvider(owner, { allowedEmailDomains: ["example.com"] });
+    await invoke(updatePolicy, {
+      method: "PATCH",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(owner),
+      body: { autoLinkVerifiedEmail: true }
+    });
+    const mfaKey = Buffer.alloc(32, 7).toString("base64");
+
+    await withEnvOverride(
+      {
+        ...FULL_ONLINE_SSO_ENV,
+        AUTH_MFA_ENABLED: "true",
+        AUTH_MFA_SECRET_ENCRYPTION_KEY: mfaKey
+      },
+      async () => {
+        const { POST: enrollStart } =
+          await import("../../src/pages/api/v1/auth/mfa/totp/enroll/start");
+        const { POST: enrollVerify } =
+          await import("../../src/pages/api/v1/auth/mfa/totp/enroll/verify");
+        const { generateTotpCode, base32Decode } =
+          await import("../../src/lib/auth/totp");
+
+        const start = await invoke<{ data: { secret: string } }>(enrollStart, {
+          method: "POST",
+          path: "/api/v1/auth/mfa/totp/enroll/start",
+          headers: authHeaders(owner)
+        });
+        const code = generateTotpCode(
+          base32Decode(start.body.data.secret),
+          Date.now(),
+          { periodSec: 30, digits: 6 }
+        );
+        const verify = await invoke(enrollVerify, {
+          method: "POST",
+          path: "/api/v1/auth/mfa/totp/enroll/verify",
+          headers: authHeaders(owner),
+          body: { code }
+        });
+        expect(verify.status).toBe(200);
+
+        const options: StubOktaOptions = {};
+
+        await withStubbedOkta(options, async () => {
+          const { state, nonce } = await startSsoLogin(owner.tenantId);
+          options.idToken = signIdToken({
+            iss: OKTA_ISSUER,
+            aud: OKTA_CLIENT_ID,
+            sub: "okta-subject-mfa-owner",
+            email: OWNER_LOGIN,
+            email_verified: true,
+            nonce,
+            exp: Math.floor(Date.now() / 1000) + 3600
+          });
+
+          const callback = await invoke<{
+            error: { code: string; details?: { mfaChallengeToken?: string } };
+          }>(ssoCallback, {
+            method: "GET",
+            path: `/api/v1/auth/sso/okta/callback?code=some-code&state=${encodeURIComponent(state)}`,
+            params: { providerKey: "okta" }
+          });
+
+          expect(callback.status).toBe(401);
+          expect(callback.body.error.code).toBe("MFA_REQUIRED");
+          expect(typeof callback.body.error.details?.mfaChallengeToken).toBe(
+            "string"
+          );
+        });
+      }
+    );
+  });
+});

--- a/tests/integration/tenant-sso-schema.integration.test.ts
+++ b/tests/integration/tenant-sso-schema.integration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Integration tests for the generic tenant OIDC SSO schema/RLS (Issue #591,
+ * epic: full-online auth hardening) against a real PostgreSQL — migration
+ * 036's two new tables (`awcms_mini_auth_providers`,
+ * `awcms_mini_tenant_auth_policies`). Same pattern as
+ * `google-oidc-schema.integration.test.ts` (#590): exercise constraints and
+ * RLS enforcement directly via `withTenant`/raw admin SQL, independent of
+ * the endpoint-level flow covered by `tenant-sso-flow.integration.test.ts`.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+
+const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+async function seedTenants(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES
+      (${TENANT_A}, 'tenant-a', 'Tenant A', 'Tenant A Legal', 'active', 'en', 'light'),
+      (${TENANT_B}, 'tenant-b', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite(
+  "Tenant OIDC SSO schema — RLS isolation and constraints (Issue #591)",
+  () => {
+    beforeAll(async () => {
+      await applyMigrations();
+      await provisionAppRole();
+    });
+
+    beforeEach(async () => {
+      await resetDatabase();
+      await seedTenants();
+    });
+
+    test("auth providers: tenant A cannot see tenant B's provider (RLS isolation)", async () => {
+      const admin = getAdminSql();
+      await admin`
+      INSERT INTO awcms_mini_auth_providers
+        (tenant_id, provider_key, display_name, issuer_url, client_id, client_secret_env_var)
+      VALUES
+        (${TENANT_A}, 'okta', 'Okta A', 'https://a.okta.com', 'client-a', 'A_SECRET'),
+        (${TENANT_B}, 'okta', 'Okta B', 'https://b.okta.com', 'client-b', 'B_SECRET')
+    `;
+
+      const sql = getDatabaseClient();
+      const rows = await withTenant(
+        sql,
+        TENANT_A,
+        (tx) => tx`SELECT provider_key FROM awcms_mini_auth_providers`
+      );
+
+      expect(rows).toHaveLength(1);
+      expect((rows as { provider_key: string }[])[0]?.provider_key).toBe(
+        "okta"
+      );
+    });
+
+    test("querying auth providers without a tenant GUC set returns no rows (fail-closed)", async () => {
+      const admin = getAdminSql();
+      await admin`
+      INSERT INTO awcms_mini_auth_providers
+        (tenant_id, provider_key, display_name, issuer_url, client_id, client_secret_env_var)
+      VALUES (${TENANT_A}, 'okta', 'Okta A', 'https://a.okta.com', 'client-a', 'A_SECRET')
+    `;
+
+      const sql = getDatabaseClient();
+      const rows =
+        await sql`SELECT provider_key FROM awcms_mini_auth_providers`;
+      expect(rows).toHaveLength(0);
+    });
+
+    test("provider_key is unique per tenant among non-deleted providers", async () => {
+      const admin = getAdminSql();
+      await admin`
+      INSERT INTO awcms_mini_auth_providers
+        (tenant_id, provider_key, display_name, issuer_url, client_id, client_secret_env_var)
+      VALUES (${TENANT_A}, 'okta', 'Okta A', 'https://a.okta.com', 'client-a', 'A_SECRET')
+    `;
+
+      let didThrow = false;
+      try {
+        await admin`
+        INSERT INTO awcms_mini_auth_providers
+          (tenant_id, provider_key, display_name, issuer_url, client_id, client_secret_env_var)
+        VALUES (${TENANT_A}, 'okta', 'Okta A (dup)', 'https://a2.okta.com', 'client-a2', 'A2_SECRET')
+      `;
+      } catch {
+        didThrow = true;
+      }
+
+      expect(didThrow).toBe(true);
+    });
+
+    test("a soft-deleted provider's key can be reused", async () => {
+      const admin = getAdminSql();
+      const rows = await admin`
+      INSERT INTO awcms_mini_auth_providers
+        (tenant_id, provider_key, display_name, issuer_url, client_id, client_secret_env_var)
+      VALUES (${TENANT_A}, 'okta', 'Okta A', 'https://a.okta.com', 'client-a', 'A_SECRET')
+      RETURNING id
+    `;
+      const providerId = (rows[0] as { id: string }).id;
+
+      await admin`
+      UPDATE awcms_mini_auth_providers
+      SET deleted_at = now(), deleted_by = NULL, delete_reason = 'test'
+      WHERE id = ${providerId}
+    `;
+
+      const reinsert = await admin`
+      INSERT INTO awcms_mini_auth_providers
+        (tenant_id, provider_key, display_name, issuer_url, client_id, client_secret_env_var)
+      VALUES (${TENANT_A}, 'okta', 'Okta A (new)', 'https://a-new.okta.com', 'client-a-new', 'A_NEW_SECRET')
+      RETURNING id
+    `;
+
+      expect(reinsert).toHaveLength(1);
+    });
+
+    test("rejects a provider with BOTH client_secret_ciphertext and client_secret_env_var set", async () => {
+      const admin = getAdminSql();
+      let didThrow = false;
+
+      try {
+        await admin`
+        INSERT INTO awcms_mini_auth_providers
+          (tenant_id, provider_key, display_name, issuer_url, client_id,
+           client_secret_ciphertext, client_secret_env_var)
+        VALUES (${TENANT_A}, 'okta', 'Okta A', 'https://a.okta.com', 'client-a', 'v1:a:b:c', 'A_SECRET')
+      `;
+      } catch {
+        didThrow = true;
+      }
+
+      expect(didThrow).toBe(true);
+    });
+
+    test("rejects a provider with NEITHER client_secret_ciphertext nor client_secret_env_var set", async () => {
+      const admin = getAdminSql();
+      let didThrow = false;
+
+      try {
+        await admin`
+        INSERT INTO awcms_mini_auth_providers
+          (tenant_id, provider_key, display_name, issuer_url, client_id)
+        VALUES (${TENANT_A}, 'okta', 'Okta A', 'https://a.okta.com', 'client-a')
+      `;
+      } catch {
+        didThrow = true;
+      }
+
+      expect(didThrow).toBe(true);
+    });
+
+    test("rejects an invalid provider_key format", async () => {
+      const admin = getAdminSql();
+      let didThrow = false;
+
+      try {
+        await admin`
+        INSERT INTO awcms_mini_auth_providers
+          (tenant_id, provider_key, display_name, issuer_url, client_id, client_secret_env_var)
+        VALUES (${TENANT_A}, 'Not Valid!', 'Bad', 'https://a.okta.com', 'client-a', 'A_SECRET')
+      `;
+      } catch {
+        didThrow = true;
+      }
+
+      expect(didThrow).toBe(true);
+    });
+
+    test("tenant auth policies: tenant A cannot see tenant B's policy (RLS isolation)", async () => {
+      const admin = getAdminSql();
+      await admin`
+      INSERT INTO awcms_mini_tenant_auth_policies (tenant_id, sso_required)
+      VALUES (${TENANT_A}, false), (${TENANT_B}, false)
+    `;
+
+      const sql = getDatabaseClient();
+      const rows = await withTenant(
+        sql,
+        TENANT_A,
+        (tx) => tx`SELECT tenant_id FROM awcms_mini_tenant_auth_policies`
+      );
+
+      expect(rows).toHaveLength(1);
+      expect((rows as { tenant_id: string }[])[0]?.tenant_id).toBe(TENANT_A);
+    });
+
+    test("only one auth policy row per tenant (unique index)", async () => {
+      const admin = getAdminSql();
+      await admin`
+      INSERT INTO awcms_mini_tenant_auth_policies (tenant_id) VALUES (${TENANT_A})
+    `;
+
+      let didThrow = false;
+      try {
+        await admin`
+        INSERT INTO awcms_mini_tenant_auth_policies (tenant_id) VALUES (${TENANT_A})
+      `;
+      } catch {
+        didThrow = true;
+      }
+
+      expect(didThrow).toBe(true);
+    });
+
+    test("rejects a policy with BOTH password_login_enabled and sso_enabled false", async () => {
+      const admin = getAdminSql();
+      let didThrow = false;
+
+      try {
+        await admin`
+        INSERT INTO awcms_mini_tenant_auth_policies
+          (tenant_id, password_login_enabled, sso_enabled)
+        VALUES (${TENANT_A}, false, false)
+      `;
+      } catch {
+        didThrow = true;
+      }
+
+      expect(didThrow).toBe(true);
+    });
+
+    test("identity_provider_accounts (migration 035) accepts a non-google provider value — reused generically by #591", async () => {
+      const admin = getAdminSql();
+      const profileRows = await admin`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${TENANT_A}, 'person', 'Owner A')
+      RETURNING id
+    `;
+      const identityRows = await admin`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${TENANT_A}, ${(profileRows[0] as { id: string }).id}, 'owner-a@example.com', 'hash')
+      RETURNING id
+    `;
+
+      const rows = await admin`
+      INSERT INTO awcms_mini_identity_provider_accounts
+        (tenant_id, identity_id, provider, provider_subject)
+      VALUES (${TENANT_A}, ${(identityRows[0] as { id: string }).id}, 'okta', 'okta-subject-1')
+      RETURNING id
+    `;
+
+      expect(rows).toHaveLength(1);
+    });
+  }
+);

--- a/tests/unit/login-policy.test.ts
+++ b/tests/unit/login-policy.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import { evaluateLoginAttempt } from "../../src/modules/identity-access/domain/login-policy";
+
+const BASE_INPUT = {
+  now: new Date("2026-01-01T00:00:00Z"),
+  tenantStatus: "active",
+  tenantUserStatus: "active" as const,
+  passwordMatches: true,
+  maxFailedAttempts: 5,
+  lockoutMinutes: 15
+};
+
+describe("evaluateLoginAttempt — password_login_disabled (Issue #591)", () => {
+  test("denies with password_login_disabled when the flag is set for an existing identity, even with a correct password", () => {
+    const result = evaluateLoginAttempt({
+      ...BASE_INPUT,
+      identity: { status: "active", failedLoginCount: 0, lockedUntil: null },
+      passwordLoginDisabled: true
+    });
+
+    expect(result).toEqual({
+      outcome: "deny",
+      reason: "password_login_disabled"
+    });
+  });
+
+  test("does not increment failed_login_count when denying for password_login_disabled", () => {
+    const result = evaluateLoginAttempt({
+      ...BASE_INPUT,
+      identity: { status: "active", failedLoginCount: 2, lockedUntil: null },
+      passwordLoginDisabled: true
+    });
+
+    expect(result.outcome).toBe("deny");
+    if (result.outcome === "deny") {
+      expect(result.failedLoginCount).toBeUndefined();
+    }
+  });
+
+  test("default (flag omitted) preserves existing behavior — allows a valid login", () => {
+    const result = evaluateLoginAttempt({
+      ...BASE_INPUT,
+      identity: { status: "active", failedLoginCount: 0, lockedUntil: null }
+    });
+
+    expect(result.outcome).toBe("allow");
+  });
+
+  test("flag false has no effect — still allows a valid login", () => {
+    const result = evaluateLoginAttempt({
+      ...BASE_INPUT,
+      identity: { status: "active", failedLoginCount: 0, lockedUntil: null },
+      passwordLoginDisabled: false
+    });
+
+    expect(result.outcome).toBe("allow");
+  });
+
+  test("tenant_inactive takes priority over password_login_disabled", () => {
+    const result = evaluateLoginAttempt({
+      ...BASE_INPUT,
+      tenantStatus: "suspended",
+      identity: { status: "active", failedLoginCount: 0, lockedUntil: null },
+      passwordLoginDisabled: true
+    });
+
+    expect(result).toEqual({ outcome: "deny", reason: "tenant_inactive" });
+  });
+
+  test("locked takes priority over password_login_disabled", () => {
+    const result = evaluateLoginAttempt({
+      ...BASE_INPUT,
+      identity: { status: "locked", failedLoginCount: 0, lockedUntil: null },
+      passwordLoginDisabled: true
+    });
+
+    expect(result).toEqual({ outcome: "deny", reason: "locked" });
+  });
+
+  test("passwordLoginDisabled with no identity resolved falls through to invalid_credentials (no account-existence oracle change)", () => {
+    const result = evaluateLoginAttempt({
+      ...BASE_INPUT,
+      identity: null,
+      passwordLoginDisabled: true
+    });
+
+    expect(result.outcome).toBe("deny");
+    if (result.outcome === "deny") {
+      expect(result.reason).toBe("invalid_credentials");
+    }
+  });
+});

--- a/tests/unit/sso-config.test.ts
+++ b/tests/unit/sso-config.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isSsoEnabled,
+  isSsoRequired,
+  resolveSsoDiscoveryTimeoutMs,
+  resolveSsoRedirectUri
+} from "../../src/lib/auth/sso-config";
+
+describe("sso-config (Issue #591)", () => {
+  test("isSsoEnabled is false when unset", () => {
+    expect(isSsoEnabled({})).toBe(false);
+  });
+
+  test("isSsoEnabled is true only for the literal string 'true'", () => {
+    expect(isSsoEnabled({ AUTH_SSO_ENABLED: "true" })).toBe(true);
+    expect(isSsoEnabled({ AUTH_SSO_ENABLED: "yes" })).toBe(false);
+  });
+
+  test("isSsoRequired is false when the full-online gate is off, even with AUTH_SSO_ENABLED=true", () => {
+    expect(
+      isSsoRequired({
+        AUTH_SSO_ENABLED: "true",
+        AUTH_ONLINE_SECURITY_ENABLED: "false"
+      })
+    ).toBe(false);
+  });
+
+  test("isSsoRequired is false when AUTH_SSO_ENABLED is not true, even with the gate active", () => {
+    expect(
+      isSsoRequired({
+        AUTH_ONLINE_SECURITY_ENABLED: "true",
+        AUTH_ONLINE_SECURITY_PROFILE: "full_online"
+      })
+    ).toBe(false);
+  });
+
+  test("isSsoRequired is true only when both agree", () => {
+    expect(
+      isSsoRequired({
+        AUTH_ONLINE_SECURITY_ENABLED: "true",
+        AUTH_ONLINE_SECURITY_PROFILE: "full_online",
+        AUTH_SSO_ENABLED: "true"
+      })
+    ).toBe(true);
+  });
+
+  test("resolveSsoDiscoveryTimeoutMs falls back to 5000ms for unset/invalid values", () => {
+    expect(resolveSsoDiscoveryTimeoutMs({})).toBe(5000);
+    expect(
+      resolveSsoDiscoveryTimeoutMs({ AUTH_SSO_DISCOVERY_TIMEOUT_MS: "abc" })
+    ).toBe(5000);
+    expect(
+      resolveSsoDiscoveryTimeoutMs({ AUTH_SSO_DISCOVERY_TIMEOUT_MS: "-5" })
+    ).toBe(5000);
+  });
+
+  test("resolveSsoDiscoveryTimeoutMs honors a valid positive override", () => {
+    expect(
+      resolveSsoDiscoveryTimeoutMs({ AUTH_SSO_DISCOVERY_TIMEOUT_MS: "8000" })
+    ).toBe(8000);
+  });
+
+  test("resolveSsoRedirectUri builds a deployment-owned callback path per provider key, never client-supplied", () => {
+    const url = resolveSsoRedirectUri("okta", {
+      APP_URL: "https://app.example.com"
+    });
+    expect(url).toBe("https://app.example.com/api/v1/auth/sso/okta/callback");
+  });
+});

--- a/tests/unit/sso-credential-crypto.test.ts
+++ b/tests/unit/sso-credential-crypto.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  decryptSsoClientSecret,
+  encryptSsoClientSecret,
+  resolveSsoEncryptionKey
+} from "../../src/lib/auth/sso-credential-crypto";
+
+const VALID_KEY_BASE64 = Buffer.alloc(32, 5).toString("base64");
+
+describe("resolveSsoEncryptionKey", () => {
+  test("null when unset", () => {
+    expect(resolveSsoEncryptionKey({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  test("null when the decoded key is not exactly 32 bytes", () => {
+    const shortKey = Buffer.alloc(16, 1).toString("base64");
+    expect(
+      resolveSsoEncryptionKey({
+        AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY: shortKey
+      } as NodeJS.ProcessEnv)
+    ).toBeNull();
+  });
+
+  test("returns a 32-byte buffer for a valid key", () => {
+    const key = resolveSsoEncryptionKey({
+      AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY: VALID_KEY_BASE64
+    } as NodeJS.ProcessEnv);
+    expect(key).not.toBeNull();
+    expect(key).toHaveLength(32);
+  });
+});
+
+describe("encryptSsoClientSecret/decryptSsoClientSecret", () => {
+  const key = resolveSsoEncryptionKey({
+    AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY: VALID_KEY_BASE64
+  } as NodeJS.ProcessEnv)!;
+
+  test("round-trips a client secret", () => {
+    const plaintext = "super-secret-oidc-client-secret";
+    const ciphertext = encryptSsoClientSecret(plaintext, key);
+    expect(ciphertext).not.toContain(plaintext);
+    expect(decryptSsoClientSecret(ciphertext, key)).toBe(plaintext);
+  });
+
+  test("two encryptions of the same plaintext produce different ciphertext (random IV)", () => {
+    const a = encryptSsoClientSecret("same-secret", key);
+    const b = encryptSsoClientSecret("same-secret", key);
+    expect(a).not.toBe(b);
+  });
+
+  test("decrypting with the wrong key throws (authenticated cipher rejects it)", () => {
+    const otherKey = Buffer.alloc(32, 9);
+    const ciphertext = encryptSsoClientSecret("secret", key);
+    expect(() => decryptSsoClientSecret(ciphertext, otherKey)).toThrow();
+  });
+
+  test("decrypting a tampered ciphertext throws", () => {
+    const ciphertext = encryptSsoClientSecret("secret", key);
+    const parts = ciphertext.split(":");
+    const tamperedCiphertextPart = Buffer.from(parts[3]!, "base64");
+    tamperedCiphertextPart[0] = (tamperedCiphertextPart[0]! + 1) % 256;
+    const tampered = [
+      parts[0],
+      parts[1],
+      parts[2],
+      tamperedCiphertextPart.toString("base64")
+    ].join(":");
+
+    expect(() => decryptSsoClientSecret(tampered, key)).toThrow();
+  });
+
+  test("decrypting an unrecognized format throws", () => {
+    expect(() => decryptSsoClientSecret("not-a-valid-format", key)).toThrow();
+    expect(() => decryptSsoClientSecret("v2:a:b:c", key)).toThrow();
+  });
+});

--- a/tests/unit/tenant-sso-policy.test.ts
+++ b/tests/unit/tenant-sso-policy.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluateBreakGlassRequirement,
+  isAutoLinkAllowedForProvider,
+  validateCreateAuthProviderInput,
+  validateUpdateAuthProviderInput,
+  validateUpdateTenantAuthPolicyInput
+} from "../../src/modules/identity-access/domain/tenant-sso-policy";
+
+describe("evaluateBreakGlassRequirement (Issue #591)", () => {
+  test("ok when neither restrictive setting is requested, even with zero break-glass identities", () => {
+    const result = evaluateBreakGlassRequirement({
+      passwordLoginEnabled: true,
+      ssoRequired: false,
+      breakGlassIdentityIds: [],
+      eligibleBreakGlassCount: 0
+    });
+    expect(result.outcome).toBe("ok");
+  });
+
+  test("invalid when sso_required=true and there is no eligible break-glass identity", () => {
+    const result = evaluateBreakGlassRequirement({
+      passwordLoginEnabled: true,
+      ssoRequired: true,
+      breakGlassIdentityIds: [],
+      eligibleBreakGlassCount: 0
+    });
+    expect(result).toEqual({
+      outcome: "invalid",
+      reason: "break_glass_required"
+    });
+  });
+
+  test("invalid when password_login_enabled=false and there is no eligible break-glass identity", () => {
+    const result = evaluateBreakGlassRequirement({
+      passwordLoginEnabled: false,
+      ssoRequired: false,
+      breakGlassIdentityIds: ["identity-1"],
+      eligibleBreakGlassCount: 0
+    });
+    expect(result.outcome).toBe("invalid");
+  });
+
+  test("ok when sso_required=true and at least one break-glass identity is eligible", () => {
+    const result = evaluateBreakGlassRequirement({
+      passwordLoginEnabled: true,
+      ssoRequired: true,
+      breakGlassIdentityIds: ["identity-1"],
+      eligibleBreakGlassCount: 1
+    });
+    expect(result.outcome).toBe("ok");
+  });
+
+  test("invalid even with listed break-glass ids if none of them are currently eligible (stale/deactivated identity)", () => {
+    const result = evaluateBreakGlassRequirement({
+      passwordLoginEnabled: false,
+      ssoRequired: true,
+      breakGlassIdentityIds: ["identity-1", "identity-2"],
+      eligibleBreakGlassCount: 0
+    });
+    expect(result.outcome).toBe("invalid");
+  });
+});
+
+describe("isAutoLinkAllowedForProvider (Issue #591)", () => {
+  test("false when the tenant policy master switch is off, regardless of domain match", () => {
+    expect(
+      isAutoLinkAllowedForProvider(false, true, true, [], "example.com")
+    ).toBe(false);
+  });
+
+  test("false when email is not verified", () => {
+    expect(
+      isAutoLinkAllowedForProvider(true, false, true, [], "example.com")
+    ).toBe(false);
+  });
+
+  test("false when the provider's own domain list does not allow this domain (fail closed)", () => {
+    expect(
+      isAutoLinkAllowedForProvider(true, true, false, [], "example.com")
+    ).toBe(false);
+  });
+
+  test("true when master switch on, email verified, provider domain allowed, and tenant policy list is empty (no extra restriction)", () => {
+    expect(
+      isAutoLinkAllowedForProvider(true, true, true, [], "example.com")
+    ).toBe(true);
+  });
+
+  test("false when the tenant policy list is non-empty and does not include this domain (defense in depth)", () => {
+    expect(
+      isAutoLinkAllowedForProvider(
+        true,
+        true,
+        true,
+        ["other.example"],
+        "example.com"
+      )
+    ).toBe(false);
+  });
+
+  test("true when the tenant policy list is non-empty and includes this domain", () => {
+    expect(
+      isAutoLinkAllowedForProvider(
+        true,
+        true,
+        true,
+        ["example.com"],
+        "example.com"
+      )
+    ).toBe(true);
+  });
+
+  test("false when domain could not be extracted from the email", () => {
+    expect(isAutoLinkAllowedForProvider(true, true, true, [], null)).toBe(
+      false
+    );
+  });
+});
+
+describe("validateCreateAuthProviderInput (Issue #591)", () => {
+  const validBody = {
+    providerKey: "okta",
+    displayName: "Okta",
+    issuerUrl: "https://example.okta.com",
+    clientId: "client-123",
+    clientSecret: "super-secret"
+  };
+
+  test("accepts a well-formed body with clientSecret", () => {
+    const result = validateCreateAuthProviderInput(validBody);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.providerKey).toBe("okta");
+      expect(result.value.clientSecretEnvVar).toBeNull();
+    }
+  });
+
+  test("accepts a well-formed body with clientSecretEnvVar instead", () => {
+    const result = validateCreateAuthProviderInput({
+      ...validBody,
+      clientSecret: undefined,
+      clientSecretEnvVar: "OKTA_CLIENT_SECRET"
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a body with neither clientSecret nor clientSecretEnvVar", () => {
+    const result = validateCreateAuthProviderInput({
+      ...validBody,
+      clientSecret: undefined
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a body with BOTH clientSecret and clientSecretEnvVar", () => {
+    const result = validateCreateAuthProviderInput({
+      ...validBody,
+      clientSecretEnvVar: "OKTA_CLIENT_SECRET"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an invalid providerKey", () => {
+    const result = validateCreateAuthProviderInput({
+      ...validBody,
+      providerKey: "Not Valid!"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a non-https issuerUrl", () => {
+    const result = validateCreateAuthProviderInput({
+      ...validBody,
+      issuerUrl: "http://example.okta.com"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a missing displayName", () => {
+    const result = validateCreateAuthProviderInput({
+      ...validBody,
+      displayName: ""
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("defaults scopes and allowedEmailDomains when omitted", () => {
+    const result = validateCreateAuthProviderInput(validBody);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.scopes).toBe("openid email profile");
+      expect(result.value.allowedEmailDomains).toEqual([]);
+    }
+  });
+});
+
+describe("validateUpdateAuthProviderInput (Issue #591)", () => {
+  test("accepts an empty body (no-op partial update)", () => {
+    expect(validateUpdateAuthProviderInput({}).valid).toBe(true);
+  });
+
+  test("rejects setting BOTH clientSecret and clientSecretEnvVar in one update", () => {
+    const result = validateUpdateAuthProviderInput({
+      clientSecret: "a",
+      clientSecretEnvVar: "B"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("accepts updating only enabled", () => {
+    const result = validateUpdateAuthProviderInput({ enabled: true });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.enabled).toBe(true);
+    }
+  });
+});
+
+describe("validateUpdateTenantAuthPolicyInput (Issue #591)", () => {
+  test("accepts an empty body", () => {
+    expect(validateUpdateTenantAuthPolicyInput({}).valid).toBe(true);
+  });
+
+  test("rejects a non-boolean ssoRequired", () => {
+    const result = validateUpdateTenantAuthPolicyInput({ ssoRequired: "yes" });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a malformed breakGlassIdentityIds entry", () => {
+    const result = validateUpdateTenantAuthPolicyInput({
+      breakGlassIdentityIds: ["not-a-uuid"]
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("de-duplicates breakGlassIdentityIds", () => {
+    const id = "11111111-1111-1111-1111-111111111111";
+    const result = validateUpdateTenantAuthPolicyInput({
+      breakGlassIdentityIds: [id, id]
+    });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.breakGlassIdentityIds).toEqual([id]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Generalizes Issue #590's Google-specific OIDC login into a tenant-configurable generic OIDC SSO provider (Okta, Azure AD, Keycloak, etc.), gated by the existing #587 full-online gate plus a new `AUTH_SSO_ENABLED` flag. Google's own code path (`google-oidc.ts`) is untouched.
- New tenant-scoped tables: `awcms_mini_auth_providers` (provider config, client secret encrypted at rest or env-referenced) and `awcms_mini_tenant_auth_policies` (password_login_enabled/sso_enabled/sso_required/auto_link/allowed domains/break-glass identities). Reuses migration 035's already provider-agnostic `awcms_mini_identity_provider_accounts`/`awcms_mini_oidc_auth_requests` for the new generic flow instead of duplicating them.
- New endpoints: `GET/POST /api/v1/auth/sso/{providerKey}/{start,callback,link,unlink}` (public login/link flow) and admin CRUD `/api/v1/identity/sso/providers`, `/api/v1/identity/sso/policy` (ABAC-protected, in scope per the issue text — full admin UI is #592).
- Break-glass enforcement is server-side at policy-save time (fresh DB read, never trusted from the request body) — a tenant can never persist a policy (`sso_required=true` or `password_login_enabled=false`) that would strand every local login.
- ID tokens verified cryptographically per-provider (RS256 via WebCrypto, issuer/audience/expiry/nonce), same approach as #590. Provider accounts linked by `sub` only, never email. Discovery/JWKS/token-exchange calls are timeout-bounded with per-provider circuit breakers that only trip on genuine transport failure — applying the PR #596/#598 lesson from day one.
- New env vars: `AUTH_SSO_ENABLED`, `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY`, `AUTH_SSO_DISCOVERY_TIMEOUT_MS`, all wired into `config:validate`/`security:readiness`.

## Test plan
- [x] New unit tests: `sso-config`, `sso-credential-crypto`, `tenant-sso-policy`, `login-policy`.
- [x] New integration tests: `tenant-sso-schema` (RLS/constraints on both new tables), `tenant-sso-flow` (full login/link/unlink, break-glass rejection/acceptance, MFA step-up integration, wrong-issuer rejection, tenant-existence-check-before-insert regression per #598/#599).
- [x] `bun run check` (lint, docs, api:spec:check, typecheck, full test suite against real Postgres, build) — 1478 pass, 0 fail, verified independently.
- [x] Changeset added.
- [x] Docs updated: `.env.example`, doc 18, `deployment-profiles.md`, `src/modules/identity-access/README.md`, `awcms-mini-auth-online-hardening` skill.

## Remaining limitations (tracked for follow-up, not blocking)
- No admin UI pages consume this API — explicitly deferred to Issue #592.
- `awcms_mini_tenant_auth_policies.mfa_required` is schema-present but not yet enforced (reserved for future MFA centralization).

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)