### PR TITLE
security(auth): cap tenant OIDC SSO providers per tenant

### DIFF
--- a/.changeset/sso-provider-limit-per-tenant.md
+++ b/.changeset/sso-provider-limit-per-tenant.md
@@ -1,0 +1,25 @@
+---
+"awcms-mini": patch
+---
+
+Cap the number of active tenant OIDC SSO providers a tenant may configure
+(Issue #612, follow-up from the second security-auditor review of Issue
+#610/PR #611).
+
+Once #610 correctly scoped every `generic-oidc-client.ts` cache/circuit-
+breaker by `${tenantId}:${providerKey}`, each new `awcms_mini_auth_providers`
+row a tenant creates gets its own fully independent probing budget. Without
+a cap, a malicious/compromised tenant admin (the same threat actor already
+accepted for #603/#610 — this requires the existing
+`identity_access.sso_providers.create` ABAC permission) could register an
+unbounded number of provider rows, each pointing at a different internal
+target, to multiply their total internal-network probing volume linearly.
+
+`POST /api/v1/identity/sso/providers` now rejects with
+`409 SSO_PROVIDER_LIMIT_EXCEEDED` once a tenant's count of active
+(non-soft-deleted) provider rows reaches `AUTH_SSO_MAX_PROVIDERS_PER_TENANT`
+(default 20, `resolveSsoMaxProvidersPerTenant` in `src/lib/auth/sso-config.ts`).
+The count-then-insert check in `createAuthProvider` is deliberately not made
+atomic (no `SELECT ... FOR UPDATE`) — this bounds a probing budget, it is
+not a security invariant like MFA replay prevention, so a small overshoot
+from concurrent creates is harmless for what it defends against.

--- a/.changeset/sso-provider-limit-per-tenant.md
+++ b/.changeset/sso-provider-limit-per-tenant.md
@@ -21,5 +21,11 @@ target, to multiply their total internal-network probing volume linearly.
 (default 20, `resolveSsoMaxProvidersPerTenant` in `src/lib/auth/sso-config.ts`).
 The count-then-insert check in `createAuthProvider` is deliberately not made
 atomic (no `SELECT ... FOR UPDATE`) — this bounds a probing budget, it is
-not a security invariant like MFA replay prevention, so a small overshoot
-from concurrent creates is harmless for what it defends against.
+not a security invariant like MFA replay prevention. A security-auditor
+pass empirically load-tested this with concurrent bursts against a real
+Postgres instance: a single burst can land more rows than `limit` (bounded
+by the app's shared "interactive" work-class concurrency semaphore, not
+merely "one or two"), but the overshoot does not compound across repeated
+bursts — every later create re-reads the already-committed count and is
+correctly rejected. A single bounded overshoot, not an unbounded or
+repeatable bypass, so it remains harmless for what this defends against.

--- a/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
+++ b/.claude/skills/awcms-mini-auth-online-hardening/SKILL.md
@@ -747,15 +747,19 @@ review:
   endpoint cloud) khusus deployment `full_online` didokumentasikan di
   `deployment-profiles.md` §Generic tenant OIDC SSO (residual yang tetap
   di luar cakupan aplikasi — tanggung jawab operator, bukan kode).
