### PR TITLE
feat(admin): add full-online auth security policy admin UI

### DIFF
--- a/.changeset/auth-security-admin-ui-full-online.md
+++ b/.changeset/auth-security-admin-ui-full-online.md
@@ -1,0 +1,72 @@
+---
+"awcms-mini": minor
+---
+
+Add admin UI for full-online auth security policy (Issue #592, epic
+#587-#593) — a new `/admin/security` page that surfaces and edits what
+#587-#591 already built, without re-implementing any of their
+enforcement. Consumes the existing admin CRUD API from #591
+(`GET/PATCH /api/v1/identity/sso/policy`,
+`GET/POST/PATCH/DELETE /api/v1/identity/sso/providers[/{id}]`) — no new
+API endpoints were needed for this issue.
+
+The page has two independent, server-side-enforced gates:
+
+1. **Deployment gate** (`isFullOnlineSecurityActive(env)`, #587) — on
+   every local/offline/LAN deployment (the default), the page renders
+   ONLY an informational notice ("Full-online auth hardening is disabled
+   for this deployment profile") and nothing else: no status summary, no
+   policy form, no provider list/forms. This is checked in the page's own
+   SSR frontmatter before any of that markup is even generated, not
+   hidden with CSS.
+2. **ABAC permission** (`identity_access.sso_policy.*`/`sso_providers.*`,
+   migration 037, already seeded by #591) — when the gate is active but
+   the caller holds neither permission, the page renders an
+   access-denied notice instead of crashing or exposing a broken form.
+
+When both are satisfied, the page shows: the shared gate's status plus
+Turnstile/MFA/Google-login/SSO enabled+configured flags (new
+`src/lib/auth/auth-security-status.ts`, a pure env-only aggregator — no
+provider credential value is ever exposed, only `configured: true/false`
+booleans built from each feature's own `*_REQUIRED_WHEN_ENABLED` env var
+list); an editable tenant authentication policy form (password login
+enabled, SSO enabled/required, auto-link-by-verified-email, allowed email
+domains, break-glass local owners); and a tenant SSO provider
+list/create/edit/soft-delete UI. Client secret fields are write-only —
+never pre-filled or round-tripped from the API on edit.
+
+Break-glass UX: the form always shows the break-glass requirement inline
+next to `sso_required`/"disable password login", blocks an
+obviously-doomed submit client-side (no break-glass identity selected at
+all), and surfaces the server's authoritative `409 BREAK_GLASS_REQUIRED`
+rejection through the same translated error-message banner every other
+mutation on the page uses — the eligibility check itself is never
+re-implemented client-side, only the server's own decision (#591's
+`saveTenantAuthPolicy`) is trusted.
+
+`StateNotice.astro` gains a third `kind="info"` variant (`role="status"`,
+distinct from the existing `"denied"`/`"error"` kinds) for this
+deployment-profile-disabled state — a neutral fact, not a permission
+problem or a failure. `identity_access`'s module descriptor now declares
+an admin navigation entry (`/admin/security`, gated on
+`identity_access.sso_policy.read`) so the page appears in the admin
+sidebar via the existing module-navigation registry, no `AdminLayout.astro`
+changes needed.
+
+New tests: `tests/unit/auth-security-status.test.ts` (the status
+aggregator); `tests/integration/admin-security-ui.integration.test.ts`
+(PATCH policy requires `sso_policy.update`, ABAC default-deny; a
+successful policy update and provider create/delete each write their own
+audit event; a break-glass-rejected policy update writes no audit event);
+`tests/e2e/admin-security-disabled.e2e.ts` and
+`tests/e2e/admin-security-enabled.e2e.ts` (Playwright — the two rendering
+states, gate off vs gate on, seeded via a direct-SQL owner/tenant fixture
+since `POST /setup/initialize` is a once-only singleton lock).
+
+i18n: new `admin.layout.nav_security` and `admin.security.*` strings
+(`en`/`id`) — no new error codes were needed, every code this page's
+mutations can return (`BREAK_GLASS_REQUIRED`, `SSO_PROVIDER_KEY_CONFLICT`,
+`SSO_MISCONFIGURED`, etc.) already had catalog entries from #591.
+
+Docs updated: `src/modules/identity-access/README.md`, skill
+`awcms-mini-auth-online-hardening`.

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -36,7 +36,7 @@ keputusan desain yang mengikat semua issue di epic ini sekaligus.
 | #589  | MFA/TOTP login challenge                               | **Selesai** — lihat §MFA/TOTP di bawah                         |
 | #590  | Google OIDC login                                      | **Selesai** — lihat §Google OIDC login di bawah                |
 | #591  | Generic tenant OIDC SSO provider                       | **Selesai** — lihat §Generic tenant OIDC SSO provider di bawah |
-| #592  | Admin UI kebijakan auth security online                | Belum dikerjakan (depends #587 selesai + #591 selesai)         |
+| #592  | Admin UI kebijakan auth security online                | **Selesai** — lihat §Admin policy UI di bawah                  |
 | #593  | Docs/kontrak/readiness penutup epic                    | Belum dikerjakan (finalisasi setelah #588-592)                 |
 
 ## Yang sudah ada — pakai ulang, jangan re-derive
@@ -442,6 +442,96 @@ BREAK_GLASS_REQUIRED` and never persisted. `login.ts` itself only
   `_provider_key_conflict`, plus `break_glass_required`/
   `password_login_disabled` (`error-messages.ts`, `i18n/en.po`+`id.po`).
 
+### Admin policy UI (Issue #592)
+
+`src/pages/admin/security.astro` + `src/lib/auth/auth-security-status.ts`
+(pure env-only status aggregator, no DB/network I/O). Consumes #591's
+existing admin CRUD API as-is — **no new API endpoint was added for this
+issue**, and none was needed:
+
+- SSR reads `getTenantAuthPolicy`/`listAuthProviders` (#591's own
+  application-layer functions) directly inside the page's own
+  `withTenant` transaction, same "call the application layer directly
+  instead of round-tripping through this app's own HTTP API" convention
+  `admin/settings.astro`/`admin/blog/settings.astro` already use.
+  Mutations (policy save, provider create/update/delete) go through the
+  REAL `PATCH /api/v1/identity/sso/policy` /
+  `POST|PATCH|DELETE /api/v1/identity/sso/providers[/{id}]` endpoints via
+  `submitJson` (`admin-form-client.ts`) — every mutation still runs
+  through those endpoints' own ABAC + break-glass + audit logic; this
+  page never writes to the database directly.
+- **Two independent gates control what renders** (issue's own acceptance
+  criteria): (1) the deployment gate `isFullOnlineSecurityActive(env)`
+  (#587) — inactive on every local/offline/LAN deployment (the default),
+  the page renders ONLY an informational `StateNotice` (`kind="info"`,
+  new third variant alongside `"denied"`/`"error"`, `role="status"`) and
+  nothing else, checked server-side in the page's own frontmatter BEFORE
+  any of the status/policy/provider markup is generated — never just
+  hidden with CSS; (2) ABAC (`identity_access.sso_policy.*`/
+  `sso_providers.*`, migration 037, already seeded by #591) — gate active
+  but neither permission held renders an access-denied `StateNotice`
+  instead. Each section (policy form, provider table) additionally checks
+  its OWN specific permission independently, same per-fieldset-permission
+  convention `admin/access-users.astro` established.
+- **Status summary never re-derives each feature's own gate** —
+  `resolveAuthSecurityStatusSummary(env)` imports `isTurnstileEnabled`/
+  `isMfaEnabled`/`isGoogleLoginEnabled`/`isSsoEnabled` plus each feature's
+  own `*_REQUIRED_WHEN_ENABLED` env var name list
+  (`TURNSTILE_REQUIRED_WHEN_ENABLED`, `AUTH_MFA_REQUIRED_WHEN_ENABLED`,
+  `GOOGLE_OIDC_REQUIRED_WHEN_ENABLED`, `SSO_REQUIRED_WHEN_ENABLED`)
+  directly from those features' own config modules rather than
+  re-listing var names here — `configured: boolean` only ever reflects
+  whether the required var(s) are PRESENT, never a value (issue's own
+  security note: "Avoid leaking whether a provider credential exists
+  beyond safe status flags such as `configured: true`").
+- **Break-glass UX does not re-implement the eligibility check** — the
+  form always shows the requirement inline next to `sso_required`/
+  "disable password login", blocks an obviously-doomed submit
+  client-side (zero break-glass identities selected at all) as a fast UX
+  nicety, and always surfaces the server's authoritative
+  `409 BREAK_GLASS_REQUIRED` rejection through the same translated
+  error-message banner (`error.break_glass_required`, already in
+  `error-messages.ts` since #591) every other mutation on the page uses.
+  The break-glass identity picker itself needs `identity_access.user_management.read`
+  (reused from `admin/access-users.astro`'s own guard) to render a
+  checkbox list of tenant users; without it, the page falls back to a
+  plain comma-separated-UUID text input so the form stays usable under
+  least privilege rather than disappearing entirely.
+- **Client secret fields are write-only** — never pre-filled or
+  round-tripped from the API on the provider edit form, matching #591's
+  own `AuthProviderView` never exposing `client_secret_ciphertext`.
+- `identity_access`'s module descriptor (`module.ts`) now declares a
+  `navigation` entry (`/admin/security`, `requiredPermission:
+"identity_access.sso_policy.read"`) — the existing module-navigation
+  registry (#518) renders it in the admin sidebar automatically; no
+  `AdminLayout.astro` hardcoding needed, same pattern
+  `tenant_domain`/`module_management`'s own descriptors already use.
+- Playwright E2E specs (`tests/e2e/admin-security-disabled.e2e.ts`/
+  `admin-security-enabled.e2e.ts`) log in through the REAL `/login` form
+  (fill + submit + wait for the `/admin` redirect), not
+  `page.request.post("/api/v1/auth/login")` — empirically, in this
+  environment, a SUCCESSFUL login's `Set-Cookie` response headers going
+  through Playwright's `page.request` API (as opposed to a real
+  navigation/form submit) intermittently broke every subsequent
+  `page.request`/`page.goto` call with an unrelated-looking `TypeError:
+"<path>" cannot be parsed as a URL.` — reproduces even with a fully
+  qualified absolute URL string, only after a 200 response carrying
+  `Set-Cookie`; a failed login attempt (401/403, no cookie) never
+  reproduces it. Root cause not fully isolated (did not reproduce from
+  `Bun.spawn`, `Bun.SQL`, or `Bun.password.hash` in isolation, only their
+  combination through a specific call path) — logged here so a future
+  issue that needs `page.request` for an authenticated flow in this repo
+  doesn't have to re-discover it from scratch; driving the real login
+  form sidesteps the whole class of that bug and is arguably the more
+  faithful "browser E2E" exercise anyway. Both specs seed an isolated
+  owner/tenant fixture directly via SQL (`tests/e2e/helpers/seed-owner-tenant.ts`,
+  run in a SEPARATE `bun` subprocess via `seed-owner-tenant-cli.ts` —
+  keeping the argon2/Postgres work out of the same process that drives
+  Playwright regardless of the exact trigger above) rather than
+  `POST /api/v1/setup/initialize`, which is a once-only singleton-locked
+  endpoint (`awcms_mini_setup_state`) almost always already claimed on
+  any long-lived dev database.
+
 ## Aturan lintas-issue yang wajib diikuti (#588-#593)
 
 1. **Setiap fitur (#588-#592) WAJIB memanggil `isFullOnlineSecurityActive(env)`
@@ -517,15 +607,18 @@ BREAK_GLASS_REQUIRED` and never persisted. `login.ts` itself only
 
 ## Belum ada — jangan asumsikan sudah dikerjakan
 
-Admin policy UI (#592) plus dokumentasi/kontrak penutup epic (#593)
-masih backlog per 2026-07-09 — gate bersama (#587), Cloudflare Turnstile
-(#588), MFA/TOTP (#589), Google OIDC login (#590), DAN generic tenant
-OIDC SSO provider (#591, termasuk admin CRUD API-nya) sudah ada di repo
-ini. `awcms_mini_auth_providers`/`awcms_mini_tenant_auth_policies`
-(migration 036), endpoint `/api/v1/auth/sso/*`, dan admin CRUD API
-`/api/v1/identity/sso/providers`/`/api/v1/identity/sso/policy` SUDAH
-ada — jangan bangun ulang. Yang BELUM ada: admin UI PAGES untuk
-kebijakan ini (Issue #592 — admin CRUD API dari #591 belum punya
-halaman `/admin/*` yang mengonsumsinya). `/api/v1/auth/providers/google/*`
-SUDAH ada (#590) — jangan bangun ulang, dan #591 sengaja TIDAK
-mengubah/menggantinya (lihat §Generic tenant OIDC SSO provider di atas).
+Hanya dokumentasi/kontrak/readiness penutup epic (#593) yang masih
+backlog per 2026-07-09 — gate bersama (#587), Cloudflare Turnstile
+(#588), MFA/TOTP (#589), Google OIDC login (#590), generic tenant OIDC
+SSO provider (#591, termasuk admin CRUD API-nya), DAN admin policy UI
+(#592, `/admin/security`) sudah ada di repo ini. `awcms_mini_auth_providers`/
+`awcms_mini_tenant_auth_policies` (migration 036), endpoint
+`/api/v1/auth/sso/*`, admin CRUD API `/api/v1/identity/sso/providers`/
+`/api/v1/identity/sso/policy`, DAN halaman admin `/admin/security` yang
+mengonsumsinya SUDAH ada — jangan bangun ulang.
+`/api/v1/auth/providers/google/*` SUDAH ada (#590) — jangan bangun
+ulang, dan #591 sengaja TIDAK mengubah/menggantinya (lihat §Generic
+tenant OIDC SSO provider di atas). Yang BELUM ada: dokumentasi/kontrak
+penutup epic dan production-readiness sign-off lintas #587-#592 (Issue
+#593) — lihat §Admin policy UI di atas untuk apa yang sudah dibangun
+sebagai sumber materi #593.

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -253,6 +253,10 @@ msgstr "Modules"
 msgid "admin.layout.nav_module_matrix"
 msgstr "Module Matrix"
 
+#. Issue #592, epic: full-online auth hardening #587-#593
+msgid "admin.layout.nav_security"
+msgstr "Security"
+
 msgid "admin.layout.breadcrumb_aria_label"
 msgstr "Breadcrumb"
 
@@ -2009,3 +2013,212 @@ msgstr "Status"
 msgid "admin.tenant_domain.invalid_hostname"
 msgstr "Enter a valid hostname (no scheme, no port, e.g. shop.example.com)."
 
+
+#. admin.security (Issue #592, epic: full-online auth hardening #587-#593)
+
+msgid "admin.security.heading"
+msgstr "Full-online auth security"
+
+msgid "admin.security.gate_disabled_title"
+msgstr "Full-online auth hardening is disabled for this deployment profile."
+
+msgid "admin.security.gate_disabled_body"
+msgstr "This deployment runs with local/offline/LAN authentication only. Cloudflare Turnstile, MFA, Google login, and SSO configuration controls are hidden because AUTH_ONLINE_SECURITY_ENABLED/AUTH_ONLINE_SECURITY_PROFILE are not set to full_online on this server. Ask an operator to enable the full-online security profile if this tenant needs these features."
+
+msgid "admin.security.access_denied_title"
+msgstr "You do not have access to security settings."
+
+msgid "admin.security.access_denied_body"
+msgstr "Ask a tenant admin to grant you the authentication policy or SSO provider permission."
+
+msgid "admin.security.status_legend"
+msgstr "Online auth hardening status"
+
+msgid "admin.security.gate_label"
+msgstr "Full-online security gate"
+
+msgid "admin.security.gate_active_value"
+msgstr "Active"
+
+msgid "admin.security.gate_inactive_value"
+msgstr "Inactive"
+
+msgid "admin.security.gate_profile_label"
+msgstr "Deployment profile"
+
+msgid "admin.security.feature_status_enabled"
+msgstr "Enabled"
+
+msgid "admin.security.feature_status_disabled"
+msgstr "Disabled"
+
+msgid "admin.security.feature_configured"
+msgstr "Configured"
+
+msgid "admin.security.feature_not_configured"
+msgstr "Not configured"
+
+msgid "admin.security.turnstile_label"
+msgstr "Cloudflare Turnstile"
+
+msgid "admin.security.mfa_label"
+msgstr "MFA / TOTP"
+
+msgid "admin.security.google_login_label"
+msgstr "Google login"
+
+msgid "admin.security.sso_label"
+msgstr "Generic tenant SSO"
+
+msgid "admin.security.policy_legend"
+msgstr "Tenant authentication policy"
+
+msgid "admin.security.password_login_enabled_label"
+msgstr "Local password login enabled"
+
+msgid "admin.security.sso_enabled_label"
+msgstr "SSO login enabled"
+
+msgid "admin.security.sso_required_label"
+msgstr "SSO login required (disables password login for non-break-glass identities)"
+
+msgid "admin.security.sso_required_hint"
+msgstr "Requires at least one currently-active break-glass local owner selected below, or the server will reject this change."
+
+msgid "admin.security.auto_link_verified_email_label"
+msgstr "Auto-link accounts by verified email domain"
+
+msgid "admin.security.allowed_email_domains_label"
+msgstr "Allowed email domains (comma-separated)"
+
+msgid "admin.security.allowed_email_domains_hint"
+msgstr "Leave blank to allow every domain the provider itself allows. Example: example.com, example.org"
+
+msgid "admin.security.break_glass_legend"
+msgstr "Break-glass local owners"
+
+msgid "admin.security.break_glass_hint"
+msgstr "At least one selected identity here must remain an active local login for this tenant if SSO is required or password login is disabled."
+
+msgid "admin.security.break_glass_manual_label"
+msgstr "Break-glass identity IDs (comma-separated UUIDs)"
+
+msgid "admin.security.break_glass_manual_hint"
+msgstr "You do not have permission to browse the user list, so enter identity UUIDs directly. Ask a user administrator for the correct values."
+
+msgid "admin.security.break_glass_client_warning"
+msgstr "Select at least one break-glass local owner before requiring SSO login or disabling password login."
+
+msgid "admin.security.policy_save_button"
+msgstr "Save authentication policy"
+
+msgid "admin.security.policy_save_success"
+msgstr "Authentication policy saved."
+
+msgid "admin.security.providers_legend"
+msgstr "Tenant SSO providers"
+
+msgid "admin.security.providers_table_key_column"
+msgstr "Provider key"
+
+msgid "admin.security.providers_table_name_column"
+msgstr "Display name"
+
+msgid "admin.security.providers_table_issuer_column"
+msgstr "Issuer URL"
+
+msgid "admin.security.providers_table_secret_column"
+msgstr "Client secret"
+
+msgid "admin.security.providers_table_scopes_column"
+msgstr "Scopes"
+
+msgid "admin.security.providers_table_domains_column"
+msgstr "Allowed domains"
+
+msgid "admin.security.providers_table_status_column"
+msgstr "Status"
+
+msgid "admin.security.providers_table_actions_column"
+msgstr "Actions"
+
+msgid "admin.security.no_providers"
+msgstr "No SSO providers configured yet."
+
+msgid "admin.security.provider_enabled_value"
+msgstr "Enabled"
+
+msgid "admin.security.provider_disabled_value"
+msgstr "Disabled"
+
+msgid "admin.security.secret_source_encrypted_value"
+msgstr "Encrypted (hidden)"
+
+msgid "admin.security.secret_source_env_value"
+msgstr "Env var: {name}"
+
+msgid "admin.security.create_provider_summary"
+msgstr "Add SSO provider"
+
+msgid "admin.security.provider_key_label"
+msgstr "Provider key"
+
+msgid "admin.security.provider_key_hint"
+msgstr "Lowercase letters, numbers, hyphens, underscores only. Cannot be changed later. Example: okta"
+
+msgid "admin.security.display_name_label"
+msgstr "Display name"
+
+msgid "admin.security.issuer_url_label"
+msgstr "Issuer URL (https only)"
+
+msgid "admin.security.client_id_label"
+msgstr "Client ID"
+
+msgid "admin.security.client_secret_label"
+msgstr "Client secret value"
+
+msgid "admin.security.client_secret_hint"
+msgstr "Stored encrypted at rest. Never shown again after saving — leave blank when editing to keep the current secret."
+
+msgid "admin.security.client_secret_env_var_label"
+msgstr "Client secret environment variable name"
+
+msgid "admin.security.client_secret_env_var_hint"
+msgstr "The server reads the secret from this environment variable instead of storing it in the database. Provide exactly one of client secret value or environment variable name."
+
+msgid "admin.security.scopes_label"
+msgstr "OAuth scopes"
+
+msgid "admin.security.enabled_label"
+msgstr "Enabled"
+
+msgid "admin.security.create_provider_submit"
+msgstr "Add provider"
+
+msgid "admin.security.create_provider_success"
+msgstr "SSO provider added."
+
+msgid "admin.security.edit_provider_summary"
+msgstr "Edit"
+
+msgid "admin.security.update_provider_submit"
+msgstr "Save changes"
+
+msgid "admin.security.update_provider_success"
+msgstr "SSO provider updated."
+
+msgid "admin.security.delete_provider_button"
+msgstr "Delete"
+
+msgid "admin.security.delete_provider_prompt"
+msgstr "Reason for deleting this SSO provider:"
+
+msgid "admin.security.delete_provider_success"
+msgstr "SSO provider deleted."
+
+msgid "admin.security.invalid_secret_choice"
+msgstr "Provide at most one of client secret value or environment variable name."
+
+msgid "admin.security.invalid_create_secret_choice"
+msgstr "Provide exactly one of client secret value or environment variable name."

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -253,6 +253,10 @@ msgstr "Modul"
 msgid "admin.layout.nav_module_matrix"
 msgstr "Matriks Modul"
 
+#. Issue #592, epic: full-online auth hardening #587-#593
+msgid "admin.layout.nav_security"
+msgstr "Keamanan"
+
 msgid "admin.layout.breadcrumb_aria_label"
 msgstr "Breadcrumb"
 
@@ -2009,3 +2013,212 @@ msgstr "Status"
 msgid "admin.tenant_domain.invalid_hostname"
 msgstr "Masukkan hostname yang valid (tanpa skema, tanpa port, mis. shop.example.com)."
 
+
+#. admin.security (Issue #592, epic: full-online auth hardening #587-#593)
+
+msgid "admin.security.heading"
+msgstr "Keamanan autentikasi full-online"
+
+msgid "admin.security.gate_disabled_title"
+msgstr "Pengerasan autentikasi full-online dinonaktifkan untuk profil deployment ini."
+
+msgid "admin.security.gate_disabled_body"
+msgstr "Deployment ini berjalan hanya dengan autentikasi lokal/offline/LAN. Kontrol konfigurasi Cloudflare Turnstile, MFA, login Google, dan SSO disembunyikan karena AUTH_ONLINE_SECURITY_ENABLED/AUTH_ONLINE_SECURITY_PROFILE belum diset ke full_online di server ini. Minta operator mengaktifkan profil keamanan full-online jika tenant ini membutuhkan fitur-fitur ini."
+
+msgid "admin.security.access_denied_title"
+msgstr "Anda tidak memiliki akses ke pengaturan keamanan."
+
+msgid "admin.security.access_denied_body"
+msgstr "Minta admin tenant memberikan izin kebijakan autentikasi atau penyedia SSO kepada Anda."
+
+msgid "admin.security.status_legend"
+msgstr "Status pengerasan autentikasi online"
+
+msgid "admin.security.gate_label"
+msgstr "Gerbang keamanan full-online"
+
+msgid "admin.security.gate_active_value"
+msgstr "Aktif"
+
+msgid "admin.security.gate_inactive_value"
+msgstr "Tidak aktif"
+
+msgid "admin.security.gate_profile_label"
+msgstr "Profil deployment"
+
+msgid "admin.security.feature_status_enabled"
+msgstr "Aktif"
+
+msgid "admin.security.feature_status_disabled"
+msgstr "Nonaktif"
+
+msgid "admin.security.feature_configured"
+msgstr "Terkonfigurasi"
+
+msgid "admin.security.feature_not_configured"
+msgstr "Belum terkonfigurasi"
+
+msgid "admin.security.turnstile_label"
+msgstr "Cloudflare Turnstile"
+
+msgid "admin.security.mfa_label"
+msgstr "MFA / TOTP"
+
+msgid "admin.security.google_login_label"
+msgstr "Login Google"
+
+msgid "admin.security.sso_label"
+msgstr "SSO tenant generik"
+
+msgid "admin.security.policy_legend"
+msgstr "Kebijakan autentikasi tenant"
+
+msgid "admin.security.password_login_enabled_label"
+msgstr "Login password lokal diaktifkan"
+
+msgid "admin.security.sso_enabled_label"
+msgstr "Login SSO diaktifkan"
+
+msgid "admin.security.sso_required_label"
+msgstr "Login SSO wajib (menonaktifkan login password untuk identitas non-break-glass)"
+
+msgid "admin.security.sso_required_hint"
+msgstr "Membutuhkan minimal satu pemilik lokal break-glass yang saat ini aktif dipilih di bawah, atau server akan menolak perubahan ini."
+
+msgid "admin.security.auto_link_verified_email_label"
+msgstr "Tautkan otomatis akun berdasarkan domain email terverifikasi"
+
+msgid "admin.security.allowed_email_domains_label"
+msgstr "Domain email yang diizinkan (pisahkan dengan koma)"
+
+msgid "admin.security.allowed_email_domains_hint"
+msgstr "Kosongkan untuk mengizinkan semua domain yang diizinkan provider itu sendiri. Contoh: example.com, example.org"
+
+msgid "admin.security.break_glass_legend"
+msgstr "Pemilik lokal break-glass"
+
+msgid "admin.security.break_glass_hint"
+msgstr "Minimal satu identitas yang dipilih di sini harus tetap bisa login lokal aktif untuk tenant ini jika SSO diwajibkan atau login password dinonaktifkan."
+
+msgid "admin.security.break_glass_manual_label"
+msgstr "ID identitas break-glass (UUID dipisahkan koma)"
+
+msgid "admin.security.break_glass_manual_hint"
+msgstr "Anda tidak memiliki izin untuk menelusuri daftar pengguna, jadi masukkan UUID identitas secara langsung. Minta nilai yang benar dari admin pengguna."
+
+msgid "admin.security.break_glass_client_warning"
+msgstr "Pilih minimal satu pemilik lokal break-glass sebelum mewajibkan login SSO atau menonaktifkan login password."
+
+msgid "admin.security.policy_save_button"
+msgstr "Simpan kebijakan autentikasi"
+
+msgid "admin.security.policy_save_success"
+msgstr "Kebijakan autentikasi disimpan."
+
+msgid "admin.security.providers_legend"
+msgstr "Penyedia SSO tenant"
+
+msgid "admin.security.providers_table_key_column"
+msgstr "Kunci provider"
+
+msgid "admin.security.providers_table_name_column"
+msgstr "Nama tampilan"
+
+msgid "admin.security.providers_table_issuer_column"
+msgstr "URL issuer"
+
+msgid "admin.security.providers_table_secret_column"
+msgstr "Client secret"
+
+msgid "admin.security.providers_table_scopes_column"
+msgstr "Scopes"
+
+msgid "admin.security.providers_table_domains_column"
+msgstr "Domain yang diizinkan"
+
+msgid "admin.security.providers_table_status_column"
+msgstr "Status"
+
+msgid "admin.security.providers_table_actions_column"
+msgstr "Aksi"
+
+msgid "admin.security.no_providers"
+msgstr "Belum ada penyedia SSO yang dikonfigurasi."
+
+msgid "admin.security.provider_enabled_value"
+msgstr "Aktif"
+
+msgid "admin.security.provider_disabled_value"
+msgstr "Nonaktif"
+
+msgid "admin.security.secret_source_encrypted_value"
+msgstr "Terenkripsi (disembunyikan)"
+
+msgid "admin.security.secret_source_env_value"
+msgstr "Env var: {name}"
+
+msgid "admin.security.create_provider_summary"
+msgstr "Tambah penyedia SSO"
+
+msgid "admin.security.provider_key_label"
+msgstr "Kunci provider"
+
+msgid "admin.security.provider_key_hint"
+msgstr "Hanya huruf kecil, angka, tanda hubung, garis bawah. Tidak dapat diubah setelah dibuat. Contoh: okta"
+
+msgid "admin.security.display_name_label"
+msgstr "Nama tampilan"
+
+msgid "admin.security.issuer_url_label"
+msgstr "URL issuer (hanya https)"
+
+msgid "admin.security.client_id_label"
+msgstr "Client ID"
+
+msgid "admin.security.client_secret_label"
+msgstr "Nilai client secret"
+
+msgid "admin.security.client_secret_hint"
+msgstr "Disimpan terenkripsi. Tidak pernah ditampilkan lagi setelah disimpan — kosongkan saat mengedit untuk mempertahankan secret saat ini."
+
+msgid "admin.security.client_secret_env_var_label"
+msgstr "Nama environment variable client secret"
+
+msgid "admin.security.client_secret_env_var_hint"
+msgstr "Server membaca secret dari environment variable ini alih-alih menyimpannya di database. Isi tepat salah satu: nilai client secret atau nama environment variable."
+
+msgid "admin.security.scopes_label"
+msgstr "OAuth scopes"
+
+msgid "admin.security.enabled_label"
+msgstr "Aktif"
+
+msgid "admin.security.create_provider_submit"
+msgstr "Tambah provider"
+
+msgid "admin.security.create_provider_success"
+msgstr "Penyedia SSO ditambahkan."
+
+msgid "admin.security.edit_provider_summary"
+msgstr "Edit"
+
+msgid "admin.security.update_provider_submit"
+msgstr "Simpan perubahan"
+
+msgid "admin.security.update_provider_success"
+msgstr "Penyedia SSO diperbarui."
+
+msgid "admin.security.delete_provider_button"
+msgstr "Hapus"
+
+msgid "admin.security.delete_provider_prompt"
+msgstr "Alasan menghapus penyedia SSO ini:"
+
+msgid "admin.security.delete_provider_success"
+msgstr "Penyedia SSO dihapus."
+
+msgid "admin.security.invalid_secret_choice"
+msgstr "Isi paling banyak salah satu: nilai client secret atau nama environment variable."
+
+msgid "admin.security.invalid_create_secret_choice"
+msgstr "Isi tepat salah satu: nilai client secret atau nama environment variable."

--- a/src/components/ui/StateNotice.astro
+++ b/src/components/ui/StateNotice.astro
@@ -18,9 +18,19 @@
  * distinguishes the two cases (permission vs. transient failure) so the
  * copy and follow-up action make sense for each — "contact your admin" for
  * denied, "try again" for error.
+ *
+ * `kind="info"` (Issue #592, `/admin/security`) covers a THIRD, distinct
+ * case none of the above fit: a feature that is simply not active for this
+ * deployment profile ("Full-online auth hardening is disabled for this
+ * deployment profile") — not a permission problem, not a failure, just a
+ * neutral fact the admin should know before the page renders (or omits)
+ * further controls. `role="status"` (not `"alert"`) for this kind
+ * specifically: an informational banner on normal page load is not the
+ * urgent, must-interrupt announcement `role="alert"` implies for the
+ * denied/error branches.
  */
 interface Props {
-  kind: "denied" | "error";
+  kind: "denied" | "error" | "info";
   title: string;
   body: string;
   retryLabel?: string;
@@ -28,12 +38,21 @@ interface Props {
 }
 
 const { kind, title, body, retryLabel, retryHref } = Astro.props;
+const ICONS: Record<Props["kind"], string> = {
+  denied: "⛔",
+  error: "⚠️",
+  info: "ℹ️"
+};
 ---
 
-<div class="state-notice" data-kind={kind} role="alert">
+<div
+  class="state-notice"
+  data-kind={kind}
+  role={kind === "info" ? "status" : "alert"}
+>
   <p class="state-notice-heading">
     <span class="state-notice-icon" aria-hidden="true">
-      {kind === "denied" ? "⛔" : "⚠️"}
+      {ICONS[kind]}
     </span>
     <strong>{title}</strong>
   </p>
@@ -57,6 +76,10 @@ const { kind, title, body, retryLabel, retryHref } = Astro.props;
 
   .state-notice[data-kind="error"] {
     border-color: var(--color-warning);
+  }
+
+  .state-notice[data-kind="info"] {
+    border-color: var(--color-info);
   }
 
   .state-notice-heading {

--- a/src/lib/auth/auth-security-status.ts
+++ b/src/lib/auth/auth-security-status.ts
@@ -1,0 +1,94 @@
+/**
+ * Full-online auth security status summary (Issue #592, epic: full-online
+ * auth hardening #587-#593) — a single pure, env-derived read that the
+ * `/admin/security` SSR page (Issue #592) uses to render the epic's five
+ * gates (#587 shared gate, #588 Turnstile, #589 MFA, #590 Google login,
+ * #591 generic SSO) at a glance.
+ *
+ * No DB/network I/O here — mirrors every other feature's own `*-config.ts`
+ * gate module in this epic (`online-security-config.ts`, `mfa-config.ts`,
+ * `google-oidc-config.ts`, `sso-config.ts`, `../security/turnstile.ts`),
+ * just recombined into one summary. This deliberately avoids adding a new
+ * API endpoint purely to expose deployment-wide status booleans that are
+ * not tenant-scoped data — the admin page calls this directly from its own
+ * frontmatter, same convention `admin/settings.astro` uses to call
+ * `fetchTenantSettings` directly instead of round-tripping through its own
+ * HTTP API.
+ *
+ * `configured` never exposes a credential's VALUE, only whether the
+ * env var(s) a feature needs are present (issue's own security note:
+ * "Avoid leaking whether a provider credential exists beyond safe status
+ * flags such as `configured: true`") — every list of required var NAMES is
+ * imported from the feature's own config module (`TURNSTILE_REQUIRED_WHEN_ENABLED`,
+ * `AUTH_MFA_REQUIRED_WHEN_ENABLED`, `GOOGLE_OIDC_REQUIRED_WHEN_ENABLED`,
+ * `SSO_REQUIRED_WHEN_ENABLED`) rather than re-listing var names here, so
+ * this file can never drift from `scripts/validate-env.ts`'s own
+ * requirements.
+ */
+import {
+  isFullOnlineSecurityActive,
+  isOnlineSecurityEnabled,
+  resolveOnlineSecurityProfile,
+  type OnlineSecurityProfile
+} from "./online-security-config";
+import {
+  isTurnstileEnabled,
+  TURNSTILE_REQUIRED_WHEN_ENABLED
+} from "../security/turnstile";
+import { isMfaEnabled, AUTH_MFA_REQUIRED_WHEN_ENABLED } from "./mfa-config";
+import {
+  isGoogleLoginEnabled,
+  GOOGLE_OIDC_REQUIRED_WHEN_ENABLED
+} from "./google-oidc-config";
+import { isSsoEnabled, SSO_REQUIRED_WHEN_ENABLED } from "./sso-config";
+
+function allEnvVarsPresent(
+  names: readonly string[],
+  env: NodeJS.ProcessEnv
+): boolean {
+  return names.every((name) => Boolean(env[name]?.trim()));
+}
+
+export type AuthSecurityFeatureStatus = {
+  /** This feature's own flag (e.g. `TURNSTILE_ENABLED`) is `"true"`. Does NOT by itself mean the feature is actually active — see `AuthSecurityStatusSummary.gateActive`, which every feature also requires. */
+  enabled: boolean;
+  /** Every env var this feature requires when enabled is present (non-empty) — never reflects the var's actual value. */
+  configured: boolean;
+};
+
+export type AuthSecurityStatusSummary = {
+  gateEnabled: boolean;
+  gateProfile: OnlineSecurityProfile;
+  /** The single boolean every feature below is gated by in addition to its own `enabled` flag — `isFullOnlineSecurityActive(env)`, Issue #587. */
+  gateActive: boolean;
+  turnstile: AuthSecurityFeatureStatus;
+  mfa: AuthSecurityFeatureStatus;
+  googleLogin: AuthSecurityFeatureStatus;
+  sso: AuthSecurityFeatureStatus;
+};
+
+export function resolveAuthSecurityStatusSummary(
+  env: NodeJS.ProcessEnv = process.env
+): AuthSecurityStatusSummary {
+  return {
+    gateEnabled: isOnlineSecurityEnabled(env),
+    gateProfile: resolveOnlineSecurityProfile(env),
+    gateActive: isFullOnlineSecurityActive(env),
+    turnstile: {
+      enabled: isTurnstileEnabled(env),
+      configured: allEnvVarsPresent(TURNSTILE_REQUIRED_WHEN_ENABLED, env)
+    },
+    mfa: {
+      enabled: isMfaEnabled(env),
+      configured: allEnvVarsPresent(AUTH_MFA_REQUIRED_WHEN_ENABLED, env)
+    },
+    googleLogin: {
+      enabled: isGoogleLoginEnabled(env),
+      configured: allEnvVarsPresent(GOOGLE_OIDC_REQUIRED_WHEN_ENABLED, env)
+    },
+    sso: {
+      enabled: isSsoEnabled(env),
+      configured: allEnvVarsPresent(SSO_REQUIRED_WHEN_ENABLED, env)
+    }
+  };
+}

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -150,18 +150,18 @@ Astro secara default menolak (403, tanpa body) permintaan `POST`/`PUT`/`PATCH`/`
 
 CRUD ABAC policy row (`awcms_mini_abac_policies` — schema tersedia, evaluator masih pakai aturan generik bawaan, belum ada endpoint kelola policy), dan publikasi event `identity.login.succeeded`/`identity.login.failed` (doc 05, menyusul modul Observability/Logging) belum ada pada tahap ini. `/access/decision-logs` tetap `LIMIT 50` per halaman tapi kini punya keyset pagination opsional (Issue #435, `?cursor=`/`nextCursor` — lihat `src/modules/_shared/keyset-pagination.ts`).
 
-Admin policy UI (Issue #592, minimal UI verifikasi terpisah dari admin
-CRUD API yang sudah ada — lihat §Generic tenant OIDC SSO provider di
-bawah) masih backlog untuk epic full-online auth security hardening
-(#587-#593). #587 (gate bersama, lihat §Full-online-only auth security
-feature gate di bawah), #588 (Cloudflare Turnstile,
-`src/lib/security/turnstile.ts` — bukan bagian modul ini, tapi
-dipanggil dari `POST /auth/login` di modul ini via
-`enforceTurnstileIfRequired`), #589 (MFA/TOTP, lihat §MFA/TOTP login
-challenge di bawah), #590 (Google OIDC login, lihat §Google OIDC login
-di bawah), dan #591 (generic tenant OIDC SSO provider, lihat §Generic
-tenant OIDC SSO provider di bawah) sudah selesai. Lihat skill
-`awcms-mini-auth-online-hardening` untuk detail lintas-issue.
+Untuk epic full-online auth security hardening (#587-#593): #587 (gate
+bersama, lihat §Full-online-only auth security feature gate di bawah),
+#588 (Cloudflare Turnstile, `src/lib/security/turnstile.ts` — bukan
+bagian modul ini, tapi dipanggil dari `POST /auth/login` di modul ini
+via `enforceTurnstileIfRequired`), #589 (MFA/TOTP, lihat §MFA/TOTP
+login challenge di bawah), #590 (Google OIDC login, lihat §Google OIDC
+login di bawah), #591 (generic tenant OIDC SSO provider, lihat
+§Generic tenant OIDC SSO provider di bawah), DAN #592 (admin policy UI
+`/admin/security`, lihat §Admin policy UI di bawah) sudah selesai.
+Hanya #593 (dokumentasi/kontrak/readiness penutup epic) yang masih
+backlog. Lihat skill `awcms-mini-auth-online-hardening` untuk detail
+lintas-issue.
 
 ## MFA/TOTP login challenge (Issue #589)
 
@@ -378,3 +378,38 @@ acceptance criteria issue ini). Detail env var lengkap:
 `docs/awcms-mini/18_configuration_env_reference.md` §Full-online auth
 security hardening, `docs/awcms-mini/deployment-profiles.md` §Full-online
 auth security hardening.
+
+## Admin policy UI (Issue #592)
+
+`src/pages/admin/security.astro` (bukan bagian `src/modules/`, tapi
+satu-satunya UI yang mengonsumsi admin CRUD API modul ini dari #591) +
+`src/lib/auth/auth-security-status.ts` (aggregator status env-only,
+tanpa I/O — bukan bagian modul ini juga, tapi dipakai halaman ini).
+
+- **Tidak ada endpoint API baru** — halaman ini murni UI di atas API
+  #591 yang sudah ada (`GET/PATCH /api/v1/identity/sso/policy`,
+  `GET/POST/PATCH/DELETE /api/v1/identity/sso/providers[/{id}]`). SSR
+  membaca `getTenantAuthPolicy`/`listAuthProviders` langsung di dalam
+  `withTenant` milik halaman (pola sama `admin/settings.astro`), mutation
+  lewat endpoint sungguhan via `submitJson` (`admin-form-client.ts`) —
+  ABAC + break-glass + audit tetap sepenuhnya ditegakkan server-side oleh
+  endpoint #591, halaman ini tidak pernah menulis DB langsung.
+- **Dua gate independen**: gate deployment (`isFullOnlineSecurityActive(env)`,
+  #587 — nonaktif berarti HANYA notice informational yang dirender,
+  dicek server-side di frontmatter SEBELUM markup lain dibuat) dan ABAC
+  (`identity_access.sso_policy.*`/`sso_providers.*`, migration 037 —
+  gate aktif tapi tanpa permission berarti notice access-denied).
+- `StateNotice.astro` (`src/components/ui`) dapat varian ketiga
+  `kind="info"` (`role="status"`) untuk state "fitur nonaktif untuk
+  profil deployment ini" — beda semantik dari `"denied"`/`"error"`.
+- `identityAccessModule`'s `navigation` (Issue #518's registry) kini
+  mendaftarkan `/admin/security` (`requiredPermission:
+"identity_access.sso_policy.read"`) — muncul di sidebar admin otomatis,
+  tidak menyentuh `AdminLayout.astro`.
+- Break-glass picker checkbox butuh `identity_access.user_management.read`
+  (dipakai ulang dari guard `admin/access-users.astro`) untuk daftar
+  tenant user; tanpa izin itu, form jatuh ke textarea UUID manual supaya
+  tetap bisa dipakai di bawah least privilege, bukan hilang total.
+- Detail lengkap + rasional lintas-issue (termasuk kuirk
+  Playwright+Bun `page.request` yang ditemukan saat menulis E2E spec-nya):
+  skill `awcms-mini-auth-online-hardening` §Admin policy UI.

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -11,5 +11,22 @@ export const identityAccessModule = defineModule({
   api: {
     openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
     basePath: "/api/v1"
-  }
+  },
+  // Issue #592 (epic: full-online auth hardening #587-#593) — admin UI for
+  // the #591 tenant auth policy/SSO provider admin CRUD API. Gated on
+  // `sso_policy.read` (migration 037): a caller who can read the policy but
+  // not the provider list still sees a meaningful (partial) page, same
+  // navigation-visibility-is-not-authorization convention every other
+  // module-declared nav entry follows (`domain/navigation-registry.ts`'s own
+  // docblock) — the page itself re-checks both `sso_policy.*` and
+  // `sso_providers.*` permissions independently before rendering each
+  // section.
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_security",
+      path: "/admin/security",
+      order: 55,
+      requiredPermission: "identity_access.sso_policy.read"
+    }
+  ]
 });

--- a/src/pages/admin/security.astro
+++ b/src/pages/admin/security.astro
@@ -1,0 +1,1048 @@
+---
+/**
+ * Full-online auth security admin UI (Issue #592, epic: full-online auth
+ * hardening #587-#593). Surfaces and edits what #587-#591 already built —
+ * this page adds no new enforcement of its own (issue's own security note:
+ * "Avoid making the UI the only enforcement point; server-side checks
+ * remain mandatory"), it only renders the #587 gate's status and, when that
+ * gate is active, the #591 tenant auth policy + SSO provider admin CRUD
+ * API's data through the existing admin-form-client.ts mutation pattern.
+ *
+ * Two independent gates control what renders, per the issue's own
+ * acceptance criteria:
+ *
+ * 1. **Deployment gate** (`isFullOnlineSecurityActive`, #587) — when
+ *    inactive (every local/offline/LAN deployment, the default), the page
+ *    renders ONLY an informational `StateNotice` (`kind="info"`) and
+ *    nothing else: no Turnstile/MFA/Google/SSO status, no forms. This is
+ *    checked here, server-side, in the page's own frontmatter — never just
+ *    hidden with CSS (issue's own guardrail: "No Cloudflare/Google/OIDC
+ *    call is triggered merely by rendering admin UI on local/offline/LAN").
+ * 2. **ABAC permission** (`identity_access.sso_policy.*`/`sso_providers.*`,
+ *    migration 037) — when the gate is active but the caller holds neither
+ *    permission, the page renders an access-denied `StateNotice`. Each
+ *    section below additionally checks its OWN specific permission
+ *    (`CAN_READ_POLICY`/`CAN_READ_PROVIDERS`) independently, same
+ *    "each fieldset gated on its own permission" convention
+ *    `admin/access-users.astro` already established.
+ *
+ * SSR reads the #591 application-layer functions directly inside this
+ * page's own `withTenant` transaction (`getTenantAuthPolicy`,
+ * `listAuthProviders`) rather than round-tripping through this app's own
+ * HTTP API — same convention `admin/settings.astro`/`admin/blog/settings.astro`
+ * already use. Mutations go through the real
+ * `PATCH /api/v1/identity/sso/policy` /
+ * `POST|PATCH|DELETE /api/v1/identity/sso/providers[/{id}]` endpoints via
+ * `submitJson` (`admin-form-client.ts`), so every mutation still runs
+ * through the endpoints' own ABAC + break-glass + audit logic — this page
+ * never writes to the database directly.
+ *
+ * Break-glass UX (issue's own acceptance criterion: "UI prevents enabling
+ * `sso_required` unless a valid break-glass local owner/account exists"):
+ * this page does NOT re-implement the eligibility check the server already
+ * owns (`saveTenantAuthPolicy`'s fresh DB read) — that would be a second,
+ * potentially-divergent source of truth. Instead it (a) always shows the
+ * break-glass requirement inline next to the risky toggles, (b) blocks an
+ * obviously-doomed submit client-side (no break-glass identity selected at
+ * all while requesting `sso_required`/disabling password login) as a fast
+ * UX nicety, and (c) always surfaces the server's authoritative
+ * `409 BREAK_GLASS_REQUIRED` rejection through the same translated
+ * error-message banner every other mutation on this page uses
+ * (`error.break_glass_required`, already in `error-messages.ts` since
+ * Issue #591 — see that file's own comment).
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import StateNotice from "../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { resolveAuthSecurityStatusSummary } from "../../lib/auth/auth-security-status";
+import {
+  getTenantAuthPolicy,
+  type TenantAuthPolicyView
+} from "../../modules/identity-access/application/tenant-auth-policy";
+import {
+  listAuthProviders,
+  type AuthProviderView
+} from "../../modules/identity-access/application/auth-provider-directory";
+import { fetchTenantUsersWithRoles } from "../../modules/identity-access/application/user-directory";
+import { createTranslator } from "../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/security.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const clientStrings = {
+  policySaveSuccess: t("admin.security.policy_save_success"),
+  createProviderSuccess: t("admin.security.create_provider_success"),
+  updateProviderSuccess: t("admin.security.update_provider_success"),
+  deleteProviderSuccess: t("admin.security.delete_provider_success"),
+  deleteProviderPrompt: t("admin.security.delete_provider_prompt"),
+  breakGlassClientWarning: t("admin.security.break_glass_client_warning"),
+  invalidSecretChoice: t("admin.security.invalid_secret_choice"),
+  invalidCreateSecretChoice: t("admin.security.invalid_create_secret_choice"),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+// Gate 1 (#587) — checked server-side before anything else. Inactive on
+// every local/offline/LAN deployment (the default): nothing below this
+// branch ever runs, no DB read beyond this summary (env-only, no I/O).
+const statusSummary = resolveAuthSecurityStatusSummary();
+
+const CAN_READ_POLICY = context.permissions.has(
+  permissionKey("identity_access", "sso_policy", "read")
+);
+const CAN_UPDATE_POLICY = context.permissions.has(
+  permissionKey("identity_access", "sso_policy", "update")
+);
+const CAN_READ_PROVIDERS = context.permissions.has(
+  permissionKey("identity_access", "sso_providers", "read")
+);
+const CAN_CREATE_PROVIDERS = context.permissions.has(
+  permissionKey("identity_access", "sso_providers", "create")
+);
+const CAN_UPDATE_PROVIDERS = context.permissions.has(
+  permissionKey("identity_access", "sso_providers", "update")
+);
+const CAN_DELETE_PROVIDERS = context.permissions.has(
+  permissionKey("identity_access", "sso_providers", "delete")
+);
+const CAN_READ_USERS = context.permissions.has(
+  permissionKey("identity_access", "user_management", "read")
+);
+
+const CAN_READ_ANYTHING = CAN_READ_POLICY || CAN_READ_PROVIDERS;
+
+let policy: TenantAuthPolicyView | null = null;
+let providers: AuthProviderView[] = [];
+let breakGlassCandidates: Awaited<
+  ReturnType<typeof fetchTenantUsersWithRoles>
+> = [];
+let loadError = false;
+
+if (statusSummary.gateActive && CAN_READ_ANYTHING) {
+  try {
+    await withTenant(getDatabaseClient(), context.tenantId, async (tx) => {
+      if (CAN_READ_POLICY) {
+        policy = await getTenantAuthPolicy(tx, context.tenantId);
+      }
+      if (CAN_READ_PROVIDERS) {
+        providers = await listAuthProviders(tx, context.tenantId);
+      }
+      if (CAN_READ_POLICY && CAN_READ_USERS) {
+        breakGlassCandidates = await fetchTenantUsersWithRoles(
+          tx,
+          context.tenantId
+        );
+      }
+    });
+  } catch (error) {
+    console.error("admin/security.astro: failed to load security data", error);
+    loadError = true;
+  }
+}
+
+function featureStatusLabel(enabled: boolean): string {
+  return enabled
+    ? t("admin.security.feature_status_enabled")
+    : t("admin.security.feature_status_disabled");
+}
+
+function configuredLabel(configured: boolean): string {
+  return configured
+    ? t("admin.security.feature_configured")
+    : t("admin.security.feature_not_configured");
+}
+---
+
+<AdminLayout title={t("admin.layout.nav_security")}>
+  <h1>{t("admin.security.heading")}</h1>
+
+  {
+    !statusSummary.gateActive && (
+      <StateNotice
+        kind="info"
+        title={t("admin.security.gate_disabled_title")}
+        body={t("admin.security.gate_disabled_body")}
+      />
+    )
+  }
+
+  {
+    statusSummary.gateActive && !CAN_READ_ANYTHING && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.security.access_denied_title")}
+        body={t("admin.security.access_denied_body")}
+      />
+    )
+  }
+
+  {
+    statusSummary.gateActive && CAN_READ_ANYTHING && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+
+  {
+    statusSummary.gateActive && CAN_READ_ANYTHING && !loadError && (
+      <div class="security-admin">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        <section class="sec-section" aria-labelledby="status-legend">
+          <h2 id="status-legend">{t("admin.security.status_legend")}</h2>
+          <dl class="status-grid">
+            <dt>{t("admin.security.gate_label")}</dt>
+            <dd>
+              <span
+                class="status-pill"
+                data-status={statusSummary.gateActive ? "active" : "inactive"}
+              >
+                {statusSummary.gateActive
+                  ? t("admin.security.gate_active_value")
+                  : t("admin.security.gate_inactive_value")}
+              </span>
+            </dd>
+
+            <dt>{t("admin.security.gate_profile_label")}</dt>
+            <dd>
+              <code>{statusSummary.gateProfile}</code>
+            </dd>
+
+            <dt>{t("admin.security.turnstile_label")}</dt>
+            <dd>
+              {featureStatusLabel(statusSummary.turnstile.enabled)} ·{" "}
+              {configuredLabel(statusSummary.turnstile.configured)}
+            </dd>
+
+            <dt>{t("admin.security.mfa_label")}</dt>
+            <dd>
+              {featureStatusLabel(statusSummary.mfa.enabled)} ·{" "}
+              {configuredLabel(statusSummary.mfa.configured)}
+            </dd>
+
+            <dt>{t("admin.security.google_login_label")}</dt>
+            <dd>
+              {featureStatusLabel(statusSummary.googleLogin.enabled)} ·{" "}
+              {configuredLabel(statusSummary.googleLogin.configured)}
+            </dd>
+
+            <dt>{t("admin.security.sso_label")}</dt>
+            <dd>
+              {featureStatusLabel(statusSummary.sso.enabled)} ·{" "}
+              {configuredLabel(statusSummary.sso.configured)}
+            </dd>
+          </dl>
+        </section>
+
+        {policy && CAN_READ_POLICY && (
+          <section class="sec-section" aria-labelledby="policy-legend">
+            <h2 id="policy-legend">{t("admin.security.policy_legend")}</h2>
+            <form id="policy-form" class="sec-form">
+              <fieldset disabled={!CAN_UPDATE_POLICY}>
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    name="passwordLoginEnabled"
+                    checked={policy.passwordLoginEnabled}
+                  />
+                  {t("admin.security.password_login_enabled_label")}
+                </label>
+
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    name="ssoEnabled"
+                    checked={policy.ssoEnabled}
+                  />
+                  {t("admin.security.sso_enabled_label")}
+                </label>
+
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    name="ssoRequired"
+                    checked={policy.ssoRequired}
+                  />
+                  {t("admin.security.sso_required_label")}
+                </label>
+                <p class="field-hint field-hint-warning">
+                  {t("admin.security.sso_required_hint")}
+                </p>
+
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    name="autoLinkVerifiedEmail"
+                    checked={policy.autoLinkVerifiedEmail}
+                  />
+                  {t("admin.security.auto_link_verified_email_label")}
+                </label>
+
+                <label>
+                  {t("admin.security.allowed_email_domains_label")}
+                  <input
+                    type="text"
+                    name="allowedEmailDomains"
+                    value={policy.allowedEmailDomains.join(", ")}
+                  />
+                </label>
+                <p class="field-hint">
+                  {t("admin.security.allowed_email_domains_hint")}
+                </p>
+
+                <fieldset class="break-glass-fieldset">
+                  <legend>{t("admin.security.break_glass_legend")}</legend>
+                  <p class="field-hint">
+                    {t("admin.security.break_glass_hint")}
+                  </p>
+                  {CAN_READ_USERS ? (
+                    <div class="role-checkbox-group">
+                      {breakGlassCandidates.map((user) => (
+                        <label class="checkbox-label">
+                          <input
+                            type="checkbox"
+                            name="breakGlassIdentityIds"
+                            value={user.identityId}
+                            checked={policy.breakGlassIdentityIds.includes(
+                              user.identityId
+                            )}
+                          />
+                          {user.displayName} ({user.loginIdentifier})
+                        </label>
+                      ))}
+                    </div>
+                  ) : (
+                    <label>
+                      {t("admin.security.break_glass_manual_label")}
+                      <input
+                        type="text"
+                        name="breakGlassIdentityIdsManual"
+                        value={policy.breakGlassIdentityIds.join(", ")}
+                      />
+                      <p class="field-hint">
+                        {t("admin.security.break_glass_manual_hint")}
+                      </p>
+                    </label>
+                  )}
+                </fieldset>
+
+                {CAN_UPDATE_POLICY && (
+                  <button type="submit" id="policy-save-button">
+                    {t("admin.security.policy_save_button")}
+                  </button>
+                )}
+              </fieldset>
+            </form>
+          </section>
+        )}
+
+        {CAN_READ_PROVIDERS && (
+          <section class="sec-section" aria-labelledby="providers-legend">
+            <h2 id="providers-legend">
+              {t("admin.security.providers_legend")}
+            </h2>
+
+            <div class="table-scroll">
+              <table class="sec-table">
+                <thead>
+                  <tr>
+                    <th>{t("admin.security.providers_table_key_column")}</th>
+                    <th>{t("admin.security.providers_table_name_column")}</th>
+                    <th>{t("admin.security.providers_table_issuer_column")}</th>
+                    <th>{t("admin.security.providers_table_secret_column")}</th>
+                    <th>{t("admin.security.providers_table_scopes_column")}</th>
+                    <th>
+                      {t("admin.security.providers_table_domains_column")}
+                    </th>
+                    <th>{t("admin.security.providers_table_status_column")}</th>
+                    {(CAN_UPDATE_PROVIDERS || CAN_DELETE_PROVIDERS) && (
+                      <th>
+                        {t("admin.security.providers_table_actions_column")}
+                      </th>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {providers.length === 0 && (
+                    <tr>
+                      <td
+                        colspan={
+                          CAN_UPDATE_PROVIDERS || CAN_DELETE_PROVIDERS ? 8 : 7
+                        }
+                      >
+                        {t("admin.security.no_providers")}
+                      </td>
+                    </tr>
+                  )}
+                  {providers.map((provider) => (
+                    <tr data-provider-row={provider.id}>
+                      <td>
+                        <code>{provider.providerKey}</code>
+                      </td>
+                      <td>{provider.displayName}</td>
+                      <td>{provider.issuerUrl}</td>
+                      <td>
+                        {provider.secretSource === "encrypted"
+                          ? t("admin.security.secret_source_encrypted_value")
+                          : t("admin.security.secret_source_env_value", {
+                              name: provider.clientSecretEnvVar ?? ""
+                            })}
+                      </td>
+                      <td>{provider.scopes}</td>
+                      <td>{provider.allowedEmailDomains.join(", ")}</td>
+                      <td>
+                        <span
+                          class="status-pill"
+                          data-status={provider.enabled ? "active" : "inactive"}
+                        >
+                          {provider.enabled
+                            ? t("admin.security.provider_enabled_value")
+                            : t("admin.security.provider_disabled_value")}
+                        </span>
+                      </td>
+                      {(CAN_UPDATE_PROVIDERS || CAN_DELETE_PROVIDERS) && (
+                        <td class="sec-actions-cell">
+                          {CAN_UPDATE_PROVIDERS && (
+                            <details>
+                              <summary>
+                                {t("admin.security.edit_provider_summary")}
+                              </summary>
+                              <form
+                                class="edit-provider-form sec-form"
+                                data-provider-id={provider.id}
+                              >
+                                <label>
+                                  {t("admin.security.display_name_label")}
+                                  <input
+                                    type="text"
+                                    name="displayName"
+                                    value={provider.displayName}
+                                    required
+                                  />
+                                </label>
+                                <label>
+                                  {t("admin.security.issuer_url_label")}
+                                  <input
+                                    type="url"
+                                    name="issuerUrl"
+                                    value={provider.issuerUrl}
+                                    required
+                                  />
+                                </label>
+                                <label>
+                                  {t("admin.security.client_id_label")}
+                                  <input
+                                    type="text"
+                                    name="clientId"
+                                    value={provider.clientId}
+                                    required
+                                  />
+                                </label>
+                                <label>
+                                  {t("admin.security.client_secret_label")}
+                                  <input
+                                    type="password"
+                                    name="clientSecret"
+                                    autocomplete="new-password"
+                                  />
+                                </label>
+                                <label>
+                                  {t(
+                                    "admin.security.client_secret_env_var_label"
+                                  )}
+                                  <input
+                                    type="text"
+                                    name="clientSecretEnvVar"
+                                  />
+                                </label>
+                                <p class="field-hint">
+                                  {t("admin.security.client_secret_hint")}
+                                </p>
+                                <label>
+                                  {t("admin.security.scopes_label")}
+                                  <input
+                                    type="text"
+                                    name="scopes"
+                                    value={provider.scopes}
+                                    required
+                                  />
+                                </label>
+                                <label>
+                                  {t(
+                                    "admin.security.allowed_email_domains_label"
+                                  )}
+                                  <input
+                                    type="text"
+                                    name="allowedEmailDomains"
+                                    value={provider.allowedEmailDomains.join(
+                                      ", "
+                                    )}
+                                  />
+                                </label>
+                                <label class="checkbox-label">
+                                  <input
+                                    type="checkbox"
+                                    name="enabled"
+                                    checked={provider.enabled}
+                                  />
+                                  {t("admin.security.enabled_label")}
+                                </label>
+                                <button type="submit">
+                                  {t("admin.security.update_provider_submit")}
+                                </button>
+                              </form>
+                            </details>
+                          )}
+                          {CAN_DELETE_PROVIDERS && (
+                            <button
+                              type="button"
+                              class="delete-provider-button"
+                              data-delete-provider={provider.id}
+                            >
+                              {t("admin.security.delete_provider_button")}
+                            </button>
+                          )}
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {CAN_CREATE_PROVIDERS && (
+              <details class="sec-create">
+                <summary>{t("admin.security.create_provider_summary")}</summary>
+                <form id="create-provider-form" class="sec-form">
+                  <label>
+                    {t("admin.security.provider_key_label")}
+                    <input
+                      type="text"
+                      name="providerKey"
+                      pattern="^[a-z0-9][a-z0-9_-]*$"
+                      required
+                    />
+                  </label>
+                  <p class="field-hint">
+                    {t("admin.security.provider_key_hint")}
+                  </p>
+                  <label>
+                    {t("admin.security.display_name_label")}
+                    <input type="text" name="displayName" required />
+                  </label>
+                  <label>
+                    {t("admin.security.issuer_url_label")}
+                    <input type="url" name="issuerUrl" required />
+                  </label>
+                  <label>
+                    {t("admin.security.client_id_label")}
+                    <input type="text" name="clientId" required />
+                  </label>
+                  <label>
+                    {t("admin.security.client_secret_label")}
+                    <input
+                      type="password"
+                      name="clientSecret"
+                      autocomplete="new-password"
+                    />
+                  </label>
+                  <label>
+                    {t("admin.security.client_secret_env_var_label")}
+                    <input type="text" name="clientSecretEnvVar" />
+                  </label>
+                  <p class="field-hint">
+                    {t("admin.security.client_secret_env_var_hint")}
+                  </p>
+                  <label>
+                    {t("admin.security.scopes_label")}
+                    <input
+                      type="text"
+                      name="scopes"
+                      value="openid email profile"
+                      required
+                    />
+                  </label>
+                  <label>
+                    {t("admin.security.allowed_email_domains_label")}
+                    <input type="text" name="allowedEmailDomains" />
+                  </label>
+                  <label class="checkbox-label">
+                    <input type="checkbox" name="enabled" />
+                    {t("admin.security.enabled_label")}
+                  </label>
+                  <button type="submit">
+                    {t("admin.security.create_provider_submit")}
+                  </button>
+                </form>
+              </details>
+            )}
+          </section>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .security-admin {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-5);
+    max-width: 960px;
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .sec-section {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+  }
+
+  .sec-section h2 {
+    margin: 0;
+    font-size: var(--fs-md);
+  }
+
+  .status-grid {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: var(--sp-1) var(--sp-3);
+    margin: 0;
+  }
+
+  .status-grid dt {
+    font-weight: 600;
+    color: var(--color-text-muted);
+  }
+
+  .status-grid dd {
+    margin: 0;
+  }
+
+  .status-pill {
+    display: inline-block;
+    padding: 0 var(--sp-2);
+    border-radius: var(--radius-pill, 999px);
+    font-size: var(--fs-xs);
+    font-weight: 600;
+  }
+
+  .status-pill[data-status="active"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 20%,
+      var(--color-surface)
+    );
+    color: var(--color-success-strong, var(--color-success));
+  }
+
+  .status-pill[data-status="inactive"] {
+    background: var(--color-surface-2);
+    color: var(--color-text-muted);
+  }
+
+  .sec-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+  }
+
+  .sec-form fieldset {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-3);
+  }
+
+  .sec-form legend {
+    font-weight: 600;
+    padding: 0 var(--sp-1);
+  }
+
+  .sec-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .checkbox-label {
+    flex-direction: row !important;
+    align-items: center;
+    gap: var(--sp-2) !important;
+  }
+
+  .sec-form input,
+  .sec-form select,
+  .sec-form textarea {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-family: inherit;
+  }
+
+  .field-hint {
+    margin: 0;
+    font-size: var(--fs-xs);
+    color: var(--color-text-muted);
+  }
+
+  .field-hint-warning {
+    color: var(--color-warning);
+  }
+
+  .break-glass-fieldset {
+    border: 1px dashed var(--color-border);
+  }
+
+  .role-checkbox-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    max-height: 220px;
+    overflow-y: auto;
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  .sec-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--fs-sm);
+  }
+
+  .sec-table th,
+  .sec-table td {
+    text-align: left;
+    padding: var(--sp-2);
+    border-bottom: 1px solid var(--color-border);
+    vertical-align: top;
+  }
+
+  .sec-actions-cell {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    min-width: 140px;
+  }
+
+  .sec-form button,
+  .delete-provider-button {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-2) var(--sp-4);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .delete-provider-button {
+    background: var(--color-danger-strong, var(--color-danger));
+  }
+
+  .sec-form button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  @media (max-width: 768px) {
+    .sec-form input,
+    .sec-form select {
+      min-height: 44px;
+    }
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../lib/ui/admin-form-client";
+
+  interface SecurityStrings {
+    policySaveSuccess: string;
+    createProviderSuccess: string;
+    updateProviderSuccess: string;
+    deleteProviderSuccess: string;
+    deleteProviderPrompt: string;
+    breakGlassClientWarning: string;
+    invalidSecretChoice: string;
+    invalidCreateSecretChoice: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<SecurityStrings>();
+
+  function submitButtonOf(form: HTMLFormElement): HTMLButtonElement | null {
+    return form.querySelector('button[type="submit"]');
+  }
+
+  function parseDomainList(raw: FormDataEntryValue | null): string[] {
+    return String(raw ?? "")
+      .split(",")
+      .map((domain) => domain.trim())
+      .filter((domain) => domain.length > 0);
+  }
+
+  function parseIdList(raw: FormDataEntryValue | null): string[] {
+    return String(raw ?? "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
+  }
+
+  // Fast, non-authoritative client-side nudge (issue's own acceptance
+  // criterion: "UI prevents enabling sso_required unless a valid
+  // break-glass local owner/account exists") — the server's own
+  // `saveTenantAuthPolicy` (fresh DB read, Issue #591) remains the only
+  // authoritative check; a request that slips past this still gets a
+  // clear `409 BREAK_GLASS_REQUIRED` from the API, mapped through
+  // `errorMessages` below exactly like any other rejection.
+  document
+    .getElementById("policy-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = document.getElementById(
+        "policy-save-button"
+      ) as HTMLButtonElement | null;
+      if (button?.disabled) return;
+
+      const formData = new FormData(form);
+      const passwordLoginEnabled =
+        formData.get("passwordLoginEnabled") === "on";
+      const ssoRequired = formData.get("ssoRequired") === "on";
+      const breakGlassIdentityIds = formData.has("breakGlassIdentityIds")
+        ? (formData.getAll("breakGlassIdentityIds") as string[])
+        : parseIdList(formData.get("breakGlassIdentityIdsManual"));
+
+      const requiresBreakGlass = ssoRequired || !passwordLoginEnabled;
+      if (requiresBreakGlass && breakGlassIdentityIds.length === 0) {
+        showBanner("action-banner", strings.breakGlassClientWarning, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const body = {
+          passwordLoginEnabled,
+          ssoEnabled: formData.get("ssoEnabled") === "on",
+          ssoRequired,
+          autoLinkVerifiedEmail: formData.get("autoLinkVerifiedEmail") === "on",
+          allowedEmailDomains: parseDomainList(
+            formData.get("allowedEmailDomains")
+          ),
+          breakGlassIdentityIds
+        };
+
+        const result = await submitJson(
+          "/api/v1/identity/sso/policy",
+          "PATCH",
+          body,
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.policySaveSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document
+    .getElementById("create-provider-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = submitButtonOf(form);
+      if (button?.disabled) return;
+
+      const formData = new FormData(form);
+      const clientSecret = String(formData.get("clientSecret") ?? "").trim();
+      const clientSecretEnvVar = String(
+        formData.get("clientSecretEnvVar") ?? ""
+      ).trim();
+
+      if (clientSecret.length > 0 === clientSecretEnvVar.length > 0) {
+        showBanner("action-banner", strings.invalidCreateSecretChoice, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const result = await submitJson(
+          "/api/v1/identity/sso/providers",
+          "POST",
+          {
+            providerKey: formData.get("providerKey"),
+            displayName: formData.get("displayName"),
+            issuerUrl: formData.get("issuerUrl"),
+            clientId: formData.get("clientId"),
+            clientSecret: clientSecret.length > 0 ? clientSecret : null,
+            clientSecretEnvVar:
+              clientSecretEnvVar.length > 0 ? clientSecretEnvVar : null,
+            scopes: formData.get("scopes"),
+            allowedEmailDomains: parseDomainList(
+              formData.get("allowedEmailDomains")
+            ),
+            enabled: formData.get("enabled") === "on"
+          },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.createProviderSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document.querySelectorAll(".edit-provider-form").forEach((formEl) => {
+    formEl.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = submitButtonOf(form);
+      if (button?.disabled) return;
+
+      const providerId = form.dataset.providerId!;
+      const formData = new FormData(form);
+      const clientSecret = String(formData.get("clientSecret") ?? "").trim();
+      const clientSecretEnvVar = String(
+        formData.get("clientSecretEnvVar") ?? ""
+      ).trim();
+
+      if (clientSecret.length > 0 && clientSecretEnvVar.length > 0) {
+        showBanner("action-banner", strings.invalidSecretChoice, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const body: Record<string, unknown> = {
+          displayName: formData.get("displayName"),
+          issuerUrl: formData.get("issuerUrl"),
+          clientId: formData.get("clientId"),
+          scopes: formData.get("scopes"),
+          allowedEmailDomains: parseDomainList(
+            formData.get("allowedEmailDomains")
+          ),
+          enabled: formData.get("enabled") === "on"
+        };
+        if (clientSecret.length > 0) body.clientSecret = clientSecret;
+        if (clientSecretEnvVar.length > 0) {
+          body.clientSecretEnvVar = clientSecretEnvVar;
+        }
+
+        const result = await submitJson(
+          `/api/v1/identity/sso/providers/${providerId}`,
+          "PATCH",
+          body,
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.updateProviderSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+  });
+
+  document.querySelectorAll(".delete-provider-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+
+      const providerId = el.dataset.deleteProvider!;
+      const reason = window.prompt(strings.deleteProviderPrompt);
+      if (!reason || reason.trim().length === 0) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const result = await submitJson(
+          `/api/v1/identity/sso/providers/${providerId}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteProviderSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+</script>

--- a/tests/e2e/admin-security-disabled.e2e.ts
+++ b/tests/e2e/admin-security-disabled.e2e.ts
@@ -1,0 +1,83 @@
+/**
+ * E2E spec (Playwright + Bun, skill `awcms-mini-browser-test`) — Issue #592
+ * testing checklist item "UI test: offline/local informational state only".
+ *
+ * Targets `/admin/security` with the dev server running WITHOUT
+ * `AUTH_ONLINE_SECURITY_ENABLED`/`AUTH_ONLINE_SECURITY_PROFILE` set (the
+ * default for every local/offline/LAN deployment) — the issue's own
+ * acceptance criterion: "On local/offline/LAN or when #587 gate is
+ * disabled, UI shows informational status only... Full configuration
+ * controls are rendered only when #587 gate is enabled." This is a
+ * server-side branch (`src/pages/admin/security.astro`'s own frontmatter
+ * checks `isFullOnlineSecurityActive` before rendering anything else), so
+ * this spec asserts the policy/provider forms are entirely ABSENT from the
+ * rendered DOM — not merely hidden by CSS — which only a real render can
+ * prove.
+ *
+ * Logs in through the real `/login` form (fill + submit + wait for the
+ * `/admin` redirect), NOT `page.request.post("/api/v1/auth/login")` —
+ * empirically, a SUCCESSFUL login's `Set-Cookie` response headers going
+ * through Playwright's `page.request` API (as opposed to a real navigation/
+ * form submit) intermittently broke every subsequent `page.request`/
+ * `page.goto` call in this environment with an unrelated-looking
+ * `TypeError: "<path>" cannot be parsed as a URL.` (isolated by bisection
+ * during this issue's own implementation — reproduces even with a fully
+ * qualified absolute URL, only after a 200 response carrying `Set-Cookie`;
+ * a failed login attempt, or the same request with no cookie-setting
+ * response, never reproduces it). Driving the real login form sidesteps
+ * the whole class of that bug AND is arguably the more faithful "browser
+ * E2E" exercise per this skill's own purpose anyway.
+ *
+ * Requires:
+ *   - `E2E_SEED_DATABASE_URL` — the PRIVILEGED (superuser) Postgres role,
+ *     used once to seed an isolated owner/tenant fixture directly (see
+ *     `helpers/seed-owner-tenant.ts` for why `POST /setup/initialize`
+ *     itself cannot be reused for this).
+ *   - The dev server under `E2E_BASE_URL` (default `http://localhost:4321`)
+ *     must be running against the SAME database, with
+ *     `AUTH_ONLINE_SECURITY_ENABLED` unset/not `"true"`.
+ *
+ * Run: `bun run test:e2e tests/e2e/admin-security-disabled.e2e.ts` — see
+ * this repo's own skill doc for the full dev-server/DB setup this assumes.
+ */
+import { test, expect } from "@playwright/test";
+
+import { seedOwnerTenant } from "./helpers/seed-owner-tenant";
+
+test.describe("admin/security — full-online gate disabled", () => {
+  test("renders only the informational notice, no policy/provider forms", async ({
+    page
+  }) => {
+    const seedDatabaseUrl = process.env.E2E_SEED_DATABASE_URL;
+    test.skip(
+      !seedDatabaseUrl,
+      "E2E_SEED_DATABASE_URL not set — see this file's own header comment."
+    );
+
+    const owner = await seedOwnerTenant(
+      seedDatabaseUrl!,
+      `e2e-sec-off-${crypto.randomUUID().slice(0, 8)}`
+    );
+
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(owner.tenantId);
+    await page.locator("#login-identifier").fill(owner.loginIdentifier);
+    await page.locator("#password").fill(owner.password);
+    await page.locator("#login-submit").click();
+    await page.waitForURL("**/admin");
+
+    await page.goto("/admin/security");
+
+    const infoNotice = page.locator('.state-notice[data-kind="info"]');
+    await expect(infoNotice).toBeVisible();
+    await expect(infoNotice).toHaveAttribute("role", "status");
+
+    // The full configuration controls must not exist in the DOM at all —
+    // proving the server-side branch, not just a CSS `display: none`.
+    await expect(page.locator("#policy-form")).toHaveCount(0);
+    await expect(page.locator("#create-provider-form")).toHaveCount(0);
+    await expect(page.locator('.state-notice[data-kind="denied"]')).toHaveCount(
+      0
+    );
+  });
+});

--- a/tests/e2e/admin-security-enabled.e2e.ts
+++ b/tests/e2e/admin-security-enabled.e2e.ts
@@ -1,0 +1,85 @@
+/**
+ * E2E spec (Playwright + Bun, skill `awcms-mini-browser-test`) — Issue #592
+ * testing checklist item "UI test: full-online policy form visible when
+ * gate enabled".
+ *
+ * Targets `/admin/security` with the dev server running WITH
+ * `AUTH_ONLINE_SECURITY_ENABLED=true`/`AUTH_ONLINE_SECURITY_PROFILE=full_online`
+ * — the issue's own acceptance criterion: "Full configuration controls are
+ * rendered only when #587 gate is enabled." The seeded owner has every
+ * permission (mirrors `POST /setup/initialize`'s own owner role — see
+ * `helpers/seed-owner-tenant.ts`), so both the tenant auth policy form and
+ * the SSO provider create form must render.
+ *
+ * Logs in through the real `/login` form — see
+ * `admin-security-disabled.e2e.ts`'s own header comment for why
+ * `page.request.post("/api/v1/auth/login")` is deliberately NOT used here.
+ *
+ * Deliberately does NOT submit either form or exercise the break-glass
+ * rejection here — the orchestrating issue's own instructions route that
+ * coverage to `tests/integration/admin-security-ui.integration.test.ts`
+ * (ABAC 403 + audit rows) and Issue #591's own
+ * `tenant-sso-flow.integration.test.ts` (break-glass 409), both far
+ * cheaper than a browser for asserting API status codes/DB rows. This spec
+ * only proves the two forms exist and are usable in a real render.
+ *
+ * Requires:
+ *   - `E2E_SEED_DATABASE_URL` — see `admin-security-disabled.e2e.ts`'s own
+ *     header comment.
+ *   - The dev server under `E2E_BASE_URL` must be running against the SAME
+ *     database, with `AUTH_ONLINE_SECURITY_ENABLED=true` and
+ *     `AUTH_ONLINE_SECURITY_PROFILE=full_online`.
+ *
+ * Run: `bun run test:e2e tests/e2e/admin-security-enabled.e2e.ts`.
+ */
+import { test, expect } from "@playwright/test";
+
+import { seedOwnerTenant } from "./helpers/seed-owner-tenant";
+
+test.describe("admin/security — full-online gate enabled", () => {
+  test("renders the status summary plus policy and create-provider forms", async ({
+    page
+  }) => {
+    const seedDatabaseUrl = process.env.E2E_SEED_DATABASE_URL;
+    test.skip(
+      !seedDatabaseUrl,
+      "E2E_SEED_DATABASE_URL not set — see this file's own header comment."
+    );
+
+    const owner = await seedOwnerTenant(
+      seedDatabaseUrl!,
+      `e2e-sec-on-${crypto.randomUUID().slice(0, 8)}`
+    );
+
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(owner.tenantId);
+    await page.locator("#login-identifier").fill(owner.loginIdentifier);
+    await page.locator("#password").fill(owner.password);
+    await page.locator("#login-submit").click();
+    await page.waitForURL("**/admin");
+
+    await page.goto("/admin/security");
+
+    // No informational-only or access-denied branch — the full page.
+    await expect(page.locator('.state-notice[data-kind="info"]')).toHaveCount(
+      0
+    );
+    await expect(page.locator('.state-notice[data-kind="denied"]')).toHaveCount(
+      0
+    );
+
+    const policyForm = page.locator("#policy-form");
+    await expect(policyForm).toBeVisible();
+    await expect(policyForm.locator('input[name="ssoRequired"]')).toBeVisible();
+    await expect(
+      policyForm.locator('input[name="passwordLoginEnabled"]')
+    ).toBeVisible();
+    await expect(page.locator("#policy-save-button")).toBeVisible();
+
+    const createProviderForm = page.locator("#create-provider-form");
+    await expect(createProviderForm).toBeAttached();
+    await expect(
+      createProviderForm.locator('input[name="providerKey"]')
+    ).toBeAttached();
+  });
+});

--- a/tests/e2e/helpers/seed-owner-tenant-cli.ts
+++ b/tests/e2e/helpers/seed-owner-tenant-cli.ts
@@ -1,0 +1,37 @@
+/**
+ * Standalone CLI entry point for `seed-owner-tenant.ts`'s seeding logic —
+ * run as a SEPARATE `bun` subprocess by `seedOwnerTenant()` (see that
+ * file's own comment) rather than in-process inside the Playwright test
+ * runner. Empirically, calling `Bun.password.hash` (argon2, CPU-bound
+ * native work) together with several sequential `Bun.SQL` queries in the
+ * SAME process that also drives Playwright's browser via its
+ * `--remote-debugging-pipe` IPC channel intermittently breaks that IPC
+ * channel — subsequent `page.request.*`/`page.goto` calls fail with
+ * `TypeError: "<path>" cannot be parsed as a URL.` even for calls that
+ * pass an already-absolute URL string, with no relation to the URL
+ * handling code itself (isolated by bisection during Issue #592's own
+ * implementation: the same query sequence without the `hashPassword` call
+ * never reproduces it, but isolating `hashPassword` + a couple of queries
+ * on their own also doesn't reliably reproduce it — the trigger is
+ * timing-sensitive, matching the class of `chromium.launch()`/Bun IPC pipe
+ * issues `.claude/skills/awcms-mini-browser-test/SKILL.md` already
+ * documents for `oven-sh/bun#15679`). Running this in a child process
+ * sidesteps the interaction entirely: no argon2/Postgres work ever shares
+ * an event loop with Playwright's own IPC.
+ *
+ * Usage: `bun tests/e2e/helpers/seed-owner-tenant-cli.ts <databaseUrl> <tenantCode>`
+ * — prints one JSON line (`SeededOwner`) to stdout on success.
+ */
+import { seedOwnerTenantInProcess } from "./seed-owner-tenant";
+
+const [databaseUrl, tenantCode] = process.argv.slice(2);
+
+if (!databaseUrl || !tenantCode) {
+  console.error(
+    "Usage: bun seed-owner-tenant-cli.ts <databaseUrl> <tenantCode>"
+  );
+  process.exit(1);
+}
+
+const owner = await seedOwnerTenantInProcess(databaseUrl, tenantCode);
+console.log(JSON.stringify(owner));

--- a/tests/e2e/helpers/seed-owner-tenant.ts
+++ b/tests/e2e/helpers/seed-owner-tenant.ts
@@ -1,0 +1,133 @@
+/**
+ * E2E-only tenant/owner seeding helper (Issue #592). `POST
+ * /api/v1/setup/initialize` cannot be reused here: it is a once-only,
+ * singleton-locked endpoint (`awcms_mini_setup_state`, see that route's own
+ * comment) that has almost certainly already been claimed on any long-lived
+ * dev database — exactly the situation memory `manual-admin-ui-smoke-test`
+ * documents for the curl-based recipe this helper adapts for Playwright.
+ * Mirrors that endpoint's own insert order/columns
+ * (`src/pages/api/v1/setup/initialize.ts`) via a direct, privileged
+ * (superuser) `Bun.SQL` connection instead, so any number of isolated E2E
+ * tenants can be created regardless of that lock's state — every tenant
+ * code passed in must be unique per test run.
+ *
+ * Connects with `DATABASE_URL` as-is: E2E specs are expected to export the
+ * PRIVILEGED (superuser) role for this helper specifically (same
+ * "DATABASE_URL is the superuser role" convention
+ * `tests/integration/harness.ts` documents for `getAdminSql()`) — seeding
+ * bypasses RLS entirely, which is fine here since this is fixture setup,
+ * not something under test. The dev server under test connects with its
+ * OWN, separate `DATABASE_URL` (the least-privilege `awcms_mini_app` role,
+ * same as production) in its own process/environment — this file has no
+ * relationship to that connection.
+ *
+ * `seedOwnerTenant` (the export every spec file actually calls) runs
+ * `seedOwnerTenantInProcess` below in a SEPARATE `bun` subprocess via
+ * `seed-owner-tenant-cli.ts` — see that file's own comment for why calling
+ * `Bun.password.hash` + several `Bun.SQL` queries directly inside the same
+ * process that drives Playwright's browser intermittently breaks
+ * Playwright's own IPC channel to Chromium. Never call
+ * `seedOwnerTenantInProcess` directly from a `*.e2e.ts` spec file.
+ */
+import { hashPassword } from "../../../src/lib/auth/password";
+
+export type SeededOwner = {
+  tenantId: string;
+  loginIdentifier: string;
+  password: string;
+};
+
+export async function seedOwnerTenant(
+  databaseUrl: string,
+  tenantCode: string
+): Promise<SeededOwner> {
+  const cliPath = new URL("./seed-owner-tenant-cli.ts", import.meta.url)
+    .pathname;
+  const proc = Bun.spawn(["bun", cliPath, databaseUrl, tenantCode], {
+    stdout: "pipe",
+    stderr: "pipe"
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited
+  ]);
+
+  if (exitCode !== 0) {
+    throw new Error(
+      `seed-owner-tenant-cli.ts failed (exit ${exitCode}): ${stderr}`
+    );
+  }
+
+  return JSON.parse(stdout.trim()) as SeededOwner;
+}
+
+export async function seedOwnerTenantInProcess(
+  databaseUrl: string,
+  tenantCode: string
+): Promise<SeededOwner> {
+  const sql = new Bun.SQL(databaseUrl);
+  const loginIdentifier = `${tenantCode}-owner@example.com`;
+  const password = "e2e-security-owner-password";
+
+  try {
+    const tenantRows = await sql`
+      INSERT INTO awcms_mini_tenants (tenant_code, tenant_name)
+      VALUES (${tenantCode}, ${`E2E ${tenantCode}`})
+      RETURNING id
+    `;
+    const tenantId = tenantRows[0]!.id as string;
+
+    await sql`
+      INSERT INTO awcms_mini_tenant_settings (tenant_id) VALUES (${tenantId})
+    `;
+
+    await sql`
+      INSERT INTO awcms_mini_offices (tenant_id, office_code, office_name, office_type)
+      VALUES (${tenantId}, 'hq', 'Head Office', 'head_office')
+    `;
+
+    const profileRows = await sql`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', 'E2E Owner')
+      RETURNING id
+    `;
+    const profileId = profileRows[0]!.id as string;
+
+    const passwordHash = await hashPassword(password);
+    const identityRows = await sql`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profileId}, ${loginIdentifier}, ${passwordHash})
+      RETURNING id
+    `;
+    const identityId = identityRows[0]!.id as string;
+
+    const tenantUserRows = await sql`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${tenantId}, ${identityId})
+      RETURNING id
+    `;
+    const tenantUserId = tenantUserRows[0]!.id as string;
+
+    const roleRows = await sql`
+      INSERT INTO awcms_mini_roles (tenant_id, role_code, role_name, is_system)
+      VALUES (${tenantId}, 'owner', 'Owner', true)
+      RETURNING id
+    `;
+    const roleId = roleRows[0]!.id as string;
+
+    await sql`
+      INSERT INTO awcms_mini_role_permissions (tenant_id, role_id, permission_id)
+      SELECT ${tenantId}, ${roleId}, id FROM awcms_mini_permissions
+    `;
+
+    await sql`
+      INSERT INTO awcms_mini_access_assignments (tenant_id, tenant_user_id, role_id, assigned_by)
+      VALUES (${tenantId}, ${tenantUserId}, ${roleId}, ${tenantUserId})
+    `;
+
+    return { tenantId, loginIdentifier, password };
+  } finally {
+    await sql.end();
+  }
+}

--- a/tests/integration/admin-security-ui.integration.test.ts
+++ b/tests/integration/admin-security-ui.integration.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Integration tests for the `/admin/security` admin UI's own testing
+ * checklist (Issue #592, epic: full-online auth hardening #587-#593).
+ *
+ * This page is not rendered through a browser/SSR harness for the two
+ * ABAC/audit checks below (see `tests/integration/tenant-domain-admin.integration.test.ts`'s
+ * own docblock for why — this repo has no such harness for `/admin/*`
+ * pages other than the Playwright specs under `tests/e2e/*.e2e.ts`, which
+ * cover the two rendering states this issue's testing checklist calls out
+ * separately: `tests/e2e/admin-security-disabled.e2e.ts` and
+ * `tests/e2e/admin-security-enabled.e2e.ts`). Instead this file exercises
+ * the real route handlers the page's mutation forms call
+ * (`PATCH /api/v1/identity/sso/policy`,
+ * `POST`/`DELETE /api/v1/identity/sso/providers[/{id}]`) against a real
+ * PostgreSQL, for the two checklist items Issue #591's own
+ * `tenant-sso-flow.integration.test.ts` did not already cover:
+ *
+ * 1. "Integration test: policy update requires permission" — #591's own
+ *    suite covers ABAC default-deny for `GET /identity/sso/providers`
+ *    ("ABAC: an identity with no role/permission is denied admin provider
+ *    access") but never exercises `PATCH /identity/sso/policy` itself
+ *    without the `sso_policy.update` permission specifically.
+ * 2. "Audit test for policy changes" — #591's endpoints already call
+ *    `recordAuditEvent` for `sso_policy_updated`/`sso_provider_created`/
+ *    `sso_provider_deleted` (see those route files' own comments) but no
+ *    test asserted a matching row actually lands in
+ *    `awcms_mini_audit_events`, the same gap
+ *    `tenant-domain-api.integration.test.ts`'s own audit assertions close
+ *    for that module.
+ *
+ * "sso_required blocked without break-glass" is exhaustively covered by
+ * #591's own suite (`tenant-sso-flow.integration.test.ts`'s two
+ * "break-glass enforcement..." tests) — not repeated here.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import {
+  GET as getPolicy,
+  PATCH as updatePolicy
+} from "../../src/pages/api/v1/identity/sso/policy/index";
+import { POST as createProvider } from "../../src/pages/api/v1/identity/sso/providers/index";
+import { DELETE as deleteProvider } from "../../src/pages/api/v1/identity/sso/providers/[id]";
+import { resetDatabaseCircuitBreakerForTests } from "../../src/lib/database/circuit-breaker";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+const NOROLE_LOGIN = "norole@example.com";
+const NOROLE_PASSWORD = "integration-test-norole-password";
+
+type Bootstrap = { tenantId: string; token: string };
+
+async function bootstrapTenant(tenantCode = "acme"): Promise<Bootstrap> {
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: `Tenant ${tenantCode}`,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "Head Office",
+      ownerLoginIdentifier: OWNER_LOGIN,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId, token: login.body.data.token };
+}
+
+/** Creates a second identity in the same tenant with a `tenant_users` membership but zero role assignments — the same "default deny" fixture shape `tenant-sso-flow.integration.test.ts`'s own ABAC test uses. */
+async function bootstrapNoRoleUser(tenantId: string): Promise<Bootstrap> {
+  const admin = getAdminSql();
+
+  const profileRows = await admin`
+    INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+    VALUES (${tenantId}, 'person', 'No Role User') RETURNING id
+  `;
+  const passwordHash = await Bun.password.hash(NOROLE_PASSWORD);
+  await admin`
+    INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${tenantId}, ${(profileRows[0] as { id: string }).id}, ${NOROLE_LOGIN}, ${passwordHash})
+  `;
+  const identityRows = await admin`
+    SELECT id FROM awcms_mini_identities WHERE login_identifier = ${NOROLE_LOGIN}
+  `;
+  await admin`
+    INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+    VALUES (${tenantId}, ${(identityRows[0] as { id: string }).id})
+  `;
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier: NOROLE_LOGIN, password: NOROLE_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId, token: login.body.data.token };
+}
+
+function authHeaders(actor: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": actor.tenantId,
+    authorization: `Bearer ${actor.token}`
+  };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("Admin security UI (Issue #592) — ABAC + audit", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    resetDatabaseCircuitBreakerForTests();
+    process.env.AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY = Buffer.alloc(
+      32,
+      4
+    ).toString("base64");
+  });
+
+  test("PATCH /identity/sso/policy without sso_policy.update permission is denied (default deny), and the policy is unchanged", async () => {
+    const owner = await bootstrapTenant();
+    const norole = await bootstrapNoRoleUser(owner.tenantId);
+
+    const result = await invoke<{ error: { code: string } }>(updatePolicy, {
+      method: "PATCH",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(norole),
+      body: { ssoEnabled: true }
+    });
+    expect(result.status).toBe(403);
+    expect(result.body.error.code).toBe("ACCESS_DENIED");
+
+    const unchanged = await invoke<{ data: { ssoEnabled: boolean } }>(
+      getPolicy,
+      {
+        method: "GET",
+        path: "/api/v1/identity/sso/policy",
+        headers: authHeaders(owner)
+      }
+    );
+    expect(unchanged.body.data.ssoEnabled).toBe(false);
+  });
+
+  test("a successful PATCH /identity/sso/policy writes an sso_policy_updated audit event for the actor", async () => {
+    const owner = await bootstrapTenant();
+
+    const result = await invoke(updatePolicy, {
+      method: "PATCH",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(owner),
+      body: { ssoEnabled: true, autoLinkVerifiedEmail: true }
+    });
+    expect(result.status).toBe(200);
+
+    const admin = getAdminSql();
+    const auditRows = (await admin`
+      SELECT action, resource_type, resource_id, actor_tenant_user_id, severity
+      FROM awcms_mini_audit_events
+      WHERE tenant_id = ${owner.tenantId} AND action = 'sso_policy_updated'
+    `) as {
+      action: string;
+      resource_type: string;
+      resource_id: string;
+      actor_tenant_user_id: string | null;
+      severity: string;
+    }[];
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]!.resource_type).toBe("tenant_auth_policy");
+    expect(auditRows[0]!.resource_id).toBe(owner.tenantId);
+    expect(auditRows[0]!.actor_tenant_user_id).not.toBeNull();
+    expect(auditRows[0]!.severity).toBe("warning");
+  });
+
+  test("a rejected break-glass PATCH (409) does NOT write an sso_policy_updated audit event", async () => {
+    const owner = await bootstrapTenant();
+
+    const result = await invoke<{ error: { code: string } }>(updatePolicy, {
+      method: "PATCH",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(owner),
+      body: { ssoEnabled: true, ssoRequired: true }
+    });
+    expect(result.status).toBe(409);
+    expect(result.body.error.code).toBe("BREAK_GLASS_REQUIRED");
+
+    const admin = getAdminSql();
+    const auditRows = await admin`
+      SELECT id FROM awcms_mini_audit_events
+      WHERE tenant_id = ${owner.tenantId} AND action = 'sso_policy_updated'
+    `;
+    expect(auditRows).toHaveLength(0);
+  });
+
+  test("SSO provider create then delete each write their own audit event", async () => {
+    const owner = await bootstrapTenant();
+
+    const created = await invoke<{ data: { id: string } }>(createProvider, {
+      method: "POST",
+      path: "/api/v1/identity/sso/providers",
+      headers: authHeaders(owner),
+      body: {
+        providerKey: "okta",
+        displayName: "Okta",
+        issuerUrl: "https://acme.okta.example.com",
+        clientId: "test-okta-client-id",
+        clientSecretEnvVar: "OKTA_TEST_CLIENT_SECRET",
+        enabled: true
+      }
+    });
+    expect(created.status).toBe(200);
+    const providerId = created.body.data.id;
+
+    const deleted = await invoke(deleteProvider, {
+      method: "DELETE",
+      path: `/api/v1/identity/sso/providers/${providerId}`,
+      params: { id: providerId },
+      headers: authHeaders(owner),
+      body: { reason: "rotating away from Okta in this test" }
+    });
+    expect(deleted.status).toBe(200);
+
+    const admin = getAdminSql();
+    const auditRows = (await admin`
+      SELECT action, resource_id
+      FROM awcms_mini_audit_events
+      WHERE tenant_id = ${owner.tenantId}
+        AND action IN ('sso_provider_created', 'sso_provider_deleted')
+      ORDER BY created_at ASC
+    `) as { action: string; resource_id: string }[];
+
+    expect(auditRows).toHaveLength(2);
+    expect(auditRows[0]).toEqual({
+      action: "sso_provider_created",
+      resource_id: providerId
+    });
+    expect(auditRows[1]).toEqual({
+      action: "sso_provider_deleted",
+      resource_id: providerId
+    });
+  });
+});

--- a/tests/unit/auth-security-status.test.ts
+++ b/tests/unit/auth-security-status.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveAuthSecurityStatusSummary } from "../../src/lib/auth/auth-security-status";
+
+const GATE_ON = {
+  AUTH_ONLINE_SECURITY_ENABLED: "true",
+  AUTH_ONLINE_SECURITY_PROFILE: "full_online"
+};
+
+describe("auth-security-status (Issue #592)", () => {
+  test("every deployment default (all env unset) reports the gate off and every feature disabled/unconfigured", () => {
+    const summary = resolveAuthSecurityStatusSummary({});
+
+    expect(summary.gateEnabled).toBe(false);
+    expect(summary.gateProfile).toBe("disabled");
+    expect(summary.gateActive).toBe(false);
+    expect(summary.turnstile).toEqual({ enabled: false, configured: false });
+    expect(summary.mfa).toEqual({ enabled: false, configured: false });
+    expect(summary.googleLogin).toEqual({ enabled: false, configured: false });
+    expect(summary.sso).toEqual({ enabled: false, configured: false });
+  });
+
+  test("gateActive requires BOTH AUTH_ONLINE_SECURITY_ENABLED=true AND profile=full_online", () => {
+    expect(
+      resolveAuthSecurityStatusSummary({
+        AUTH_ONLINE_SECURITY_ENABLED: "true"
+      }).gateActive
+    ).toBe(false);
+
+    expect(resolveAuthSecurityStatusSummary(GATE_ON).gateActive).toBe(true);
+  });
+
+  test("a feature's own *_ENABLED flag is independent of the shared gate — reported even when the gate is off (so an admin can see it was flipped on prematurely)", () => {
+    const summary = resolveAuthSecurityStatusSummary({
+      TURNSTILE_ENABLED: "true"
+    });
+
+    expect(summary.gateActive).toBe(false);
+    expect(summary.turnstile.enabled).toBe(true);
+  });
+
+  test("turnstile.configured is true only once BOTH TURNSTILE_SITE_KEY and TURNSTILE_SECRET_KEY are present", () => {
+    expect(
+      resolveAuthSecurityStatusSummary({
+        ...GATE_ON,
+        TURNSTILE_ENABLED: "true",
+        TURNSTILE_SITE_KEY: "site-key"
+      }).turnstile.configured
+    ).toBe(false);
+
+    expect(
+      resolveAuthSecurityStatusSummary({
+        ...GATE_ON,
+        TURNSTILE_ENABLED: "true",
+        TURNSTILE_SITE_KEY: "site-key",
+        TURNSTILE_SECRET_KEY: "secret-key"
+      }).turnstile.configured
+    ).toBe(true);
+  });
+
+  test("mfa.configured requires AUTH_MFA_SECRET_ENCRYPTION_KEY", () => {
+    expect(
+      resolveAuthSecurityStatusSummary({
+        ...GATE_ON,
+        AUTH_MFA_ENABLED: "true"
+      }).mfa.configured
+    ).toBe(false);
+
+    expect(
+      resolveAuthSecurityStatusSummary({
+        ...GATE_ON,
+        AUTH_MFA_ENABLED: "true",
+        AUTH_MFA_SECRET_ENCRYPTION_KEY: "a".repeat(32)
+      }).mfa.configured
+    ).toBe(true);
+  });
+
+  test("googleLogin.configured requires both AUTH_GOOGLE_CLIENT_ID and AUTH_GOOGLE_CLIENT_SECRET", () => {
+    expect(
+      resolveAuthSecurityStatusSummary({
+        ...GATE_ON,
+        AUTH_GOOGLE_LOGIN_ENABLED: "true",
+        AUTH_GOOGLE_CLIENT_ID: "client-id"
+      }).googleLogin.configured
+    ).toBe(false);
+
+    expect(
+      resolveAuthSecurityStatusSummary({
+        ...GATE_ON,
+        AUTH_GOOGLE_LOGIN_ENABLED: "true",
+        AUTH_GOOGLE_CLIENT_ID: "client-id",
+        AUTH_GOOGLE_CLIENT_SECRET: "client-secret"
+      }).googleLogin.configured
+    ).toBe(true);
+  });
+
+  test("sso.configured requires AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY", () => {
+    expect(
+      resolveAuthSecurityStatusSummary({
+        ...GATE_ON,
+        AUTH_SSO_ENABLED: "true"
+      }).sso.configured
+    ).toBe(false);
+
+    expect(
+      resolveAuthSecurityStatusSummary({
+        ...GATE_ON,
+        AUTH_SSO_ENABLED: "true",
+        AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY: "a".repeat(32)
+      }).sso.configured
+    ).toBe(true);
+  });
+
+  test("never throws for a completely empty env object", () => {
+    expect(() => resolveAuthSecurityStatusSummary({})).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- New `/admin/security` page surfacing and editing everything #587-#591 already built: online-hardening gate status, Turnstile/MFA/Google/SSO feature status, tenant auth policy (password login / SSO enabled / SSO required / auto-link / allowed domains / break-glass owners), and tenant SSO provider CRUD.
- **No new API endpoints or migrations** — the page consumes #591's existing admin CRUD API (`/api/v1/identity/sso/policy`, `/api/v1/identity/sso/providers[/{id}]`) via the standard `admin-form-client.ts` mutation pattern; it never writes to the database directly.
- Two independent gates, both server-side (never CSS-hidden): the deployment gate (`isFullOnlineSecurityActive`) — inactive on every local/offline/LAN deployment, showing only an informational notice — and ABAC permission checks per-section (`identity_access.sso_policy.*`/`sso_providers.*`).
- Break-glass UX shows the requirement inline and surfaces the server's authoritative `409 BREAK_GLASS_REQUIRED` rejection rather than re-implementing eligibility checking client-side.
- Client secret fields are write-only, never pre-filled on edit.

## Test plan
- [x] New unit tests: `auth-security-status.test.ts`.
- [x] New integration tests: `admin-security-ui.integration.test.ts` (ABAC 403, audit events for policy update / provider create+delete, no audit event on break-glass rejection).
- [x] New E2E tests (Playwright via `bun --bun playwright test`): `admin-security-disabled.e2e.ts`, `admin-security-enabled.e2e.ts` — both pass against live dev servers (skip cleanly without `E2E_SEED_DATABASE_URL`, consistent with existing `awcms-mini-browser-test` convention).
- [x] `bun run check` (lint, docs, api:spec:check, typecheck, full test suite against real Postgres, build) — 1490 pass, 0 fail, verified independently (one earlier run showed transient DB-container-not-warm-yet flakiness; re-run was clean).
- [x] Changeset added.
- [x] Docs updated: `src/modules/identity-access/README.md`, `awcms-mini-auth-online-hardening` skill (status table now shows only #593 remaining).

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)