### PR TITLE
feat(visitor-analytics): add visitor identity, user-agent, and human/bot classification helpers

### DIFF
--- a/.changeset/visitor-analytics-domain-helpers.md
+++ b/.changeset/visitor-analytics-domain-helpers.md
@@ -1,0 +1,10 @@
+---
+"awcms-mini": minor
+---
+
+Add visitor identity, user-agent parsing, human/bot classification, path
+sanitization, and referrer extraction helpers (Issue #619, epic: visitor
+analytics #617-#624) under `src/modules/visitor-analytics/domain/`. Pure,
+unit-tested functions (visitor-key, user-agent, human-classifier,
+path-sanitizer, referrer) — not wired into any request path yet; the
+middleware collector lands in Issue #620.

--- a/.claude/skills/awcms-mini-visitor-analytics/SKILL.md
+++ b/.claude/skills/awcms-mini-visitor-analytics/SKILL.md
@@ -24,16 +24,16 @@ spesifik** yang menjembatani beberapa issue sekaligus.
 
 ## Status per issue (jangan bangun ulang yang sudah ada)
 
-| Issue | Scope                                                          | Status                               |
-| ----- | -------------------------------------------------------------- | ------------------------------------ |
-| #617  | Module descriptor, permission catalog, config gate             | **Selesai** — lihat §Config di bawah |
-| #618  | Visitor session/event/rollup schema + RLS                      | **Selesai** — lihat §Schema di bawah |
-| #619  | Visitor identity, user-agent, human/bot classification helpers | Belum dikerjakan                     |
-| #620  | Middleware telemetry collection (admin + public)               | Belum dikerjakan                     |
-| #621  | Analytics API + OpenAPI contract (`/api/v1/analytics`)         | Belum dikerjakan                     |
-| #623  | Trusted online geolocation enrichment                          | Belum dikerjakan                     |
-| #622  | Admin visitor analytics dashboard UI (`/admin/analytics`)      | Belum dikerjakan                     |
-| #624  | Rollup job, retention purge job, readiness checks, docs pass   | Belum dikerjakan                     |
+| Issue | Scope                                                          | Status                                       |
+| ----- | -------------------------------------------------------------- | -------------------------------------------- |
+| #617  | Module descriptor, permission catalog, config gate             | **Selesai** — lihat §Config di bawah         |
+| #618  | Visitor session/event/rollup schema + RLS                      | **Selesai** — lihat §Schema di bawah         |
+| #619  | Visitor identity, user-agent, human/bot classification helpers | **Selesai** — lihat §Domain helpers di bawah |
+| #620  | Middleware telemetry collection (admin + public)               | Belum dikerjakan                             |
+| #621  | Analytics API + OpenAPI contract (`/api/v1/analytics`)         | Belum dikerjakan                             |
+| #623  | Trusted online geolocation enrichment                          | Belum dikerjakan                             |
+| #622  | Admin visitor analytics dashboard UI (`/admin/analytics`)      | Belum dikerjakan                             |
+| #624  | Rollup job, retention purge job, readiness checks, docs pass   | Belum dikerjakan                             |
 
 Urutan dependency (dari body issue masing-masing): 617 → 618 → 619 → 620 →
 621 → 622; 623 boleh setelah 620 (paralel dengan 621/622); 624 butuh
@@ -70,8 +70,10 @@ user-agent/geolokasi yang tersimpan:
   integer positif **bila diisi**; tak diisi → default di atas, tidak
   pernah gagal validasi.
 - `VISITOR_ANALYTICS_HASH_SALT` (default `""`) — salt untuk fingerprint
-  visitor pseudonymous, dikonsumsi Issue #619 (belum ada fungsi hashing
-  apa pun yang membacanya sampai issue itu).
+  visitor pseudonymous, dikonsumsi `domain/visitor-key.ts`'s
+  `hashVisitorKey`/`hashIpAddress`/`hashUserAgent` (Issue #619) — lihat
+  §Domain helpers di bawah. Belum ada caller yang benar-benar memanggil
+  fungsi hashing ini dengan nilai request nyata sampai middleware #620.
 
 Entry point: `resolveVisitorAnalyticsConfig(env)` — SATU fungsi yang
 harus dipanggil issue lanjutan (#619 helper, #620 middleware), jangan
@@ -179,6 +181,47 @@ dalam tenant context pemanggil sendiri (tidak pernah dari raw UUID
 client yang langsung dicocokkan ke FK). Tambahkan test integrasi di #620
 yang membuktikan UUID palsu/lintas-tenant di salah satu field ditolak
 sebelum sempat menyentuh FK.
+
+### Domain helpers (Issue #619, `src/modules/visitor-analytics/domain/`)
+
+Lima file, semua pure/hampir-pure, **belum dipanggil siapa pun** —
+middleware (#620) adalah caller pertama. Jangan re-derive logic ini di
+#620; import langsung.
+
+- `visitor-key.ts` — `generateVisitorKey`/`isValidVisitorKey`/
+  `resolveVisitorKey` (cookie anonim, tolak nilai forged/non-UUID) dan
+  `hashVisitorKey`/`hashIpAddress`/`hashUserAgent` (HMAC-SHA256 di-key
+  dengan `VISITOR_ANALYTICS_HASH_SALT` — beda dari `hashIdentifier`
+  profile-identity yang sengaja unsalted, lihat file ini untuk alasan
+  lengkap).
+- `user-agent.ts` — `parseUserAgent`/`isBotUserAgent`. Tabel regex
+  ringkas (bukan dependency npm) untuk browser (Chrome/Firefox/Safari/
+  Edge/Opera/Samsung Internet/IE), OS (Windows/macOS/iOS/Android/Chrome
+  OS/Linux — **urutan cek OS penting**: iOS/Android/CrOS dicek sebelum
+  Windows/macOS/Linux karena UA iPhone/iPad selalu membawa token
+  kompatibilitas "like Mac OS X" dan UA Android/CrOS dibangun di atas
+  string kernel Linux — cek yang lebih spesifik dulu mencegah salah
+  klasifikasi), device type, dan ~30 signature bot/crawler/social-preview/
+  automation-client. **Bukan titik keputusan otorisasi/keamanan** — UA
+  bisa dipalsukan trivial.
+- `human-classifier.ts` — `classifyHumanStatus` (tri-state
+  human/bot/unknown untuk `visit_events.human_status`: bot UA selalu
+  menang; sesi terautentikasi + UA apa pun non-bot = human; request
+  anonim + UA tak dikenal = **unknown**, tidak pernah default human) dan
+  `classifySessionHumanity` (boolean `is_human`/`bot_reason` untuk
+  `visitor_sessions`, yang tidak punya kolom tri-state).
+- `path-sanitizer.ts` — `sanitizePath` (buang 11 query param sensitif
+  minimum issue: token/code/password/secret/email/phone/authorization/
+  access_token/refresh_token/reset_token/mfaChallengeToken, case-
+  insensitive) dan `isTrackablePath` (exclude static asset, `/_astro/*`,
+  favicon, endpoint health, path spec OpenAPI/AsyncAPI dari hitungan
+  pageview).
+- `referrer.ts` — `extractReferrerDomain` (hostname saja, tidak pernah
+  path/query/fragment, `null` untuk scheme non-http(s)).
+
+Test: `tests/unit/visitor-analytics-{visitor-key,user-agent,human-classifier,path-sanitizer,referrer}.test.ts`
+— `user-agent.test.ts` mencakup 20+ contoh UA nyata (desktop/mobile/
+tablet/13 signature bot/unknown).
 
 ## Prinsip yang wajib dipertahankan di setiap issue lanjutan
 

--- a/src/modules/visitor-analytics/README.md
+++ b/src/modules/visitor-analytics/README.md
@@ -43,8 +43,13 @@ Issue #618 (`sql/039_awcms_mini_visitor_analytics_schema.sql`): adds
 LEVEL SECURITY` (see §Schema below). **Schema only — no writer yet.**
 Nothing inserts into these tables until the middleware collector (#620).
 
-Issue #619: visitor identity, user-agent, and human/bot classification
-helpers.
+Issue #619 (`domain/visitor-key.ts`, `domain/user-agent.ts`,
+`domain/human-classifier.ts`, `domain/path-sanitizer.ts`,
+`domain/referrer.ts`): pure, unit-tested helpers for visitor identity,
+user-agent parsing, human/bot classification, path/query sanitization,
+and referrer extraction (see §Domain helpers below). **Helpers only — not
+wired into any request path yet.** Nothing calls these until the
+middleware collector (#620).
 
 Issue #620: middleware telemetry collection (admin + public routes).
 
@@ -139,10 +144,55 @@ including the two `jsonb` catch-alls. Verified by
 `tests/integration/visitor-analytics-schema.integration.test.ts`'s
 column-name scan and per-table RLS isolation/fail-closed tests.
 
+## Domain helpers (Issue #619)
+
+Pure, unit-tested functions under `domain/` — no request/cookie I/O, no
+database writes. The middleware collector (#620) is the first caller.
+
+- **`visitor-key.ts`** — `generateVisitorKey()` (CSPRNG UUID),
+  `isValidVisitorKey()`/`resolveVisitorKey()` (reuse a valid existing
+  cookie value or mint a new one — never trusts a forged/non-UUID value
+  as-is), and `hashVisitorKey`/`hashIpAddress`/`hashUserAgent` (HMAC-SHA256
+  keyed by `VISITOR_ANALYTICS_HASH_SALT`, not plain SHA256 — a deployment
+  salt prevents cross-deployment correlation via precomputed hash tables,
+  unlike `profile-identity/domain/identifier.ts`'s deliberately unsalted
+  `hashIdentifier`).
+- **`user-agent.ts`** — `parseUserAgent()` returns browser name/major
+  version, OS name, `deviceType` (`desktop`/`mobile`/`tablet`/`bot`/
+  `unknown`), and bot detection (`isBotUserAgent()`). No UA-parsing
+  library dependency — a compact regex table covers common browser/OS/bot
+  families; missing an exotic UA degrades to `"unknown"`, never a wrong
+  guess presented as certain. **Never a security/authorization decision
+  point** — a spoofed UA trivially defeats it, which is acceptable for
+  analytics but never for access control.
+- **`human-classifier.ts`** — `classifyHumanStatus()` (tri-state
+  `human`/`bot`/`unknown` for `awcms_mini_visit_events.human_status`: bot
+  UA always wins; an authenticated session with any non-bot UA is human;
+  an unauthenticated request with an unrecognized UA is `unknown`, never
+  defaulted to human) and `classifySessionHumanity()` (boolean
+  `is_human`/`bot_reason` for `awcms_mini_visitor_sessions`, which has no
+  `unknown` tri-state column).
+- **`path-sanitizer.ts`** — `sanitizePath()` strips the issue's minimum
+  sensitive query parameter list (`token`, `code`, `password`, `secret`,
+  `email`, `phone`, `authorization`, `access_token`, `refresh_token`,
+  `reset_token`, `mfaChallengeToken`, matched case-insensitively) before a
+  path may ever reach `path_sanitized`; `isTrackablePath()` excludes
+  static assets, `/_astro/*` build output, favicon, health endpoints, and
+  OpenAPI/AsyncAPI spec paths from pageview counting.
+- **`referrer.ts`** — `extractReferrerDomain()` returns a bare lowercase
+  hostname only (never path/query/fragment, which routinely carry the
+  referring page's own tokens), `null` for anything unparseable or a
+  non-http(s) scheme.
+
+Test: `tests/unit/visitor-analytics-visitor-key.test.ts`,
+`-user-agent.test.ts` (20+ real user-agent strings — desktop, mobile,
+tablet, tablet-via-Android-without-Mobile-token, 13 bot/crawler
+signatures, unknown/gibberish), `-human-classifier.test.ts`,
+`-path-sanitizer.test.ts`, `-referrer.test.ts`.
+
 ## Not yet available
 
 - Any data collection — Issue #620 (middleware).
-- Identity/UA/bot classification helpers — Issue #619.
 - REST API (`/api/v1/analytics/*`) — Issue #621.
 - Admin dashboard UI (`/admin/analytics`) — Issue #622.
 - Geolocation enrichment — Issue #623.

--- a/src/modules/visitor-analytics/domain/human-classifier.ts
+++ b/src/modules/visitor-analytics/domain/human-classifier.ts
@@ -1,0 +1,68 @@
+/**
+ * Human/bot classification (Issue #619, epic: visitor analytics
+ * #617-#624). Pure — combines `user-agent.ts`'s parse result with
+ * whether the request is on an authenticated session to decide the
+ * `human_status`/`is_human` values migration 039's tables expect.
+ *
+ * BINDING (acceptance criterion, repeated from `user-agent.ts`): this
+ * classification is for ANALYTICS ONLY — never wire its output into an
+ * authorization, rate-limit, or security decision. A spoofed UA
+ * trivially defeats it, and that is an acceptable trade-off for
+ * analytics but not for access control.
+ */
+import type { ParsedUserAgent } from "./user-agent";
+
+/** Matches `awcms_mini_visit_events.human_status`'s CHECK constraint exactly. */
+export type HumanStatus = "human" | "bot" | "unknown";
+
+export type ClassifyHumanInput = {
+  isAuthenticated: boolean;
+  parsedUserAgent: ParsedUserAgent;
+};
+
+/**
+ * `bot` wins regardless of authentication (a clearly-bot UA is never
+ * reclassified as human just because it presented a valid session).
+ * An authenticated session with a non-bot but unparseable UA is still
+ * `human` (acceptance criterion: "Authenticated admin/user sessions may
+ * be classified as human unless the user-agent is clearly bot").
+ * Everything else with an unrecognized device type is `unknown`, never
+ * defaulted to `human` — unknown/ambiguous user-agents must not be
+ * blindly trusted.
+ */
+export function classifyHumanStatus(input: ClassifyHumanInput): HumanStatus {
+  const { isAuthenticated, parsedUserAgent } = input;
+
+  if (parsedUserAgent.isBot) return "bot";
+  if (isAuthenticated) return "human";
+  if (parsedUserAgent.deviceType === "unknown") return "unknown";
+  return "human";
+}
+
+export type ClassifySessionHumanityInput = {
+  isAuthenticated: boolean;
+  parsedUserAgent: ParsedUserAgent;
+};
+
+export type SessionHumanity = {
+  isHuman: boolean;
+  botReason: string | null;
+};
+
+/**
+ * `awcms_mini_visitor_sessions.is_human` is a plain boolean (no
+ * `unknown` tri-state, and defaults `true`) — an unparseable/unknown UA
+ * on a session stays `is_human: true` unless the UA is clearly a bot,
+ * matching the table's own privacy-first default rather than inventing
+ * a third state the schema has no column for.
+ */
+export function classifySessionHumanity(
+  input: ClassifySessionHumanityInput
+): SessionHumanity {
+  const { parsedUserAgent } = input;
+
+  return {
+    isHuman: !parsedUserAgent.isBot,
+    botReason: parsedUserAgent.isBot ? parsedUserAgent.botReason : null
+  };
+}

--- a/src/modules/visitor-analytics/domain/path-sanitizer.ts
+++ b/src/modules/visitor-analytics/domain/path-sanitizer.ts
@@ -33,10 +33,18 @@ const SENSITIVE_QUERY_PARAM_NAMES = new Set([
 
 /**
  * Strips every sensitive query parameter and returns `pathname` (+
- * remaining safe query string, if any). Never throws — an unparseable
- * `rawPath` degrades to returning it unchanged rather than dropping the
- * page entirely (a pageview with an odd path is still useful analytics
- * signal; failing loudly here is not).
+ * remaining safe query string, if any). Never throws.
+ *
+ * Fail SAFE, not fail open: a `rawPath` that `URL` cannot parse degrades
+ * to its path portion only (query string dropped entirely), never to the
+ * raw, un-sanitized input — the very thing this function exists to
+ * prevent from reaching `path_sanitized`. A pageview with a stripped
+ * query string is still useful analytics signal; echoing an
+ * unparseable-and-therefore-unstrippable query string is a real leak
+ * path (post-review fix — the first version of this function returned
+ * `rawPath` unchanged here, which could echo a sensitive param verbatim
+ * whenever its malformed surroundings made the whole string
+ * unparseable, e.g. a broken IPv6 literal or percent-encoding).
  */
 export function sanitizePath(rawPath: string): string {
   let url: URL;
@@ -44,7 +52,7 @@ export function sanitizePath(rawPath: string): string {
   try {
     url = new URL(rawPath, "http://internal.invalid");
   } catch {
-    return rawPath;
+    return rawPath.split("?")[0] ?? rawPath;
   }
 
   for (const key of [...url.searchParams.keys()]) {

--- a/src/modules/visitor-analytics/domain/path-sanitizer.ts
+++ b/src/modules/visitor-analytics/domain/path-sanitizer.ts
@@ -1,0 +1,135 @@
+/**
+ * Path/query sanitization and pageview-eligibility helpers (Issue #619,
+ * epic: visitor analytics #617-#624). Pure — no request I/O; the
+ * middleware collector (#620) calls these with the request's own
+ * pathname+query before anything is stored in `awcms_mini_visit_events`.
+ *
+ * BINDING: `sanitizePath`'s output is the ONLY form a path may take
+ * before it reaches `path_sanitized` (migration 039) — a raw,
+ * un-sanitized path/query string must never be persisted, since query
+ * strings routinely carry tokens/secrets (password reset links, OAuth
+ * codes, MFA challenge tokens) that must never land in an analytics
+ * table.
+ */
+
+/**
+ * Matched case-insensitively against query parameter names. Exactly the
+ * issue's own minimum list — `mfaChallengeToken` included verbatim (its
+ * lowercase form is what's actually compared against).
+ */
+const SENSITIVE_QUERY_PARAM_NAMES = new Set([
+  "token",
+  "code",
+  "password",
+  "secret",
+  "email",
+  "phone",
+  "authorization",
+  "access_token",
+  "refresh_token",
+  "reset_token",
+  "mfachallengetoken"
+]);
+
+/**
+ * Strips every sensitive query parameter and returns `pathname` (+
+ * remaining safe query string, if any). Never throws — an unparseable
+ * `rawPath` degrades to returning it unchanged rather than dropping the
+ * page entirely (a pageview with an odd path is still useful analytics
+ * signal; failing loudly here is not).
+ */
+export function sanitizePath(rawPath: string): string {
+  let url: URL;
+
+  try {
+    url = new URL(rawPath, "http://internal.invalid");
+  } catch {
+    return rawPath;
+  }
+
+  for (const key of [...url.searchParams.keys()]) {
+    if (SENSITIVE_QUERY_PARAM_NAMES.has(key.toLowerCase())) {
+      url.searchParams.delete(key);
+    }
+  }
+
+  const query = url.searchParams.toString();
+
+  return query ? `${url.pathname}?${query}` : url.pathname;
+}
+
+const STATIC_ASSET_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "svg",
+  "webp",
+  "avif",
+  "ico",
+  "css",
+  "js",
+  "mjs",
+  "woff",
+  "woff2",
+  "ttf",
+  "eot",
+  "otf",
+  "map"
+]);
+
+/** Path prefixes that are always internal build/runtime assets, never a pageview. */
+const SKIPPED_PATH_PREFIXES = ["/_astro/", "/_actions/", "/_image"];
+
+/** Any path segment (case-insensitive) that marks the whole path as non-trackable. */
+const SKIPPED_PATH_SEGMENTS = new Set(["health"]);
+
+function fileExtension(pathname: string): string | null {
+  const match = pathname.match(/\.([a-z0-9]+)$/i);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+/**
+ * `false` for static assets, internal framework/build paths, health
+ * endpoints, and OpenAPI/AsyncAPI spec files — none of these represent a
+ * human/bot visiting a page, so the middleware collector (#620) must
+ * skip writing a `visit_events` row for them (acceptance criterion).
+ * `pathname` should already be the sanitized form from `sanitizePath`
+ * (or any plain path) — this function never inspects the query string.
+ */
+export function isTrackablePath(pathname: string): boolean {
+  const normalized = pathname.split("?")[0] ?? pathname;
+
+  if (SKIPPED_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+    return false;
+  }
+
+  if (normalized.toLowerCase().includes("favicon")) {
+    return false;
+  }
+
+  const extension = fileExtension(normalized);
+  if (extension && STATIC_ASSET_EXTENSIONS.has(extension)) {
+    return false;
+  }
+
+  if (/^\/(openapi|asyncapi)(\/|$)/i.test(normalized)) {
+    return false;
+  }
+
+  if (
+    (extension === "yaml" || extension === "yml") &&
+    /spec/i.test(normalized)
+  ) {
+    return false;
+  }
+
+  const segments = normalized.split("/").filter(Boolean);
+  if (
+    segments.some((segment) => SKIPPED_PATH_SEGMENTS.has(segment.toLowerCase()))
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/modules/visitor-analytics/domain/referrer.ts
+++ b/src/modules/visitor-analytics/domain/referrer.ts
@@ -1,0 +1,32 @@
+/**
+ * Safe referrer-domain extraction (Issue #619, epic: visitor analytics
+ * #617-#624). Pure — never throws, never returns anything beyond a bare
+ * hostname (no path, query, or fragment, which routinely carry the
+ * referring page's own tokens/PII — must never be copied into
+ * `awcms_mini_visit_events.referrer_domain`).
+ */
+
+/**
+ * `null` for a missing/empty/unparseable `Referer` header, or any
+ * non-http(s) scheme (e.g. `javascript:`, `data:` — never worth trusting
+ * as a referrer domain).
+ */
+export function extractReferrerDomain(
+  rawReferrer: string | null | undefined
+): string | null {
+  if (!rawReferrer) return null;
+
+  let url: URL;
+
+  try {
+    url = new URL(rawReferrer);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return null;
+  }
+
+  return url.hostname ? url.hostname.toLowerCase() : null;
+}

--- a/src/modules/visitor-analytics/domain/user-agent.ts
+++ b/src/modules/visitor-analytics/domain/user-agent.ts
@@ -1,0 +1,198 @@
+/**
+ * Lightweight, dependency-free user-agent parsing and bot detection
+ * (Issue #619, epic: visitor analytics #617-#624). Pure string parsing —
+ * no external bot-intelligence provider, no fingerprinting beyond
+ * ordinary browser/OS/device-type detection from the UA string itself.
+ *
+ * Deliberately does NOT pull in a UA-parsing library (`ua-parser-js` and
+ * similar are large, frequently-updated-for-new-devices dependencies
+ * that would need Bun-compatibility verification per AGENTS.md rule 14) —
+ * a compact regex table covering the handful of browser/OS/bot families
+ * that matter for aggregate analytics is enough; this is not a security
+ * or billing decision point (see file header note below), so
+ * occasionally missing an exotic UA and falling back to `"unknown"` is
+ * an acceptable trade-off, not a defect.
+ *
+ * BINDING: human/bot classification here is for ANALYTICS ONLY. Never
+ * wire `isBotUserAgent`/`parseUserAgent`'s output into an authorization,
+ * rate-limit, or security decision — a spoofed UA trivially defeats it.
+ */
+
+export type DeviceType = "desktop" | "mobile" | "tablet" | "bot" | "unknown";
+
+export type ParsedUserAgent = {
+  browserName: string | null;
+  browserVersionMajor: string | null;
+  osName: string | null;
+  deviceType: DeviceType;
+  isBot: boolean;
+  botReason: string | null;
+};
+
+/**
+ * Common crawler/bot/preview-fetcher signatures — search engines
+ * (Googlebot, Bingbot, Slurp, DuckDuckBot, Baiduspider, YandexBot,
+ * Applebot), social link-preview fetchers (facebookexternalhit,
+ * Twitterbot, LinkedInBot, Slackbot, WhatsApp, TelegramBot,
+ * Discordbot), SEO/monitoring crawlers (AhrefsBot, SemrushBot,
+ * MJ12bot, PetalBot, DotBot, UptimeRobot), and generic
+ * script/automation clients (curl, wget, python-requests,
+ * Go-http-client, PostmanRuntime, HeadlessChrome, PhantomJS,
+ * Selenium). Matched case-insensitively against the raw UA string.
+ */
+const BOT_SIGNATURES: readonly { pattern: RegExp; name: string }[] = [
+  { pattern: /googlebot/i, name: "Googlebot" },
+  { pattern: /bingbot/i, name: "Bingbot" },
+  { pattern: /slurp/i, name: "Yahoo Slurp" },
+  { pattern: /duckduckbot/i, name: "DuckDuckBot" },
+  { pattern: /baiduspider/i, name: "Baiduspider" },
+  { pattern: /yandexbot/i, name: "YandexBot" },
+  { pattern: /applebot/i, name: "Applebot" },
+  { pattern: /facebookexternalhit/i, name: "Facebook" },
+  { pattern: /twitterbot/i, name: "Twitterbot" },
+  { pattern: /linkedinbot/i, name: "LinkedInBot" },
+  { pattern: /slackbot/i, name: "Slackbot" },
+  { pattern: /whatsapp/i, name: "WhatsApp" },
+  { pattern: /telegrambot/i, name: "TelegramBot" },
+  { pattern: /discordbot/i, name: "Discordbot" },
+  { pattern: /ahrefsbot/i, name: "AhrefsBot" },
+  { pattern: /semrushbot/i, name: "SemrushBot" },
+  { pattern: /mj12bot/i, name: "MJ12bot" },
+  { pattern: /petalbot/i, name: "PetalBot" },
+  { pattern: /dotbot/i, name: "DotBot" },
+  { pattern: /uptimerobot/i, name: "UptimeRobot" },
+  { pattern: /curl\//i, name: "curl" },
+  { pattern: /wget\//i, name: "Wget" },
+  { pattern: /python-requests/i, name: "python-requests" },
+  { pattern: /go-http-client/i, name: "Go-http-client" },
+  { pattern: /postmanruntime/i, name: "PostmanRuntime" },
+  { pattern: /headlesschrome/i, name: "HeadlessChrome" },
+  { pattern: /phantomjs/i, name: "PhantomJS" },
+  { pattern: /selenium/i, name: "Selenium" },
+  { pattern: /\bbot\b/i, name: "generic bot" },
+  { pattern: /crawler/i, name: "generic crawler" },
+  { pattern: /spider/i, name: "generic spider" }
+];
+
+export function isBotUserAgent(userAgent: string | null | undefined): {
+  isBot: boolean;
+  botReason: string | null;
+} {
+  if (!userAgent) {
+    return { isBot: false, botReason: null };
+  }
+
+  const match = BOT_SIGNATURES.find(({ pattern }) => pattern.test(userAgent));
+
+  return match
+    ? { isBot: true, botReason: match.name }
+    : { isBot: false, botReason: null };
+}
+
+const BROWSER_PATTERNS: readonly { pattern: RegExp; name: string }[] = [
+  // Order matters — many browser UAs include multiple engine tokens
+  // (Chrome/Safari/Edge all include "Safari"; Edge/Opera include
+  // "Chrome"), so more specific tokens are checked first.
+  { pattern: /edg\//i, name: "Edge" },
+  { pattern: /opr\//i, name: "Opera" },
+  { pattern: /samsungbrowser\//i, name: "Samsung Internet" },
+  { pattern: /firefox\//i, name: "Firefox" },
+  { pattern: /chrome\//i, name: "Chrome" },
+  { pattern: /crios\//i, name: "Chrome" },
+  { pattern: /fxios\//i, name: "Firefox" },
+  { pattern: /version\/.*safari/i, name: "Safari" },
+  { pattern: /safari\//i, name: "Safari" },
+  { pattern: /msie |trident\//i, name: "Internet Explorer" }
+];
+
+const BROWSER_VERSION_PATTERNS: Record<string, RegExp> = {
+  Edge: /edg\/(\d+)/i,
+  Opera: /opr\/(\d+)/i,
+  "Samsung Internet": /samsungbrowser\/(\d+)/i,
+  Firefox: /(?:firefox|fxios)\/(\d+)/i,
+  Chrome: /(?:chrome|crios)\/(\d+)/i,
+  Safari: /version\/(\d+)/i,
+  "Internet Explorer": /(?:msie |rv:)(\d+)/i
+};
+
+function detectBrowser(userAgent: string): {
+  name: string | null;
+  versionMajor: string | null;
+} {
+  const match = BROWSER_PATTERNS.find(({ pattern }) => pattern.test(userAgent));
+
+  if (!match) {
+    return { name: null, versionMajor: null };
+  }
+
+  const versionPattern = BROWSER_VERSION_PATTERNS[match.name];
+  const versionMatch = versionPattern ? userAgent.match(versionPattern) : null;
+
+  return { name: match.name, versionMajor: versionMatch?.[1] ?? null };
+}
+
+const OS_PATTERNS: readonly { pattern: RegExp; name: string }[] = [
+  // iOS/Android/CrOS checked before Windows/macOS/Linux: iPhone/iPad UAs
+  // always carry a "like Mac OS X" compatibility token, and Android/CrOS
+  // UAs are built on a Linux kernel string — checking the more specific
+  // mobile/OS tokens first avoids misclassifying them as macOS/Linux.
+  { pattern: /iphone|ipad|ipod/i, name: "iOS" },
+  { pattern: /android/i, name: "Android" },
+  { pattern: /cros/i, name: "Chrome OS" },
+  { pattern: /windows nt/i, name: "Windows" },
+  { pattern: /mac os x/i, name: "macOS" },
+  { pattern: /linux/i, name: "Linux" }
+];
+
+function detectOs(userAgent: string): string | null {
+  return (
+    OS_PATTERNS.find(({ pattern }) => pattern.test(userAgent))?.name ?? null
+  );
+}
+
+function detectDeviceType(userAgent: string, isBot: boolean): DeviceType {
+  if (isBot) return "bot";
+  if (/ipad|tablet/i.test(userAgent)) return "tablet";
+  // Android tablets omit "Mobile" in their UA; Android phones include it.
+  if (/android/i.test(userAgent) && !/mobile/i.test(userAgent)) return "tablet";
+  if (/mobi|iphone|ipod/i.test(userAgent)) return "mobile";
+  if (/android/i.test(userAgent)) return "mobile";
+  if (/windows nt|mac os x|linux|cros/i.test(userAgent)) return "desktop";
+  return "unknown";
+}
+
+/**
+ * Never throws. Empty/missing UA and completely unrecognized UAs both
+ * resolve to `deviceType: "unknown"` with null browser/OS fields —
+ * "unknown" is deliberately never conflated with "human" or "bot"
+ * (acceptance criterion: unknown/ambiguous user-agents must not be
+ * blindly trusted as human).
+ */
+export function parseUserAgent(
+  userAgent: string | null | undefined
+): ParsedUserAgent {
+  const { isBot, botReason } = isBotUserAgent(userAgent);
+
+  if (!userAgent) {
+    return {
+      browserName: null,
+      browserVersionMajor: null,
+      osName: null,
+      deviceType: "unknown",
+      isBot,
+      botReason
+    };
+  }
+
+  const { name: browserName, versionMajor: browserVersionMajor } =
+    detectBrowser(userAgent);
+
+  return {
+    browserName,
+    browserVersionMajor,
+    osName: detectOs(userAgent),
+    deviceType: detectDeviceType(userAgent, isBot),
+    isBot,
+    botReason
+  };
+}

--- a/src/modules/visitor-analytics/domain/visitor-key.ts
+++ b/src/modules/visitor-analytics/domain/visitor-key.ts
@@ -1,0 +1,65 @@
+/**
+ * Anonymous visitor key + salted hashing helpers (Issue #619, epic:
+ * visitor analytics #617-#624). Pure — no cookie/request I/O here; the
+ * middleware collector (#620) reads/writes the actual cookie and calls
+ * `resolveVisitorKey` with whatever raw value it found (or `undefined`).
+ *
+ * All three hash functions here are HMAC-SHA256 keyed by
+ * `VISITOR_ANALYTICS_HASH_SALT` (Issue #617's config gate,
+ * `resolveVisitorAnalyticsConfig().hashSalt`), not plain SHA256 —
+ * unlike `profile-identity/domain/identifier.ts`'s `hashIdentifier`
+ * (deliberately unsalted, see that file's own comment), a deployment
+ * salt here prevents an external party from correlating these hashes
+ * against a precomputed table of `sha256(ip)`/`sha256(userAgent)` values
+ * computed for some *other* deployment or purpose — IP addresses and
+ * user-agents are far lower-entropy and more universally observable than
+ * the identifiers `hashIdentifier` hashes. These remain lookup/dedup
+ * hashes, not credential storage: enumeration risk is mitigated by RLS
+ * on the tables that store them (migration 039), not by hash cost, so a
+ * fast keyed hash (not bcrypt/argon2) is correct here too.
+ */
+import { createHmac, randomUUID } from "node:crypto";
+
+const VISITOR_KEY_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** A fresh, cryptographically random anonymous visitor key (cookie value). */
+export function generateVisitorKey(): string {
+  return randomUUID();
+}
+
+/** True only for a value shaped like something `generateVisitorKey` produced. */
+export function isValidVisitorKey(
+  value: string | undefined | null
+): value is string {
+  return typeof value === "string" && VISITOR_KEY_PATTERN.test(value);
+}
+
+/**
+ * Reuses `existingValue` if it looks like a real visitor key, otherwise
+ * mints a new one — never trusts an arbitrary client-supplied string
+ * (e.g. a forged non-UUID cookie value) as-is.
+ */
+export function resolveVisitorKey(
+  existingValue: string | undefined | null
+): string {
+  return isValidVisitorKey(existingValue)
+    ? existingValue
+    : generateVisitorKey();
+}
+
+function hmacSha256(value: string, salt: string): string {
+  return `sha256:${createHmac("sha256", salt).update(value).digest("hex")}`;
+}
+
+export function hashVisitorKey(visitorKey: string, salt: string): string {
+  return hmacSha256(visitorKey, salt);
+}
+
+export function hashIpAddress(ipAddress: string, salt: string): string {
+  return hmacSha256(ipAddress, salt);
+}
+
+export function hashUserAgent(userAgent: string, salt: string): string {
+  return hmacSha256(userAgent, salt);
+}

--- a/tests/unit/visitor-analytics-human-classifier.test.ts
+++ b/tests/unit/visitor-analytics-human-classifier.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  classifyHumanStatus,
+  classifySessionHumanity
+} from "../../src/modules/visitor-analytics/domain/human-classifier";
+import { parseUserAgent } from "../../src/modules/visitor-analytics/domain/user-agent";
+
+const HUMAN_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+const BOT_UA =
+  "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+const UNKNOWN_UA = "some-custom-internal-client/1.0";
+
+describe("classifyHumanStatus", () => {
+  test("a clearly-bot UA is always bot, authenticated or not", () => {
+    const parsedUserAgent = parseUserAgent(BOT_UA);
+    expect(
+      classifyHumanStatus({ isAuthenticated: false, parsedUserAgent })
+    ).toBe("bot");
+    expect(
+      classifyHumanStatus({ isAuthenticated: true, parsedUserAgent })
+    ).toBe("bot");
+  });
+
+  test("an authenticated session with a recognized browser is human", () => {
+    const parsedUserAgent = parseUserAgent(HUMAN_UA);
+    expect(
+      classifyHumanStatus({ isAuthenticated: true, parsedUserAgent })
+    ).toBe("human");
+  });
+
+  test("an authenticated session is human even with an unrecognized UA", () => {
+    const parsedUserAgent = parseUserAgent(UNKNOWN_UA);
+    expect(
+      classifyHumanStatus({ isAuthenticated: true, parsedUserAgent })
+    ).toBe("human");
+  });
+
+  test("an unauthenticated request with a recognized browser is human", () => {
+    const parsedUserAgent = parseUserAgent(HUMAN_UA);
+    expect(
+      classifyHumanStatus({ isAuthenticated: false, parsedUserAgent })
+    ).toBe("human");
+  });
+
+  test("an unauthenticated request with an unrecognized UA is unknown, never blindly human", () => {
+    const parsedUserAgent = parseUserAgent(UNKNOWN_UA);
+    expect(
+      classifyHumanStatus({ isAuthenticated: false, parsedUserAgent })
+    ).toBe("unknown");
+  });
+});
+
+describe("classifySessionHumanity", () => {
+  test("is_human stays true for an unrecognized UA (schema has no unknown tri-state)", () => {
+    const parsedUserAgent = parseUserAgent(UNKNOWN_UA);
+    expect(
+      classifySessionHumanity({ isAuthenticated: false, parsedUserAgent })
+    ).toEqual({ isHuman: true, botReason: null });
+  });
+
+  test("is_human is false with a bot_reason for a clearly-bot UA", () => {
+    const parsedUserAgent = parseUserAgent(BOT_UA);
+    expect(
+      classifySessionHumanity({ isAuthenticated: false, parsedUserAgent })
+    ).toEqual({ isHuman: false, botReason: "Googlebot" });
+  });
+
+  test("is_human is true for a recognized human browser", () => {
+    const parsedUserAgent = parseUserAgent(HUMAN_UA);
+    expect(
+      classifySessionHumanity({ isAuthenticated: true, parsedUserAgent })
+    ).toEqual({ isHuman: true, botReason: null });
+  });
+});

--- a/tests/unit/visitor-analytics-path-sanitizer.test.ts
+++ b/tests/unit/visitor-analytics-path-sanitizer.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isTrackablePath,
+  sanitizePath
+} from "../../src/modules/visitor-analytics/domain/path-sanitizer";
+
+describe("sanitizePath", () => {
+  test("leaves a path with no query string unchanged", () => {
+    expect(sanitizePath("/news/hello-world")).toBe("/news/hello-world");
+  });
+
+  test("keeps a safe, non-sensitive query string intact", () => {
+    expect(sanitizePath("/news?utm_source=newsletter&page=2")).toBe(
+      "/news?utm_source=newsletter&page=2"
+    );
+  });
+
+  for (const param of [
+    "token",
+    "code",
+    "password",
+    "secret",
+    "email",
+    "phone",
+    "authorization",
+    "access_token",
+    "refresh_token",
+    "reset_token",
+    "mfaChallengeToken"
+  ]) {
+    test(`strips the sensitive query parameter "${param}"`, () => {
+      const result = sanitizePath(`/auth/callback?${param}=super-secret-value`);
+      expect(result).not.toContain("super-secret-value");
+      expect(result).not.toContain(param.toLowerCase());
+    });
+  }
+
+  test("strips sensitive params case-insensitively", () => {
+    const result = sanitizePath("/auth/callback?TOKEN=abc&Password=xyz");
+    expect(result).not.toContain("abc");
+    expect(result).not.toContain("xyz");
+  });
+
+  test("strips sensitive params while keeping other safe params", () => {
+    const result = sanitizePath(
+      "/auth/reset?reset_token=abc123&utm_source=email"
+    );
+    expect(result).toBe("/auth/reset?utm_source=email");
+  });
+
+  test("returns just the pathname when every query param was sensitive", () => {
+    expect(sanitizePath("/auth/callback?token=abc")).toBe("/auth/callback");
+  });
+
+  test("never throws on a malformed path", () => {
+    expect(() => sanitizePath("not a url at all \0")).not.toThrow();
+  });
+});
+
+describe("isTrackablePath", () => {
+  test("a normal content path is trackable", () => {
+    expect(isTrackablePath("/news/hello-world")).toBe(true);
+    expect(isTrackablePath("/admin/dashboard")).toBe(true);
+  });
+
+  test("Astro build assets are not trackable", () => {
+    expect(isTrackablePath("/_astro/client.abc123.js")).toBe(false);
+  });
+
+  test("favicon is not trackable", () => {
+    expect(isTrackablePath("/favicon.ico")).toBe(false);
+  });
+
+  for (const extension of [
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "svg",
+    "webp",
+    "avif",
+    "ico",
+    "css",
+    "js",
+    "mjs",
+    "woff",
+    "woff2",
+    "ttf",
+    "eot",
+    "otf",
+    "map"
+  ]) {
+    test(`a static .${extension} asset is not trackable`, () => {
+      expect(isTrackablePath(`/assets/file.${extension}`)).toBe(false);
+    });
+  }
+
+  test("health endpoints are not trackable", () => {
+    expect(isTrackablePath("/api/v1/health")).toBe(false);
+    expect(isTrackablePath("/api/v1/database/pool/health")).toBe(false);
+    expect(isTrackablePath("/api/v1/modules/blog_content/health")).toBe(false);
+  });
+
+  test("OpenAPI/AsyncAPI spec paths are not trackable", () => {
+    expect(isTrackablePath("/openapi/awcms-mini-public-api.yaml")).toBe(false);
+    expect(isTrackablePath("/asyncapi/awcms-mini-domain-events.yaml")).toBe(
+      false
+    );
+  });
+
+  test("a path that merely contains a query string is still evaluated on its pathname", () => {
+    expect(isTrackablePath("/news/hello-world?utm_source=x")).toBe(true);
+    expect(isTrackablePath("/assets/file.css?v=2")).toBe(false);
+  });
+});

--- a/tests/unit/visitor-analytics-path-sanitizer.test.ts
+++ b/tests/unit/visitor-analytics-path-sanitizer.test.ts
@@ -56,6 +56,22 @@ describe("sanitizePath", () => {
   test("never throws on a malformed path", () => {
     expect(() => sanitizePath("not a url at all \0")).not.toThrow();
   });
+
+  // Post-review fix: the first version of the malformed-input fallback
+  // returned rawPath unchanged, which could echo an unstrippable
+  // sensitive query param verbatim whenever the surrounding string made
+  // the whole thing unparseable. It must now fail SAFE (drop the query
+  // string entirely), never fail open (echo the raw input).
+  for (const malformed of [
+    "http://[::1/x?token=SECRET123",
+    "http://a:99999999999/x?token=SECRET123",
+    "http://a:b:c/x?token=SECRET123",
+    "http://%zz/x?token=SECRET123"
+  ]) {
+    test(`never echoes a sensitive query string on unparseable input: "${malformed}"`, () => {
+      expect(sanitizePath(malformed)).not.toContain("SECRET123");
+    });
+  }
 });
 
 describe("isTrackablePath", () => {

--- a/tests/unit/visitor-analytics-referrer.test.ts
+++ b/tests/unit/visitor-analytics-referrer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractReferrerDomain } from "../../src/modules/visitor-analytics/domain/referrer";
+
+describe("extractReferrerDomain", () => {
+  test("extracts the hostname from a full https URL", () => {
+    expect(extractReferrerDomain("https://www.google.com/search?q=awcms")).toBe(
+      "www.google.com"
+    );
+  });
+
+  test("extracts the hostname from a full http URL", () => {
+    expect(extractReferrerDomain("http://example.com/some/path")).toBe(
+      "example.com"
+    );
+  });
+
+  test("lowercases the hostname", () => {
+    expect(extractReferrerDomain("https://EXAMPLE.com/Path")).toBe(
+      "example.com"
+    );
+  });
+
+  test("never includes the path or query string", () => {
+    const result = extractReferrerDomain(
+      "https://example.com/secret-path?token=abc123"
+    );
+    expect(result).toBe("example.com");
+    expect(result).not.toContain("secret-path");
+    expect(result).not.toContain("abc123");
+  });
+
+  test("returns null for missing/empty referrer", () => {
+    expect(extractReferrerDomain(null)).toBeNull();
+    expect(extractReferrerDomain(undefined)).toBeNull();
+    expect(extractReferrerDomain("")).toBeNull();
+  });
+
+  test("returns null for a malformed URL", () => {
+    expect(extractReferrerDomain("not a url")).toBeNull();
+  });
+
+  test("returns null for a non-http(s) scheme", () => {
+    expect(extractReferrerDomain("javascript:alert(1)")).toBeNull();
+    expect(extractReferrerDomain("data:text/html,<script>")).toBeNull();
+  });
+});

--- a/tests/unit/visitor-analytics-user-agent.test.ts
+++ b/tests/unit/visitor-analytics-user-agent.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isBotUserAgent,
+  parseUserAgent
+} from "../../src/modules/visitor-analytics/domain/user-agent";
+
+describe("parseUserAgent — desktop browsers", () => {
+  test("Chrome on Windows", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+    );
+    expect(result).toMatchObject({
+      browserName: "Chrome",
+      browserVersionMajor: "126",
+      osName: "Windows",
+      deviceType: "desktop",
+      isBot: false
+    });
+  });
+
+  test("Firefox on Linux", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0"
+    );
+    expect(result).toMatchObject({
+      browserName: "Firefox",
+      browserVersionMajor: "127",
+      osName: "Linux",
+      deviceType: "desktop",
+      isBot: false
+    });
+  });
+
+  test("Safari on macOS", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15"
+    );
+    expect(result).toMatchObject({
+      browserName: "Safari",
+      browserVersionMajor: "17",
+      osName: "macOS",
+      deviceType: "desktop",
+      isBot: false
+    });
+  });
+
+  test("Edge on Windows", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0"
+    );
+    expect(result).toMatchObject({
+      browserName: "Edge",
+      browserVersionMajor: "126",
+      osName: "Windows",
+      deviceType: "desktop",
+      isBot: false
+    });
+  });
+
+  test("Opera on Windows", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 OPR/111.0.0.0"
+    );
+    expect(result).toMatchObject({
+      browserName: "Opera",
+      browserVersionMajor: "111",
+      deviceType: "desktop"
+    });
+  });
+
+  test("Chrome on Chrome OS", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+    );
+    expect(result).toMatchObject({
+      browserName: "Chrome",
+      osName: "Chrome OS",
+      deviceType: "desktop"
+    });
+  });
+
+  test("Internet Explorer 11 on Windows", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"
+    );
+    expect(result).toMatchObject({
+      browserName: "Internet Explorer",
+      browserVersionMajor: "11",
+      osName: "Windows",
+      deviceType: "desktop"
+    });
+  });
+});
+
+describe("parseUserAgent — mobile browsers", () => {
+  test("Chrome on Android phone", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36"
+    );
+    expect(result).toMatchObject({
+      browserName: "Chrome",
+      osName: "Android",
+      deviceType: "mobile",
+      isBot: false
+    });
+  });
+
+  test("Safari on iPhone", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1"
+    );
+    expect(result).toMatchObject({
+      browserName: "Safari",
+      osName: "iOS",
+      deviceType: "mobile",
+      isBot: false
+    });
+  });
+
+  test("Firefox on Android phone", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (Android 14; Mobile; rv:127.0) Gecko/127.0 Firefox/127.0"
+    );
+    expect(result).toMatchObject({
+      browserName: "Firefox",
+      osName: "Android",
+      deviceType: "mobile"
+    });
+  });
+
+  test("Samsung Internet on Android phone", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (Linux; Android 14; SM-S928B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/25.0 Chrome/115.0.0.0 Mobile Safari/537.36"
+    );
+    expect(result).toMatchObject({
+      browserName: "Samsung Internet",
+      deviceType: "mobile"
+    });
+  });
+
+  test("Chrome on iPhone (CriOS)", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/126.0.0.0 Mobile/15E148 Safari/604.1"
+    );
+    expect(result).toMatchObject({
+      browserName: "Chrome",
+      osName: "iOS",
+      deviceType: "mobile"
+    });
+  });
+});
+
+describe("parseUserAgent — tablets", () => {
+  test("Safari on iPad", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1"
+    );
+    expect(result).toMatchObject({
+      browserName: "Safari",
+      osName: "iOS",
+      deviceType: "tablet"
+    });
+  });
+
+  test("Chrome on Android tablet (no Mobile token)", () => {
+    const result = parseUserAgent(
+      "Mozilla/5.0 (Linux; Android 14; SM-X710) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+    );
+    expect(result).toMatchObject({
+      browserName: "Chrome",
+      osName: "Android",
+      deviceType: "tablet"
+    });
+  });
+});
+
+describe("parseUserAgent — bots and crawlers", () => {
+  const botCases: { ua: string; reason: string }[] = [
+    {
+      ua: "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+      reason: "Googlebot"
+    },
+    {
+      ua: "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)",
+      reason: "Bingbot"
+    },
+    {
+      ua: "Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)",
+      reason: "Yahoo Slurp"
+    },
+    {
+      ua: "DuckDuckBot/1.1; (+http://duckduckgo.com/duckduckbot.html)",
+      reason: "DuckDuckBot"
+    },
+    {
+      ua: "Baiduspider+(+http://www.baidu.com/search/spider.htm)",
+      reason: "Baiduspider"
+    },
+    {
+      ua: "Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)",
+      reason: "YandexBot"
+    },
+    {
+      ua: "Mozilla/5.0 (Applebot/0.1; +http://www.apple.com/go/applebot)",
+      reason: "Applebot"
+    },
+    {
+      ua: "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
+      reason: "Facebook"
+    },
+    { ua: "Twitterbot/1.0", reason: "Twitterbot" },
+    {
+      ua: "LinkedInBot/1.0 (compatible; Mozilla/5.0; +http://www.linkedin.com)",
+      reason: "LinkedInBot"
+    },
+    { ua: "curl/8.4.0", reason: "curl" },
+    { ua: "python-requests/2.31.0", reason: "python-requests" },
+    { ua: "PostmanRuntime/7.36.0", reason: "PostmanRuntime" }
+  ];
+
+  for (const { ua, reason } of botCases) {
+    test(`classifies "${ua}" as bot (${reason})`, () => {
+      const result = parseUserAgent(ua);
+      expect(result.isBot).toBe(true);
+      expect(result.botReason).toBe(reason);
+      expect(result.deviceType).toBe("bot");
+    });
+  }
+
+  test("isBotUserAgent matches parseUserAgent's own bot decision", () => {
+    const ua =
+      "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+    expect(isBotUserAgent(ua)).toEqual({ isBot: true, botReason: "Googlebot" });
+  });
+});
+
+describe("parseUserAgent — unknown/ambiguous, never trusted as human", () => {
+  test("empty string", () => {
+    const result = parseUserAgent("");
+    expect(result).toMatchObject({
+      browserName: null,
+      osName: null,
+      deviceType: "unknown",
+      isBot: false
+    });
+  });
+
+  test("null/undefined", () => {
+    expect(parseUserAgent(null).deviceType).toBe("unknown");
+    expect(parseUserAgent(undefined).deviceType).toBe("unknown");
+  });
+
+  test("gibberish string with no recognizable tokens", () => {
+    const result = parseUserAgent("some-custom-internal-client/1.0");
+    expect(result).toMatchObject({
+      browserName: null,
+      osName: null,
+      deviceType: "unknown",
+      isBot: false
+    });
+  });
+});

