### PR TITLE
feat(visitor-analytics): collect admin and public visitor telemetry in middleware

### DIFF
--- a/.changeset/visitor-analytics-middleware-collector.md
+++ b/.changeset/visitor-analytics-middleware-collector.md
@@ -1,0 +1,15 @@
+---
+"awcms-mini": minor
+---
+
+Wire visitor analytics collection into the request lifecycle (Issue #620,
+epic: visitor analytics #617-#624). `src/middleware.ts` now collects
+lightweight telemetry for `/admin/*` and public page requests (gated by
+the Issue #617 config flags), writing to `awcms_mini_visitor_sessions`/
+`awcms_mini_visit_events` via the new `application/collector.ts` service.
+Fail-open (a collector error never breaks the real response), raw IP/UA
+stay hashed unless explicitly opted in, and `identityId`/
+`visitor_session_id` are always server-derived — never a client-supplied
+value, closing the cross-tenant FK-oracle risk the Issue #618 security
+audit flagged ahead of time. Adds migration `040` (session lookup index).
+No API endpoints or dashboard UI yet — those land in Issues #621-#622.

--- a/.claude/skills/awcms-mini-visitor-analytics/SKILL.md
+++ b/.claude/skills/awcms-mini-visitor-analytics/SKILL.md
@@ -29,7 +29,7 @@ spesifik** yang menjembatani beberapa issue sekaligus.
 | #617  | Module descriptor, permission catalog, config gate             | **Selesai** — lihat §Config di bawah         |
 | #618  | Visitor session/event/rollup schema + RLS                      | **Selesai** — lihat §Schema di bawah         |
 | #619  | Visitor identity, user-agent, human/bot classification helpers | **Selesai** — lihat §Domain helpers di bawah |
-| #620  | Middleware telemetry collection (admin + public)               | Belum dikerjakan                             |
+| #620  | Middleware telemetry collection (admin + public)               | **Selesai** — lihat §Collector di bawah      |
 | #621  | Analytics API + OpenAPI contract (`/api/v1/analytics`)         | Belum dikerjakan                             |
 | #623  | Trusted online geolocation enrichment                          | Belum dikerjakan                             |
 | #622  | Admin visitor analytics dashboard UI (`/admin/analytics`)      | Belum dikerjakan                             |
@@ -161,8 +161,8 @@ token/cookie/authorization/request_body).
 Docs: `docs/awcms-mini/04_erd_data_dictionary.md` §Visitor Analytics
 (ERD ringkas) dan §Retention awal (dua baris retensi baru).
 
-**Temuan security-auditor Issue #618 (Medium, binding untuk Issue #620,
-bukan blocker PR #618 sendiri — schema-only, belum ada writer):** FK biasa
+**Temuan security-auditor Issue #618 (Medium, DITUTUP di Issue #620 — lihat
+§Collector di bawah):** FK biasa
 (`identity_id uuid REFERENCES awcms_mini_identities (id)`,
 `visitor_session_id uuid REFERENCES awcms_mini_visitor_sessions (id)`)
 **tidak dilindungi RLS** — constraint-check FK PostgreSQL berjalan dengan
@@ -184,9 +184,9 @@ sebelum sempat menyentuh FK.
 
 ### Domain helpers (Issue #619, `src/modules/visitor-analytics/domain/`)
 
