### PR TITLE
chore(security): triage and dismiss pre-existing CodeQL alerts

### DIFF
--- a/.claude/skills/awcms-mini-codeql-triage/SKILL.md
+++ b/.claude/skills/awcms-mini-codeql-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: awcms-mini-codeql-triage
-description: Triase dan perbaiki temuan CodeQL code scanning AWCMS-Mini (github.com/ahliweb/awcms-mini/security/code-scanning). Gunakan saat diminta "analisis code scanning"/"perbaiki CodeQL", saat sebuah PR gagal check CodeQL, atau saat menemukan alert baru. Mendokumentasikan tiga false-positive nyata yang sudah ditemukan (name-heuristic password, incompatible-types typeof/null, URL substring-sanitization di test mock) supaya tidak diinvestigasi ulang dari nol.
+description: Triase dan perbaiki temuan CodeQL code scanning AWCMS-Mini (github.com/ahliweb/awcms-mini/security/code-scanning). Gunakan saat diminta "analisis code scanning"/"perbaiki CodeQL", saat sebuah PR gagal check CodeQL, atau saat menemukan alert baru. Mendokumentasikan empat false-positive nyata yang sudah ditemukan (name-heuristic password, incompatible-types typeof/null, URL substring-sanitization di test mock, dan dua kasus dismiss resmi tanpa reformulasi kode) supaya tidak diinvestigasi ulang dari nol.
 ---
 
 # AWCMS-Mini — Triase CodeQL Code Scanning