--- a/tests/unit/visitor-analytics-visitor-key.test.ts
+++ b/tests/unit/visitor-analytics-visitor-key.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  generateVisitorKey,
+  hashIpAddress,
+  hashUserAgent,
+  hashVisitorKey,
+  isValidVisitorKey,
+  resolveVisitorKey
+} from "../../src/modules/visitor-analytics/domain/visitor-key";
+
+describe("generateVisitorKey", () => {
+  test("returns a UUID-shaped string", () => {
+    expect(isValidVisitorKey(generateVisitorKey())).toBe(true);
+  });
+
+  test("returns a different value on every call", () => {
+    expect(generateVisitorKey()).not.toBe(generateVisitorKey());
+  });
+});
+
+describe("isValidVisitorKey", () => {
+  test("accepts a well-formed UUID", () => {
+    expect(isValidVisitorKey("550e8400-e29b-41d4-a716-446655440000")).toBe(
+      true
+    );
+  });
+
+  test("rejects non-UUID, empty, undefined, and null values", () => {
+    expect(isValidVisitorKey("not-a-uuid")).toBe(false);
+    expect(isValidVisitorKey("")).toBe(false);
+    expect(isValidVisitorKey(undefined)).toBe(false);
+    expect(isValidVisitorKey(null)).toBe(false);
+  });
+});
+
+describe("resolveVisitorKey", () => {
+  test("reuses a valid existing key", () => {
+    const existing = "550e8400-e29b-41d4-a716-446655440000";
+    expect(resolveVisitorKey(existing)).toBe(existing);
+  });
+
+  test("mints a new key when the existing value is missing or forged", () => {
+    expect(isValidVisitorKey(resolveVisitorKey(undefined))).toBe(true);
+    expect(isValidVisitorKey(resolveVisitorKey(null))).toBe(true);
+    expect(
+      isValidVisitorKey(resolveVisitorKey("<script>alert(1)</script>"))
+    ).toBe(true);
+  });
+});
+
+describe("salted hash helpers", () => {
+  test("hashVisitorKey/hashIpAddress/hashUserAgent are deterministic and sha256:-prefixed", () => {
+    const salt = "deployment-salt";
+    expect(hashVisitorKey("visitor-1", salt)).toBe(
+      hashVisitorKey("visitor-1", salt)
+    );
+    expect(hashVisitorKey("visitor-1", salt)).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(hashIpAddress("203.0.113.1", salt)).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(hashUserAgent("Mozilla/5.0", salt)).toMatch(/^sha256:[a-f0-9]{64}$/);
+  });
+
+  test("different salts produce different hashes for the same value", () => {
+    expect(hashIpAddress("203.0.113.1", "salt-a")).not.toBe(
+      hashIpAddress("203.0.113.1", "salt-b")
+    );
+  });
+
+  test("different values produce different hashes under the same salt", () => {
+    const salt = "deployment-salt";
+    expect(hashVisitorKey("visitor-1", salt)).not.toBe(
+      hashVisitorKey("visitor-2", salt)
+    );
+  });
+
+  test("never returns the raw input value", () => {
+    const salt = "deployment-salt";
+    expect(hashIpAddress("203.0.113.1", salt)).not.toContain("203.0.113.1");
+    expect(hashUserAgent("Mozilla/5.0 secret-marker", salt)).not.toContain(
+      "secret-marker"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds five pure, unit-tested domain helper modules under `src/modules/visitor-analytics/domain/`, per Issue #619:

- **`visitor-key.ts`** — anonymous visitor key generation/resolution (`generateVisitorKey`, `isValidVisitorKey`, `resolveVisitorKey` — reuses a valid existing cookie value, mints a new one for anything forged/missing) and salted HMAC-SHA256 hashing (`hashVisitorKey`/`hashIpAddress`/`hashUserAgent`, keyed by `VISITOR_ANALYTICS_HASH_SALT`).
- **`user-agent.ts`** — dependency-free browser name/major-version, OS, and device-type (`desktop`/`mobile`/`tablet`/`bot`/`unknown`) parsing, plus ~30 bot/crawler/social-preview/automation-client signatures (`isBotUserAgent`).
- **`human-classifier.ts`** — `classifyHumanStatus` (tri-state `human`/`bot`/`unknown` for `visit_events.human_status`) and `classifySessionHumanity` (boolean `is_human`/`bot_reason` for `visitor_sessions`).
- **`path-sanitizer.ts`** — `sanitizePath` strips the issue's 11 minimum sensitive query params case-insensitively; `isTrackablePath` excludes static assets, `/_astro/*`, favicon, health endpoints, and OpenAPI/AsyncAPI spec paths from pageview counting.
- **`referrer.ts`** — `extractReferrerDomain` returns a bare lowercase hostname only, never path/query/fragment.

No UA-parsing library dependency — a compact regex table is enough for common families; human/bot classification is explicitly documented as analytics-only, never an authorization/security decision point.

Not wired into any request path yet — the middleware collector lands in Issue #620.

Closes #619

## Test plan
- [x] `bun run lint`
- [x] `bun run check:docs`
- [x] `bun run api:spec:check`
- [x] `bun run typecheck`
- [x] `bun test` — 1649/1649 pass, including 96 new unit tests (`user-agent.test.ts` alone covers 20+ real user-agent strings: desktop, mobile, tablet, 13 bot/crawler signatures, unknown/gibberish)
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)