### PR TITLE
feat(visitor-analytics): add module descriptor, permissions, and configuration gate

### DIFF
--- a/.changeset/visitor-analytics-foundation.md
+++ b/.changeset/visitor-analytics-foundation.md
@@ -1,0 +1,14 @@
+---
+"awcms-mini": minor
+---
+
+Add the `visitor_analytics` module foundation (Issue #617, epic: visitor
+analytics #617-#624) — a new `type: "system"` module (like
+`reporting`/`logging`) for privacy-first human visitor statistics. Adds
+`src/modules/visitor-analytics` (module descriptor, env-based
+configuration gate with `basic`/`detailed` modes, all raw-detail/geo
+collection disabled by default), the 8-entry `visitor_analytics.*`
+permission seed (migration `038`), and `checkVisitorAnalyticsConfig` in
+`bun run config:validate`. No analytics tables, middleware collector,
+API, dashboard UI, geolocation enrichment, or rollup/retention jobs yet —
+those land in Issues #618-#624.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -38,6 +38,7 @@ Skill Claude Code tingkat-proyek untuk AWCMS-Mini. Setiap skill meng-encode stan
 | `awcms-mini-blog-content`                              | Kerjakan bagian mana pun epic blog_content (Issue #537-#543)                          | blog-content/README.md         |
 | `awcms-mini-tenant-domain-routing`                     | Kerjakan bagian mana pun epic online public routing & tenant domain (Issue #556-#567) | tenant-domain-routing/SKILL.md |
 | `awcms-mini-auth-online-hardening`                     | Kerjakan bagian mana pun epic full-online auth security hardening (Issue #587-#593)   | auth-online-hardening/SKILL.md |
+| `awcms-mini-visitor-analytics`                         | Kerjakan bagian mana pun epic visitor analytics (Issue #617-#624)                     | visitor-analytics/SKILL.md     |
 
 ## Katalog peningkatan (improvement/hardening)
 
@@ -102,6 +103,12 @@ flowchart TD
   AOH --> ABAC
   AOH --> AUD
   AOH --> SD
+  II --> VA[awcms-mini-visitor-analytics]
+  VA --> MIG
+  VA --> NM
+  VA --> EP
+  VA --> UI
+  VA --> SD
   II --> PR[awcms-mini-pr-review]
   PR --> SEC[awcms-mini-security-review]
   PR --> CQ[awcms-mini-codeql-triage]

--- a/.claude/skills/awcms-mini-visitor-analytics/SKILL.md
+++ b/.claude/skills/awcms-mini-visitor-analytics/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: awcms-mini-visitor-analytics
+description: Kerjakan bagian mana pun dari epic visitor analytics AWCMS-Mini (Issue #617-#624). Gunakan saat menambah/mengubah VISITOR_ANALYTICS_* env config, skema session/event/rollup, helper identity/UA/bot classification, middleware collector, API/dashboard `/admin/analytics`, enrichment geolokasi, atau job rollup/retention purge. Merangkum keputusan yang sudah dibuat supaya issue lanjutan tidak mengulang/kontradiksi.
+---
+
+# AWCMS-Mini — Visitor Analytics
+
+Epic visitor analytics (#617-#624) menambah **statistik pengunjung manusia
+privacy-first** untuk rute admin dan publik, di konfigurasi online maupun
+offline/LAN. Modul baru `visitor_analytics` (`type: "system"`) — bukan
+diperluas dari `reporting`/`logging` yang sudah ada, karena volume,
+retensi, dan kontrol privasi visitor telemetry berbeda dari keduanya
+(lihat `src/modules/visitor-analytics/README.md` §Why a separate module).
+
+## Kapan pakai skill ini vs skill generik
+
+Skill ini melengkapi (bukan menggantikan) `awcms-mini-new-endpoint`,
+`awcms-mini-new-migration`, `awcms-mini-new-module`,
+`awcms-mini-abac-guard`, `awcms-mini-sensitive-data` (IP/user-agent/geo
+adalah data sensitif), `awcms-mini-ui-screen` (dashboard #622), dan
+`awcms-mini-observability` (retensi/purge, korelasi dengan audit log yang
+sudah ada). Skill ini menyediakan konteks **cross-cutting epic
+spesifik** yang menjembatani beberapa issue sekaligus.
+
+## Status per issue (jangan bangun ulang yang sudah ada)
+
+| Issue | Scope                                                          | Status                               |
+| ----- | -------------------------------------------------------------- | ------------------------------------ |
+| #617  | Module descriptor, permission catalog, config gate             | **Selesai** — lihat §Config di bawah |
+| #618  | Visitor session/event/rollup schema + RLS                      | Belum dikerjakan                     |
+| #619  | Visitor identity, user-agent, human/bot classification helpers | Belum dikerjakan                     |
+| #620  | Middleware telemetry collection (admin + public)               | Belum dikerjakan                     |
+| #621  | Analytics API + OpenAPI contract (`/api/v1/analytics`)         | Belum dikerjakan                     |
+| #623  | Trusted online geolocation enrichment                          | Belum dikerjakan                     |
+| #622  | Admin visitor analytics dashboard UI (`/admin/analytics`)      | Belum dikerjakan                     |
+| #624  | Rollup job, retention purge job, readiness checks, docs pass   | Belum dikerjakan                     |
+
+Urutan dependency (dari body issue masing-masing): 617 → 618 → 619 → 620 →
+621 → 622; 623 boleh setelah 620 (paralel dengan 621/622); 624 butuh
+617+618+620+621 dan melengkapi 622/623.
+
+## Yang sudah ada — pakai ulang, jangan re-derive
+
+### Config (Issue #617, `src/modules/visitor-analytics/domain/visitor-analytics-config.ts`)
+
+Enam belas env var, semuanya **opsional** dan privacy-first — kalau tidak
+di-set sama sekali, `config:validate` tetap PASS dan tidak ada raw IP/raw
+user-agent/geolokasi yang tersimpan:
+
+- `VISITOR_ANALYTICS_ENABLED` (default `true`) — master switch.
+- `VISITOR_ANALYTICS_MODE` (default `basic`) — enum `basic | detailed`
+  (`VISITOR_ANALYTICS_MODES`, `isKnownVisitorAnalyticsMode`). Nilai tak
+  dikenal jatuh ke `basic`, tidak pernah throw.
+- `VISITOR_ANALYTICS_COLLECT_ADMIN` / `_COLLECT_PUBLIC` / `_COLLECT_API` —
+  toggle per permukaan (default `true`/`true`/`false`).
+- `VISITOR_ANALYTICS_DETAILED_ENABLED` — cadangan mode `detailed` (default
+  `false`, belum dikonsumsi apa pun).
+- `VISITOR_ANALYTICS_RAW_IP_ENABLED` / `_RAW_USER_AGENT_ENABLED` /
+  `_GEO_ENABLED` — **default `false` semuanya**, ini inti privacy-first
+  gate-nya. Independen dari `VISITOR_ANALYTICS_MODE` — mode tidak pernah
+  menyalakan ketiganya secara implisit.
+- `VISITOR_ANALYTICS_TRUST_PROXY` / `_TRUST_CLOUDFLARE` — default `false`;
+  sama prinsip keamanan dengan `PUBLIC_TRUST_PROXY` (skill
+  `awcms-mini-tenant-domain-routing`) — hanya `true` di belakang proxy
+  tepercaya yang benar-benar mengisi ulang header, bukan meneruskan nilai
+  klien.
+- Empat var retensi/jendela — `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS`
+  (300), `_EVENT_RETENTION_DAYS` (90), `_RAW_DETAIL_RETENTION_DAYS` (30),
+  `_ROLLUP_RETENTION_DAYS` (730) — divalidasi `parsePositiveInt`, wajib
+  integer positif **bila diisi**; tak diisi → default di atas, tidak
+  pernah gagal validasi.
+- `VISITOR_ANALYTICS_HASH_SALT` (default `""`) — salt untuk fingerprint
+  visitor pseudonymous, dikonsumsi Issue #619 (belum ada fungsi hashing
+  apa pun yang membacanya sampai issue itu).
+
+Entry point: `resolveVisitorAnalyticsConfig(env)` — SATU fungsi yang
+harus dipanggil issue lanjutan (#619 helper, #620 middleware), jangan
+re-derive baca `process.env.VISITOR_ANALYTICS_*` langsung. Gate boolean
+tunggal: `isVisitorAnalyticsEnabled(env)`.
+
+Validasi: `checkVisitorAnalyticsConfig()` (`scripts/validate-env.ts`),
+dipanggil dari `runEnvValidation()`. Didokumentasikan di
+`docs/awcms-mini/18_configuration_env_reference.md` §Visitor analytics.
+Test: `tests/unit/visitor-analytics-config.test.ts`,
+`tests/validate-env.test.ts`'s `describe("checkVisitorAnalyticsConfig", ...)`.
+
+### Module descriptor (Issue #617, `src/modules/visitor-analytics/module.ts`)
+
+Modul `visitor_analytics` terdaftar di `src/modules/index.ts`'s
+`listModules()`. **Hanya descriptor + config** — tidak ada tabel/API/UI/
+middleware di sini, itu semua issue lanjutan.
+
+- `key: "visitor_analytics"`, `type: "system"` (bukan `"domain"`) —
+  observability infrastructure yang dipakai bersama semua tenant, sama
+  alasan dengan `reporting`/`logging`/`tenant_domain`.
+- `dependencies: ["tenant_admin", "identity_access", "logging", "reporting"]`
+  (persis daftar di body issue #617).
+- `api: { basePath: "/api/v1/analytics", openApiPath:
+"openapi/awcms-mini-public-api.openapi.yaml" }` dan `navigation: [{
+path: "/admin/analytics", requiredPermission:
+"visitor_analytics.dashboard.read", order: 70 }]` **dideklarasikan
+  sekarang** meski API (#621)/dashboard (#622) belum ada — konvensi sama
+  dengan `tenant_domain`'s descriptor sebelum #562. Konsekuensinya sama:
+  Module Management's `openApiDocumentedSignal` akan `fail` untuk modul
+  ini sampai #621 menambah path OpenAPI nyata.
+- `permissions`: 8 entry (`dashboard.read`, `realtime.read`,
+  `sessions.read`, `events.read`, `raw_detail.read`, `settings.read`,
+  `settings.update`, `retention.purge`), match persis seed migration 038
+  — divalidasi `tests/modules/visitor-analytics-module.test.ts`.
+  `raw_detail.read` **sengaja terpisah** dari `dashboard.read` — operator
+  bisa memberi akses dashboard agregat tanpa memberi akses PII mentah
+  (IP/user-agent).
+- Tidak ada field `settings`/`jobs`/`health` — belum ada
+  settings-API/job/health-check nyata untuk didokumentasikan (konsisten
+  konvensi `module_management/README.md`, lihat juga precedent
+  `tenant_domain` Issue #558).
+- Tidak ada folder `application/`/`infrastructure`/`api` yang dibuat di
+  Issue #617 — hanya `module.ts` + `domain/visitor-analytics-config.ts` +
+  `README.md`. Folder lain menyusul issue yang benar-benar butuh
+  (#618 schema, #619 helpers, #620 middleware, #621 API).
+
+Permission migration: `sql/038_awcms_mini_visitor_analytics_permissions.sql`
+— pola sama `sql/032_awcms_mini_tenant_domain_permissions.sql` (`INSERT ...
+ON CONFLICT (module_key, activity_code, action) DO NOTHING`), belum ada
+role/access assignment yang memakainya.
+
+## Prinsip yang wajib dipertahankan di setiap issue lanjutan
+
+1. **Privacy-first default** — raw IP, raw user-agent, geolokasi selalu
+   default mati. Jangan pernah membuat issue lanjutan menyalakannya secara
+   implisit lewat `VISITOR_ANALYTICS_MODE=detailed` atau flag lain; wajib
+   opt-in eksplisit per flag masing-masing.
+2. **`raw_detail.read` terpisah dari `dashboard.read`** — endpoint/UI yang
+   menampilkan IP/user-agent mentah wajib cek permission `raw_detail.read`
+   secara eksplisit, bukan cukup `dashboard.read`.
+3. **Tenant isolation** — skema (#618) wajib tenant-scoped + RLS `ENABLE`
+   - `FORCE`, sama pola semua tabel tenant-scoped lain di repo ini (lihat
+     `docs/adr/0003-postgresql-rls-multi-tenant.md`).
+4. **Bukan dependency operasional** — koleksi telemetry tidak boleh
+   memblokir/memperlambat request admin/publik yang sebenarnya (mis. tulis
+   event lewat outbox/fire-and-forget, bukan inline blocking DB write di
+   jalur request kritis) — prinsip sama ADR-0006 untuk provider eksternal.
+5. **Retensi lebih pendek untuk data lebih sensitif** — raw detail (30
+   hari default) < event (90 hari default) < rollup agregat (730 hari
+   default). Jangan balik urutan ini di issue lanjutan tanpa alasan eksplisit.
+6. **`VISITOR_ANALYTICS_HASH_SALT` bukan credential provider** — dipakai
+   untuk fingerprint pseudonymous (dedup visitor tanpa cookie persisten),
+   bukan untuk autentikasi apa pun. Jangan expose di response/log/audit.
+
+## Referensi
+
+- `src/modules/visitor-analytics/README.md` — detail per-issue di dalam modul.
+- `docs/awcms-mini/18_configuration_env_reference.md` §Visitor analytics.
+- `AGENTS.md` skill table.

--- a/.env.example
+++ b/.env.example
@@ -223,6 +223,32 @@ PUBLIC_TRUST_PROXY=false
 # always falls back to the safe default (8000ms), never fails boot.
 # TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS=8000
 
+# Visitor analytics (opsional, Issue #617, epic: visitor analytics
+# #617-#624, modul `visitor_analytics`). Setiap var di bawah ini opsional
+# dengan default privacy-first — tidak di-set sama sekali tetap PASS
+# `bun run config:validate` dan berperilaku aman untuk offline/LAN. Raw IP,
+# raw user-agent, dan geolokasi TIDAK PERNAH disimpan kecuali di-opt-in
+# eksplisit lewat tiga flag *_RAW_IP_ENABLED/*_RAW_USER_AGENT_ENABLED/
+# *_GEO_ENABLED (lihat src/modules/visitor-analytics/README.md).
+VISITOR_ANALYTICS_ENABLED=true
+VISITOR_ANALYTICS_MODE=basic
+VISITOR_ANALYTICS_COLLECT_ADMIN=true
+VISITOR_ANALYTICS_COLLECT_PUBLIC=true
+VISITOR_ANALYTICS_COLLECT_API=false
+VISITOR_ANALYTICS_DETAILED_ENABLED=false
+VISITOR_ANALYTICS_RAW_IP_ENABLED=false
+VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED=false
+VISITOR_ANALYTICS_GEO_ENABLED=false
+VISITOR_ANALYTICS_TRUST_PROXY=false
+VISITOR_ANALYTICS_TRUST_CLOUDFLARE=false
+VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS=300
+VISITOR_ANALYTICS_EVENT_RETENTION_DAYS=90
+VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS=30
+VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS=730
+# Opsional — salt untuk fingerprint visitor pseudonymous (Issue #619).
+# Kosong di file ini secara sengaja; jangan isi dengan nilai rahasia asli.
+VISITOR_ANALYTICS_HASH_SALT=
+
 # Provider eksternal opsional (default off) — base tidak menetapkan provider
 # tertentu; aplikasi turunan menambah flag provider-nya sendiri di sini
 # (lihat contoh domain retail/POS di doc 18 §Provider CRM/AI analyst).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ AWCMS-Mini menyediakan **skill Claude Code tingkat-proyek** yang meng-encode sta
 | Migrasi data legacy (dry-run, backfill)                                | `awcms-mini-legacy-migration`      |
 | Kerjakan bagian mana pun epic blog_content (Issue #537-#543)           | `awcms-mini-blog-content`          |
 | Epic online public routing & tenant domain (Issue #556-#567)           | `awcms-mini-tenant-domain-routing` |
+| Epic visitor analytics (Issue #617-#624)                               | `awcms-mini-visitor-analytics`     |
 
 **Peningkatan (audit & hardening artefak yang sudah ada):**
 
@@ -167,6 +168,12 @@ flowchart LR
   II --> BLOG[blog-content]
   BLOG --> EP
   BLOG --> MIG
+  II --> VA[visitor-analytics]
+  VA --> MIG
+  VA --> NM
+  VA --> EP
+  VA --> UI2
+  VA --> SD
 ```
 
 Skill merujuk `docs/awcms-mini/*` sebagai sumber kebenaran; bila standar berubah, perbarui doc **dan** skill terkait.

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -414,6 +414,45 @@ provider timeout-bounded (default 8 detik, bisa diubah lewat
 `TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS` — security audit follow-up PR #580,
 sebelumnya hardcoded) dan dijalankan di luar transaksi DB mana pun (ADR-0006).
 
+### Visitor analytics (opsional, privacy-first — Issue #617, epic: visitor analytics #617-#624)
+
+Modul `visitor_analytics` (`src/modules/visitor-analytics/`). Setiap var
+di bawah ini opsional dengan default privacy-first — tidak di-set sama
+sekali tetap lulus `config:validate` dan tidak pernah menyimpan raw IP,
+raw user-agent, atau geolokasi. **Config-only saat Issue #617 ditulis** —
+belum ada tabel analytics (#618), middleware collector (#620), API
+(#621), dashboard (#622), atau enrichment geolokasi (#623) yang membaca
+var-var ini; itu semua issue lanjutan di epic yang sama.
+`scripts/validate-env.ts` (`checkVisitorAnalyticsConfig`) menegakkan
+tabel ini.
+
+| Var                                           | Wajib | Default | Sensitif | Fungsi                                                                               |
+| --------------------------------------------- | ----- | ------- | -------- | ------------------------------------------------------------------------------------ |
+| `VISITOR_ANALYTICS_ENABLED`                   | –     | `true`  | –        | Master switch koleksi telemetry pengunjung                                           |
+| `VISITOR_ANALYTICS_MODE`                      | –     | `basic` | –        | `basic`/`detailed` — nilai lain gagal validasi                                       |
+| `VISITOR_ANALYTICS_COLLECT_ADMIN`             | –     | `true`  | –        | Koleksi telemetry rute `/admin/*`                                                    |
+| `VISITOR_ANALYTICS_COLLECT_PUBLIC`            | –     | `true`  | –        | Koleksi telemetry rute publik                                                        |
+| `VISITOR_ANALYTICS_COLLECT_API`               | –     | `false` | –        | Koleksi telemetry panggilan `/api/v1/*`                                              |
+| `VISITOR_ANALYTICS_DETAILED_ENABLED`          | –     | `false` | –        | Cadangan granularitas session/event mode `detailed`                                  |
+| `VISITOR_ANALYTICS_RAW_IP_ENABLED`            | –     | `false` | –        | Simpan alamat IP mentah — default aman: mati                                         |
+| `VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED`    | –     | `false` | –        | Simpan string user-agent mentah — default aman: mati                                 |
+| `VISITOR_ANALYTICS_GEO_ENABLED`               | –     | `false` | –        | Aktifkan enrichment geolokasi (Issue #623) — default aman: mati                      |
+| `VISITOR_ANALYTICS_TRUST_PROXY`               | –     | `false` | –        | Percaya header `X-Forwarded-For` dkk. — **hanya** `true` di belakang proxy tepercaya |
+| `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`          | –     | `false` | –        | Percaya header khusus Cloudflare (`CF-Connecting-IP`, `CF-IPCountry`)                |
+| `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS`     | –     | `300`   | –        | Jendela waktu "online sekarang" — wajib integer positif bila diisi                   |
+| `VISITOR_ANALYTICS_EVENT_RETENTION_DAYS`      | –     | `90`    | –        | Retensi event — wajib integer positif bila diisi                                     |
+| `VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS` | –     | `30`    | –        | Retensi raw detail — wajib integer positif bila diisi                                |
+| `VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS`     | –     | `730`   | –        | Retensi rollup agregat — wajib integer positif bila diisi                            |
+| `VISITOR_ANALYTICS_HASH_SALT`                 | –     | `""`    | Ya       | Salt fingerprint visitor pseudonymous (Issue #619) — jangan isi nilai asli di sini   |
+
+Aturan validasi (`checkVisitorAnalyticsConfig`): `VISITOR_ANALYTICS_MODE`
+bila diisi wajib salah satu dari `VISITOR_ANALYTICS_MODES` (`basic` |
+`detailed`); empat var retensi/jendela di atas bila diisi wajib integer
+positif (`parsePositiveInt`) — nilai kosong/tidak valid pada var boolean
+manapun selalu jatuh ke `false`, mengikuti konvensi var boolean lain di
+repo ini. Belum ada aturan cross-field seperti `EMAIL_PROVIDER`/
+`TENANT_DOMAIN_DNS_PROVIDER` — provider geolokasi (Issue #623) belum ada.
+
 ### Provider CRM (opsional) — contoh domain retail/POS
 
 | Var                    | Wajib      | Default | Sensitif | Fungsi             |
@@ -517,6 +556,14 @@ EMAIL_SEND_MAX_RETRIES=5
 PUBLIC_CANONICAL_BASE_PATH=/news
 PUBLIC_TRUST_PROXY=false
 
+# Visitor analytics (opsional, privacy-first — Issue #617, epic: visitor
+# analytics #617-#624). Tidak di-set sama sekali = default aman di atas.
+VISITOR_ANALYTICS_ENABLED=true
+VISITOR_ANALYTICS_MODE=basic
+VISITOR_ANALYTICS_RAW_IP_ENABLED=false
+VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED=false
+VISITOR_ANALYTICS_GEO_ENABLED=false
+
 # Provider opsional (default off) — contoh domain retail/POS
 STARSENDER_ENABLED=false
 MAILKETING_ENABLED=false
@@ -566,6 +613,12 @@ flowchart TB
   `PUBLIC_CANONICAL_BASE_PATH` bukan absolute path → gagal start (Issue #556;
   lihat §Public routing di atas). Var ini tidak di-set sama sekali tetap
   lulus (perilaku legacy offline/LAN tidak berubah).
+- `VISITOR_ANALYTICS_MODE` diisi nilai selain `basic`/`detailed`, atau
+  salah satu dari empat var retensi/jendela (`VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS`/
+  `_EVENT_RETENTION_DAYS`/`_RAW_DETAIL_RETENTION_DAYS`/`_ROLLUP_RETENTION_DAYS`)
+  diisi nilai bukan integer positif → gagal start (Issue #617; lihat
+  §Visitor analytics di atas). Semua var ini tidak di-set sama sekali
+  tetap lulus dengan default privacy-first.
 - Secret tidak pernah masuk log (redaction, doc 10).
 
 ## Acceptance criteria

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -119,6 +119,16 @@
  *     `resolveMfaEncryptionKey`) — not just be present. Whether MFA actually
  *     activates at runtime depends on BOTH this flag AND the #587 gate
  *     (`isMfaRequired()`), not on this validation alone.
+ * 10. Visitor analytics (Issue #617, epic: visitor analytics #617-#624):
+ *     every VISITOR_ANALYTICS_* var is optional with a privacy-first
+ *     default (`../src/modules/visitor-analytics/domain/visitor-analytics-config`) —
+ *     leaving all of them unset always passes. If
+ *     VISITOR_ANALYTICS_MODE is set, it must be one of
+ *     `VISITOR_ANALYTICS_MODES` (`basic` | `detailed`). The four retention/
+ *     window vars, if set, must each parse as a positive integer
+ *     (`parsePositiveInt`). No conditional cross-field requirement exists
+ *     yet (unlike EMAIL_PROVIDER/TENANT_DOMAIN_DNS_PROVIDER) — geolocation
+ *     enrichment provider config lands in a later issue (#623).
  *
  * Never prints actual secret values — only which variable name is
  * missing/invalid (doc 18: "Var wajib hilang → gagal start dengan pesan
@@ -156,6 +166,12 @@ import {
   SSO_REQUIRED_WHEN_ENABLED
 } from "../src/lib/auth/sso-config";
 import { resolveSsoEncryptionKey } from "../src/lib/auth/sso-credential-crypto";
+import {
+  isKnownVisitorAnalyticsMode,
+  parsePositiveInt,
+  VISITOR_ANALYTICS_MODES,
+  VISITOR_ANALYTICS_POSITIVE_INT_VARS
+} from "../src/modules/visitor-analytics/domain/visitor-analytics-config";
 
 export type EnvCheckResult = {
   name: string;
@@ -767,6 +783,70 @@ export function checkSsoConfig(
   });
 }
 
+/**
+ * Visitor analytics (Issue #617, epic: visitor analytics #617-#624). Every
+ * var is optional — unset always passes, mirroring
+ * `resolveVisitorAnalyticsConfig`'s own fall-back-to-default behavior so a
+ * deployment that never touches these vars stays privacy-first by
+ * default (see file header comment §10).
+ */
+export function checkVisitorAnalyticsConfig(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult[] {
+  const results: EnvCheckResult[] = [];
+  const rawMode = env.VISITOR_ANALYTICS_MODE;
+
+  if (!isSet(rawMode)) {
+    results.push({
+      name: "VISITOR_ANALYTICS_MODE",
+      status: "pass",
+      detail: "VISITOR_ANALYTICS_MODE is not set — defaults to basic."
+    });
+  } else if (isKnownVisitorAnalyticsMode((rawMode as string).trim())) {
+    results.push({
+      name: "VISITOR_ANALYTICS_MODE",
+      status: "pass",
+      detail: `VISITOR_ANALYTICS_MODE is a known mode (${(rawMode as string).trim()}).`
+    });
+  } else {
+    results.push({
+      name: "VISITOR_ANALYTICS_MODE",
+      status: "fail",
+      detail: `VISITOR_ANALYTICS_MODE must be one of ${VISITOR_ANALYTICS_MODES.join(", ")}; got "${(rawMode as string).trim()}".`
+    });
+  }
+
+  for (const name of VISITOR_ANALYTICS_POSITIVE_INT_VARS) {
+    const raw = env[name];
+
+    if (!isSet(raw)) {
+      results.push({
+        name,
+        status: "pass",
+        detail: `${name} is not set — a privacy-first default applies.`
+      });
+      continue;
+    }
+
+    if (parsePositiveInt(raw) !== undefined) {
+      results.push({
+        name,
+        status: "pass",
+        detail: `${name} is a positive integer.`
+      });
+      continue;
+    }
+
+    results.push({
+      name,
+      status: "fail",
+      detail: `${name} must be a positive integer when set; got "${(raw as string).trim()}".`
+    });
+  }
+
+  return results;
+}
+
 export function runEnvValidation(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -781,7 +861,8 @@ export function runEnvValidation(
     ...checkMfaConfig(env),
     ...checkGoogleOidcConfig(env),
     ...checkSsoConfig(env),
-    ...checkOnlineAuthSecurityConfig(env)
+    ...checkOnlineAuthSecurityConfig(env),
+    ...checkVisitorAnalyticsConfig(env)
   ];
 }
 

--- a/sql/038_awcms_mini_visitor_analytics_permissions.sql
+++ b/sql/038_awcms_mini_visitor_analytics_permissions.sql
@@ -1,0 +1,18 @@
+-- Issue #617 (epic: visitor analytics #617-#624) — permission catalog seed
+-- for the new `visitor_analytics` module descriptor
+-- (src/modules/visitor-analytics/module.ts). Same shape as
+-- `sql/032_awcms_mini_tenant_domain_permissions.sql` — extends the global
+-- ABAC permission catalog only, no roles/access-assignments wired here, no
+-- new tables (the visitor session/event/rollup schema lands in the next
+-- issue, #618).
+INSERT INTO awcms_mini_permissions (module_key, activity_code, action, description)
+VALUES
+  ('visitor_analytics', 'dashboard', 'read', 'Read the visitor analytics dashboard'),
+  ('visitor_analytics', 'realtime', 'read', 'Read real-time/online visitor counts'),
+  ('visitor_analytics', 'sessions', 'read', 'Read visitor session records'),
+  ('visitor_analytics', 'events', 'read', 'Read visitor page-view/event records'),
+  ('visitor_analytics', 'raw_detail', 'read', 'Read raw visitor detail (IP address, user-agent) separate from aggregate dashboard access'),
+  ('visitor_analytics', 'settings', 'read', 'Read visitor analytics module settings'),
+  ('visitor_analytics', 'settings', 'update', 'Update visitor analytics module settings'),
+  ('visitor_analytics', 'retention', 'purge', 'Purge visitor analytics data past its retention window')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -10,6 +10,7 @@ import { reportingModule } from "./reporting/module";
 import { syncStorageModule } from "./sync-storage/module";
 import { tenantAdminModule } from "./tenant-admin/module";
 import { tenantDomainModule } from "./tenant-domain/module";
+import { visitorAnalyticsModule } from "./visitor-analytics/module";
 import { workflowApprovalModule } from "./workflow-approval/module";
 
 export const modules: ModuleDescriptor[] = [
@@ -24,7 +25,8 @@ export const modules: ModuleDescriptor[] = [
   emailModule,
   moduleManagementModule,
   blogContentModule,
-  tenantDomainModule
+  tenantDomainModule,
+  visitorAnalyticsModule
 ];
 
 export function getModuleByKey(

--- a/src/modules/visitor-analytics/README.md
+++ b/src/modules/visitor-analytics/README.md
@@ -1,0 +1,119 @@
+# Visitor Analytics
+
+Epic: visitor analytics (Issue #617-#624). Privacy-first human visitor
+statistics for admin and public routes, in both online and offline/LAN
+configurations. This module (`key: visitor_analytics`) is a `type:
+"system"` module — platform/observability infrastructure every tenant
+shares the mechanism of, the same reasoning as `reporting`/`logging` — not
+a tenant-facing business feature. See
+`.claude/skills/awcms-mini-visitor-analytics/SKILL.md` for the full
+cross-issue context.
+
+## Why a separate module
+
+AWCMS-Mini already has `reporting` (management reporting views) and
+`logging` (audit trail). Visitor telemetry does not belong in either:
+
+- **Volume**: a page-view/event stream from every admin and public request
+  is orders of magnitude higher-volume than audit events (which are
+  emitted only for high-risk actions) or reporting's read-aggregation
+  queries.
+- **Retention**: visitor events/raw-detail need short, independently
+  tunable retention windows (days, not years) distinct from the audit
+  trail's compliance-driven retention.
+- **Privacy controls**: visitor telemetry touches IP address, user-agent,
+  and (optionally) geolocation — data classes `reporting`/`logging` do not
+  otherwise handle, needing their own dedicated opt-in flags and a
+  raw-detail permission separate from aggregate dashboard access.
+
+## Scope per issue
+
+Issue #617 (this module — `module.ts`, `domain/visitor-analytics-config.ts`):
+registers `visitor_analytics` in the trusted code module catalog
+(`src/modules/index.ts`) so it syncs into `awcms_mini_modules` via
+`bun run modules:sync`, declares the eight permissions from migration 038
+(see §Permission seed), and adds the env-based configuration gate (see
+§Configuration). **No analytics tables, no middleware collector, no API,
+no dashboard UI, no geolocation enrichment, and no rollup/retention jobs
+yet** — see §Not yet available below.
+
+Issue #618: visitor session/event/rollup schema with RLS.
+
+Issue #619: visitor identity, user-agent, and human/bot classification
+helpers.
+
+Issue #620: middleware telemetry collection (admin + public routes).
+
+Issue #621: analytics API + OpenAPI contract at `/api/v1/analytics`.
+
+Issue #623: trusted online geolocation enrichment.
+
+Issue #622: admin visitor analytics dashboard UI at `/admin/analytics`.
+
+Issue #624: rollup job, retention purge job, readiness checks, and final
+docs pass.
+
+## Configuration (`domain/visitor-analytics-config.ts`)
+
+Every `VISITOR_ANALYTICS_*` env var is optional with a privacy-first
+default — leaving all of them unset keeps `bun run config:validate`
+passing and the module behaving safely for offline/LAN deployments.
+`resolveVisitorAnalyticsConfig(env)` is the single entry point later
+issues (#619 identity helpers, #620 middleware collector) should call
+rather than re-reading `process.env.VISITOR_ANALYTICS_*` themselves.
+
+| Var                                           | Default | Notes                                                                                           |
+| --------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `VISITOR_ANALYTICS_ENABLED`                   | `true`  | Master switch. `false` disables collection entirely.                                            |
+| `VISITOR_ANALYTICS_MODE`                      | `basic` | `basic` \| `detailed` (`VISITOR_ANALYTICS_MODES`). Unknown value falls back to `basic`.         |
+| `VISITOR_ANALYTICS_COLLECT_ADMIN`             | `true`  | Collect telemetry for `/admin/*` routes.                                                        |
+| `VISITOR_ANALYTICS_COLLECT_PUBLIC`            | `true`  | Collect telemetry for public routes.                                                            |
+| `VISITOR_ANALYTICS_COLLECT_API`               | `false` | Collect telemetry for `/api/v1/*` calls.                                                        |
+| `VISITOR_ANALYTICS_DETAILED_ENABLED`          | `false` | Reserved for `detailed` mode's richer session/event granularity.                                |
+| `VISITOR_ANALYTICS_RAW_IP_ENABLED`            | `false` | Store the raw IP address. Privacy-first default: off.                                           |
+| `VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED`    | `false` | Store the raw user-agent string. Privacy-first default: off.                                    |
+| `VISITOR_ANALYTICS_GEO_ENABLED`               | `false` | Enable geolocation enrichment (Issue #623). Privacy-first default: off.                         |
+| `VISITOR_ANALYTICS_TRUST_PROXY`               | `false` | Trust `X-Forwarded-For`/similar headers. Only set `true` behind a trusted reverse proxy.        |
+| `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`          | `false` | Trust Cloudflare-specific headers (`CF-Connecting-IP`, `CF-IPCountry`). Only behind Cloudflare. |
+| `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS`     | `300`   | Positive integer. Real-time "online now" window.                                                |
+| `VISITOR_ANALYTICS_EVENT_RETENTION_DAYS`      | `90`    | Positive integer.                                                                               |
+| `VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS` | `30`    | Positive integer. Shorter than event retention — raw detail is the most sensitive data class.   |
+| `VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS`     | `730`   | Positive integer. Aggregated rollups can be kept far longer than raw events.                    |
+| `VISITOR_ANALYTICS_HASH_SALT`                 | `""`    | Optional salt for the pseudonymous visitor fingerprint (Issue #619). Never a real secret here.  |
+
+`bun run config:validate`'s `checkVisitorAnalyticsConfig` validates
+`VISITOR_ANALYTICS_MODE` against `VISITOR_ANALYTICS_MODES` and each
+retention/window var against `parsePositiveInt` when set — never against
+the raw boolean flags (any value other than the literal string `"true"`
+is treated as `false`, the same convention every other boolean env var in
+this repo follows).
+
+## Permission seed (migration `038_awcms_mini_visitor_analytics_permissions.sql`, Issue #617)
+
+`module_key = 'visitor_analytics'`:
+
+- `dashboard.read` — read the visitor analytics dashboard.
+- `realtime.read` — read real-time/online visitor counts.
+- `sessions.read` — read visitor session records.
+- `events.read` — read visitor page-view/event records.
+- `raw_detail.read` — read raw visitor detail (IP, user-agent), kept
+  separate from aggregate dashboard access so an operator can grant
+  dashboard visibility without granting raw PII access.
+- `settings.read` / `settings.update` — read/update module settings.
+- `retention.purge` — purge data past its retention window.
+
+No endpoints or roles are wired to these yet.
+
+## Not yet available
+
+- Analytics tables (session/event/rollup) — Issue #618.
+- Any data collection — Issue #620 (middleware).
+- Identity/UA/bot classification helpers — Issue #619.
+- REST API (`/api/v1/analytics/*`) — Issue #621.
+- Admin dashboard UI (`/admin/analytics`) — Issue #622.
+- Geolocation enrichment — Issue #623.
+- Rollup/retention purge jobs — Issue #624.
+
+The `api.basePath`/navigation `path` in `module.ts` are pre-declared ahead
+of their landing issues (same convention `tenant_domain`'s descriptor
+followed ahead of Issue #562) — no route exists at either path yet.

--- a/src/modules/visitor-analytics/domain/visitor-analytics-config.ts
+++ b/src/modules/visitor-analytics/domain/visitor-analytics-config.ts
@@ -1,0 +1,191 @@
+/**
+ * Privacy-first configuration gate for the `visitor_analytics` module
+ * (Issue #617, epic: visitor analytics #617-#624). Pure — no
+ * `process.env` reads here; `scripts/validate-env.ts` passes in whatever
+ * `env` it was given, same split as `email/domain/email-config.ts` and
+ * `tenant-domain/domain/tenant-domain-dns-config.ts`.
+ *
+ * This file only resolves/validates the env-var shape. It does not
+ * collect, store, or process any visitor data — that is later issues:
+ * schema (#618), identity/UA/bot classification (#619), the middleware
+ * collector (#620), the API (#621), geolocation enrichment (#623), and
+ * rollup/retention (#624).
+ *
+ * `VISITOR_ANALYTICS_MODE=basic` is the privacy-first default: raw IP,
+ * raw user-agent, and geolocation collection are all disabled by
+ * default and require an explicit opt-in env var, independent of
+ * `VISITOR_ANALYTICS_MODE` itself (the mode only distinguishes
+ * aggregate-only `basic` collection from a future `detailed` mode with
+ * richer session/event granularity — it never implies the raw-detail
+ * flags below turn on by itself).
+ */
+export const VISITOR_ANALYTICS_MODES = ["basic", "detailed"] as const;
+
+export type VisitorAnalyticsMode = (typeof VISITOR_ANALYTICS_MODES)[number];
+
+export function isKnownVisitorAnalyticsMode(
+  value: string | undefined
+): value is VisitorAnalyticsMode {
+  return (VISITOR_ANALYTICS_MODES as readonly string[]).includes(value ?? "");
+}
+
+export type VisitorAnalyticsConfig = {
+  enabled: boolean;
+  mode: VisitorAnalyticsMode;
+  collectAdmin: boolean;
+  collectPublic: boolean;
+  collectApi: boolean;
+  detailedEnabled: boolean;
+  rawIpEnabled: boolean;
+  rawUserAgentEnabled: boolean;
+  geoEnabled: boolean;
+  trustProxy: boolean;
+  trustCloudflare: boolean;
+  onlineWindowSeconds: number;
+  eventRetentionDays: number;
+  rawDetailRetentionDays: number;
+  rollupRetentionDays: number;
+  hashSalt: string;
+};
+
+/** Safe defaults matching the issue's `.env.example` block exactly. */
+export const VISITOR_ANALYTICS_DEFAULTS: VisitorAnalyticsConfig = {
+  enabled: true,
+  mode: "basic",
+  collectAdmin: true,
+  collectPublic: true,
+  collectApi: false,
+  detailedEnabled: false,
+  rawIpEnabled: false,
+  rawUserAgentEnabled: false,
+  geoEnabled: false,
+  trustProxy: false,
+  trustCloudflare: false,
+  onlineWindowSeconds: 300,
+  eventRetentionDays: 90,
+  rawDetailRetentionDays: 30,
+  rollupRetentionDays: 730,
+  hashSalt: ""
+};
+
+/**
+ * The env var names whose value must parse as a positive integer when
+ * set — checked by `checkVisitorAnalyticsConfig` in
+ * `scripts/validate-env.ts` and reused here so both files agree on
+ * exactly which keys are "positive integer" shaped.
+ */
+export const VISITOR_ANALYTICS_POSITIVE_INT_VARS = [
+  "VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS",
+  "VISITOR_ANALYTICS_EVENT_RETENTION_DAYS",
+  "VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS",
+  "VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS"
+] as const;
+
+function isSet(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (!isSet(value)) return fallback;
+  return value === "true";
+}
+
+/** `undefined` when unset/blank/non-positive-integer — never throws, never NaN. */
+export function parsePositiveInt(
+  value: string | undefined
+): number | undefined {
+  if (!isSet(value)) return undefined;
+
+  const trimmed = (value as string).trim();
+
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  const parsed = Number.parseInt(trimmed, 10);
+
+  return parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * Resolves the full config from `env`, falling back to
+ * `VISITOR_ANALYTICS_DEFAULTS` for anything unset or malformed. Never
+ * throws — malformed numeric values are reported by
+ * `checkVisitorAnalyticsConfig` (`scripts/validate-env.ts`), not here;
+ * this resolver always returns a usable config so later issues (#619,
+ * #620) can call it unconditionally.
+ */
+export function resolveVisitorAnalyticsConfig(
+  env: NodeJS.ProcessEnv = process.env
+): VisitorAnalyticsConfig {
+  const modeRaw = env.VISITOR_ANALYTICS_MODE;
+
+  return {
+    enabled: parseBoolean(
+      env.VISITOR_ANALYTICS_ENABLED,
+      VISITOR_ANALYTICS_DEFAULTS.enabled
+    ),
+    mode: isKnownVisitorAnalyticsMode(modeRaw)
+      ? modeRaw
+      : VISITOR_ANALYTICS_DEFAULTS.mode,
+    collectAdmin: parseBoolean(
+      env.VISITOR_ANALYTICS_COLLECT_ADMIN,
+      VISITOR_ANALYTICS_DEFAULTS.collectAdmin
+    ),
+    collectPublic: parseBoolean(
+      env.VISITOR_ANALYTICS_COLLECT_PUBLIC,
+      VISITOR_ANALYTICS_DEFAULTS.collectPublic
+    ),
+    collectApi: parseBoolean(
+      env.VISITOR_ANALYTICS_COLLECT_API,
+      VISITOR_ANALYTICS_DEFAULTS.collectApi
+    ),
+    detailedEnabled: parseBoolean(
+      env.VISITOR_ANALYTICS_DETAILED_ENABLED,
+      VISITOR_ANALYTICS_DEFAULTS.detailedEnabled
+    ),
+    rawIpEnabled: parseBoolean(
+      env.VISITOR_ANALYTICS_RAW_IP_ENABLED,
+      VISITOR_ANALYTICS_DEFAULTS.rawIpEnabled
+    ),
+    rawUserAgentEnabled: parseBoolean(
+      env.VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED,
+      VISITOR_ANALYTICS_DEFAULTS.rawUserAgentEnabled
+    ),
+    geoEnabled: parseBoolean(
+      env.VISITOR_ANALYTICS_GEO_ENABLED,
+      VISITOR_ANALYTICS_DEFAULTS.geoEnabled
+    ),
+    trustProxy: parseBoolean(
+      env.VISITOR_ANALYTICS_TRUST_PROXY,
+      VISITOR_ANALYTICS_DEFAULTS.trustProxy
+    ),
+    trustCloudflare: parseBoolean(
+      env.VISITOR_ANALYTICS_TRUST_CLOUDFLARE,
+      VISITOR_ANALYTICS_DEFAULTS.trustCloudflare
+    ),
+    onlineWindowSeconds:
+      parsePositiveInt(env.VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS) ??
+      VISITOR_ANALYTICS_DEFAULTS.onlineWindowSeconds,
+    eventRetentionDays:
+      parsePositiveInt(env.VISITOR_ANALYTICS_EVENT_RETENTION_DAYS) ??
+      VISITOR_ANALYTICS_DEFAULTS.eventRetentionDays,
+    rawDetailRetentionDays:
+      parsePositiveInt(env.VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS) ??
+      VISITOR_ANALYTICS_DEFAULTS.rawDetailRetentionDays,
+    rollupRetentionDays:
+      parsePositiveInt(env.VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS) ??
+      VISITOR_ANALYTICS_DEFAULTS.rollupRetentionDays,
+    hashSalt:
+      env.VISITOR_ANALYTICS_HASH_SALT ?? VISITOR_ANALYTICS_DEFAULTS.hashSalt
+  };
+}
+
+/**
+ * The single boolean every later issue (#619 identity helpers, #620
+ * middleware collector) should gate real work on — mirrors
+ * `isFullOnlineSecurityActive`'s role in `online-security-config.ts`.
+ */
+export function isVisitorAnalyticsEnabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return resolveVisitorAnalyticsConfig(env).enabled;
+}

--- a/src/modules/visitor-analytics/module.ts
+++ b/src/modules/visitor-analytics/module.ts
@@ -1,0 +1,87 @@
+import { defineModule } from "../_shared/module-contract";
+
+/**
+ * `visitor_analytics` (Issue #617, epic: visitor analytics #617-#624).
+ * This issue registers the module descriptor, permission catalog, and
+ * env-based configuration gate only — no analytics tables (#618), no
+ * identity/UA/bot classification (#619), no middleware collector (#620),
+ * no API/dashboard (#621/#622), no geolocation enrichment (#623), and no
+ * rollup/retention jobs (#624) yet.
+ *
+ * `type: "system"` (not `"domain"`): human visitor telemetry is
+ * platform/observability infrastructure every tenant shares the
+ * mechanism of (same reasoning as `reporting`/`logging`), not a
+ * tenant-facing business feature (contrast `blog_content`, `type:
+ * "domain"`). Higher volume and different retention/privacy needs than
+ * `reporting`/`logging` is exactly why it is its own module instead of
+ * being folded into either (see README.md §Why a separate module).
+ */
+export const visitorAnalyticsModule = defineModule({
+  key: "visitor_analytics",
+  name: "Visitor Analytics",
+  version: "0.1.0",
+  status: "active",
+  description:
+    "Privacy-first human visitor statistics for admin and public routes, in both online and offline/LAN configurations (epic: visitor analytics #617-#624). Issue #617 (this descriptor) adds the module registration, permission catalog, and env-based configuration gate — VISITOR_ANALYTICS_MODE=basic by default, with raw IP, raw user-agent, and geolocation collection all disabled unless explicitly opted in (see domain/visitor-analytics-config.ts). No analytics tables, middleware collector, API, dashboard UI, geolocation enrichment, or rollup/retention jobs exist yet.",
+  dependencies: ["tenant_admin", "identity_access", "logging", "reporting"],
+  type: "system",
+  // Pre-declared ahead of the API landing (Issue #621), same convention
+  // `tenant_domain`'s descriptor followed ahead of its own API issue
+  // (#562) — the OpenAPI path is the repo-wide single spec file, not a
+  // per-module file.
+  api: {
+    openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
+    basePath: "/api/v1/analytics"
+  },
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_visitor_analytics",
+      path: "/admin/analytics",
+      order: 70,
+      requiredPermission: "visitor_analytics.dashboard.read"
+    }
+  ],
+  permissions: [
+    {
+      activityCode: "dashboard",
+      action: "read",
+      description: "Read the visitor analytics dashboard"
+    },
+    {
+      activityCode: "realtime",
+      action: "read",
+      description: "Read real-time/online visitor counts"
+    },
+    {
+      activityCode: "sessions",
+      action: "read",
+      description: "Read visitor session records"
+    },
+    {
+      activityCode: "events",
+      action: "read",
+      description: "Read visitor page-view/event records"
+    },
+    {
+      activityCode: "raw_detail",
+      action: "read",
+      description:
+        "Read raw visitor detail (IP address, user-agent) separate from aggregate dashboard access"
+    },
+    {
+      activityCode: "settings",
+      action: "read",
+      description: "Read visitor analytics module settings"
+    },
+    {
+      activityCode: "settings",
+      action: "update",
+      description: "Update visitor analytics module settings"
+    },
+    {
+      activityCode: "retention",
+      action: "purge",
+      description: "Purge visitor analytics data past its retention window"
+    }
+  ]
+});

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -58,8 +58,8 @@ describe("soft delete helper", () => {
 });
 
 describe("module registry", () => {
-  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, email, module_management, blog_content, and tenant_domain are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498, #511-#513, #537, #558", () => {
-    expect(listModules()).toHaveLength(12);
+  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, email, module_management, blog_content, tenant_domain, and visitor_analytics are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498, #511-#513, #537, #558, #617", () => {
+    expect(listModules()).toHaveLength(13);
     expect(getModuleByKey("tenant_admin")).toMatchObject({
       key: "tenant_admin",
       status: "active"
@@ -123,6 +123,12 @@ describe("module registry", () => {
       status: "active",
       type: "system",
       dependencies: ["tenant_admin", "identity_access"]
+    });
+    expect(getModuleByKey("visitor_analytics")).toMatchObject({
+      key: "visitor_analytics",
+      status: "active",
+      type: "system",
+      dependencies: ["tenant_admin", "identity_access", "logging", "reporting"]
     });
     expect(getModuleByKey("unknown_module")).toBeUndefined();
   });
@@ -240,7 +246,8 @@ describe("database migration runner helpers", () => {
       "034_awcms_mini_mfa_totp_schema.sql",
       "035_awcms_mini_google_oidc_schema.sql",
       "036_awcms_mini_tenant_oidc_sso_schema.sql",
-      "037_awcms_mini_tenant_oidc_sso_permissions.sql"
+      "037_awcms_mini_tenant_oidc_sso_permissions.sql",
+      "038_awcms_mini_visitor_analytics_permissions.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/module-presets.integration.test.ts
+++ b/tests/integration/module-presets.integration.test.ts
@@ -142,9 +142,18 @@ suite("tenant module preset application service", () => {
     for (const key of ["tenant_domain", "blog_content", "email", "reporting"]) {
       expect(changeByKey.has(key)).toBe(false);
     }
-    // logging/workflow/form_drafts aren't listed and nothing depends on
-    // them, so they're safely disabled to actually produce the profile.
-    for (const key of ["logging", "workflow", "form_drafts"]) {
+    // logging/workflow/form_drafts/visitor_analytics aren't listed and
+    // nothing (that stays enabled) depends on them, so they're safely
+    // disabled to actually produce the profile. visitor_analytics itself
+    // depends on logging/reporting, but nothing depends on
+    // visitor_analytics — a pure leaf — so it disables cleanly and, once
+    // it's gone, unblocks logging the same way.
+    for (const key of [
+      "logging",
+      "workflow",
+      "form_drafts",
+      "visitor_analytics"
+    ]) {
       expect(changeByKey.get(key)?.outcome).toBe("applied");
       expect(changeByKey.get(key)?.action).toBe("disabled");
     }
@@ -165,6 +174,7 @@ suite("tenant module preset application service", () => {
     expect(state.get("logging")).toBe(false);
     expect(state.get("workflow")).toBe(false);
     expect(state.get("form_drafts")).toBe(false);
+    expect(state.get("visitor_analytics")).toBe(false);
 
     const auditRows = await fetchAuditActions(owner.tenantId);
     const disabledResourceIds = auditRows
@@ -172,7 +182,7 @@ suite("tenant module preset application service", () => {
       .map((r) => r.resource_id)
       .sort();
     expect(disabledResourceIds).toEqual(
-      ["form_drafts", "logging", "workflow"].sort()
+      ["form_drafts", "logging", "workflow", "visitor_analytics"].sort()
     );
     // No audit event for modules that were already in the target state.
     expect(auditRows.some((r) => r.action === "tenant_module_enabled")).toBe(
@@ -257,7 +267,8 @@ suite("tenant module preset application service", () => {
       "sync_storage",
       "tenant_domain",
       "workflow",
-      "form_drafts"
+      "form_drafts",
+      "visitor_analytics"
     ]) {
       expect(state.get(key)).toBe(false);
     }

--- a/tests/modules/visitor-analytics-module.test.ts
+++ b/tests/modules/visitor-analytics-module.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+
+import { getModuleByKey, listModules } from "../../src/modules";
+import { visitorAnalyticsModule } from "../../src/modules/visitor-analytics/module";
+
+// Issue #617 — the eight permissions seeded by
+// sql/038_awcms_mini_visitor_analytics_permissions.sql, verbatim. The
+// descriptor's `permissions` array must match this list exactly
+// (activityCode/action/description) or Module Management's permission
+// sync/status report will show `missing`/`mismatched_description` for
+// this module.
+const MIGRATION_038_PERMISSIONS = [
+  {
+    activityCode: "dashboard",
+    action: "read",
+    description: "Read the visitor analytics dashboard"
+  },
+  {
+    activityCode: "realtime",
+    action: "read",
+    description: "Read real-time/online visitor counts"
+  },
+  {
+    activityCode: "sessions",
+    action: "read",
+    description: "Read visitor session records"
+  },
+  {
+    activityCode: "events",
+    action: "read",
+    description: "Read visitor page-view/event records"
+  },
+  {
+    activityCode: "raw_detail",
+    action: "read",
+    description:
+      "Read raw visitor detail (IP address, user-agent) separate from aggregate dashboard access"
+  },
+  {
+    activityCode: "settings",
+    action: "read",
+    description: "Read visitor analytics module settings"
+  },
+  {
+    activityCode: "settings",
+    action: "update",
+    description: "Update visitor analytics module settings"
+  },
+  {
+    activityCode: "retention",
+    action: "purge",
+    description: "Purge visitor analytics data past its retention window"
+  }
+];
+
+describe("visitor_analytics module descriptor (Issue #617)", () => {
+  test("listModules() includes visitor_analytics", () => {
+    expect(listModules().some((m) => m.key === "visitor_analytics")).toBe(true);
+    expect(getModuleByKey("visitor_analytics")).toBe(visitorAnalyticsModule);
+  });
+
+  test("descriptor shape matches the issue's requirements", () => {
+    expect(visitorAnalyticsModule.key).toBe("visitor_analytics");
+    expect(visitorAnalyticsModule.status).toBe("active");
+    expect(visitorAnalyticsModule.type).toBe("system");
+    expect(visitorAnalyticsModule.dependencies).toEqual([
+      "tenant_admin",
+      "identity_access",
+      "logging",
+      "reporting"
+    ]);
+  });
+
+  test("api.basePath matches the issue's later API scope (#621)", () => {
+    expect(visitorAnalyticsModule.api?.basePath).toBe("/api/v1/analytics");
+    expect(visitorAnalyticsModule.api?.openApiPath).toBe(
+      "openapi/awcms-mini-public-api.openapi.yaml"
+    );
+  });
+
+  test("navigation.path matches the issue's requirement and is permission-gated", () => {
+    expect(visitorAnalyticsModule.navigation).toHaveLength(1);
+    expect(visitorAnalyticsModule.navigation?.[0]?.path).toBe(
+      "/admin/analytics"
+    );
+    expect(visitorAnalyticsModule.navigation?.[0]?.requiredPermission).toBe(
+      "visitor_analytics.dashboard.read"
+    );
+  });
+
+  test("permissions array matches migration 038's seed exactly", () => {
+    expect(visitorAnalyticsModule.permissions).toEqual(
+      MIGRATION_038_PERMISSIONS
+    );
+  });
+
+  test("permissions use the same module_key/activity_code the migration seeded", () => {
+    const permissionKeys = (visitorAnalyticsModule.permissions ?? []).map(
+      (p) => `${visitorAnalyticsModule.key}.${p.activityCode}.${p.action}`
+    );
+
+    expect(permissionKeys).toEqual([
+      "visitor_analytics.dashboard.read",
+      "visitor_analytics.realtime.read",
+      "visitor_analytics.sessions.read",
+      "visitor_analytics.events.read",
+      "visitor_analytics.raw_detail.read",
+      "visitor_analytics.settings.read",
+      "visitor_analytics.settings.update",
+      "visitor_analytics.retention.purge"
+    ]);
+  });
+
+  test("raw_detail.read is a distinct permission from dashboard.read (privacy separation)", () => {
+    const activityCodes = (visitorAnalyticsModule.permissions ?? []).map(
+      (p) => p.activityCode
+    );
+
+    expect(activityCodes).toContain("raw_detail");
+    expect(activityCodes).toContain("dashboard");
+  });
+
+  test("descriptor never declares a secret, token, or provider credential", () => {
+    const serialized = JSON.stringify(visitorAnalyticsModule).toLowerCase();
+
+    for (const forbidden of [
+      "password",
+      "token",
+      "secret",
+      "credential",
+      "apikey",
+      "api_key"
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+
+  test("the module never declares jobs, health, or settings before those capabilities are real", () => {
+    // Consistent with tenant_domain's own precedent (Issue #558): a
+    // descriptor should only claim jobs/health/settings once the
+    // corresponding feature exists. None of them exist for
+    // visitor_analytics as of Issue #617 (rollup/retention jobs land in
+    // #624; no module-settings surface has been built yet either).
+    expect(visitorAnalyticsModule.jobs).toBeUndefined();
+    expect(visitorAnalyticsModule.health).toBeUndefined();
+    expect(visitorAnalyticsModule.settings).toBeUndefined();
+  });
+});

--- a/tests/unit/visitor-analytics-config.test.ts
+++ b/tests/unit/visitor-analytics-config.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isKnownVisitorAnalyticsMode,
+  isVisitorAnalyticsEnabled,
+  parsePositiveInt,
+  resolveVisitorAnalyticsConfig,
+  VISITOR_ANALYTICS_DEFAULTS,
+  VISITOR_ANALYTICS_MODES
+} from "../../src/modules/visitor-analytics/domain/visitor-analytics-config";
+
+describe("isKnownVisitorAnalyticsMode", () => {
+  test("accepts the two known modes", () => {
+    expect(isKnownVisitorAnalyticsMode("basic")).toBe(true);
+    expect(isKnownVisitorAnalyticsMode("detailed")).toBe(true);
+  });
+
+  test("rejects unknown/undefined values", () => {
+    expect(isKnownVisitorAnalyticsMode("full")).toBe(false);
+    expect(isKnownVisitorAnalyticsMode(undefined)).toBe(false);
+    expect(isKnownVisitorAnalyticsMode("")).toBe(false);
+  });
+});
+
+describe("parsePositiveInt", () => {
+  test("undefined for unset/blank", () => {
+    expect(parsePositiveInt(undefined)).toBeUndefined();
+    expect(parsePositiveInt("")).toBeUndefined();
+    expect(parsePositiveInt("   ")).toBeUndefined();
+  });
+
+  test("undefined for non-numeric, negative, zero, or float values", () => {
+    expect(parsePositiveInt("abc")).toBeUndefined();
+    expect(parsePositiveInt("-5")).toBeUndefined();
+    expect(parsePositiveInt("0")).toBeUndefined();
+    expect(parsePositiveInt("1.5")).toBeUndefined();
+  });
+
+  test("parses a valid positive integer", () => {
+    expect(parsePositiveInt("300")).toBe(300);
+    expect(parsePositiveInt("1")).toBe(1);
+  });
+});
+
+describe("resolveVisitorAnalyticsConfig", () => {
+  test("returns VISITOR_ANALYTICS_DEFAULTS when env is empty (privacy-first default)", () => {
+    expect(resolveVisitorAnalyticsConfig({} as NodeJS.ProcessEnv)).toEqual(
+      VISITOR_ANALYTICS_DEFAULTS
+    );
+  });
+
+  test("raw IP, raw user-agent, and geolocation stay off unless explicitly opted in", () => {
+    const config = resolveVisitorAnalyticsConfig({
+      VISITOR_ANALYTICS_MODE: "detailed"
+    } as NodeJS.ProcessEnv);
+
+    expect(config.mode).toBe("detailed");
+    expect(config.rawIpEnabled).toBe(false);
+    expect(config.rawUserAgentEnabled).toBe(false);
+    expect(config.geoEnabled).toBe(false);
+  });
+
+  test("falls back to basic mode for an unrecognized VISITOR_ANALYTICS_MODE — never throws", () => {
+    expect(
+      resolveVisitorAnalyticsConfig({
+        VISITOR_ANALYTICS_MODE: "full"
+      } as NodeJS.ProcessEnv).mode
+    ).toBe("basic");
+  });
+
+  test("falls back to the default retention/window values for malformed integers", () => {
+    const config = resolveVisitorAnalyticsConfig({
+      VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS: "not-a-number",
+      VISITOR_ANALYTICS_EVENT_RETENTION_DAYS: "-1",
+      VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS: "0"
+    } as NodeJS.ProcessEnv);
+
+    expect(config.onlineWindowSeconds).toBe(
+      VISITOR_ANALYTICS_DEFAULTS.onlineWindowSeconds
+    );
+    expect(config.eventRetentionDays).toBe(
+      VISITOR_ANALYTICS_DEFAULTS.eventRetentionDays
+    );
+    expect(config.rawDetailRetentionDays).toBe(
+      VISITOR_ANALYTICS_DEFAULTS.rawDetailRetentionDays
+    );
+  });
+
+  test("respects explicit opt-in overrides", () => {
+    const config = resolveVisitorAnalyticsConfig({
+      VISITOR_ANALYTICS_ENABLED: "false",
+      VISITOR_ANALYTICS_RAW_IP_ENABLED: "true",
+      VISITOR_ANALYTICS_GEO_ENABLED: "true",
+      VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS: "365",
+      VISITOR_ANALYTICS_HASH_SALT: "a-non-secret-example-salt"
+    } as NodeJS.ProcessEnv);
+
+    expect(config.enabled).toBe(false);
+    expect(config.rawIpEnabled).toBe(true);
+    expect(config.geoEnabled).toBe(true);
+    expect(config.rollupRetentionDays).toBe(365);
+    expect(config.hashSalt).toBe("a-non-secret-example-salt");
+  });
+
+  test('boolean flags are true only for the literal string "true"', () => {
+    expect(
+      resolveVisitorAnalyticsConfig({
+        VISITOR_ANALYTICS_RAW_IP_ENABLED: "TRUE"
+      } as NodeJS.ProcessEnv).rawIpEnabled
+    ).toBe(false);
+    expect(
+      resolveVisitorAnalyticsConfig({
+        VISITOR_ANALYTICS_RAW_IP_ENABLED: "1"
+      } as NodeJS.ProcessEnv).rawIpEnabled
+    ).toBe(false);
+  });
+});
+
+describe("isVisitorAnalyticsEnabled", () => {
+  test("true by default (unset env)", () => {
+    expect(isVisitorAnalyticsEnabled({} as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  test("false when explicitly disabled", () => {
+    expect(
+      isVisitorAnalyticsEnabled({
+        VISITOR_ANALYTICS_ENABLED: "false"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+});
+
+describe("VISITOR_ANALYTICS_MODES", () => {
+  test("is exactly [basic, detailed]", () => {
+    expect(VISITOR_ANALYTICS_MODES).toEqual(["basic", "detailed"]);
+  });
+});

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -11,6 +11,7 @@ import {
   checkTenantDomainDnsConfig,
   checkMfaConfig,
   checkTurnstileConfig,
+  checkVisitorAnalyticsConfig,
   runEnvValidation
 } from "../scripts/validate-env";
 
@@ -623,6 +624,72 @@ describe("checkGoogleOidcConfig", () => {
     for (const result of results) {
       expect(result.detail).not.toContain("super-secret-google-value");
     }
+  });
+});
+
+describe("checkVisitorAnalyticsConfig", () => {
+  test("all pass when no VISITOR_ANALYTICS_* var is set (privacy-first default)", () => {
+    const results = checkVisitorAnalyticsConfig({} as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  test("passes when VISITOR_ANALYTICS_MODE=basic or detailed", () => {
+    expect(
+      checkVisitorAnalyticsConfig({
+        VISITOR_ANALYTICS_MODE: "basic"
+      } as NodeJS.ProcessEnv).every((result) => result.status === "pass")
+    ).toBe(true);
+    expect(
+      checkVisitorAnalyticsConfig({
+        VISITOR_ANALYTICS_MODE: "detailed"
+      } as NodeJS.ProcessEnv).every((result) => result.status === "pass")
+    ).toBe(true);
+  });
+
+  test("fails when VISITOR_ANALYTICS_MODE is not a known mode", () => {
+    const results = checkVisitorAnalyticsConfig({
+      VISITOR_ANALYTICS_MODE: "full"
+    } as NodeJS.ProcessEnv);
+
+    const modeResult = results.find(
+      (result) => result.name === "VISITOR_ANALYTICS_MODE"
+    );
+    expect(modeResult?.status).toBe("fail");
+  });
+
+  test("fails and names each malformed retention/window var", () => {
+    const results = checkVisitorAnalyticsConfig({
+      VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS: "not-a-number",
+      VISITOR_ANALYTICS_EVENT_RETENTION_DAYS: "-1",
+      VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS: "0",
+      VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS: "730"
+    } as NodeJS.ProcessEnv);
+
+    const failedNames = results
+      .filter((result) => result.status === "fail")
+      .map((result) => result.name)
+      .sort();
+
+    expect(failedNames).toEqual(
+      [
+        "VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS",
+        "VISITOR_ANALYTICS_EVENT_RETENTION_DAYS",
+        "VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS"
+      ].sort()
+    );
+  });
+
+  test("all pass when every var is set to a valid value", () => {
+    const results = checkVisitorAnalyticsConfig({
+      VISITOR_ANALYTICS_MODE: "detailed",
+      VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS: "300",
+      VISITOR_ANALYTICS_EVENT_RETENTION_DAYS: "90",
+      VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS: "30",
+      VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS: "730"
+    } as NodeJS.ProcessEnv);
+
+    expect(results.every((result) => result.status === "pass")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Registers the `visitor_analytics` module (`type: system`, like `reporting`/`logging`) in `src/modules/index.ts`, with an 8-entry permission catalog (migration `038`) and navigation entry at `/admin/analytics`.
- Adds a privacy-first env-based configuration gate (`domain/visitor-analytics-config.ts`, `checkVisitorAnalyticsConfig` in `scripts/validate-env.ts`): `VISITOR_ANALYTICS_MODE=basic` by default, raw IP/raw user-agent/geolocation collection all off unless explicitly opted in, four retention/window vars validated as positive integers when set.
- Adds skill `.claude/skills/awcms-mini-visitor-analytics/SKILL.md` to track cross-issue epic decisions, and updates `AGENTS.md`/`.claude/skills/README.md` catalogs.
- Updates `.env.example` and `docs/awcms-mini/18_configuration_env_reference.md` with the new §Visitor analytics section.
- Adds a changeset (`minor`).

No analytics tables, middleware collector, API, dashboard UI, geolocation enrichment, or rollup/retention jobs yet — those land in Issues #618-#624 (tracked in the new skill's status table).

Closes #617

## Test plan
- [x] `bun run db:migrate` — migration `038` applies cleanly
- [x] `bun run lint`
- [x] `bun run check:docs`
- [x] `bun run api:spec:check`
- [x] `bun run typecheck`
- [x] `bun test` — 1538/1538 pass (against real PostgreSQL, integration suite included)
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)