@@ -23,12 +23,13 @@ CodeQL (`.github/workflows/codeql.yml`, matrix `actions` + `javascript-typescrip
    - Cek apakah pola kode yang sama persis ada di file lain **tanpa** alert — kalau ada, itu sinyal kuat false positive kontekstual (CodeQL flow-sensitive analysis kadang berbeda hasil per call-site untuk kode identik).
    - Baca pesan CodeQL kata-per-kata dan uji terhadap semantik JS/TS sesungguhnya — kalau pesannya menyebut sesuatu yang secara data-flow **tidak mungkin** (mis. menyebut sebuah fungsi yang terbukti tidak pernah mengembalikan field yang dituduh), itu bukti definitif false positive, bukan tebakan.
    - **Jangan** langsung tambah suppression comment (`// codeql[rule-id]`) sebagai upaya pertama — sudah terbukti **tidak efektif** di setup CI repo ini (diverifikasi PR #505, Issue #496: suppression comment tetap muncul ulang di run berikutnya).
-4. **Perbaiki dengan code change minimal, behavior-preserving** — bukan menekan alert. Kalau setelah investigasi ternyata false positive murni tanpa cara reformulasi kode yang wajar, baru pertimbangkan dismiss resmi lewat API:
+4. **Perbaiki dengan code change minimal, behavior-preserving** — bukan menekan alert. Kalau setelah investigasi ternyata false positive murni tanpa cara reformulasi kode yang wajar, baru pertimbangkan dismiss resmi lewat API (lihat §4 katalog di bawah untuk dua kasus nyata):
    ```bash
    gh api repos/ahliweb/awcms-mini/code-scanning/alerts/<N> -X PATCH \
-     -f state=dismissed -f dismissed_reason=false_positive \
-     -f dismissed_comment="<alasan konkret + bukti>"
+     -f state=dismissed -f "dismissed_reason=false positive" \
+     -f dismissed_comment="<alasan konkret + bukti, maks 280 karakter>"
    ```
+   `dismissed_reason` harus PERSIS `"false positive"` / `"won't fix"` / `"used in tests"` (dengan spasi) — `false_positive` dengan underscore ditolak API (422). `dismissed_comment` dibatasi 280 karakter; taruh alasan lengkap di katalog skill ini, bukan di comment.
 5. **Verifikasi**: `bun run check` hijau, push, tunggu CI — konfirmasi CodeQL run berikutnya tidak lagi menampilkan alert yang sama (bukan cuma "kelihatannya benar").
 
 ## Katalog false-positive yang sudah dikonfirmasi
@@ -98,6 +99,60 @@ berdasarkan host/origin, pakai `new URL(url).origin === <origin>` alih-alih
 `startsWith(<origin>)` — sama presisinya untuk niat aslinya (cocok semua
 path di origin itu), tapi tidak memicu heuristik CodeQL yang menyasar pola
 "substring sanitization" di kode produksi.
+
+### 4. `js/insufficient-password-hash` dan `js/clear-text-logging` — dismiss resmi tanpa reformulasi kode (Issue #614)
+
+Ditemukan 2026-07-09 (alert #16, #17, #18), diinvestigasi dan di-dismiss
+2026-07-10. Berbeda dari pattern #1-#3 di atas (semua diperbaiki dengan
+code change), ketiga alert ini di-dismiss resmi lewat API karena
+reformulasi kode yang wajar tidak tersedia tanpa mengorbankan tujuan
+sungguhan kode tersebut:
+
+- **Alert #18** (`js/insufficient-password-hash`,
+  `src/lib/auth/oauth-state-token.ts:30`): CodeQL menandai return value
+  `generateOAuthState()`/`parseOAuthStateParam()` yang mengalir ke
+  `hashOAuthState`'s sha256 sebagai "password". BUKAN heuristik nama fungsi
+  (pattern #1) — nama fungsi ini sama sekali tidak mengandung substring
+  "password", jadi trigger mechanism-nya berbeda dan tidak sepenuhnya
+  dikonfirmasi. Tapi argumen keamanannya independen dan kokoh:
+  `generateOAuthState()` mengembalikan `randomBytes(32).toString("base64url")`
+  — nilai CSPRNG 256-bit, BUKAN input user/password. `hashOAuthState`
+  memakai bentuk fast-hash-with-prefix (`sha256:<hex>`) yang PERSIS sama
+  dengan tiga file token lain yang TIDAK di-flag (`session-token.ts`'s
+  `hashSessionToken`, `password-reset-token.ts`'s `hashResetToken`,
+  `mfa-challenge-token.ts`'s `hashChallengeToken`) — alasan yang sama
+  berlaku: hash lambat (bcrypt/argon2/scrypt) hanya menambah biaya
+  verifikasi tanpa manfaat keamanan nyata untuk nilai random 256-bit yang
+  mustahil di-brute-force offline berapa pun kecepatan hash-nya. Mencoba
+  rename tanpa tahu trigger mechanism pastinya berisiko sia-sia (CI cycle
+  terbuang tanpa kepastian fix), jadi dismiss dipilih dengan bukti
+  keamanan independen sebagai justifikasi, bukan sekadar asumsi "sama
+  seperti pattern #1".
+- **Alert #16, #17** (`js/clear-text-logging`, `scripts/validate-env.ts:794,803`):
+  CodeQL menandai `console.log` yang mem-print `EnvCheckResult.name`/`.detail`
+  sebagai membocorkan `AUTH_MFA_REQUIRED_WHEN_ENABLED` (array konstan berisi
+  NAMA var, isinya `["AUTH_MFA_SECRET_ENCRYPTION_KEY"]`) secara clear-text.
+  Diverifikasi langsung dari `checkMfaConfig`: yang benar-benar mengalir ke
+  `console.log` hanya STRING LITERAL nama var (`name`, mis.
+  `"AUTH_MFA_SECRET_ENCRYPTION_KEY"`) dan teks statis (`"is set."`, `"is
+missing or empty."`, dst) — nilai asli `env[name]` (secret sungguhan)
+  HANYA pernah dipakai di dalam predikat boolean (`isSet(env[name])`,
+  `isMfaEncryptionKeyWellFormed(env)`), tidak pernah masuk ke variabel yang
+  di-log. Reformulasi kode tidak masuk akal di sini karena tujuan
+  `console.log` ini MEMANG untuk memberi tahu operator var mana yang hilang
+  saat `bun run config:validate` gagal — menghapus nama var dari pesan
+  error menghancurkan kegunaan tool ini untuk operator.
+
+**Pencegahan**: kalau menemukan alert serupa (nama VAR/konstanta config
+di-flag sebagai "sensitive data" padahal yang di-log cuma label/nama, bukan
+nilai), verifikasi eksplisit dengan membaca SETIAP jalur data yang
+benar-benar sampai ke sink (console.log/hash call) sebelum memutuskan
+dismiss — jangan asumsikan dari nama alert saja. Simpan bukti konkret di
+`dismissed_comment` (API `PATCH .../code-scanning/alerts/<N>`, `dismissed_reason`
+harus persis `"false positive"`/`"won't fix"`/`"used in tests"` dengan spasi,
+BUKAN `false_positive` dengan underscore — API menolak keduanya kalau
+salah format; `dismissed_comment` dibatasi 280 karakter, taruh alasan
+lengkap di skill ini, bukan di comment).
 
 ## Verifikasi
 


### PR DESCRIPTION
## Summary
- Investigates and resolves Issue #614: 3 pre-existing CodeQL alerts (#16, #17, #18) unrelated to any active feature epic, discovered while merging PR #611/#613.
- All three confirmed false positives with concrete, traced evidence (not assumption):
  - **#18** `js/insufficient-password-hash` (`oauth-state-token.ts:30`): `generateOAuthState()` returns a 256-bit CSPRNG value, never a password. `hashOAuthState`'s fast-hash shape is identical to 3 other unflagged token files in this repo (session/reset/challenge tokens).
  - **#16, #17** `js/clear-text-logging` (`validate-env.ts:794,803`): traced the full data flow in `checkMfaConfig` — only the constant env-var-NAME string (e.g. `"AUTH_MFA_SECRET_ENCRYPTION_KEY"`) reaches `console.log`, never `env[name]` (the actual value).
- No reasonable code reformulation exists for either case without either sacrificing operator debuggability (which var is missing) or guessing at an unconfirmed CodeQL trigger mechanism, so all three were dismissed via the code-scanning API (`gh api .../code-scanning/alerts/<N> -X PATCH`) with evidence recorded in the dismissal comment and this PR's skill update.
- Documents this as a new pattern (#4) in `.claude/skills/awcms-mini-codeql-triage/SKILL.md`, alongside a fix to the skill's own dismiss-API example (`dismissed_reason` must be `"false positive"` with a space, not `false_positive` — the old example would 422).

## Test plan
- [x] `bun run check` (lint, docs, api spec, typecheck, 1510 tests, build) green.
- [x] All 3 alerts confirmed `state: dismissed` via `gh api repos/ahliweb/awcms-mini/code-scanning/alerts/{16,17,18}`.
- [x] No changeset (docs/chore only, no runtime behavior change, per AGENTS.md DoD).

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)