### PR TITLE
fix(auth): tighten break-glass identity UX/data hygiene

### DIFF
--- a/.changeset/break-glass-picker-data-hygiene.md
+++ b/.changeset/break-glass-picker-data-hygiene.md
@@ -37,3 +37,11 @@ New regression test in `tests/integration/tenant-sso-flow.integration.test.ts`:
 persists ONLY the valid one" — submits one real identity id alongside two
 syntactically-valid-but-nonexistent UUIDs and confirms only the real one is
 ever persisted, verified via a fresh re-read of the policy.
+
+Per a security-auditor follow-up finding on this PR: the `sso_policy_updated`
+audit event now also records `breakGlassIdentityIdsSubmittedCount`/
+`breakGlassIdentityIdsPersistedCount` (counts only, never the ids
+themselves) whenever `breakGlassIdentityIds` is part of the request, so a
+forensic review of the audit log alone can see that a save silently dropped
+ineligible/garbage ids, without needing a before/after database snapshot
+diff. Covered by a new test in `tests/integration/admin-security-ui.integration.test.ts`.

--- a/.changeset/break-glass-picker-data-hygiene.md
+++ b/.changeset/break-glass-picker-data-hygiene.md
@@ -1,0 +1,39 @@
+---
+"awcms-mini": patch
+---
+
+Fix two non-blocking UX-integrity gaps around tenant auth policy break-glass
+identity selection (Issue #605, follow-up from the security-auditor review
+of PR #604/Issue #592). Neither was a bypassable security boundary —
+`saveTenantAuthPolicy` (Issue #591) has always re-validated break-glass
+eligibility via a fresh database read before allowing `sso_required=true`/
+`password_login_enabled=false` to persist.
+
+- `src/pages/admin/security.astro`'s break-glass checkbox picker now filters
+  candidates to `tenant_user.status === 'active' && identity.status ===
+  'active'` before rendering, instead of listing every tenant user
+  (including suspended/inactive ones) as a selectable break-glass owner —
+  an admin no longer discovers a doomed selection only after submitting.
+  `fetchTenantUsersWithRoles` itself is unchanged (shared with
+  `admin/access-users.astro`, which does need the full list); the filter
+  is applied at the point of use.
+- `saveTenantAuthPolicy` (`src/modules/identity-access/application/tenant-auth-policy.ts`)
+  now persists only the ids confirmed eligible right now, never the
+  submitted list verbatim. Previously it only checked that *at least one*
+  submitted id was eligible before allowing the save — a submission of "1
+  valid + N garbage/typo'd/nonexistent ids" (possible via the admin UI's
+  manual free-text fallback for admins without `user_management.read`, or
+  a direct API call) would silently persist all of them. `break_glass_identity_ids`
+  is now self-cleaning on every save.
+- `countEligibleBreakGlassIdentities` is now a thin wrapper around a new
+  `fetchEligibleBreakGlassIdentityIds` (returns the actual eligible ids, not
+  just a count) so the filtering and the count check share one query
+  instead of two divergent implementations. `scripts/security-readiness.ts`'s
+  `checkSsoBreakGlassReady` (Issue #593) is unaffected — its call site's
+  signature is unchanged.
+
+New regression test in `tests/integration/tenant-sso-flow.integration.test.ts`:
+"break-glass hygiene: saving policy with 1 valid + N garbage/ineligible ids
+persists ONLY the valid one" — submits one real identity id alongside two
+syntactically-valid-but-nonexistent UUIDs and confirms only the real one is
+ever persisted, verified via a fresh re-read of the policy.

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -653,8 +653,36 @@ dihasilkan:
   `src/modules/identity-access/README.md` sudah akurat sejak #587-#591
   masing-masing — dikonfirmasi ulang oleh #593, tidak diubah.
 
-Issue #601 (SQLSTATE class 22 circuit-breaker exclusion), #603 (SSRF
-hardening untuk `issuer_url` OIDC tenant-configured), dan #605 (break-glass
-picker/data-hygiene UX admin) tetap terbuka sebagai issue terpisah — #593
-sengaja tidak mencoba menutupnya (lihat §Batasan yang dicatat, bukan
-diabaikan di threat model doc 20 untuk detailnya).
+Issue #601 (SQLSTATE class 22 circuit-breaker exclusion) dan #605
+(break-glass picker/data-hygiene UX admin) sudah **selesai** sebagai
+follow-up terpisah setelah #593 (lihat §Break-glass picker/data-hygiene di
+bawah untuk #605). Issue #603 (SSRF hardening untuk `issuer_url` OIDC
+tenant-configured) tetap terbuka.
+
+### Break-glass picker/data-hygiene (Issue #605, selesai)
+
+Follow-up dari security-auditor review PR #604 (#592) — dua celah UX
+non-blocking (bukan bypass keamanan; `saveTenantAuthPolicy` selalu tetap
+jadi kontrol otoritatif) diperbaiki:
+
+- **Picker checkbox `admin/security.astro` sekarang memfilter kandidat ke
+  `tenant_user.status === 'active' && identity.status === 'active'`**
+  sebelum dirender — sebelumnya menampilkan SEMUA tenant user (termasuk
+  yang suspended/inactive) sebagai pilihan break-glass, sehingga admin
+  bisa memilih identity yang jelas akan ditolak server baru diketahui
+  setelah submit. `fetchTenantUsersWithRoles` (dipakai bersama
+  `admin/access-users.astro`) sendiri TIDAK diubah — filternya di titik
+  pemakaian (`security.astro`), bukan di query yang dipakai bersama.
+- **`saveTenantAuthPolicy` sekarang memfilter `break_glass_identity_ids`
+  yang DIPERSIST ke hanya id yang dikonfirmasi eligible** oleh
+  `fetchEligibleBreakGlassIdentityIds` (fungsi baru — `countEligibleBreakGlassIdentities`
+  kini wrapper tipis di atasnya, `scripts/security-readiness.ts`'s
+  `checkSsoBreakGlassReady` tidak berubah karena signature count-nya
+  sama), bukan menyimpan list yang disubmit apa adanya. Sebelumnya,
+  submit "1 id valid + N id sampah/salah ketik" (mis. lewat manual
+  free-text fallback picker untuk admin tanpa `user_management.read`,
+  atau panggilan API langsung) akan menyimpan SEMUA id termasuk yang
+  sampah, walau hanya satu yang pernah menentukan hasil save. Regression
+  test: `tests/integration/tenant-sso-flow.integration.test.ts`'s
+  "break-glass hygiene: saving policy with 1 valid + N garbage/ineligible
+  ids persists ONLY the valid one".