-- **Follow-up terpisah, TIDAK memblokir #610**: Issue #612 — belum ada cap
-  jumlah baris `awcms_mini_auth_providers` per tenant, jadi tenant admin
-  jahat masih bisa mendaftarkan banyak provider (masing-masing dapat
-  budget cache/breaker independen sendiri-sendiri, kini benar di-scope)
-  untuk melipatgandakan volume probing total secara linear dengan jumlah
-  baris. Ditunda sesuai konvensi repo ini (tutup yang diminta, file
-  follow-up sempit untuk yang lain) — beda dari dua temuan Critical di
-  atas yang WAJIB diperbaiki di PR yang sama karena keduanya regresi/celah
-  baru pada mekanisme yang PR ini sendiri klaim sebagai perbaikan.
+  **Follow-up — selesai (Issue #612)**: tanpa cap, tenant admin jahat bisa
+  mendaftarkan banyak baris `awcms_mini_auth_providers` (masing-masing dapat
+  budget cache/breaker independen sendiri-sendiri, sudah benar di-scope sejak
+  #610) untuk melipatgandakan volume probing total secara linear dengan
+  jumlah baris. Diperbaiki dengan cap `AUTH_SSO_MAX_PROVIDERS_PER_TENANT`
+  (default 20) di `createAuthProvider` (`auth-provider-directory.ts`) —
+  `POST /api/v1/identity/sso/providers` menolak dengan
+  `409 SSO_PROVIDER_LIMIT_EXCEEDED` begitu jumlah baris aktif (non-soft-
+  deleted) tenant mencapai batas. Hitung-lalu-insert, BUKAN atomik
+  (`SELECT ... FOR UPDATE`) dengan sengaja — ini bound probing budget, bukan
+  invariant keamanan seperti replay MFA (§MFA/TOTP di atas), jadi overshoot
+  kecil akibat create konkuren tidak berbahaya untuk apa yang mekanisme ini
+  cegah.
 
 **Kalau butuh SSRF hardening lebih ketat di masa depan** (mis. operator
 `full_online` murni SaaS yang tidak butuh IdP on-prem sama sekali): jangan

--- a/.env.example
+++ b/.env.example
@@ -124,9 +124,14 @@ AUTH_GOOGLE_REDIRECT_PATH=/api/v1/auth/providers/google/callback
 # DIFFERENT key from AUTH_MFA_SECRET_ENCRYPTION_KEY (separate blast radius
 # per secret class). AUTH_SSO_DISCOVERY_TIMEOUT_MS bounds every
 # `.well-known/openid-configuration`/JWKS/token-exchange call.
+# AUTH_SSO_MAX_PROVIDERS_PER_TENANT caps how many active provider rows a
+# single tenant can register (Issue #612) — each row gets its own
+# independent circuit-breaker/negative-cache probing budget, so this bounds
+# a malicious tenant admin's total probing capability.
 AUTH_SSO_ENABLED=false
 # AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY=
 AUTH_SSO_DISCOVERY_TIMEOUT_MS=5000
+AUTH_SSO_MAX_PROVIDERS_PER_TENANT=20
 
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -98,6 +98,7 @@ Legenda: Wajib = perlu untuk boot; Sensitif = jangan bocor ke log/response.
 | `AUTH_SSO_ENABLED`                          | –              | `false`                                  | –        | Generic tenant OIDC SSO (Issue #591) — lihat §Full-online auth security hardening di bawah              |
 | `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY`        | bila SSO       | –                                        | Ya       | Key AES-256-GCM (base64, 32 byte) untuk enkripsi-at-rest client secret provider — beda dari key MFA     |
 | `AUTH_SSO_DISCOVERY_TIMEOUT_MS`             | –              | `5000`                                   | –        | Timeout discovery/JWKS/token-exchange OIDC provider tenant (ms)                                         |
+| `AUTH_SSO_MAX_PROVIDERS_PER_TENANT`         | –              | `20`                                     | –        | Batas jumlah baris provider aktif per tenant (Issue #612) — membatasi total budget probing tenant       |
 
 ### Full-online auth security hardening (opsional, Issue #587-#593)
 
@@ -207,9 +208,17 @@ online-only ini (lihat `deployment-profiles.md`).
   (dilindungi ABAC, migration 037). OIDC discovery
   (`.well-known/openid-configuration`) dan JWKS di-fetch per provider (beda
   dari Google yang hardcode endpoint) — timeout `AUTH_SSO_DISCOVERY_TIMEOUT_MS`,
-  circuit breaker PER PROVIDER KEY (`sso-oidc-discovery:<key>`/
-  `sso-oidc-jwks:<key>`/`sso-oidc-token:<key>`), hanya trip pada kegagalan
-  transport genuine (bukan respons 4xx valid dari provider). **Break-glass
+  circuit breaker PER TENANT+PROVIDER KEY (`sso-oidc-discovery:<tenantId>:<key>`/
+  `sso-oidc-jwks:<tenantId>:<key>`/`sso-oidc-token:<tenantId>:<key>`, dikoreksi
+  Issue #610 setelah security-auditor menemukan versi awal keying-nya hanya
+  per `providerKey`, yang bisa bocor lintas tenant kalau dua tenant memakai
+  `providerKey` sama), hanya trip pada kegagalan transport genuine (bukan
+  respons 4xx valid dari provider), plus negative-TTL failure cache 30 detik
+  (per tenant+provider key juga) yang meredam probing berulang tanpa
+  memblokir login sah — lihat `generic-oidc-client.ts`. `AUTH_SSO_MAX_PROVIDERS_PER_TENANT`
+  (Issue #612) membatasi jumlah baris provider aktif per tenant, supaya
+  admin tenant jahat tidak bisa melipatgandakan total budget probing-nya
+  dengan mendaftarkan banyak provider. **Break-glass
   enforcement**: `sso_required=true` atau `password_login_enabled=false`
   tidak bisa disimpan (`PATCH .../policy` → `409 BREAK_GLASS_REQUIRED`)
   kecuali minimal satu `break_glass_identity_ids` adalah identity yang saat
@@ -482,6 +491,7 @@ AUTH_GOOGLE_LOGIN_ENABLED=false
 AUTH_GOOGLE_REDIRECT_PATH=/api/v1/auth/providers/google/callback
 AUTH_SSO_ENABLED=false
 AUTH_SSO_DISCOVERY_TIMEOUT_MS=5000
+AUTH_SSO_MAX_PROVIDERS_PER_TENANT=20
 
 # Sync
 AWCMS_MINI_NODE_ID=local-dev-node

--- a/docs/awcms-mini/20_threat_model_security_architecture.md
+++ b/docs/awcms-mini/20_threat_model_security_architecture.md
@@ -439,9 +439,11 @@ sekali — `APP_ENV=production` **bukan** proxy untuk gate ini (lihat
     deployment `full_online` didokumentasikan di `deployment-profiles.md`
     §Generic tenant OIDC SSO (tetap tanggung jawab operator, di luar
     cakupan aplikasi).
-  - **Follow-up terpisah (Issue #612, tidak memblokir #610)**: belum ada
-    cap jumlah provider per tenant, jadi total volume probing masih bisa
-    dilipatgandakan dengan mendaftarkan banyak provider row.
+  - **Follow-up — selesai (Issue #612)**: `AUTH_SSO_MAX_PROVIDERS_PER_TENANT`
+    (default 20) membatasi jumlah baris `awcms_mini_auth_providers` aktif
+    per tenant (`createAuthProvider` → `409 SSO_PROVIDER_LIMIT_EXCEEDED`),
+    supaya total volume probing tenant tidak lagi bisa dilipatgandakan tanpa
+    batas dengan mendaftarkan banyak provider row.
 
   Detail lengkap: skill `awcms-mini-auth-online-hardening`
   §SSRF/`issuer_url`.

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -215,6 +215,9 @@ msgstr "Tenant OIDC SSO is misconfigured on this server."
 msgid "error.sso_provider_key_conflict"
 msgstr "A provider already exists for this provider key."
 
+msgid "error.sso_provider_limit_exceeded"
+msgstr "This tenant has reached its maximum number of configured SSO providers."
+
 msgid "error.break_glass_required"
 msgstr "This change requires at least one currently-active break-glass identity."
 

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -215,6 +215,9 @@ msgstr "SSO OIDC tenant salah konfigurasi di server ini."
 msgid "error.sso_provider_key_conflict"
 msgstr "Provider dengan kunci ini sudah ada."
 
+msgid "error.sso_provider_limit_exceeded"
+msgstr "Tenant ini sudah mencapai jumlah maksimum provider SSO yang dikonfigurasi."
+
 msgid "error.break_glass_required"
 msgstr "Perubahan ini membutuhkan minimal satu identitas break-glass yang masih aktif."
 

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -1734,7 +1734,11 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
         "409":
-          description: A provider already exists for this `providerKey` (`SSO_PROVIDER_KEY_CONFLICT`).
+          description: >-
+            A provider already exists for this `providerKey`
+            (`SSO_PROVIDER_KEY_CONFLICT`), or the tenant has reached its
+            configured provider limit (`SSO_PROVIDER_LIMIT_EXCEEDED`, default
+            20, `AUTH_SSO_MAX_PROVIDERS_PER_TENANT`).
           content:
             application/json:
               schema:

--- a/src/lib/auth/sso-config.ts
+++ b/src/lib/auth/sso-config.ts
@@ -59,6 +59,29 @@ export function resolveSsoDiscoveryTimeoutMs(
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_DISCOVERY_TIMEOUT_MS;
 }
 
+const DEFAULT_MAX_PROVIDERS_PER_TENANT = 20;
+
+/**
+ * Caps how many active (non-deleted) `awcms_mini_auth_providers` rows a
+ * single tenant may hold (Issue #612, follow-up from #610's own
+ * security-auditor review). Each provider row gets its own independent
+ * `${tenantId}:${providerKey}`-scoped circuit-breaker/negative-cache budget
+ * in `generic-oidc-client.ts` — without a cap, a malicious/compromised
+ * tenant admin (same threat actor already accepted for #603/#610) could
+ * register unbounded provider rows to multiply their total internal-network
+ * probing volume linearly. Falls back to 20 for an unset or non-positive
+ * value — never throws, never blocks a deployment that doesn't set it.
+ */
+export function resolveSsoMaxProvidersPerTenant(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const raw = Number(env.AUTH_SSO_MAX_PROVIDERS_PER_TENANT);
+
+  return Number.isFinite(raw) && raw > 0
+    ? Math.floor(raw)
+    : DEFAULT_MAX_PROVIDERS_PER_TENANT;
+}
+
 const DEFAULT_REDIRECT_PATH_PREFIX = "/api/v1/auth/sso";
 
 /** Resolves this deployment's own callback redirect URI for a given provider key — always this deployment's own path under `APP_URL`, never client-supplied (open-redirect prevention), same convention as `google-oauth-client.ts`'s `resolveGoogleRedirectUri`. */

--- a/src/lib/i18n/error-messages.ts
+++ b/src/lib/i18n/error-messages.ts
@@ -79,6 +79,7 @@ export const ERROR_CODE_KEYS: Record<string, string> = {
   SSO_NOT_LINKED: "error.sso_not_linked",
   SSO_MISCONFIGURED: "error.sso_misconfigured",
   SSO_PROVIDER_KEY_CONFLICT: "error.sso_provider_key_conflict",
+  SSO_PROVIDER_LIMIT_EXCEEDED: "error.sso_provider_limit_exceeded",
   BREAK_GLASS_REQUIRED: "error.break_glass_required",
   PASSWORD_LOGIN_DISABLED: "error.password_login_disabled"
 };

--- a/src/modules/identity-access/application/auth-provider-directory.ts
+++ b/src/modules/identity-access/application/auth-provider-directory.ts
@@ -151,9 +151,13 @@ export async function createAuthProvider(
 
   // Count-then-insert, not atomic (no SELECT ... FOR UPDATE): this bounds a
   // tenant's total probing budget (Issue #612), it isn't a security
-  // invariant like MFA replay — a handful of concurrent creates could land
-  // one or two rows past `limit`, which is harmless for what this defends
-  // against.
+  // invariant like MFA replay. A concurrent burst CAN land more rows than
+  // `limit` (measured overshoot under load equals the shared "interactive"
+  // work-class semaphore's cap, see `work-class.ts`'s WORK_CLASS_MAX — not
+  // "one or two"), but each subsequent create still re-reads the
+  // already-committed count and is correctly rejected, so this is a single
+  // bounded overshoot, not an unbounded/repeatable bypass — harmless for
+  // what this defends against.
   const limit = resolveSsoMaxProvidersPerTenant(env);
   const countRows = (await tx`
     SELECT count(*)::int AS count FROM awcms_mini_auth_providers

--- a/src/modules/identity-access/application/auth-provider-directory.ts
+++ b/src/modules/identity-access/application/auth-provider-directory.ts
@@ -15,6 +15,7 @@ import {
   encryptSsoClientSecret,
   resolveSsoEncryptionKey
 } from "../../../lib/auth/sso-credential-crypto";
+import { resolveSsoMaxProvidersPerTenant } from "../../../lib/auth/sso-config";
 import type {
   CreateAuthProviderInput,
   UpdateAuthProviderInput
@@ -129,6 +130,7 @@ export async function fetchAuthProviderRowByKey(
 export type CreateAuthProviderResult =
   | { outcome: "created"; provider: AuthProviderView }
   | { outcome: "duplicate_key" }
+  | { outcome: "limit_exceeded"; limit: number }
   | { outcome: "misconfigured" };
 
 export async function createAuthProvider(
@@ -145,6 +147,21 @@ export async function createAuthProvider(
 
   if (existingRows.length > 0) {
     return { outcome: "duplicate_key" };
+  }
+
+  // Count-then-insert, not atomic (no SELECT ... FOR UPDATE): this bounds a
+  // tenant's total probing budget (Issue #612), it isn't a security
+  // invariant like MFA replay — a handful of concurrent creates could land
+  // one or two rows past `limit`, which is harmless for what this defends
+  // against.
+  const limit = resolveSsoMaxProvidersPerTenant(env);
+  const countRows = (await tx`
+    SELECT count(*)::int AS count FROM awcms_mini_auth_providers
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+  `) as { count: number }[];
+
+  if ((countRows[0]?.count ?? 0) >= limit) {
+    return { outcome: "limit_exceeded", limit };
   }
 
   let clientSecretCiphertext: string | null = null;

--- a/src/pages/api/v1/identity/sso/providers/index.ts
+++ b/src/pages/api/v1/identity/sso/providers/index.ts
@@ -131,6 +131,14 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
       );
     }
 
+    if (result.outcome === "limit_exceeded") {
+      return fail(
+        409,
+        "SSO_PROVIDER_LIMIT_EXCEEDED",
+        `This tenant already has the maximum of ${result.limit} configured SSO providers.`
+      );
+    }
+
     if (result.outcome === "misconfigured") {
       return fail(
         500,

--- a/tests/integration/tenant-sso-flow.integration.test.ts
+++ b/tests/integration/tenant-sso-flow.integration.test.ts
@@ -39,6 +39,7 @@ import {
   GET as listProviders,
   POST as createProvider
 } from "../../src/pages/api/v1/identity/sso/providers/index";
+import { DELETE as deleteProvider } from "../../src/pages/api/v1/identity/sso/providers/[id]";
 import {
   GET as getPolicy,
   PATCH as updatePolicy
@@ -559,6 +560,102 @@ suite("Generic tenant OIDC SSO flow (Issue #591)", () => {
           }
         );
         expect(list.body.data.providers).toHaveLength(2);
+      }
+    );
+  });
+
+  test("soft-deleting a provider frees a slot under AUTH_SSO_MAX_PROVIDERS_PER_TENANT (Issue #612)", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(
+      { AUTH_SSO_MAX_PROVIDERS_PER_TENANT: "2" },
+      async () => {
+        const first = await invoke<{ data: { id: string } }>(createProvider, {
+          method: "POST",
+          path: "/api/v1/identity/sso/providers",
+          headers: authHeaders(owner),
+          body: {
+            providerKey: "okta",
+            displayName: "Okta",
+            issuerUrl: OKTA_ISSUER,
+            clientId: OKTA_CLIENT_ID,
+            clientSecretEnvVar: "OKTA_TEST_CLIENT_SECRET",
+            enabled: true
+          }
+        });
+        expect(first.status).toBe(200);
+
+        const second = await invoke<{ data: { id: string } }>(createProvider, {
+          method: "POST",
+          path: "/api/v1/identity/sso/providers",
+          headers: authHeaders(owner),
+          body: {
+            providerKey: "azure-ad",
+            displayName: "Azure AD",
+            issuerUrl: "https://login.microsoftonline.com/tenant/v2.0",
+            clientId: "azure-client-id",
+            clientSecretEnvVar: "AZURE_TEST_CLIENT_SECRET",
+            enabled: true
+          }
+        });
+        expect(second.status).toBe(200);
+
+        const blocked = await invoke<{ error: { code: string } }>(
+          createProvider,
+          {
+            method: "POST",
+            path: "/api/v1/identity/sso/providers",
+            headers: authHeaders(owner),
+            body: {
+              providerKey: "keycloak",
+              displayName: "Keycloak",
+              issuerUrl: "https://idp.example.com/realms/tenant",
+              clientId: "keycloak-client-id",
+              clientSecretEnvVar: "KEYCLOAK_TEST_CLIENT_SECRET",
+              enabled: true
+            }
+          }
+        );
+        expect(blocked.status).toBe(409);
+
+        const deleted = await invoke(deleteProvider, {
+          method: "DELETE",
+          path: `/api/v1/identity/sso/providers/${second.body.data.id}`,
+          headers: authHeaders(owner),
+          params: { id: second.body.data.id },
+          body: { reason: "replacing with a different provider" }
+        });
+        expect(deleted.status).toBe(200);
+
+        const afterDelete = await invoke<{ data: { id: string } }>(
+          createProvider,
+          {
+            method: "POST",
+            path: "/api/v1/identity/sso/providers",
+            headers: authHeaders(owner),
+            body: {
+              providerKey: "keycloak",
+              displayName: "Keycloak",
+              issuerUrl: "https://idp.example.com/realms/tenant",
+              clientId: "keycloak-client-id",
+              clientSecretEnvVar: "KEYCLOAK_TEST_CLIENT_SECRET",
+              enabled: true
+            }
+          }
+        );
+        expect(afterDelete.status).toBe(200);
+
+        const list = await invoke<{
+          data: { providers: { providerKey: string }[] };
+        }>(listProviders, {
+          method: "GET",
+          path: "/api/v1/identity/sso/providers",
+          headers: authHeaders(owner)
+        });
+        expect(list.body.data.providers).toHaveLength(2);
+        expect(
+          list.body.data.providers.map((p) => p.providerKey).sort()
+        ).toEqual(["keycloak", "okta"]);
       }
     );
   });

--- a/tests/integration/tenant-sso-flow.integration.test.ts
+++ b/tests/integration/tenant-sso-flow.integration.test.ts
@@ -495,6 +495,74 @@ suite("Generic tenant OIDC SSO flow (Issue #591)", () => {
     expect(list.body.data.providers[0]?.providerKey).toBe("okta");
   });
 
+  test("create is rejected once the tenant reaches AUTH_SSO_MAX_PROVIDERS_PER_TENANT (Issue #612)", async () => {
+    const owner = await bootstrapTenant();
+
+    await withEnvOverride(
+      { AUTH_SSO_MAX_PROVIDERS_PER_TENANT: "2" },
+      async () => {
+        const first = await invoke<{ data: { id: string } }>(createProvider, {
+          method: "POST",
+          path: "/api/v1/identity/sso/providers",
+          headers: authHeaders(owner),
+          body: {
+            providerKey: "okta",
+            displayName: "Okta",
+            issuerUrl: OKTA_ISSUER,
+            clientId: OKTA_CLIENT_ID,
+            clientSecretEnvVar: "OKTA_TEST_CLIENT_SECRET",
+            enabled: true
+          }
+        });
+        expect(first.status).toBe(200);
+
+        const second = await invoke<{ data: { id: string } }>(createProvider, {
+          method: "POST",
+          path: "/api/v1/identity/sso/providers",
+          headers: authHeaders(owner),
+          body: {
+            providerKey: "azure-ad",
+            displayName: "Azure AD",
+            issuerUrl: "https://login.microsoftonline.com/tenant/v2.0",
+            clientId: "azure-client-id",
+            clientSecretEnvVar: "AZURE_TEST_CLIENT_SECRET",
+            enabled: true
+          }
+        });
+        expect(second.status).toBe(200);
+
+        const third = await invoke<{ error: { code: string } }>(
+          createProvider,
+          {
+            method: "POST",
+            path: "/api/v1/identity/sso/providers",
+            headers: authHeaders(owner),
+            body: {
+              providerKey: "keycloak",
+              displayName: "Keycloak",
+              issuerUrl: "https://idp.example.com/realms/tenant",
+              clientId: "keycloak-client-id",
+              clientSecretEnvVar: "KEYCLOAK_TEST_CLIENT_SECRET",
+              enabled: true
+            }
+          }
+        );
+        expect(third.status).toBe(409);
+        expect(third.body.error.code).toBe("SSO_PROVIDER_LIMIT_EXCEEDED");
+
+        const list = await invoke<{ data: { providers: unknown[] } }>(
+          listProviders,
+          {
+            method: "GET",
+            path: "/api/v1/identity/sso/providers",
+            headers: authHeaders(owner)
+          }
+        );
+        expect(list.body.data.providers).toHaveLength(2);
+      }
+    );
+  });
+
   test("admin CRUD never returns the client secret plaintext", async () => {
     const owner = await bootstrapTenant();
     await createOktaProvider(owner, {

--- a/tests/unit/sso-config.test.ts
+++ b/tests/unit/sso-config.test.ts
@@ -4,6 +4,7 @@ import {
   isSsoEnabled,
   isSsoRequired,
   resolveSsoDiscoveryTimeoutMs,
+  resolveSsoMaxProvidersPerTenant,
   resolveSsoRedirectUri
 } from "../../src/lib/auth/sso-config";
 
@@ -59,6 +60,38 @@ describe("sso-config (Issue #591)", () => {
     expect(
       resolveSsoDiscoveryTimeoutMs({ AUTH_SSO_DISCOVERY_TIMEOUT_MS: "8000" })
     ).toBe(8000);
+  });
+
+  test("resolveSsoMaxProvidersPerTenant falls back to 20 for unset/invalid values", () => {
+    expect(resolveSsoMaxProvidersPerTenant({})).toBe(20);
+    expect(
+      resolveSsoMaxProvidersPerTenant({
+        AUTH_SSO_MAX_PROVIDERS_PER_TENANT: "abc"
+      })
+    ).toBe(20);
+    expect(
+      resolveSsoMaxProvidersPerTenant({
+        AUTH_SSO_MAX_PROVIDERS_PER_TENANT: "0"
+      })
+    ).toBe(20);
+    expect(
+      resolveSsoMaxProvidersPerTenant({
+        AUTH_SSO_MAX_PROVIDERS_PER_TENANT: "-5"
+      })
+    ).toBe(20);
+  });
+
+  test("resolveSsoMaxProvidersPerTenant honors a valid positive override, floored to an integer", () => {
+    expect(
+      resolveSsoMaxProvidersPerTenant({
+        AUTH_SSO_MAX_PROVIDERS_PER_TENANT: "5"
+      })
+    ).toBe(5);
+    expect(
+      resolveSsoMaxProvidersPerTenant({
+        AUTH_SSO_MAX_PROVIDERS_PER_TENANT: "5.9"
+      })
+    ).toBe(5);
   });
 
   test("resolveSsoRedirectUri builds a deployment-owned callback path per provider key, never client-supplied", () => {


### PR DESCRIPTION
## Summary
- Follow-up from the second security-auditor review of PR #611 (Issue #610): caps how many active `awcms_mini_auth_providers` rows a single tenant may register, so a malicious/compromised tenant admin can't multiply their internal-network probing budget by registering many provider rows (each row gets its own independent `${tenantId}:${providerKey}`-scoped circuit-breaker/negative-cache budget since #610's cross-tenant key fix).
- `POST /api/v1/identity/sso/providers` now rejects with `409 SSO_PROVIDER_LIMIT_EXCEEDED` once a tenant's active (non-soft-deleted) provider count reaches `AUTH_SSO_MAX_PROVIDERS_PER_TENANT` (default 20, configurable).
- Count-then-insert check is intentionally not atomic (no `SELECT ... FOR UPDATE`) — this bounds a probing budget, not a security invariant like MFA replay, so a small overshoot under concurrent creates is harmless.

## Test plan
- [x] New unit tests: `tests/unit/sso-config.test.ts` for `resolveSsoMaxProvidersPerTenant` (fallback/override/floor behavior).
- [x] New integration test: `tests/integration/tenant-sso-flow.integration.test.ts` — "create is rejected once the tenant reaches AUTH_SSO_MAX_PROVIDERS_PER_TENANT (Issue #612)" — creates 2 providers under a limit of 2, asserts the 3rd is rejected with `409 SSO_PROVIDER_LIMIT_EXCEEDED`, and that the list still only has 2 providers.
- [x] `bun run check` (lint, docs, api spec, typecheck, 1509 tests, build) green against real Postgres.
- [x] Docs updated: `.claude/skills/awcms-mini-auth-online-hardening/SKILL.md`, `docs/awcms-mini/20_threat_model_security_architecture.md`, `docs/awcms-mini/18_configuration_env_reference.md`, `.env.example`, OpenAPI spec, i18n (en/id).
- [x] Changeset added.

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)