-Lima file, semua pure/hampir-pure, **belum dipanggil siapa pun** —
-middleware (#620) adalah caller pertama. Jangan re-derive logic ini di
-#620; import langsung.
+Lima file, semua pure/hampir-pure. `application/collector.ts` (Issue
+#620) adalah caller pertama — jangan re-derive logic ini di issue
+lanjutan mana pun; import langsung.
 
 - `visitor-key.ts` — `generateVisitorKey`/`isValidVisitorKey`/
   `resolveVisitorKey` (cookie anonim, tolak nilai forged/non-UUID) dan
@@ -215,13 +215,69 @@ middleware (#620) adalah caller pertama. Jangan re-derive logic ini di
   access_token/refresh_token/reset_token/mfaChallengeToken, case-
   insensitive) dan `isTrackablePath` (exclude static asset, `/_astro/*`,
   favicon, endpoint health, path spec OpenAPI/AsyncAPI dari hitungan
-  pageview).
+  pageview). **Fail SAFE, bukan fail open** (post-review fix PR #627):
+  input yang gagal di-parse `URL()` membuang seluruh query string
+  (`rawPath.split("?")[0]`), bukan echo raw input — versi awal echo raw
+  input, yang bisa membocorkan query param sensitif yang justru gagal
+  di-parse (mis. IPv6 literal rusak).
 - `referrer.ts` — `extractReferrerDomain` (hostname saja, tidak pernah
   path/query/fragment, `null` untuk scheme non-http(s)).
 
 Test: `tests/unit/visitor-analytics-{visitor-key,user-agent,human-classifier,path-sanitizer,referrer}.test.ts`
 — `user-agent.test.ts` mencakup 20+ contoh UA nyata (desktop/mobile/
 tablet/13 signature bot/unknown).
+
+### Collector (Issue #620, `application/collector.ts` + `src/middleware.ts`)
+
+Satu-satunya writer `awcms_mini_visitor_sessions`/`awcms_mini_visit_events`.
+`src/middleware.ts` memanggilnya setelah `next()` resolve (di kedua
+cabang pre-admin dan `/admin/*`), jadi `response.status` sudah diketahui.
+
+- **Gate**: `shouldCollectRequest` (pure, unit-tested) — cek
+  `config.enabled` → `isTrackablePath` → flag per-area
+  (`COLLECT_ADMIN`/`COLLECT_API`/`COLLECT_PUBLIC`). `/login` diklasifikasi
+  `public` (page render), bukan `auth` — `auth`/`setup` khusus untuk
+  `/api/v1/auth/*`/`/api/v1/setup/*`, sama-sama digerbangi `COLLECT_API`
+  (`domain/request-area.ts`'s `determineArea`).
+- **Resolusi tenant**: `/admin/*` pakai `ssrContext.tenantId` yang sudah
+  ada (redirect guard sudah jalan lebih dulu). Area lain pakai
+  `resolvePublicTenantFromRequest` (#559) — best-effort, tenant tidak
+  resolve = tidak dikoleksi, bukan hard failure.
+- **Cookie visitor**: `awcms_mini_visitor_key`, `httpOnly`+`sameSite=lax`+
+  maxAge 2 tahun, di-set hanya saat request benar-benar dikoleksi.
+- **Session find-or-create**: lookup `(tenant_id, visitor_key_hash,
+area)` (index baru migration 040). Dalam window
+  `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS` → reuse row, tapi UPDATE
+  hanya jika tulisan terakhir ≥30 detik lalu (write-throttle). Di luar
+  window → session baru. Event **tidak pernah** di-throttle — selalu satu
+  baris per request yang dikoleksi. `login_identifier_snapshot` sengaja
+  selalu `null` (deferred, bukan regresi — lihat README modul).
+- **Fail-open**: `collectVisitorTelemetry` tidak pernah throw — semua
+  error ditangkap, dicatat `log("warning", "visitor_analytics.collector.failed", ...)`
+  dengan `correlationId`, tidak pernah membocorkan data sensitif.
+  `withTenant` dipanggil dengan `workClass: "background_sync"` (prioritas
+  DB terendah, doc 16).
+- **FK-oracle DITUTUP** (temuan security-auditor #618 di atas):
+  `identityId` selalu dari `ssrContext.identityId` (server-derived,
+  hanya ada setelah redirect guard `/admin/*` lolos) atau `null` untuk
+  publik — tidak pernah dari input client. `visitor_session_id` selalu
+  dari row yang baru saja ditemukan/dibuat fungsi ini sendiri di dalam
+  transaksi tenant-scoped-nya sendiri — tidak pernah dari UUID mentah
+  client.
+- **Client IP**: `domain/client-ip.ts`'s `resolveAnalyticsClientIp` —
+  saudara `lib/security/rate-limit.ts`'s `resolveClientIp` yang lebih
+  konservatif; hanya percaya `CF-Connecting-IP`/`X-Forwarded-For` saat
+  `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`/`_TRUST_PROXY` eksplisit `true`.
+
+Test: `tests/unit/visitor-analytics-collector.test.ts` (`shouldCollectRequest`),
+`tests/unit/visitor-analytics-request-area.test.ts`,
+`tests/unit/visitor-analytics-client-ip.test.ts`,
+`tests/integration/visitor-analytics-collector.integration.test.ts` (9
+test: create, sanitize, bot classify, raw-IP opt-in, throttle+reuse,
+session rollover, non-trackable no-op, fail-open invalid tenant,
+authenticated admin). Juga smoke-test manual lewat dev server + Postgres
+nyata (setup wizard → login → `/admin` → row session/event benar; `/` →
+session publik; asset statis dan `/api/v1/health` default-off → nihil).
 
 ## Prinsip yang wajib dipertahankan di setiap issue lanjutan
 

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -426,24 +426,24 @@ var-var ini; itu semua issue lanjutan di epic yang sama.
 `scripts/validate-env.ts` (`checkVisitorAnalyticsConfig`) menegakkan
 tabel ini.
 
-| Var                                           | Wajib | Default | Sensitif | Fungsi                                                                               |
-| --------------------------------------------- | ----- | ------- | -------- | ------------------------------------------------------------------------------------ |
-| `VISITOR_ANALYTICS_ENABLED`                   | –     | `true`  | –        | Master switch koleksi telemetry pengunjung                                           |
-| `VISITOR_ANALYTICS_MODE`                      | –     | `basic` | –        | `basic`/`detailed` — nilai lain gagal validasi                                       |
-| `VISITOR_ANALYTICS_COLLECT_ADMIN`             | –     | `true`  | –        | Koleksi telemetry rute `/admin/*`                                                    |
-| `VISITOR_ANALYTICS_COLLECT_PUBLIC`            | –     | `true`  | –        | Koleksi telemetry rute publik                                                        |
-| `VISITOR_ANALYTICS_COLLECT_API`               | –     | `false` | –        | Koleksi telemetry panggilan `/api/v1/*`                                              |
-| `VISITOR_ANALYTICS_DETAILED_ENABLED`          | –     | `false` | –        | Cadangan granularitas session/event mode `detailed`                                  |
-| `VISITOR_ANALYTICS_RAW_IP_ENABLED`            | –     | `false` | –        | Simpan alamat IP mentah — default aman: mati                                         |
-| `VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED`    | –     | `false` | –        | Simpan string user-agent mentah — default aman: mati                                 |
-| `VISITOR_ANALYTICS_GEO_ENABLED`               | –     | `false` | –        | Aktifkan enrichment geolokasi (Issue #623) — default aman: mati                      |
-| `VISITOR_ANALYTICS_TRUST_PROXY`               | –     | `false` | –        | Percaya header `X-Forwarded-For` dkk. — **hanya** `true` di belakang proxy tepercaya |
-| `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`          | –     | `false` | –        | Percaya header khusus Cloudflare (`CF-Connecting-IP`, `CF-IPCountry`)                |
-| `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS`     | –     | `300`   | –        | Jendela waktu "online sekarang" — wajib integer positif bila diisi                   |
-| `VISITOR_ANALYTICS_EVENT_RETENTION_DAYS`      | –     | `90`    | –        | Retensi event — wajib integer positif bila diisi                                     |
-| `VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS` | –     | `30`    | –        | Retensi raw detail — wajib integer positif bila diisi                                |
-| `VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS`     | –     | `730`   | –        | Retensi rollup agregat — wajib integer positif bila diisi                            |
-| `VISITOR_ANALYTICS_HASH_SALT`                 | –     | `""`    | Ya       | Salt fingerprint visitor pseudonymous (Issue #619) — jangan isi nilai asli di sini   |
+| Var                                           | Wajib | Default | Sensitif | Fungsi                                                                                                                                                        |
+| --------------------------------------------- | ----- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VISITOR_ANALYTICS_ENABLED`                   | –     | `true`  | –        | Master switch koleksi telemetry pengunjung                                                                                                                    |
+| `VISITOR_ANALYTICS_MODE`                      | –     | `basic` | –        | `basic`/`detailed` — nilai lain gagal validasi                                                                                                                |
+| `VISITOR_ANALYTICS_COLLECT_ADMIN`             | –     | `true`  | –        | Koleksi telemetry rute `/admin/*`                                                                                                                             |
+| `VISITOR_ANALYTICS_COLLECT_PUBLIC`            | –     | `true`  | –        | Koleksi telemetry rute publik                                                                                                                                 |
+| `VISITOR_ANALYTICS_COLLECT_API`               | –     | `false` | –        | Koleksi telemetry panggilan `/api/v1/*`                                                                                                                       |
+| `VISITOR_ANALYTICS_DETAILED_ENABLED`          | –     | `false` | –        | Cadangan granularitas session/event mode `detailed`                                                                                                           |
+| `VISITOR_ANALYTICS_RAW_IP_ENABLED`            | –     | `false` | –        | Simpan alamat IP mentah — default aman: mati                                                                                                                  |
+| `VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED`    | –     | `false` | –        | Reserved — belum ada kolom raw user-agent (migration 039 hanya `user_agent_hash`); saat ini no-op, lihat `src/modules/visitor-analytics/README.md` §Collector |
+| `VISITOR_ANALYTICS_GEO_ENABLED`               | –     | `false` | –        | Aktifkan enrichment geolokasi (Issue #623) — default aman: mati                                                                                               |
+| `VISITOR_ANALYTICS_TRUST_PROXY`               | –     | `false` | –        | Percaya header `X-Forwarded-For` dkk. — **hanya** `true` di belakang proxy tepercaya                                                                          |
+| `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`          | –     | `false` | –        | Percaya header khusus Cloudflare (`CF-Connecting-IP`, `CF-IPCountry`)                                                                                         |
+| `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS`     | –     | `300`   | –        | Jendela waktu "online sekarang" — wajib integer positif bila diisi                                                                                            |
+| `VISITOR_ANALYTICS_EVENT_RETENTION_DAYS`      | –     | `90`    | –        | Retensi event — wajib integer positif bila diisi                                                                                                              |
+| `VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS` | –     | `30`    | –        | Retensi raw detail — wajib integer positif bila diisi                                                                                                         |
+| `VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS`     | –     | `730`   | –        | Retensi rollup agregat — wajib integer positif bila diisi                                                                                                     |
+| `VISITOR_ANALYTICS_HASH_SALT`                 | –     | `""`    | Ya       | Salt fingerprint visitor pseudonymous (Issue #619) — jangan isi nilai asli di sini                                                                            |
 
 Aturan validasi (`checkVisitorAnalyticsConfig`): `VISITOR_ANALYTICS_MODE`
 bila diisi wajib salah satu dari `VISITOR_ANALYTICS_MODES` (`basic` |

--- a/sql/040_awcms_mini_visitor_analytics_session_lookup_index.sql
+++ b/sql/040_awcms_mini_visitor_analytics_session_lookup_index.sql
@@ -1,0 +1,18 @@
+-- Issue #620 (epic: visitor analytics #617-#624) — supports the
+-- middleware collector's session find-or-create lookup
+-- (`application/collector.ts`'s `upsertVisitorSession`):
+--
+--   SELECT id, last_seen_at FROM awcms_mini_visitor_sessions
+--   WHERE tenant_id = $1 AND visitor_key_hash = $2 AND area = $3
+--   ORDER BY last_seen_at DESC LIMIT 1
+--
+-- Not added by migration 039 (Issue #618, schema-only, no writer existed
+-- yet to justify it) — this is the first issue that actually queries
+-- this table by visitor_key_hash. Deliberately NOT a UNIQUE constraint:
+-- one visitor legitimately accumulates multiple session rows over time
+-- (a new row starts once the previous one falls outside
+-- VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS, see collector.ts's
+-- `upsertVisitorSession`) — a unique index would force reusing the same
+-- row forever, contradicting that intentional session-boundary design.
+CREATE INDEX IF NOT EXISTS awcms_mini_visitor_sessions_lookup_idx
+  ON awcms_mini_visitor_sessions (tenant_id, visitor_key_hash, area, last_seen_at DESC);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,4 @@
+import type { APIContext } from "astro";
 import { defineMiddleware } from "astro:middleware";
 
 import { resolveSsrContext } from "./lib/auth/ssr-session";
@@ -8,9 +9,23 @@ import {
   isApiJsonResponseCandidate,
   mergeCorrelationIdIntoApiPayload
 } from "./lib/logging/correlation-response";
+import { getDatabaseClient } from "./lib/database/client";
+import { resolvePublicTenantFromRequest } from "./lib/tenant/public-host-tenant-resolver";
+import { log } from "./lib/logging/logger";
+import { resolveVisitorAnalyticsConfig } from "./modules/visitor-analytics/domain/visitor-analytics-config";
+import { determineArea } from "./modules/visitor-analytics/domain/request-area";
+import { resolveVisitorKey } from "./modules/visitor-analytics/domain/visitor-key";
+import { resolveAnalyticsClientIp } from "./modules/visitor-analytics/domain/client-ip";
+import {
+  collectVisitorTelemetry,
+  shouldCollectRequest
+} from "./modules/visitor-analytics/application/collector";
 
 const PROTECTED_PREFIX = "/admin";
 const CORRELATION_ID_HEADER = "X-Correlation-ID";
+const VISITOR_KEY_COOKIE_NAME = "awcms_mini_visitor_key";
+/** 2 years — a conventional analytics cookie lifetime, same order of magnitude as `VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS`'s default. */
+const VISITOR_KEY_COOKIE_MAX_AGE_SECONDS = 63_072_000;
 
 /**
  * Correlation ID propagation (Issue 10.1 — Add Structured Logging and Audit
@@ -73,6 +88,122 @@ async function applyCorrelationIdToApiBody(
 }
 
 /**
+ * Visitor telemetry hook (Issue #620, epic: visitor analytics
+ * #617-#624). Called after `next()` resolves, on both the pre-admin and
+ * `/admin/*` branches below, so `response.status` is already known.
+ *
+ * BINDING (fail-open, acceptance criterion): this function never throws
+ * and never delays the response beyond its own `await` — every failure
+ * (cheap config/cookie logic here, or the DB write inside
+ * `collectVisitorTelemetry` itself) is caught and logged as a `warning`
+ * with `correlationId`, never surfaced to the caller. Tenant resolution
+ * and the actual write happen only when `shouldCollectRequest` says so,
+ * so most requests (assets, disabled areas, disabled module) pay only
+ * the cost of that one cheap pure check.
+ *
+ * `identityId`/`isAuthenticated` are always server-derived here — `null`/
+ * `false` for every non-`/admin` request (public routes never resolve a
+ * session in this middleware, see the pre-admin branch below), or
+ * `ssrContext`'s own values for `/admin/*` (only reachable after the
+ * redirect-to-`/login` guard above has already confirmed a valid
+ * session) — never a client-supplied value, closing the cross-tenant
+ * existence-oracle risk the Issue #618 security audit flagged ahead of
+ * time (recorded in `.claude/skills/awcms-mini-visitor-analytics/SKILL.md`).
+ */
+async function collectRequestAnalytics(
+  context: APIContext,
+  response: Response,
+  identityId: string | null,
+  isAuthenticated: boolean
+): Promise<void> {
+  try {
+    const config = resolveVisitorAnalyticsConfig();
+    const pathname = context.url.pathname;
+    const area = determineArea(pathname);
+
+    if (!shouldCollectRequest({ pathname, area, config })) {
+      return;
+    }
+
+    const sql = getDatabaseClient();
+    let tenantId: string | null = null;
+
+    if (area === "admin") {
+      tenantId = context.locals.ssrContext?.tenantId ?? null;
+    } else {
+      // Same env vars the tenant-domain-routing epic documents
+      // (`PUBLIC_TENANT_RESOLUTION_MODE`/`PUBLIC_TRUST_PROXY`, Issue #556)
+      // — best-effort: a request whose tenant cannot be resolved (unknown
+      // host, offline/LAN deployment with no public routing configured,
+      // etc.) is simply not collected, never a hard failure.
+      const resolution = await resolvePublicTenantFromRequest(
+        sql,
+        context.request,
+        {
+          mode: process.env.PUBLIC_TENANT_RESOLUTION_MODE,
+          trustProxy: process.env.PUBLIC_TRUST_PROXY === "true"
+        }
+      );
+      tenantId = resolution?.tenantId ?? null;
+    }
+
+    if (!tenantId) return;
+
+    const existingVisitorKey = context.cookies.get(
+      VISITOR_KEY_COOKIE_NAME
+    )?.value;
+    const visitorKey = resolveVisitorKey(existingVisitorKey);
+
+    if (visitorKey !== existingVisitorKey) {
+      context.cookies.set(VISITOR_KEY_COOKIE_NAME, visitorKey, {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        maxAge: VISITOR_KEY_COOKIE_MAX_AGE_SECONDS,
+        secure: process.env.AUTH_COOKIE_SECURE === "true"
+      });
+    }
+
+    let clientAddress: string | undefined;
+    try {
+      clientAddress = context.clientAddress;
+    } catch {
+      // Some adapters/dev contexts don't support clientAddress at all —
+      // resolveAnalyticsClientIp still falls back to a forwarded header
+      // (if trusted) or null.
+      clientAddress = undefined;
+    }
+
+    const ipAddress = resolveAnalyticsClientIp(context.request, clientAddress, {
+      trustProxy: config.trustProxy,
+      trustCloudflare: config.trustCloudflare
+    });
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId,
+      correlationId: context.locals.correlationId,
+      config,
+      method: context.request.method,
+      rawPath: `${pathname}${context.url.search}`,
+      statusCode: response.status,
+      visitorKey,
+      ipAddress,
+      userAgent: context.request.headers.get("user-agent"),
+      referrerHeader: context.request.headers.get("referer"),
+      isAuthenticated,
+      identityId
+    });
+  } catch (error) {
+    log("warning", "visitor_analytics.middleware.failed", {
+      correlationId: context.locals.correlationId,
+      moduleKey: "visitor_analytics",
+      error: error instanceof Error ? error.message : "unknown error"
+    });
+  }
+}
+
+/**
  * Applies the response headers that must be present on *every* response
  * (Issue 10.1's correlation ID, Issue #437's security headers) — factored
  * out so both the pre-auth and `/admin/*` branches below apply them
@@ -127,6 +258,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
       context.locals.correlationId
     );
 
+    await collectRequestAnalytics(context, response, null, false);
+
     return applyResponseHeaders(response, context.locals.correlationId);
   }
 
@@ -149,6 +282,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
   });
 
   const response = await next();
+
+  await collectRequestAnalytics(context, response, ssrContext.identityId, true);
 
   return applyResponseHeaders(response, context.locals.correlationId);
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -110,7 +110,21 @@ async function applyCorrelationIdToApiBody(
  * existence-oracle risk the Issue #618 security audit flagged ahead of
  * time (recorded in `.claude/skills/awcms-mini-visitor-analytics/SKILL.md`).
  */
-async function collectRequestAnalytics(
+// Not unit-testable in isolation: this file imports `astro:middleware`
+// (a virtual module Astro's own build/dev pipeline provides), which
+// `bun test` cannot resolve outside that pipeline — confirmed while
+// investigating a PR #628 review request to add a middleware-level
+// regression test; any test file that imports this module at all fails
+// immediately with "Cannot find package 'astro:middleware'". Coverage
+// for this function's actual logic instead comes from
+// `collectVisitorTelemetry`'s own thorough integration tests
+// (`tests/integration/visitor-analytics-collector.integration.test.ts`,
+// which this function is a thin, directly-traceable wrapper around) plus
+// a real dev-server + Postgres manual smoke test (see README §Collector).
+// Exported anyway (harmless — Astro's page/middleware loader only looks
+// for the exports it needs) in case a future Astro test harness makes
+// this importable.
+export async function collectRequestAnalytics(
   context: APIContext,
   response: Response,
   identityId: string | null,

--- a/src/modules/visitor-analytics/README.md
+++ b/src/modules/visitor-analytics/README.md
@@ -51,7 +51,12 @@ and referrer extraction (see §Domain helpers below). **Helpers only — not
 wired into any request path yet.** Nothing calls these until the
 middleware collector (#620).
 
-Issue #620: middleware telemetry collection (admin + public routes).
+Issue #620 (`application/collector.ts`, `domain/request-area.ts`,
+`domain/client-ip.ts`, `src/middleware.ts`): wires the domain helpers into
+the real request lifecycle — collects visitor presence/events for
+`/admin/*` and public page requests, fail-open on any error (see
+§Collector below). **First issue that actually writes to
+`awcms_mini_visitor_sessions`/`awcms_mini_visit_events`.**
 
 Issue #621: analytics API + OpenAPI contract at `/api/v1/analytics`.
 
@@ -190,9 +195,80 @@ tablet, tablet-via-Android-without-Mobile-token, 13 bot/crawler
 signatures, unknown/gibberish), `-human-classifier.test.ts`,
 `-path-sanitizer.test.ts`, `-referrer.test.ts`.
 
+## Collector (Issue #620, `application/collector.ts` + `src/middleware.ts`)
+
+The only writer of `awcms_mini_visitor_sessions`/`awcms_mini_visit_events`.
+`src/middleware.ts` calls `collectVisitorTelemetry` after `next()` resolves
+(on both its pre-admin and `/admin/*` branches), so the response status
+code is already known.
+
+- **Gate**: `shouldCollectRequest` (pure, unit-tested) — `false` unless
+  `VISITOR_ANALYTICS_ENABLED=true`, the path is trackable
+  (`isTrackablePath`), and the per-area flag is on
+  (`VISITOR_ANALYTICS_COLLECT_ADMIN` for `/admin/*`,
+  `VISITOR_ANALYTICS_COLLECT_API` for anything under `/api`,
+  `VISITOR_ANALYTICS_COLLECT_PUBLIC` for everything else, including
+  `/login` — a page render, not an API call).
+- **Area classification**: `domain/request-area.ts`'s `determineArea` —
+  `admin`/`setup`/`auth`/`api`/`public`, matching migration 039's `area`
+  CHECK constraint exactly. `setup`/`auth` are sub-classifications of API
+  space (`/api/v1/setup/*`, `/api/v1/auth/*`), both still gated by
+  `COLLECT_API`.
+- **Tenant resolution**: `/admin/*` uses `ssrContext.tenantId` (already
+  resolved by the existing auth guard). Every other area uses
+  `resolvePublicTenantFromRequest` (Issue #559) — best-effort; a request
+  whose tenant can't be resolved (unknown host, no public routing
+  configured) is simply not collected, never a hard failure.
+- **Visitor cookie**: `awcms_mini_visitor_key`, `httpOnly`/`sameSite=lax`/
+  2-year `maxAge`, set only when a request is actually collected (not on
+  every request). Value resolved via `resolveVisitorKey` (#619) — reuses
+  a valid existing cookie, mints a new one otherwise.
+- **Client IP**: `domain/client-ip.ts`'s `resolveAnalyticsClientIp` — a
+  deliberately more conservative sibling of `lib/security/rate-limit.ts`'s
+  `resolveClientIp`; only trusts `CF-Connecting-IP`/`X-Forwarded-For` when
+  `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`/`_TRUST_PROXY` are explicitly on,
+  else uses `clientAddress` (direct connection) only. Returns `null`
+  (never a fake placeholder) when nothing is resolvable.
+- **Session find-or-create**: looked up by
+  `(tenant_id, visitor_key_hash, area)` (migration 040's new lookup
+  index). A session found within `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS`
+  of `last_seen_at` is reused — its `last_seen_at`/browser/device fields
+  are refreshed, but only if the last write was itself ≥30s ago (write
+  throttle, issue's own "Recommended write-throttle behavior"); a session
+  older than the online window starts a new row instead. The event insert
+  itself is never throttled — always one row per collected request.
+  `login_identifier_snapshot` is deliberately always `null` (nullable
+  display convenience, not populated in this issue — no functional
+  requirement forces it, and it would need an extra identities lookup on
+  every new session).
+- **Fail-open**: `collectVisitorTelemetry` never throws — every failure
+  is caught and logged as `log("warning", "visitor_analytics.collector.failed", {correlationId, tenantId, moduleKey, error})`,
+  never surfaced to the request. Uses `withTenant`'s
+  `workClass: "background_sync"` (lowest-priority DB work class, doc 16)
+  so a saturated pool serves real interactive/reporting work first.
+- **FK safety** (Issue #618 security-audit follow-up, closed here):
+  `identityId` is always the caller's own server-derived authenticated
+  identity (`ssrContext.identityId` for `/admin/*`, `null` for every
+  public request) — never a client-supplied value. `visitor_session_id`
+  is always resolved from a row this function itself just found/created
+  inside its own tenant-scoped transaction — never from a raw
+  client-supplied UUID. See the skill's §Schema entry for the full
+  cross-tenant-existence-oracle reasoning this closes.
+
+Test: `tests/unit/visitor-analytics-collector.test.ts` (`shouldCollectRequest`,
+pure), `tests/unit/visitor-analytics-request-area.test.ts`,
+`tests/unit/visitor-analytics-client-ip.test.ts`,
+`tests/integration/visitor-analytics-collector.integration.test.ts`
+(session/event creation, sensitive-param stripping, bot classification,
+raw-IP opt-in, session throttle/reuse, session-boundary rollover after the
+online window, non-trackable-path no-op, fail-open on an invalid
+tenantId, authenticated admin session). Also manually smoke-tested against
+a real dev server + Postgres (setup wizard → login → `/admin` → real
+session/event rows with correct `identity_id`/`area`; `/`→ public session;
+static asset and default-off `/api/v1/health` → no rows written).
+
 ## Not yet available
 
-- Any data collection — Issue #620 (middleware).
 - REST API (`/api/v1/analytics/*`) — Issue #621.
 - Admin dashboard UI (`/admin/analytics`) — Issue #622.
 - Geolocation enrichment — Issue #623.

--- a/src/modules/visitor-analytics/README.md
+++ b/src/modules/visitor-analytics/README.md
@@ -76,24 +76,24 @@ passing and the module behaving safely for offline/LAN deployments.
 issues (#619 identity helpers, #620 middleware collector) should call
 rather than re-reading `process.env.VISITOR_ANALYTICS_*` themselves.
 
-| Var                                           | Default | Notes                                                                                           |
-| --------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `VISITOR_ANALYTICS_ENABLED`                   | `true`  | Master switch. `false` disables collection entirely.                                            |
-| `VISITOR_ANALYTICS_MODE`                      | `basic` | `basic` \| `detailed` (`VISITOR_ANALYTICS_MODES`). Unknown value falls back to `basic`.         |
-| `VISITOR_ANALYTICS_COLLECT_ADMIN`             | `true`  | Collect telemetry for `/admin/*` routes.                                                        |
-| `VISITOR_ANALYTICS_COLLECT_PUBLIC`            | `true`  | Collect telemetry for public routes.                                                            |
-| `VISITOR_ANALYTICS_COLLECT_API`               | `false` | Collect telemetry for `/api/v1/*` calls.                                                        |
-| `VISITOR_ANALYTICS_DETAILED_ENABLED`          | `false` | Reserved for `detailed` mode's richer session/event granularity.                                |
-| `VISITOR_ANALYTICS_RAW_IP_ENABLED`            | `false` | Store the raw IP address. Privacy-first default: off.                                           |
-| `VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED`    | `false` | Store the raw user-agent string. Privacy-first default: off.                                    |
-| `VISITOR_ANALYTICS_GEO_ENABLED`               | `false` | Enable geolocation enrichment (Issue #623). Privacy-first default: off.                         |
-| `VISITOR_ANALYTICS_TRUST_PROXY`               | `false` | Trust `X-Forwarded-For`/similar headers. Only set `true` behind a trusted reverse proxy.        |
-| `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`          | `false` | Trust Cloudflare-specific headers (`CF-Connecting-IP`, `CF-IPCountry`). Only behind Cloudflare. |
-| `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS`     | `300`   | Positive integer. Real-time "online now" window.                                                |
-| `VISITOR_ANALYTICS_EVENT_RETENTION_DAYS`      | `90`    | Positive integer.                                                                               |
-| `VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS` | `30`    | Positive integer. Shorter than event retention — raw detail is the most sensitive data class.   |
-| `VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS`     | `730`   | Positive integer. Aggregated rollups can be kept far longer than raw events.                    |
-| `VISITOR_ANALYTICS_HASH_SALT`                 | `""`    | Optional salt for the pseudonymous visitor fingerprint (Issue #619). Never a real secret here.  |
+| Var                                           | Default | Notes                                                                                                                                                             |
+| --------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VISITOR_ANALYTICS_ENABLED`                   | `true`  | Master switch. `false` disables collection entirely.                                                                                                              |
+| `VISITOR_ANALYTICS_MODE`                      | `basic` | `basic` \| `detailed` (`VISITOR_ANALYTICS_MODES`). Unknown value falls back to `basic`.                                                                           |
+| `VISITOR_ANALYTICS_COLLECT_ADMIN`             | `true`  | Collect telemetry for `/admin/*` routes.                                                                                                                          |
+| `VISITOR_ANALYTICS_COLLECT_PUBLIC`            | `true`  | Collect telemetry for public routes.                                                                                                                              |
+| `VISITOR_ANALYTICS_COLLECT_API`               | `false` | Collect telemetry for `/api/v1/*` calls.                                                                                                                          |
+| `VISITOR_ANALYTICS_DETAILED_ENABLED`          | `false` | Reserved for `detailed` mode's richer session/event granularity.                                                                                                  |
+| `VISITOR_ANALYTICS_RAW_IP_ENABLED`            | `false` | Store the raw IP address. Privacy-first default: off.                                                                                                             |
+| `VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED`    | `false` | Reserved — no raw-user-agent column exists yet (migration 039 only has `user_agent_hash` + parsed fields). Currently a no-op regardless of value; see §Collector. |
+| `VISITOR_ANALYTICS_GEO_ENABLED`               | `false` | Enable geolocation enrichment (Issue #623). Privacy-first default: off.                                                                                           |
+| `VISITOR_ANALYTICS_TRUST_PROXY`               | `false` | Trust `X-Forwarded-For`/similar headers. Only set `true` behind a trusted reverse proxy.                                                                          |
+| `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`          | `false` | Trust Cloudflare-specific headers (`CF-Connecting-IP`, `CF-IPCountry`). Only behind Cloudflare.                                                                   |
+| `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS`     | `300`   | Positive integer. Real-time "online now" window.                                                                                                                  |
+| `VISITOR_ANALYTICS_EVENT_RETENTION_DAYS`      | `90`    | Positive integer.                                                                                                                                                 |
+| `VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS` | `30`    | Positive integer. Shorter than event retention — raw detail is the most sensitive data class.                                                                     |
+| `VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS`     | `730`   | Positive integer. Aggregated rollups can be kept far longer than raw events.                                                                                      |
+| `VISITOR_ANALYTICS_HASH_SALT`                 | `""`    | Optional salt for the pseudonymous visitor fingerprint (Issue #619). Never a real secret here.                                                                    |
 
 `bun run config:validate`'s `checkVisitorAnalyticsConfig` validates
 `VISITOR_ANALYTICS_MODE` against `VISITOR_ANALYTICS_MODES` and each
@@ -201,6 +201,15 @@ The only writer of `awcms_mini_visitor_sessions`/`awcms_mini_visit_events`.
 `src/middleware.ts` calls `collectVisitorTelemetry` after `next()` resolves
 (on both its pre-admin and `/admin/*` branches), so the response status
 code is already known.
+
+**`VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED` is currently a no-op**:
+`collector.ts` never reads it, and neither `awcms_mini_visitor_sessions`
+nor `awcms_mini_visit_events` (migration 039) has a raw-user-agent
+column — only `user_agent_hash` and the derived `user_agent_parsed`
+jsonb exist. Unlike `VISITOR_ANALYTICS_RAW_IP_ENABLED` (genuinely gates
+the real `ip_address` column), setting this flag `true` today changes
+nothing. A future issue must either wire it to a new column or this flag
+should be removed rather than left silently non-functional.
 
 - **Gate**: `shouldCollectRequest` (pure, unit-tested) — `false` unless
   `VISITOR_ANALYTICS_ENABLED=true`, the path is trackable

--- a/src/modules/visitor-analytics/application/collector.ts
+++ b/src/modules/visitor-analytics/application/collector.ts
@@ -1,0 +1,283 @@
+/**
+ * Visitor telemetry collector (Issue #620, epic: visitor analytics
+ * #617-#624). The only writer of `awcms_mini_visitor_sessions`/
+ * `awcms_mini_visit_events` — `src/middleware.ts` is the sole caller,
+ * invoked after `next()` so the real response (including its status
+ * code) is already known.
+ *
+ * BINDING (fail-open, acceptance criterion): `collectVisitorTelemetry`
+ * never throws — every failure is caught, logged as a `warning` with
+ * `correlationId` and no sensitive data, and the request's real response
+ * is always returned regardless. Analytics must never become a critical
+ * availability dependency (security note, `withTenant`'s own
+ * `workClass: "background_sync"` reinforces this — the lowest-priority
+ * DB work class, doc 16, so a saturated pool queues real interactive/
+ * reporting work ahead of telemetry writes, never the reverse).
+ *
+ * BINDING (Issue #618 security-audit follow-up, recorded in
+ * `.claude/skills/awcms-mini-visitor-analytics/SKILL.md`): `identityId`
+ * must always be the caller's own server-derived authenticated identity
+ * (`ssrContext.identityId` for `/admin/*`, `null` for every public
+ * request) — never a client-supplied value — and `visitor_session_id` is
+ * always resolved from a session row this function itself just found or
+ * created inside its own tenant-scoped transaction, never from a raw
+ * client-supplied UUID. Neither FK is ever fed a client-controlled value
+ * directly, closing the cross-tenant existence-oracle risk that audit
+ * flagged ahead of time.
+ */
+import { withTenant } from "../../../lib/database/tenant-context";
+import { log } from "../../../lib/logging/logger";
+import { isTrackablePath, sanitizePath } from "../domain/path-sanitizer";
+import { extractReferrerDomain } from "../domain/referrer";
+import { determineArea, type RequestArea } from "../domain/request-area";
+import {
+  classifyHumanStatus,
+  classifySessionHumanity
+} from "../domain/human-classifier";
+import { parseUserAgent, type ParsedUserAgent } from "../domain/user-agent";
+import {
+  hashIpAddress,
+  hashUserAgent,
+  hashVisitorKey
+} from "../domain/visitor-key";
+import type { VisitorAnalyticsConfig } from "../domain/visitor-analytics-config";
+
+/**
+ * A session row already updated within this many seconds is left alone —
+ * `last_seen_at` still reflects "recently active" for realtime-presence
+ * purposes without a write on every single request from the same
+ * visitor (issue's own "Recommended write-throttle behavior"). Not
+ * env-tunable — a small, fixed constant, same convention as the
+ * work-class concurrency limits (`lib/database/work-class.ts`).
+ */
+const SESSION_UPDATE_THROTTLE_MS = 30_000;
+
+/**
+ * Gates whether the collector should do anything at all for this
+ * request — pure, so it's independently unit-testable without a
+ * database. `pathname` must be the RAW (unsanitized) path; static/
+ * internal/health/spec paths are excluded regardless of every other
+ * flag (an operator cannot "opt back in" to counting `/_astro/*` as a
+ * pageview).
+ */
+export function shouldCollectRequest(input: {
+  pathname: string;
+  area: RequestArea;
+  config: VisitorAnalyticsConfig;
+}): boolean {
+  const { pathname, area, config } = input;
+
+  if (!config.enabled) return false;
+  if (!isTrackablePath(pathname)) return false;
+  if (area === "admin") return config.collectAdmin;
+  if (pathname.startsWith("/api")) return config.collectApi;
+
+  return config.collectPublic;
+}
+
+export type CollectVisitorTelemetryInput = {
+  sql: Bun.SQL;
+  tenantId: string;
+  correlationId: string;
+  config: VisitorAnalyticsConfig;
+  method: string;
+  /** Raw path (with query string), NOT yet sanitized — this function sanitizes it. */
+  rawPath: string;
+  statusCode: number | null;
+  /** Resolved by the caller from the visitor cookie (`resolveVisitorKey`). */
+  visitorKey: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  referrerHeader: string | null;
+  isAuthenticated: boolean;
+  /** Server-derived from the caller's own authenticated session — see file header note. */
+  identityId: string | null;
+};
+
+type SessionRow = { id: string; last_seen_at: string };
+
+async function upsertVisitorSession(
+  tx: Bun.SQL,
+  input: {
+    tenantId: string;
+    area: RequestArea;
+    visitorKeyHash: string;
+    pathSanitized: string;
+    ipHash: string | null;
+    rawIpAddress: string | null;
+    userAgentHash: string | null;
+    parsedUserAgent: ParsedUserAgent;
+    isHuman: boolean;
+    botReason: string | null;
+    isAuthenticated: boolean;
+    identityId: string | null;
+    onlineWindowSeconds: number;
+  }
+): Promise<string> {
+  const existingRows = (await tx`
+    SELECT id, last_seen_at FROM awcms_mini_visitor_sessions
+    WHERE tenant_id = ${input.tenantId}
+      AND visitor_key_hash = ${input.visitorKeyHash}
+      AND area = ${input.area}
+    ORDER BY last_seen_at DESC
+    LIMIT 1
+  `) as SessionRow[];
+
+  const existing = existingRows[0];
+  const nowMs = Date.now();
+  const lastSeenMs = existing
+    ? new Date(existing.last_seen_at).getTime()
+    : null;
+  const withinSameSession =
+    lastSeenMs !== null &&
+    nowMs - lastSeenMs <= input.onlineWindowSeconds * 1000;
+
+  if (existing && withinSameSession) {
+    const dueForWrite =
+      lastSeenMs === null || nowMs - lastSeenMs >= SESSION_UPDATE_THROTTLE_MS;
+
+    if (dueForWrite) {
+      await tx`
+        UPDATE awcms_mini_visitor_sessions
+        SET last_seen_at = now(),
+            current_path = ${input.pathSanitized},
+            is_human = ${input.isHuman},
+            bot_reason = ${input.botReason},
+            browser_name = ${input.parsedUserAgent.browserName},
+            browser_version_major = ${input.parsedUserAgent.browserVersionMajor},
+            os_name = ${input.parsedUserAgent.osName},
+            device_type = ${input.parsedUserAgent.deviceType},
+            updated_at = now()
+        WHERE id = ${existing.id}
+      `;
+    }
+
+    return existing.id;
+  }
+
+  // No recent session for this visitor+area — start a new one.
+  // login_identifier_snapshot is deliberately always null here (see
+  // README §Domain helpers/§Not yet available): it's a nullable display
+  // convenience, not a functional requirement, and populating it would
+  // need an extra identities lookup on every new session — deferred
+  // rather than added speculatively (never populated for anonymous
+  // visitors either way, satisfying the binding privacy rule either way).
+  const insertedRows = (await tx`
+    INSERT INTO awcms_mini_visitor_sessions
+      (tenant_id, visitor_key_hash, identity_id, login_identifier_snapshot,
+       is_authenticated, area, current_path, ip_hash, ip_address,
+       user_agent_hash, browser_name, browser_version_major, os_name,
+       device_type, is_human, bot_reason)
+    VALUES (
+      ${input.tenantId}, ${input.visitorKeyHash}, ${input.identityId}, null,
+      ${input.isAuthenticated}, ${input.area}, ${input.pathSanitized},
+      ${input.ipHash}, ${input.rawIpAddress}, ${input.userAgentHash},
+      ${input.parsedUserAgent.browserName}, ${input.parsedUserAgent.browserVersionMajor},
+      ${input.parsedUserAgent.osName}, ${input.parsedUserAgent.deviceType},
+      ${input.isHuman}, ${input.botReason}
+    )
+    RETURNING id
+  `) as { id: string }[];
+
+  return insertedRows[0]!.id;
+}
+
+/**
+ * Writes one `awcms_mini_visit_events` row and creates/refreshes the
+ * matching `awcms_mini_visitor_sessions` row. Never throws — see the
+ * file header's fail-open note. Callers should still check
+ * `shouldCollectRequest` first (cheap, no DB) to avoid the function-call
+ * overhead for requests that will be skipped anyway, but this function
+ * re-checks `isTrackablePath` itself as defense in depth.
+ */
+export async function collectVisitorTelemetry(
+  input: CollectVisitorTelemetryInput
+): Promise<void> {
+  const {
+    sql,
+    tenantId,
+    correlationId,
+    config,
+    method,
+    rawPath,
+    statusCode,
+    visitorKey,
+    ipAddress,
+    userAgent,
+    referrerHeader,
+    isAuthenticated,
+    identityId
+  } = input;
+
+  try {
+    if (!isTrackablePath(rawPath)) return;
+
+    const area = determineArea(rawPath.split("?")[0] ?? rawPath);
+    const pathSanitized = sanitizePath(rawPath);
+    const parsedUserAgent = parseUserAgent(userAgent);
+    const humanStatus = classifyHumanStatus({
+      isAuthenticated,
+      parsedUserAgent
+    });
+    const sessionHumanity = classifySessionHumanity({
+      isAuthenticated,
+      parsedUserAgent
+    });
+    const visitorKeyHash = hashVisitorKey(visitorKey, config.hashSalt);
+    const ipHash = ipAddress ? hashIpAddress(ipAddress, config.hashSalt) : null;
+    const userAgentHash = userAgent
+      ? hashUserAgent(userAgent, config.hashSalt)
+      : null;
+    const rawIpAddress = config.rawIpEnabled ? ipAddress : null;
+    const referrerDomain = extractReferrerDomain(referrerHeader);
+
+    await withTenant(
+      sql,
+      tenantId,
+      async (tx) => {
+        const sessionId = await upsertVisitorSession(tx, {
+          tenantId,
+          area,
+          visitorKeyHash,
+          pathSanitized,
+          ipHash,
+          rawIpAddress,
+          userAgentHash,
+          parsedUserAgent,
+          isHuman: sessionHumanity.isHuman,
+          botReason: sessionHumanity.botReason,
+          isAuthenticated,
+          identityId,
+          onlineWindowSeconds: config.onlineWindowSeconds
+        });
+
+        const userAgentParsed = JSON.stringify({
+          browserName: parsedUserAgent.browserName,
+          browserVersionMajor: parsedUserAgent.browserVersionMajor,
+          osName: parsedUserAgent.osName,
+          deviceType: parsedUserAgent.deviceType
+        });
+
+        await tx`
+          INSERT INTO awcms_mini_visit_events
+            (tenant_id, visitor_session_id, identity_id, method, status_code,
+             area, path_sanitized, referrer_domain, ip_hash, user_agent_hash,
+             user_agent_parsed, geo, human_status, correlation_id)
+          VALUES (
+            ${tenantId}, ${sessionId}, ${identityId}, ${method}, ${statusCode},
+            ${area}, ${pathSanitized}, ${referrerDomain}, ${ipHash}, ${userAgentHash},
+            ${userAgentParsed}::jsonb, '{}'::jsonb, ${humanStatus}, ${correlationId}
+          )
+        `;
+      },
+      { workClass: "background_sync" }
+    );
+  } catch (error) {
+    log("warning", "visitor_analytics.collector.failed", {
+      correlationId,
+      tenantId,
+      moduleKey: "visitor_analytics",
+      error: error instanceof Error ? error.message : "unknown error"
+    });
+  }
+}

--- a/src/modules/visitor-analytics/application/collector.ts
+++ b/src/modules/visitor-analytics/application/collector.ts
@@ -96,6 +96,16 @@ export type CollectVisitorTelemetryInput = {
 
 type SessionRow = { id: string; last_seen_at: string };
 
+/**
+ * Known, benign limitation (noted in PR #628's review): two concurrent
+ * requests from the same visitor that both observe "no session yet" (or
+ * both observe one that just fell outside the online window) can each
+ * `INSERT` a new row — session-count fragmentation, not a
+ * correctness/security bug (tenant isolation and RLS are unaffected,
+ * `visit_events` FK integrity holds either way). Not worth a
+ * `SELECT ... FOR UPDATE`/advisory-lock fix for an analytics table where
+ * an occasional extra session row has no functional consequence.
+ */
 async function upsertVisitorSession(
   tx: Bun.SQL,
   input: {
@@ -270,7 +280,20 @@ export async function collectVisitorTelemetry(
           )
         `;
       },
-      { workClass: "background_sync" }
+      // `queueTimeoutMs` deliberately far below `withTenant`'s own 2000ms
+      // default (post-review fix, PR #628): this collector is the first
+      // *synchronous, per-request* caller of `background_sync` in the
+      // codebase — every other user (`object-dispatch.ts`,
+      // `email-dispatch.ts`) runs from a decoupled scheduled job, never
+      // inline in the HTTP request path. Awaiting the 2000ms default here
+      // would mean every collected request could pick up up to two full
+      // seconds of added latency under pool saturation before the
+      // fail-open 503 path even triggers — exactly the "critical
+      // availability dependency" the issue's own security note forbids.
+      // 200ms bounds the worst case to something a caller of `next()`
+      // never notices, while still giving the write a fair shot under
+      // ordinary (non-saturated) load.
+      { workClass: "background_sync", queueTimeoutMs: 200 }
     );
   } catch (error) {
     log("warning", "visitor_analytics.collector.failed", {

--- a/src/modules/visitor-analytics/domain/client-ip.ts
+++ b/src/modules/visitor-analytics/domain/client-ip.ts
@@ -1,0 +1,35 @@
+/**
+ * Client IP resolution for visitor analytics (Issue #620, epic: visitor
+ * analytics #617-#624). Pure — a distinct, more conservative sibling of
+ * `lib/security/rate-limit.ts`'s `resolveClientIp` (which trusts
+ * `X-Forwarded-For` unconditionally for rate-limit-key purposes). This
+ * one only ever trusts a forwarded header when the deployment has
+ * explicitly opted in via `VISITOR_ANALYTICS_TRUST_PROXY`/
+ * `VISITOR_ANALYTICS_TRUST_CLOUDFLARE` (Issue #617's config gate) — same
+ * principle as `PUBLIC_TRUST_PROXY` in the tenant-domain-routing epic:
+ * never trust a spoofable client-supplied header without a trusted proxy
+ * in front that actually overwrites it.
+ *
+ * Returns `null` (never a fake "unknown" placeholder) when no IP is
+ * resolvable — `null` correctly hashes to nothing and stores as SQL
+ * `NULL` in `ip_hash`/`ip_address`, rather than a meaningless-but-real-
+ * looking hash of the literal string `"unknown"`.
+ */
+export function resolveAnalyticsClientIp(
+  request: Request,
+  clientAddress: string | undefined,
+  trustConfig: { trustProxy: boolean; trustCloudflare: boolean }
+): string | null {
+  if (trustConfig.trustCloudflare) {
+    const cfIp = request.headers.get("cf-connecting-ip")?.trim();
+    if (cfIp) return cfIp;
+  }
+
+  if (trustConfig.trustProxy) {
+    const forwardedFor = request.headers.get("x-forwarded-for");
+    const first = forwardedFor?.split(",")[0]?.trim();
+    if (first) return first;
+  }
+
+  return clientAddress?.trim() || null;
+}

--- a/src/modules/visitor-analytics/domain/request-area.ts
+++ b/src/modules/visitor-analytics/domain/request-area.ts
@@ -1,0 +1,30 @@
+/**
+ * Request area classification (Issue #620, epic: visitor analytics
+ * #617-#624). Pure — matches `awcms_mini_visitor_sessions`/
+ * `awcms_mini_visit_events`'s own `area` CHECK constraint
+ * (`admin|public|api|auth|setup|unknown`, migration 039) exactly.
+ *
+ * `auth`/`setup` are sub-classifications of API space (`/api/v1/auth/*`,
+ * `/api/v1/setup/*`), not page renders — a real page like `/login` is
+ * `public`, same as any other rendered page, since it is gated by
+ * `VISITOR_ANALYTICS_COLLECT_PUBLIC` (page-render volume), not
+ * `VISITOR_ANALYTICS_COLLECT_API` (JSON-endpoint-call volume). This split
+ * lets a future dashboard distinguish login/setup API traffic from
+ * general API traffic without changing the collect-gate logic in
+ * `application/collector.ts`.
+ */
+export type RequestArea =
+  "admin" | "public" | "api" | "auth" | "setup" | "unknown";
+
+export function determineArea(pathname: string): RequestArea {
+  if (pathname.startsWith("/admin")) return "admin";
+  if (pathname.startsWith("/api/v1/setup")) return "setup";
+  if (pathname.startsWith("/api/v1/auth")) return "auth";
+  if (pathname.startsWith("/api")) return "api";
+  return "public";
+}
+
+/** True for every area gated by `VISITOR_ANALYTICS_COLLECT_API` (anything under `/api`). */
+export function isApiArea(area: RequestArea): boolean {
+  return area === "api" || area === "auth" || area === "setup";
+}

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -248,7 +248,8 @@ describe("database migration runner helpers", () => {
       "036_awcms_mini_tenant_oidc_sso_schema.sql",
       "037_awcms_mini_tenant_oidc_sso_permissions.sql",
       "038_awcms_mini_visitor_analytics_permissions.sql",
-      "039_awcms_mini_visitor_analytics_schema.sql"
+      "039_awcms_mini_visitor_analytics_schema.sql",
+      "040_awcms_mini_visitor_analytics_session_lookup_index.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/visitor-analytics-collector.integration.test.ts
+++ b/tests/integration/visitor-analytics-collector.integration.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Integration tests for the visitor telemetry collector (Issue #620,
+ * epic: visitor analytics #617-#624) against a real PostgreSQL — exercises
+ * `collectVisitorTelemetry` exactly as `src/middleware.ts` calls it,
+ * through the same least-privilege app-role client route handlers use
+ * (`getTestSql()`).
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  getTestSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { collectVisitorTelemetry } from "../../src/modules/visitor-analytics/application/collector";
+import { VISITOR_ANALYTICS_DEFAULTS } from "../../src/modules/visitor-analytics/domain/visitor-analytics-config";
+import { generateVisitorKey } from "../../src/modules/visitor-analytics/domain/visitor-key";
+
+const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const HUMAN_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+const BOT_UA =
+  "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+
+async function seedTenant(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES (${TENANT_A}, 'tenant-a', 'Tenant A', 'Tenant A Legal', 'active', 'en', 'light')
+  `;
+}
+
+async function fetchSessions(): Promise<Record<string, unknown>[]> {
+  const admin = getAdminSql();
+  return (await admin`
+    SELECT * FROM awcms_mini_visitor_sessions WHERE tenant_id = ${TENANT_A}
+  `) as Record<string, unknown>[];
+}
+
+async function fetchEvents(): Promise<Record<string, unknown>[]> {
+  const admin = getAdminSql();
+  return (await admin`
+    SELECT * FROM awcms_mini_visit_events WHERE tenant_id = ${TENANT_A}
+  `) as Record<string, unknown>[];
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("collectVisitorTelemetry", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenant();
+  });
+
+  test("creates a session and an event on the first request", async () => {
+    const sql = getTestSql();
+    const visitorKey = generateVisitorKey();
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-1",
+      config: VISITOR_ANALYTICS_DEFAULTS,
+      method: "GET",
+      rawPath: "/news/hello-world?utm_source=test",
+      statusCode: 200,
+      visitorKey,
+      ipAddress: "203.0.113.10",
+      userAgent: HUMAN_UA,
+      referrerHeader: "https://www.google.com/search?q=x",
+      isAuthenticated: false,
+      identityId: null
+    });
+
+    const sessions = await fetchSessions();
+    const events = await fetchEvents();
+
+    expect(sessions).toHaveLength(1);
+    expect(events).toHaveLength(1);
+
+    const session = sessions[0]!;
+    expect(session.area).toBe("public");
+    expect(session.is_human).toBe(true);
+    expect(session.is_authenticated).toBe(false);
+    expect(session.login_identifier_snapshot).toBeNull();
+    // Privacy-first default: raw IP not stored, hashed form is.
+    expect(session.ip_address).toBeNull();
+    expect(session.ip_hash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(session.browser_name).toBe("Chrome");
+    expect(session.device_type).toBe("desktop");
+
+    const event = events[0]!;
+    expect(event.method).toBe("GET");
+    expect(event.status_code).toBe(200);
+    expect(event.area).toBe("public");
+    // Sensitive-looking param stripped even though utm_source itself isn't sensitive.
+    expect(event.path_sanitized).toBe("/news/hello-world?utm_source=test");
+    expect(event.referrer_domain).toBe("www.google.com");
+    expect(event.human_status).toBe("human");
+    expect(event.correlation_id).toBe("corr-1");
+    expect(event.visitor_session_id).toBe(session.id);
+  });
+
+  test("strips sensitive query params before path_sanitized is ever written", async () => {
+    const sql = getTestSql();
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-2",
+      config: VISITOR_ANALYTICS_DEFAULTS,
+      method: "GET",
+      rawPath: "/auth/reset?reset_token=super-secret-value",
+      statusCode: 200,
+      visitorKey: generateVisitorKey(),
+      ipAddress: null,
+      userAgent: HUMAN_UA,
+      referrerHeader: null,
+      isAuthenticated: false,
+      identityId: null
+    });
+
+    const events = await fetchEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.path_sanitized).not.toContain("super-secret-value");
+  });
+
+  test("classifies a bot user-agent as bot on both session and event", async () => {
+    const sql = getTestSql();
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-3",
+      config: VISITOR_ANALYTICS_DEFAULTS,
+      method: "GET",
+      rawPath: "/news",
+      statusCode: 200,
+      visitorKey: generateVisitorKey(),
+      ipAddress: "203.0.113.20",
+      userAgent: BOT_UA,
+      referrerHeader: null,
+      isAuthenticated: false,
+      identityId: null
+    });
+
+    const sessions = await fetchSessions();
+    const events = await fetchEvents();
+
+    expect(sessions[0]!.is_human).toBe(false);
+    expect(sessions[0]!.bot_reason).toBe("Googlebot");
+    expect(events[0]!.human_status).toBe("bot");
+  });
+
+  test("stores raw IP only when VISITOR_ANALYTICS_RAW_IP_ENABLED is on", async () => {
+    const sql = getTestSql();
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-4",
+      config: { ...VISITOR_ANALYTICS_DEFAULTS, rawIpEnabled: true },
+      method: "GET",
+      rawPath: "/news",
+      statusCode: 200,
+      visitorKey: generateVisitorKey(),
+      ipAddress: "203.0.113.30",
+      userAgent: HUMAN_UA,
+      referrerHeader: null,
+      isAuthenticated: false,
+      identityId: null
+    });
+
+    const sessions = await fetchSessions();
+    expect(sessions[0]!.ip_address).toBe("203.0.113.30");
+  });
+
+  test("reuses the same session row (throttled) within the online window, but always inserts a new event", async () => {
+    const sql = getTestSql();
+    const visitorKey = generateVisitorKey();
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-5a",
+      config: VISITOR_ANALYTICS_DEFAULTS,
+      method: "GET",
+      rawPath: "/news",
+      statusCode: 200,
+      visitorKey,
+      ipAddress: "203.0.113.40",
+      userAgent: HUMAN_UA,
+      referrerHeader: null,
+      isAuthenticated: false,
+      identityId: null
+    });
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-5b",
+      config: VISITOR_ANALYTICS_DEFAULTS,
+      method: "GET",
+      rawPath: "/news/second-page",
+      statusCode: 200,
+      visitorKey,
+      ipAddress: "203.0.113.40",
+      userAgent: HUMAN_UA,
+      referrerHeader: null,
+      isAuthenticated: false,
+      identityId: null
+    });
+
+    const sessions = await fetchSessions();
+    const events = await fetchEvents();
+
+    expect(sessions).toHaveLength(1);
+    expect(events).toHaveLength(2);
+  });
+
+  test("starts a new session once the previous one falls outside the online window", async () => {
+    const sql = getTestSql();
+    const visitorKey = generateVisitorKey();
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-6a",
+      config: { ...VISITOR_ANALYTICS_DEFAULTS, onlineWindowSeconds: 300 },
+      method: "GET",
+      rawPath: "/news",
+      statusCode: 200,
+      visitorKey,
+      ipAddress: "203.0.113.50",
+      userAgent: HUMAN_UA,
+      referrerHeader: null,
+      isAuthenticated: false,
+      identityId: null
+    });
+
+    // Simulate the session going stale beyond the online window (real
+    // clock manipulation isn't available here — backdating last_seen_at
+    // via the admin client is the standard way this repo tests
+    // time-window behavior, e.g. rate-limit/session-expiry tests).
+    const admin = getAdminSql();
+    await admin`
+      UPDATE awcms_mini_visitor_sessions
+      SET last_seen_at = now() - interval '10 minutes'
+      WHERE tenant_id = ${TENANT_A}
+    `;
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-6b",
+      config: { ...VISITOR_ANALYTICS_DEFAULTS, onlineWindowSeconds: 300 },
+      method: "GET",
+      rawPath: "/news/second-visit",
+      statusCode: 200,
+      visitorKey,
+      ipAddress: "203.0.113.50",
+      userAgent: HUMAN_UA,
+      referrerHeader: null,
+      isAuthenticated: false,
+      identityId: null
+    });
+
+    const sessions = await fetchSessions();
+    const events = await fetchEvents();
+
+    expect(sessions).toHaveLength(2);
+    expect(events).toHaveLength(2);
+  });
+
+  test("does not throw and writes nothing for a static/non-trackable path", async () => {
+    const sql = getTestSql();
+
+    await expect(
+      collectVisitorTelemetry({
+        sql,
+        tenantId: TENANT_A,
+        correlationId: "corr-7",
+        config: VISITOR_ANALYTICS_DEFAULTS,
+        method: "GET",
+        rawPath: "/_astro/client.abc123.js",
+        statusCode: 200,
+        visitorKey: generateVisitorKey(),
+        ipAddress: "203.0.113.60",
+        userAgent: HUMAN_UA,
+        referrerHeader: null,
+        isAuthenticated: false,
+        identityId: null
+      })
+    ).resolves.toBeUndefined();
+
+    expect(await fetchSessions()).toHaveLength(0);
+    expect(await fetchEvents()).toHaveLength(0);
+  });
+
+  test("fail-open: an invalid tenantId never throws, and writes nothing", async () => {
+    const sql = getTestSql();
+
+    await expect(
+      collectVisitorTelemetry({
+        sql,
+        tenantId: "not-a-valid-uuid",
+        correlationId: "corr-8",
+        config: VISITOR_ANALYTICS_DEFAULTS,
+        method: "GET",
+        rawPath: "/news",
+        statusCode: 200,
+        visitorKey: generateVisitorKey(),
+        ipAddress: "203.0.113.70",
+        userAgent: HUMAN_UA,
+        referrerHeader: null,
+        isAuthenticated: false,
+        identityId: null
+      })
+    ).resolves.toBeUndefined();
+
+    expect(await fetchSessions()).toHaveLength(0);
+  });
+
+  test("an authenticated admin session records identityId and area=admin", async () => {
+    const sql = getTestSql();
+
+    // A real identity row so the FK is satisfiable — mirrors the binding
+    // rule from the Issue #618 security-audit follow-up: identityId here
+    // is always server-derived (never client-supplied) in the real
+    // middleware caller, and this test seeds a real row for the same
+    // reason a forged/foreign id must never reach this function.
+    const admin = getAdminSql();
+    const profileRows = await admin`
+      INSERT INTO awcms_mini_profiles (tenant_id, display_name, profile_type)
+      VALUES (${TENANT_A}, 'Owner', 'person')
+      RETURNING id
+    `;
+    const profileId = (profileRows as { id: string }[])[0]!.id;
+    const identityRows = await admin`
+      INSERT INTO awcms_mini_identities
+        (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${TENANT_A}, ${profileId}, 'owner@example.com', 'x')
+      RETURNING id
+    `;
+    const identityId = (identityRows as { id: string }[])[0]!.id;
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-9",
+      config: VISITOR_ANALYTICS_DEFAULTS,
+      method: "GET",
+      rawPath: "/admin/dashboard",
+      statusCode: 200,
+      visitorKey: generateVisitorKey(),
+      ipAddress: "203.0.113.80",
+      userAgent: HUMAN_UA,
+      referrerHeader: null,
+      isAuthenticated: true,
+      identityId
+    });
+
+    const sessions = await fetchSessions();
+    const events = await fetchEvents();
+
+    expect(sessions[0]!.area).toBe("admin");
+    expect(sessions[0]!.identity_id).toBe(identityId);
+    expect(sessions[0]!.is_authenticated).toBe(true);
+    expect(events[0]!.identity_id).toBe(identityId);
+    expect(events[0]!.area).toBe("admin");
+  });
+});

--- a/tests/unit/visitor-analytics-client-ip.test.ts
+++ b/tests/unit/visitor-analytics-client-ip.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveAnalyticsClientIp } from "../../src/modules/visitor-analytics/domain/client-ip";
+
+function requestWithHeaders(headers: Record<string, string>): Request {
+  return new Request("http://internal.invalid/", { headers });
+}
+
+describe("resolveAnalyticsClientIp", () => {
+  test("uses clientAddress when no trust flags are enabled, ignoring forwarded headers", () => {
+    const request = requestWithHeaders({ "x-forwarded-for": "203.0.113.9" });
+    expect(
+      resolveAnalyticsClientIp(request, "198.51.100.1", {
+        trustProxy: false,
+        trustCloudflare: false
+      })
+    ).toBe("198.51.100.1");
+  });
+
+  test("trusts X-Forwarded-For only when trustProxy is true", () => {
+    const request = requestWithHeaders({
+      "x-forwarded-for": "203.0.113.9, 10.0.0.1"
+    });
+    expect(
+      resolveAnalyticsClientIp(request, "198.51.100.1", {
+        trustProxy: true,
+        trustCloudflare: false
+      })
+    ).toBe("203.0.113.9");
+  });
+
+  test("trusts CF-Connecting-IP only when trustCloudflare is true, taking priority over X-Forwarded-For", () => {
+    const request = requestWithHeaders({
+      "cf-connecting-ip": "203.0.113.42",
+      "x-forwarded-for": "203.0.113.9"
+    });
+    expect(
+      resolveAnalyticsClientIp(request, "198.51.100.1", {
+        trustProxy: true,
+        trustCloudflare: true
+      })
+    ).toBe("203.0.113.42");
+  });
+
+  test("falls back to clientAddress when trustProxy is true but no header is present", () => {
+    const request = requestWithHeaders({});
+    expect(
+      resolveAnalyticsClientIp(request, "198.51.100.1", {
+        trustProxy: true,
+        trustCloudflare: false
+      })
+    ).toBe("198.51.100.1");
+  });
+
+  test("returns null (never a fake placeholder) when nothing is resolvable", () => {
+    const request = requestWithHeaders({});
+    expect(
+      resolveAnalyticsClientIp(request, undefined, {
+        trustProxy: false,
+        trustCloudflare: false
+      })
+    ).toBeNull();
+  });
+
+  test("never trusts a spoofed forwarded header without explicit opt-in", () => {
+    const request = requestWithHeaders({
+      "cf-connecting-ip": "203.0.113.42",
+      "x-forwarded-for": "203.0.113.9"
+    });
+    expect(
+      resolveAnalyticsClientIp(request, "198.51.100.1", {
+        trustProxy: false,
+        trustCloudflare: false
+      })
+    ).toBe("198.51.100.1");
+  });
+});

--- a/tests/unit/visitor-analytics-collector.test.ts
+++ b/tests/unit/visitor-analytics-collector.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldCollectRequest } from "../../src/modules/visitor-analytics/application/collector";
+import {
+  VISITOR_ANALYTICS_DEFAULTS,
+  type VisitorAnalyticsConfig
+} from "../../src/modules/visitor-analytics/domain/visitor-analytics-config";
+
+function configWith(
+  overrides: Partial<VisitorAnalyticsConfig>
+): VisitorAnalyticsConfig {
+  return { ...VISITOR_ANALYTICS_DEFAULTS, ...overrides };
+}
+
+describe("shouldCollectRequest", () => {
+  test("false when the module is disabled entirely", () => {
+    expect(
+      shouldCollectRequest({
+        pathname: "/news",
+        area: "public",
+        config: configWith({ enabled: false })
+      })
+    ).toBe(false);
+  });
+
+  test("false for a non-trackable path (static asset), regardless of every other flag", () => {
+    expect(
+      shouldCollectRequest({
+        pathname: "/_astro/client.js",
+        area: "public",
+        config: configWith({
+          enabled: true,
+          collectAdmin: true,
+          collectPublic: true,
+          collectApi: true
+        })
+      })
+    ).toBe(false);
+  });
+
+  test("admin area gated by collectAdmin only", () => {
+    expect(
+      shouldCollectRequest({
+        pathname: "/admin/dashboard",
+        area: "admin",
+        config: configWith({ collectAdmin: true })
+      })
+    ).toBe(true);
+    expect(
+      shouldCollectRequest({
+        pathname: "/admin/dashboard",
+        area: "admin",
+        config: configWith({ collectAdmin: false })
+      })
+    ).toBe(false);
+  });
+
+  test("api-shaped paths gated by collectApi regardless of area label", () => {
+    expect(
+      shouldCollectRequest({
+        pathname: "/api/v1/blog/posts",
+        area: "api",
+        config: configWith({ collectApi: true })
+      })
+    ).toBe(true);
+    expect(
+      shouldCollectRequest({
+        pathname: "/api/v1/blog/posts",
+        area: "api",
+        config: configWith({ collectApi: false })
+      })
+    ).toBe(false);
+  });
+
+  test("public pages gated by collectPublic", () => {
+    expect(
+      shouldCollectRequest({
+        pathname: "/news/hello-world",
+        area: "public",
+        config: configWith({ collectPublic: true })
+      })
+    ).toBe(true);
+    expect(
+      shouldCollectRequest({
+        pathname: "/news/hello-world",
+        area: "public",
+        config: configWith({ collectPublic: false })
+      })
+    ).toBe(false);
+  });
+
+  test("default config collects admin and public but not API", () => {
+    expect(
+      shouldCollectRequest({
+        pathname: "/admin/dashboard",
+        area: "admin",
+        config: VISITOR_ANALYTICS_DEFAULTS
+      })
+    ).toBe(true);
+    expect(
+      shouldCollectRequest({
+        pathname: "/news",
+        area: "public",
+        config: VISITOR_ANALYTICS_DEFAULTS
+      })
+    ).toBe(true);
+    expect(
+      shouldCollectRequest({
+        pathname: "/api/v1/health",
+        area: "api",
+        config: VISITOR_ANALYTICS_DEFAULTS
+      })
+    ).toBe(false);
+  });
+});

--- a/tests/unit/visitor-analytics-request-area.test.ts
+++ b/tests/unit/visitor-analytics-request-area.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  determineArea,
+  isApiArea
+} from "../../src/modules/visitor-analytics/domain/request-area";
+
+describe("determineArea", () => {
+  test("classifies /admin/* as admin", () => {
+    expect(determineArea("/admin")).toBe("admin");
+    expect(determineArea("/admin/dashboard")).toBe("admin");
+  });
+
+  test("classifies /api/v1/setup/* as setup", () => {
+    expect(determineArea("/api/v1/setup/initialize")).toBe("setup");
+  });
+
+  test("classifies /api/v1/auth/* as auth", () => {
+    expect(determineArea("/api/v1/auth/login")).toBe("auth");
+  });
+
+  test("classifies other /api/* paths as api", () => {
+    expect(determineArea("/api/v1/blog/posts")).toBe("api");
+  });
+
+  test("classifies everything else, including /login, as public", () => {
+    expect(determineArea("/news/hello-world")).toBe("public");
+    expect(determineArea("/login")).toBe("public");
+    expect(determineArea("/")).toBe("public");
+  });
+});
+
+describe("isApiArea", () => {
+  test("true for api/auth/setup", () => {
+    expect(isApiArea("api")).toBe(true);
+    expect(isApiArea("auth")).toBe(true);
+    expect(isApiArea("setup")).toBe(true);
+  });
+
+  test("false for admin/public/unknown", () => {
+    expect(isApiArea("admin")).toBe(false);
+    expect(isApiArea("public")).toBe(false);
+    expect(isApiArea("unknown")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Modifies `src/middleware.ts` to call a new `collectRequestAnalytics` hook after `next()` resolves (on both the pre-admin and `/admin/*` branches), so the response status code is already known when a `visit_events` row is written.
- Adds `src/modules/visitor-analytics/application/collector.ts` (`shouldCollectRequest`, `collectVisitorTelemetry`) — the only writer of `awcms_mini_visitor_sessions`/`awcms_mini_visit_events`. Session find-or-create keyed on `(tenant_id, visitor_key_hash, area)`, throttled session updates (≥30s between writes), unthrottled per-request event inserts, session rollover once `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS` elapses.
- Adds two small pure domain helpers: `domain/request-area.ts` (`admin`/`public`/`api`/`auth`/`setup` classification matching migration 039's CHECK constraint) and `domain/client-ip.ts` (conservative client-IP resolution — only trusts `CF-Connecting-IP`/`X-Forwarded-For` when the deployment explicitly opts in via `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`/`_TRUST_PROXY`).
- Adds migration `040` (session lookup index — not needed until this issue's writer existed).
- **Fail-open**: every failure path (config resolution, cookie logic, tenant resolution, the DB write itself) is caught and logged as `warning` with `correlationId`, never breaks the real page/API response. Uses `withTenant`'s `workClass: "background_sync"` so a saturated pool serves real interactive/reporting work first.
- **Closes the Issue #618 security-audit follow-up**: `identityId` is always `ssrContext.identityId` (server-derived, admin-only) or `null` (public); `visitor_session_id` is always resolved from a row this function itself just found/created inside its own tenant-scoped transaction — never a client-supplied UUID, closing the cross-tenant FK-existence-oracle risk flagged in PR #626's review.
- Privacy-first end to end: raw IP/user-agent only stored when `VISITOR_ANALYTICS_RAW_IP_ENABLED`/equivalent are explicitly on; sensitive query params stripped before `path_sanitized` is ever written; static assets/health/spec paths never counted as pageviews.

No API endpoints or dashboard UI yet — those land in Issues #621-#622.

Closes #620

## Test plan
- [x] `bun run db:migrate` — migration `040` applies cleanly
- [x] `bun run lint` / `check:docs` / `api:spec:check` / `typecheck`
- [x] `bun test` — 1690/1690 pass, including new unit tests (`shouldCollectRequest`, `determineArea`, `resolveAnalyticsClientIp`) and a 9-case integration suite (`tests/integration/visitor-analytics-collector.integration.test.ts`: session+event creation, sensitive-param stripping, bot classification, raw-IP opt-in, throttled session reuse, session rollover after the online window, non-trackable-path no-op, fail-open on an invalid tenantId, authenticated admin session)
- [x] `bun run build`
- [x] Manual smoke test against a real dev server + Postgres: ran the setup wizard, logged in, hit `/admin` (real session row with correct `identity_id`/`area=admin`) and `/` (anonymous public session), confirmed static assets and the default-off `/api/v1/health` write nothing, confirmed the `awcms_mini_visitor_key` cookie is set correctly with `httpOnly`/`sameSite=lax`

🤖 Generated with [Claude Code](https://claude.com/claude-code)