--- a/docs/awcms-mini/20_threat_model_security_architecture.md
+++ b/docs/awcms-mini/20_threat_model_security_architecture.md
@@ -373,10 +373,14 @@ sekali — `APP_ENV=production` **bukan** proxy untuk gate ini (lihat
 - **Step-up re-auth untuk disable MFA/regenerate recovery code** — trade-off
   Issue #589 di atas, belum ada follow-up issue eksplisit; dicatat di skill
   `awcms-mini-auth-online-hardening`.
-- **Break-glass identity picker/data-hygiene di admin UI** — Issue #605 (dibuka
-  terpisah dari review epic ini), tidak ditutup oleh check readiness baru di
-  atas (yang mengaudit DB, bukan UX pemilihan identity di form admin).
+- **Break-glass identity picker/data-hygiene di admin UI** — Issue #605,
+  **selesai**: picker `admin/security.astro` sekarang memfilter kandidat ke
+  identity+tenant-user `active`, dan `saveTenantAuthPolicy` memfilter
+  `break_glass_identity_ids` yang dipersist ke hanya id yang dikonfirmasi
+  eligible (lihat skill `awcms-mini-auth-online-hardening` §Break-glass
+  picker/data-hygiene).
 - **SSRF hardening untuk `issuer_url` OIDC tenant-configured (#591)** — Issue
   #603 (dibuka terpisah), belum ditutup oleh epic ini.
-- **Circuit breaker exclusion untuk SQLSTATE class 22** — Issue #601 (bug-class
-  follow-up, tidak spesifik epic ini).
+- **Circuit breaker exclusion untuk SQLSTATE class 22** — Issue #601,
+  **selesai** (`isPostgresClientInputError` di `tenant-context.ts` kini
+  mencakup kelas `22` dan `23`).

--- a/src/modules/identity-access/application/tenant-auth-policy.ts
+++ b/src/modules/identity-access/application/tenant-auth-policy.ts
@@ -84,7 +84,7 @@ export async function getTenantAuthPolicy(
 }
 
 /**
- * Counts how many of `breakGlassIdentityIds` currently resolve to an
+ * Resolves which of `breakGlassIdentityIds` currently resolve to an
  * identity that can actually still complete a local password login in this
  * tenant: the identity exists, belongs to this tenant, `status = 'active'`,
  * and has an `active` `awcms_mini_tenant_users` membership. Every identity
@@ -100,13 +100,13 @@ export async function getTenantAuthPolicy(
  * being re-saved, so save-time validation alone cannot catch that drift.
  * Do not reimplement this query a second, divergent way elsewhere.
  */
-export async function countEligibleBreakGlassIdentities(
+export async function fetchEligibleBreakGlassIdentityIds(
   tx: Bun.SQL,
   tenantId: string,
   breakGlassIdentityIds: string[]
-): Promise<number> {
+): Promise<string[]> {
   if (breakGlassIdentityIds.length === 0) {
-    return 0;
+    return [];
   }
 
   const rows = (await tx`
@@ -120,7 +120,26 @@ export async function countEligibleBreakGlassIdentities(
       AND tu.status = 'active'
   `) as { id: string }[];
 
-  return rows.length;
+  return rows.map((row) => row.id);
+}
+
+/**
+ * Count-only convenience wrapper around `fetchEligibleBreakGlassIdentityIds`
+ * for callers (e.g. `checkSsoBreakGlassReady`) that only need to know
+ * whether at least one eligible identity exists, not which ones.
+ */
+export async function countEligibleBreakGlassIdentities(
+  tx: Bun.SQL,
+  tenantId: string,
+  breakGlassIdentityIds: string[]
+): Promise<number> {
+  const eligibleIds = await fetchEligibleBreakGlassIdentityIds(
+    tx,
+    tenantId,
+    breakGlassIdentityIds
+  );
+
+  return eligibleIds.length;
 }
 
 export type SaveTenantAuthPolicyResult =
@@ -143,25 +162,38 @@ export async function saveTenantAuthPolicy(
     input.autoLinkVerifiedEmail ?? current.autoLinkVerifiedEmail;
   const allowedEmailDomains =
     input.allowedEmailDomains ?? current.allowedEmailDomains;
-  const breakGlassIdentityIds =
+  const submittedBreakGlassIdentityIds =
     input.breakGlassIdentityIds ?? current.breakGlassIdentityIds;
 
-  const eligibleBreakGlassCount = await countEligibleBreakGlassIdentities(
-    tx,
-    tenantId,
-    breakGlassIdentityIds
-  );
+  const eligibleBreakGlassIdentityIds =
+    await fetchEligibleBreakGlassIdentityIds(
+      tx,
+      tenantId,
+      submittedBreakGlassIdentityIds
+    );
 
   const breakGlassEvaluation = evaluateBreakGlassRequirement({
     passwordLoginEnabled,
     ssoRequired,
-    breakGlassIdentityIds,
-    eligibleBreakGlassCount
+    breakGlassIdentityIds: submittedBreakGlassIdentityIds,
+    eligibleBreakGlassCount: eligibleBreakGlassIdentityIds.length
   });
 
   if (breakGlassEvaluation.outcome === "invalid") {
     return { outcome: "break_glass_required" };
   }
+
+  // Issue #605: persist only the ids confirmed eligible right now, never
+  // the submitted list verbatim — otherwise a submission of "1 valid + N
+  // garbage/typo'd ids" (possible via the admin UI's manual free-text
+  // fallback, or a direct API call) would silently save the garbage ids
+  // alongside the real one, even though only the valid id ever mattered for
+  // this save to succeed. Filtering (rather than trusting the request body)
+  // keeps `break_glass_identity_ids` self-cleaning on every save.
+  const eligibleIdSet = new Set(eligibleBreakGlassIdentityIds);
+  const breakGlassIdentityIds = submittedBreakGlassIdentityIds.filter((id) =>
+    eligibleIdSet.has(id)
+  );
 
   const rows = (await tx`
     INSERT INTO awcms_mini_tenant_auth_policies

--- a/src/pages/admin/security.astro
+++ b/src/pages/admin/security.astro
@@ -139,9 +139,18 @@ if (statusSummary.gateActive && CAN_READ_ANYTHING) {
         providers = await listAuthProviders(tx, context.tenantId);
       }
       if (CAN_READ_POLICY && CAN_READ_USERS) {
-        breakGlassCandidates = await fetchTenantUsersWithRoles(
+        // Issue #605: only offer identities that could actually still pass
+        // `countEligibleBreakGlassIdentities`'s own eligibility check
+        // (`saveTenantAuthPolicy`) — the underlying directory query lists
+        // every tenant user (needed elsewhere, e.g. `admin/access-users`),
+        // but selecting an inactive/suspended one here would be a doomed
+        // choice the server rejects only after submit.
+        const allTenantUsers = await fetchTenantUsersWithRoles(
           tx,
           context.tenantId
+        );
+        breakGlassCandidates = allTenantUsers.filter(
+          (user) => user.status === "active" && user.identityStatus === "active"
         );
       }
     });

--- a/src/pages/api/v1/identity/sso/policy/index.ts
+++ b/src/pages/api/v1/identity/sso/policy/index.ts
@@ -140,6 +140,20 @@ export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
       resourceId: tenantId,
       severity: "warning",
       message: "Tenant authentication policy updated.",
+      // Counts only (never the ids themselves — redaction-safe per doc 10
+      // masking discipline) so a forensic review of the audit log alone can
+      // see that `saveTenantAuthPolicy` (Issue #605) silently dropped
+      // ineligible/garbage break-glass ids from this specific save, without
+      // needing a before/after DB snapshot diff to notice.
+      attributes:
+        input.breakGlassIdentityIds !== undefined
+          ? {
+              breakGlassIdentityIdsSubmittedCount:
+                input.breakGlassIdentityIds.length,
+              breakGlassIdentityIdsPersistedCount:
+                result.policy.breakGlassIdentityIds.length
+            }
+          : undefined,
       correlationId
     });
 

--- a/tests/integration/admin-security-ui.integration.test.ts
+++ b/tests/integration/admin-security-ui.integration.test.ts
@@ -210,6 +210,42 @@ suite("Admin security UI (Issue #592) — ABAC + audit", () => {
     expect(auditRows[0]!.severity).toBe("warning");
   });
 
+  test("the sso_policy_updated audit event records submitted-vs-persisted break-glass counts when ids are dropped (Issue #605)", async () => {
+    const owner = await bootstrapTenant();
+
+    const ownerIdentityRows = await getAdminSql()`
+      SELECT id FROM awcms_mini_identities
+      WHERE tenant_id = ${owner.tenantId} AND login_identifier = ${OWNER_LOGIN}
+    `;
+    const ownerIdentityId = (ownerIdentityRows[0] as { id: string }).id;
+    const nonexistentId = "99999999-8888-7777-6666-555555555555";
+
+    const result = await invoke<{
+      data: { breakGlassIdentityIds: string[] };
+    }>(updatePolicy, {
+      method: "PATCH",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(owner),
+      body: {
+        breakGlassIdentityIds: [ownerIdentityId, nonexistentId]
+      }
+    });
+    expect(result.status).toBe(200);
+    expect(result.body.data.breakGlassIdentityIds).toEqual([ownerIdentityId]);
+
+    const admin = getAdminSql();
+    const auditRows = (await admin`
+      SELECT attributes
+      FROM awcms_mini_audit_events
+      WHERE tenant_id = ${owner.tenantId} AND action = 'sso_policy_updated'
+    `) as { attributes: Record<string, unknown> | null }[];
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0]!.attributes).toEqual({
+      breakGlassIdentityIdsSubmittedCount: 2,
+      breakGlassIdentityIdsPersistedCount: 1
+    });
+  });
+
   test("a rejected break-glass PATCH (409) does NOT write an sso_policy_updated audit event", async () => {
     const owner = await bootstrapTenant();
 

--- a/tests/integration/tenant-sso-flow.integration.test.ts
+++ b/tests/integration/tenant-sso-flow.integration.test.ts
@@ -595,6 +595,56 @@ suite("Generic tenant OIDC SSO flow (Issue #591)", () => {
     expect(accepted.body.data.ssoRequired).toBe(true);
   });
 
+  test("break-glass hygiene: saving policy with 1 valid + N garbage/ineligible ids persists ONLY the valid one (Issue #605)", async () => {
+    const owner = await bootstrapTenant();
+    await createOktaProvider(owner);
+
+    const admin = getAdminSql();
+    const ownerIdentityRows = await admin`
+      SELECT id FROM awcms_mini_identities
+      WHERE tenant_id = ${owner.tenantId} AND login_identifier = ${OWNER_LOGIN}
+    `;
+    const ownerIdentityId = (ownerIdentityRows[0] as { id: string }).id;
+
+    // Two syntactically valid UUIDs that don't correspond to any identity in
+    // this (or any) tenant — `validateUpdateTenantAuthPolicyInput` only
+    // checks UUID *shape*, so these pass input validation and reach
+    // `saveTenantAuthPolicy`, exactly like a soft-deleted/typo'd real id
+    // would. Neither should ever end up persisted in
+    // `break_glass_identity_ids`, only the one id the server itself
+    // confirmed eligible via a fresh DB read.
+    const nonexistentId1 = "00000000-0000-0000-0000-000000000000";
+    const nonexistentId2 = "11111111-2222-3333-4444-555555555555";
+
+    const accepted = await invoke<{
+      data: { ssoRequired: boolean; breakGlassIdentityIds: string[] };
+    }>(updatePolicy, {
+      method: "PATCH",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(owner),
+      body: {
+        ssoEnabled: true,
+        ssoRequired: true,
+        breakGlassIdentityIds: [ownerIdentityId, nonexistentId1, nonexistentId2]
+      }
+    });
+
+    expect(accepted.status).toBe(200);
+    expect(accepted.body.data.ssoRequired).toBe(true);
+    expect(accepted.body.data.breakGlassIdentityIds).toEqual([ownerIdentityId]);
+
+    // Confirm the garbage/nonexistent ids were never persisted, not just
+    // absent from this response — read the policy back fresh.
+    const reread = await invoke<{
+      data: { breakGlassIdentityIds: string[] };
+    }>(getPolicy, {
+      method: "GET",
+      path: "/api/v1/identity/sso/policy",
+      headers: authHeaders(owner)
+    });
+    expect(reread.body.data.breakGlassIdentityIds).toEqual([ownerIdentityId]);
+  });
+
   test("break-glass enforcement also rejects password_login_enabled=false without an eligible break-glass identity", async () => {
     const owner = await bootstrapTenant();
 


### PR DESCRIPTION
## Summary
- Follow-up from the security-auditor review of PR #604 (Issue #592). Two non-blocking UX-integrity gaps, neither a bypassable security boundary since `saveTenantAuthPolicy` (Issue #591) always re-validates break-glass eligibility via a fresh DB read before allowing `sso_required=true`/`password_login_enabled=false` to persist.
- `src/pages/admin/security.astro`'s break-glass checkbox picker now filters candidates to `tenant_user.status === 'active' && identity.status === 'active'` at the point of use, instead of offering every tenant user (including suspended/inactive ones) as a selectable break-glass owner. `fetchTenantUsersWithRoles` itself (shared with `admin/access-users.astro`) is unchanged.
- `saveTenantAuthPolicy` now persists only the ids confirmed eligible right now, never the submitted list verbatim — a submission of "1 valid + N garbage/nonexistent ids" (possible via the admin UI's manual free-text fallback, or a direct API call) previously saved all of them since only the *count* of eligible ids was checked, not filtered.
- `countEligibleBreakGlassIdentities` is now a thin wrapper around a new `fetchEligibleBreakGlassIdentityIds` (returns the actual eligible ids) so both the count-check and the new filtering share one query. `scripts/security-readiness.ts`'s `checkSsoBreakGlassReady` (Issue #593) is unaffected — its call site signature is unchanged.

## Test plan
- [x] New integration test in `tests/integration/tenant-sso-flow.integration.test.ts`: submits 1 real identity id + 2 syntactically-valid-but-nonexistent UUIDs, confirms only the real id is ever persisted (verified via a fresh re-read of the policy, not just the mutation response).
- [x] `bun run check` (lint, docs, api:spec:check, typecheck, full test suite against real Postgres, build) — 1498 pass, 0 fail.
- [x] Changeset added.
- [x] Docs updated: `awcms-mini-auth-online-hardening` skill, `docs/awcms-mini/20_threat_model_security_architecture.md`.

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)