### PR TITLE
feat(visitor-analytics): add analytics API and OpenAPI contract

### DIFF
--- a/.changeset/visitor-analytics-api.md
+++ b/.changeset/visitor-analytics-api.md
@@ -1,0 +1,14 @@
+---
+"awcms-mini": minor
+---
+
+Add the visitor analytics REST API (Issue #621, epic: visitor analytics
+#617-#624) — eleven endpoints under `/api/v1/analytics` for realtime
+presence, range-bounded summary/pages/devices/locations/security
+aggregates, keyset-paginated sessions/events, settings, and on-demand
+retention purge. Every endpoint enforces ABAC default-deny; raw IP/
+user-agent/login-identifier detail on sessions/events is gated behind the
+separate `visitor_analytics.raw_detail.read` permission, independent of
+`sessions.read`/`events.read`. Retention purge requires an
+`Idempotency-Key` and is recorded as a `critical` audit event. OpenAPI
+contract updated with all new paths, schemas, and error responses.

--- a/.claude/skills/awcms-mini-visitor-analytics/SKILL.md
+++ b/.claude/skills/awcms-mini-visitor-analytics/SKILL.md
@@ -30,7 +30,7 @@ spesifik** yang menjembatani beberapa issue sekaligus.
 | #618  | Visitor session/event/rollup schema + RLS                      | **Selesai** — lihat §Schema di bawah         |
 | #619  | Visitor identity, user-agent, human/bot classification helpers | **Selesai** — lihat §Domain helpers di bawah |
 | #620  | Middleware telemetry collection (admin + public)               | **Selesai** — lihat §Collector di bawah      |
-| #621  | Analytics API + OpenAPI contract (`/api/v1/analytics`)         | Belum dikerjakan                             |
+| #621  | Analytics API + OpenAPI contract (`/api/v1/analytics`)         | **Selesai** — lihat §API di bawah            |
 | #623  | Trusted online geolocation enrichment                          | Belum dikerjakan                             |
 | #622  | Admin visitor analytics dashboard UI (`/admin/analytics`)      | Belum dikerjakan                             |
 | #624  | Rollup job, retention purge job, readiness checks, docs pass   | Belum dikerjakan                             |
@@ -278,6 +278,46 @@ session rollover, non-trackable no-op, fail-open invalid tenant,
 authenticated admin). Juga smoke-test manual lewat dev server + Postgres
 nyata (setup wizard → login → `/admin` → row session/event benar; `/` →
 session publik; asset statis dan `/api/v1/health` default-off → nihil).
+
+### API (Issue #621, `src/pages/api/v1/analytics/*`)
+
+11 endpoint. Semua wajib bearer session + tenant context + `authorizeInTransaction`
+(ABAC default-deny) — deny selalu `403 ACCESS_DENIED`, tidak pernah data
+analytics kosong/nol diam-diam.
+
+- `GET /realtime` (`realtime.read`), `GET /summary|pages|devices|locations|security`
+  (`dashboard.read`, `range=24h|7d|30d|12m` divalidasi ketat →
+  `400 VALIDATION_ERROR` untuk nilai lain).
+- `GET /sessions` (`sessions.read`), `GET /events` (`events.read`) — keyset
+  pagination (limit 50), field raw detail (`ipHash`/`ipAddress`/
+  `userAgentHash`/`loginIdentifierSnapshot`) `null` kecuali caller **juga**
+  punya `raw_detail.read` (dicek via `auth.grantedPermissionKeys.has(...)`
+  setelah guard utama lolos — `domain/analytics-response-shaping.ts`).
+- `GET/PATCH /settings` (`settings.read`/`.update`) — **reuse langsung**
+  storage generik Module Management (`awcms_mini_module_settings`, Issue
+  #516) via `fetchModuleSettingsView`/`updateModuleSettings`, tapi
+  di-gate permission `visitor_analytics.*` sendiri (bukan
+  `module_management.settings.*` yang dipakai endpoint generiknya). Jangan
+  bangun storage settings kedua untuk modul ini.
+- `POST /retention/purge` (`retention.purge`) — wajib `Idempotency-Key`,
+  audit `critical`. Logic nyata (bukan stub) di
+  `application/retention-purge.ts`: hapus event > `EVENT_RETENTION_DAYS`,
+  clear `ip_address`/`login_identifier_snapshot` sesi > `RAW_DETAIL_RETENTION_DAYS`
+  (row tetap), hapus sesi > `EVENT_RETENTION_DAYS` (aman dijalankan
+  setelah hapus event — `last_seen_at` sesi selalu >= `occurred_at`
+  event-nya sendiri, jadi FK `visit_events.visitor_session_id` sudah
+  bersih), hapus rollup > `ROLLUP_RETENTION_DAYS`. Issue #624's scheduled
+  job (`bun run analytics:retention:purge`) akan memanggil fungsi ini
+  langsung, jangan re-derive.
+- Query agregat (`application/analytics-queries.ts`) baca langsung dari
+  `visit_events`/`visitor_sessions` mentah, **bukan** `visitor_daily_rollups`
+  (selalu kosong sampai job rollup #624 ada).
+
+Test: `tests/unit/visitor-analytics-{range,response-shaping}.test.ts`,
+`tests/integration/visitor-analytics-api.integration.test.ts` (11 test:
+auth guard, ABAC deny lintas endpoint, realtime, summary+range validation,
+raw-detail gating dua arah, keyset pagination 55-row, settings GET/PATCH +
+secret-key rejection, retention purge idempotency+delete+audit).
 
 ## Prinsip yang wajib dipertahankan di setiap issue lanjutan
 

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -128,6 +128,16 @@ tags:
       also gate `GET /blog/{tenantCode}/feed.xml` and
       `.../sitemap-blog.xml` (Issue #540) — disabled looks identical to an
       unknown tenant (404), no distinguishing signal leaked.
+  - name: Visitor Analytics
+    description: >-
+      Tenant-scoped visitor analytics API (epic: visitor analytics
+      #617-#624, Issue #621) — realtime presence, range-bounded summary/
+      pages/devices/locations/security aggregates, keyset-paginated
+      sessions/events, settings, and on-demand retention purge. Raw
+      detail (IP address, user-agent hash, login identifier snapshot) on
+      sessions/events is omitted unless the caller holds the separate
+      `visitor_analytics.raw_detail.read` permission, independent of
+      `sessions.read`/`events.read`.
 paths:
   /api/v1/sync/push:
     post:
@@ -7365,6 +7375,430 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/analytics/realtime:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Online-now presence counts
+      operationId: analyticsRealtime
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Presence counts within the configured online window.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AnalyticsRealtimeStats"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/analytics/summary:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Range-bounded visitor/pageview summary with top paths/browsers/devices/countries
+      operationId: analyticsSummary
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/AnalyticsRange"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Summary for the requested range.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AnalyticsSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/analytics/pages:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Top pages by human pageviews within a range
+      operationId: analyticsPages
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/AnalyticsRange"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Top pages for the requested range.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AnalyticsPagesResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/analytics/devices:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Browser and device-type breakdown within a range
+      operationId: analyticsDevices
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/AnalyticsRange"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Browser/device breakdown for the requested range.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AnalyticsDevicesResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/analytics/locations:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Country breakdown within a range
+      description: >-
+        Always empty until Issue #623 (geolocation enrichment) populates
+        `visit_events.geo` — not an error, just no data yet.
+      operationId: analyticsLocations
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/AnalyticsRange"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Country breakdown for the requested range.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AnalyticsLocationsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/analytics/security:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Bot/crawler traffic breakdown within a range
+      operationId: analyticsSecurity
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/AnalyticsRange"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Bot traffic breakdown for the requested range.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AnalyticsSecurityView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/analytics/sessions:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: List visitor sessions (keyset-paginated, most recently active first)
+      description: >-
+        Raw detail (`ipHash`, `ipAddress`, `userAgentHash`,
+        `loginIdentifierSnapshot`) is `null` unless the caller also holds
+        `visitor_analytics.raw_detail.read`, independent of
+        `sessions.read`.
+      operationId: analyticsSessionsList
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/Cursor"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Visitor sessions (limit 50), most recently active first.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/VisitorSessionListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/analytics/events:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: List page-view/API visit events (keyset-paginated, newest first)
+      description: >-
+        Raw detail (`ipHash`, `userAgentHash`) is `null` unless the caller
+        also holds `visitor_analytics.raw_detail.read`, independent of
+        `events.read`.
+      operationId: analyticsEventsList
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/Cursor"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Visit events (limit 50), newest first.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/VisitEventListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/analytics/settings:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Read effective visitor analytics module settings for this tenant
+      description: >-
+        Thin wrapper around Module Management's generic per-tenant
+        settings storage (Issue #516), gated by
+        `visitor_analytics.settings.read` instead of the generic
+        endpoint's `module_management.settings.read`.
+      operationId: analyticsSettingsGet
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Effective settings (defaults merged with this tenant's override).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/ModuleSettingsView"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    patch:
+      tags:
+        - Visitor Analytics
+      summary: Update visitor analytics module settings for this tenant
+      description: >-
+        Shallow JSON-merge patch. Rejects any secret-shaped key or value
+        anywhere in the body regardless of the field's own name (`400
+        SETTINGS_SENSITIVE_KEY_REJECTED` /
+        `SETTINGS_SECRET_SHAPED_VALUE_REJECTED`) — real provider secrets
+        belong in environment variables, never tenant settings. Audited.
+      operationId: analyticsSettingsUpdate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: >-
+                Non-secret key-value pairs, shallow-merged into the
+                tenant's existing settings override.
+      responses:
+        "200":
+          description: Settings updated.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/ModuleSettingsView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/analytics/retention/purge:
+    post:
+      tags:
+        - Visitor Analytics
+      summary: Purge visitor analytics data past its configured retention window
+      description: >-
+        Destructive, high-risk mutation — requires `Idempotency-Key` and
+        is recorded as a `critical` audit event. Uses Issue #617's
+        `VISITOR_ANALYTICS_EVENT_RETENTION_DAYS`/`_RAW_DETAIL_RETENTION_DAYS`/
+        `_ROLLUP_RETENTION_DAYS` config as the cutoffs — no request body.
+      operationId: analyticsRetentionPurge
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Purge result (also returned unchanged on an idempotent replay).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/AnalyticsRetentionPurgeResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: IDEMPOTENCY_CONFLICT — this Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
 x-awcms-mini-soft-delete-pattern:
   delete:
     method: DELETE
@@ -7463,6 +7897,21 @@ components:
       description: >-
         Opaque keyset pagination cursor from a previous page's `nextCursor`.
         Omit for the first page.
+    AnalyticsRange:
+      name: range
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+          - 24h
+          - 7d
+          - 30d
+          - 12m
+        default: 7d
+      description: >-
+        Aggregate window. An unrecognized value is a `400 VALIDATION_ERROR`,
+        never silently defaulted.
   responses:
     BadRequest:
       description: Validation or request error.
@@ -9666,6 +10115,369 @@ components:
           type: string
           format: date-time
           nullable: true
+    AnalyticsRealtimeStats:
+      type: object
+      required:
+        - onlineHumanCount
+        - onlineAdminCount
+        - onlinePublicCount
+        - onlineApiCount
+        - onlineWindowSeconds
+        - lastUpdatedAt
+      additionalProperties: false
+      properties:
+        onlineHumanCount:
+          type: integer
+        onlineAdminCount:
+          type: integer
+        onlinePublicCount:
+          type: integer
+        onlineApiCount:
+          type: integer
+        onlineWindowSeconds:
+          type: integer
+        lastUpdatedAt:
+          type: string
+          format: date-time
+    AnalyticsNamedCount:
+      type: object
+      required:
+        - name
+        - count
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        count:
+          type: integer
+    AnalyticsSummary:
+      type: object
+      required:
+        - range
+        - humanUniqueVisitors
+        - humanPageviews
+        - botPageviews
+        - adminUniqueUsers
+        - publicUniqueVisitors
+        - topPaths
+        - topBrowsers
+        - topDevices
+        - topCountries
+      additionalProperties: false
+      properties:
+        range:
+          type: string
+          enum: [24h, 7d, 30d, 12m]
+        humanUniqueVisitors:
+          type: integer
+        humanPageviews:
+          type: integer
+        botPageviews:
+          type: integer
+        adminUniqueUsers:
+          type: integer
+        publicUniqueVisitors:
+          type: integer
+        topPaths:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsNamedCount"
+        topBrowsers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsNamedCount"
+        topDevices:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsNamedCount"
+        topCountries:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsNamedCount"
+    AnalyticsPagesResponse:
+      type: object
+      required:
+        - range
+        - pages
+      additionalProperties: false
+      properties:
+        range:
+          type: string
+          enum: [24h, 7d, 30d, 12m]
+        pages:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsNamedCount"
+    AnalyticsDevicesResponse:
+      type: object
+      required:
+        - range
+        - browsers
+        - devices
+      additionalProperties: false
+      properties:
+        range:
+          type: string
+          enum: [24h, 7d, 30d, 12m]
+        browsers:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsNamedCount"
+        devices:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsNamedCount"
+    AnalyticsLocationsResponse:
+      type: object
+      required:
+        - range
+        - countries
+      additionalProperties: false
+      properties:
+        range:
+          type: string
+          enum: [24h, 7d, 30d, 12m]
+        countries:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsNamedCount"
+    AnalyticsSecurityView:
+      type: object
+      required:
+        - range
+        - botPageviews
+        - topBotReasons
+        - botPageviewsByArea
+      additionalProperties: false
+      properties:
+        range:
+          type: string
+          enum: [24h, 7d, 30d, 12m]
+        botPageviews:
+          type: integer
+        topBotReasons:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsNamedCount"
+        botPageviewsByArea:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsNamedCount"
+    VisitorSessionItem:
+      type: object
+      description: >-
+        `ipHash`, `ipAddress`, `userAgentHash`, and
+        `loginIdentifierSnapshot` are `null` unless the caller holds
+        `visitor_analytics.raw_detail.read`.
+      required:
+        - id
+        - visitor_key_hash
+        - identity_id
+        - is_authenticated
+        - area
+        - current_path
+        - firstSeenAt
+        - lastSeenAt
+        - browser_name
+        - browser_version_major
+        - os_name
+        - device_type
+        - is_human
+        - bot_reason
+        - country_code
+        - region
+        - city
+        - timezone
+        - loginIdentifierSnapshot
+        - ipHash
+        - ipAddress
+        - userAgentHash
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        visitor_key_hash:
+          type: string
+        identity_id:
+          type: string
+          format: uuid
+          nullable: true
+        is_authenticated:
+          type: boolean
+        area:
+          type: string
+          enum: [admin, public, api, auth, setup, unknown]
+        current_path:
+          type: string
+          nullable: true
+        firstSeenAt:
+          type: string
+          format: date-time
+        lastSeenAt:
+          type: string
+          format: date-time
+        browser_name:
+          type: string
+          nullable: true
+        browser_version_major:
+          type: string
+          nullable: true
+        os_name:
+          type: string
+          nullable: true
+        device_type:
+          type: string
+          enum: [desktop, mobile, tablet, bot, unknown]
+          nullable: true
+        is_human:
+          type: boolean
+        bot_reason:
+          type: string
+          nullable: true
+        country_code:
+          type: string
+          nullable: true
+        region:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true
+        loginIdentifierSnapshot:
+          type: string
+          nullable: true
+        ipHash:
+          type: string
+          nullable: true
+        ipAddress:
+          type: string
+          nullable: true
+        userAgentHash:
+          type: string
+          nullable: true
+    VisitorSessionListResponse:
+      type: object
+      required:
+        - sessions
+        - nextCursor
+      additionalProperties: false
+      properties:
+        sessions:
+          type: array
+          items:
+            $ref: "#/components/schemas/VisitorSessionItem"
+        nextCursor:
+          type: string
+          nullable: true
+    VisitEventItem:
+      type: object
+      description: >-
+        `ipHash`/`userAgentHash` are `null` unless the caller holds
+        `visitor_analytics.raw_detail.read`.
+      required:
+        - id
+        - visitor_session_id
+        - identity_id
+        - occurredAt
+        - method
+        - status_code
+        - area
+        - route_pattern
+        - path_sanitized
+        - referrer_domain
+        - duration_ms
+        - user_agent_parsed
+        - geo
+        - human_status
+        - correlation_id
+        - ipHash
+        - userAgentHash
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        visitor_session_id:
+          type: string
+          format: uuid
+          nullable: true
+        identity_id:
+          type: string
+          format: uuid
+          nullable: true
+        occurredAt:
+          type: string
+          format: date-time
+        method:
+          type: string
+        status_code:
+          type: integer
+          nullable: true
+        area:
+          type: string
+          enum: [admin, public, api, auth, setup, unknown]
+        route_pattern:
+          type: string
+          nullable: true
+        path_sanitized:
+          type: string
+        referrer_domain:
+          type: string
+          nullable: true
+        duration_ms:
+          type: integer
+          nullable: true
+        user_agent_parsed:
+          type: object
+        geo:
+          type: object
+        human_status:
+          type: string
+          enum: [human, bot, unknown]
+        correlation_id:
+          type: string
+          nullable: true
+        ipHash:
+          type: string
+          nullable: true
+        userAgentHash:
+          type: string
+          nullable: true
+    VisitEventListResponse:
+      type: object
+      required:
+        - events
+        - nextCursor
+      additionalProperties: false
+      properties:
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/VisitEventItem"
+        nextCursor:
+          type: string
+          nullable: true
+    AnalyticsRetentionPurgeResult:
+      type: object
+      required:
+        - eventsDeleted
+        - sessionsRawDetailCleared
+        - sessionsDeleted
+        - rollupsDeleted
+      additionalProperties: false
+      properties:
+        eventsDeleted:
+          type: integer
+        sessionsRawDetailCleared:
+          type: integer
+        sessionsDeleted:
+          type: integer
+        rollupsDeleted:
+          type: integer
     TenantDomainItem:
       type: object
       description: >-

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -10271,20 +10271,20 @@ components:
         `visitor_analytics.raw_detail.read`.
       required:
         - id
-        - visitor_key_hash
-        - identity_id
-        - is_authenticated
+        - visitorKeyHash
+        - identityId
+        - isAuthenticated
         - area
-        - current_path
+        - currentPath
         - firstSeenAt
         - lastSeenAt
-        - browser_name
-        - browser_version_major
-        - os_name
-        - device_type
-        - is_human
-        - bot_reason
-        - country_code
+        - browserName
+        - browserVersionMajor
+        - osName
+        - deviceType
+        - isHuman
+        - botReason
+        - countryCode
         - region
         - city
         - timezone
@@ -10297,18 +10297,18 @@ components:
         id:
           type: string
           format: uuid
-        visitor_key_hash:
+        visitorKeyHash:
           type: string
-        identity_id:
+        identityId:
           type: string
           format: uuid
           nullable: true
-        is_authenticated:
+        isAuthenticated:
           type: boolean
         area:
           type: string
           enum: [admin, public, api, auth, setup, unknown]
-        current_path:
+        currentPath:
           type: string
           nullable: true
         firstSeenAt:
@@ -10317,25 +10317,25 @@ components:
         lastSeenAt:
           type: string
           format: date-time
-        browser_name:
+        browserName:
           type: string
           nullable: true
-        browser_version_major:
+        browserVersionMajor:
           type: string
           nullable: true
-        os_name:
+        osName:
           type: string
           nullable: true
-        device_type:
+        deviceType:
           type: string
           enum: [desktop, mobile, tablet, bot, unknown]
           nullable: true
-        is_human:
+        isHuman:
           type: boolean
-        bot_reason:
+        botReason:
           type: string
           nullable: true
-        country_code:
+        countryCode:
           type: string
           nullable: true
         region:
@@ -10380,20 +10380,20 @@ components:
         `visitor_analytics.raw_detail.read`.
       required:
         - id
-        - visitor_session_id
-        - identity_id
+        - visitorSessionId
+        - identityId
         - occurredAt
         - method
-        - status_code
+        - statusCode
         - area
-        - route_pattern
-        - path_sanitized
-        - referrer_domain
-        - duration_ms
-        - user_agent_parsed
+        - routePattern
+        - pathSanitized
+        - referrerDomain
+        - durationMs
+        - userAgentParsed
         - geo
-        - human_status
-        - correlation_id
+        - humanStatus
+        - correlationId
         - ipHash
         - userAgentHash
       additionalProperties: false
@@ -10401,11 +10401,11 @@ components:
         id:
           type: string
           format: uuid
-        visitor_session_id:
+        visitorSessionId:
           type: string
           format: uuid
           nullable: true
-        identity_id:
+        identityId:
           type: string
           format: uuid
           nullable: true
@@ -10414,31 +10414,31 @@ components:
           format: date-time
         method:
           type: string
-        status_code:
+        statusCode:
           type: integer
           nullable: true
         area:
           type: string
           enum: [admin, public, api, auth, setup, unknown]
-        route_pattern:
+        routePattern:
           type: string
           nullable: true
-        path_sanitized:
+        pathSanitized:
           type: string
-        referrer_domain:
+        referrerDomain:
           type: string
           nullable: true
-        duration_ms:
+        durationMs:
           type: integer
           nullable: true
-        user_agent_parsed:
+        userAgentParsed:
           type: object
         geo:
           type: object
-        human_status:
+        humanStatus:
           type: string
           enum: [human, bot, unknown]
-        correlation_id:
+        correlationId:
           type: string
           nullable: true
         ipHash:

--- a/src/modules/visitor-analytics/README.md
+++ b/src/modules/visitor-analytics/README.md
@@ -58,7 +58,14 @@ the real request lifecycle — collects visitor presence/events for
 §Collector below). **First issue that actually writes to
 `awcms_mini_visitor_sessions`/`awcms_mini_visit_events`.**
 
-Issue #621: analytics API + OpenAPI contract at `/api/v1/analytics`.
+Issue #621 (`src/pages/api/v1/analytics/*`, `application/analytics-queries.ts`,
+`application/session-directory.ts`, `application/event-directory.ts`,
+`application/retention-purge.ts`, `domain/analytics-range.ts`,
+`domain/analytics-response-shaping.ts`): eleven REST endpoints — realtime
+presence, range-bounded summary/pages/devices/locations/security
+aggregates, keyset-paginated sessions/events, settings, and on-demand
+retention purge (see §API below). First issue exposing this module's data
+through authenticated APIs.
 
 Issue #623: trusted online geolocation enrichment.
 
@@ -276,12 +283,63 @@ a real dev server + Postgres (setup wizard → login → `/admin` → real
 session/event rows with correct `identity_id`/`area`; `/`→ public session;
 static asset and default-off `/api/v1/health` → no rows written).
 
+## API (Issue #621, `src/pages/api/v1/analytics/*`)
+
+All eleven endpoints require a bearer session + tenant context and run
+`authorizeInTransaction` (ABAC default-deny) before touching any data —
+denial is always `403 ACCESS_DENIED`, never empty/zeroed analytics data.
+
+| Method    | Path                                | Guard                                 | Notes                                                                                                                                               |
+| --------- | ----------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GET       | `/api/v1/analytics/realtime`        | `realtime.read`                       | Online-now counts by area/human, `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS` window.                                                                  |
+| GET       | `/api/v1/analytics/summary`         | `dashboard.read`                      | `range=24h\|7d\|30d\|12m` (default `7d`), strictly validated (`400 VALIDATION_ERROR`).                                                              |
+| GET       | `/api/v1/analytics/pages`           | `dashboard.read`                      | Top paths by human pageviews.                                                                                                                       |
+| GET       | `/api/v1/analytics/devices`         | `dashboard.read`                      | Browser + device-type breakdown.                                                                                                                    |
+| GET       | `/api/v1/analytics/locations`       | `dashboard.read`                      | Country breakdown — empty until Issue #623 populates `geo`.                                                                                         |
+| GET       | `/api/v1/analytics/security`        | `dashboard.read`                      | Bot/crawler traffic breakdown (by `bot_reason`, by area).                                                                                           |
+| GET       | `/api/v1/analytics/sessions`        | `sessions.read` (+ `raw_detail.read`) | Keyset-paginated (limit 50, `last_seen_at DESC`).                                                                                                   |
+| GET       | `/api/v1/analytics/events`          | `events.read` (+ `raw_detail.read`)   | Keyset-paginated (limit 50, `occurred_at DESC`).                                                                                                    |
+| GET/PATCH | `/api/v1/analytics/settings`        | `settings.read`/`.update`             | Reuses Module Management's generic settings storage (Issue #516), gated by this module's own permissions instead of `module_management.settings.*`. |
+| POST      | `/api/v1/analytics/retention/purge` | `retention.purge`                     | Requires `Idempotency-Key`; `critical`-severity audit event.                                                                                        |
+
+**Raw-detail gating** (`domain/analytics-response-shaping.ts`): `sessions`/
+`events` always include non-raw fields (browser/device/OS, area,
+`human_status`, timestamps) for anyone with `sessions.read`/`events.read`
+alone. `ipHash`/`ipAddress`/`userAgentHash`/`loginIdentifierSnapshot`
+are `null` unless the caller _also_ holds
+`visitor_analytics.raw_detail.read` — checked via
+`auth.grantedPermissionKeys.has("visitor_analytics.raw_detail.read")`
+after the primary guard passes, never a substitute for it.
+
+**Aggregate queries** (`application/analytics-queries.ts`) compute
+directly from raw `awcms_mini_visit_events`/`awcms_mini_visitor_sessions`
+rows, not `awcms_mini_visitor_daily_rollups` — that table is always empty
+until Issue #624's rollup job exists. Switching `fetchAnalyticsSummary` to
+read rollups for older, fully-rolled-up ranges is future work for #624,
+not required now.
+
+**Retention purge** (`application/retention-purge.ts`) is a real,
+independently-callable function using Issue #617's config as cutoffs —
+not a stub. Issue #624's scheduled job (`bun run analytics:retention:purge`,
+mirroring `logs:audit:purge`) will call this exact function rather than
+re-deriving the purge rules. See that file's own doc comment for the
+three-cutoff design (event delete / raw-detail clear / session delete /
+rollup delete) and why session delete is safe to run after event delete.
+
+Test: `tests/unit/visitor-analytics-range.test.ts`,
+`-response-shaping.test.ts`,
+`tests/integration/visitor-analytics-api.integration.test.ts` (auth guard,
+ABAC deny across every guarded endpoint, realtime counts, summary
+aggregation + range validation, raw-detail gating both ways, keyset
+pagination across a 55-row page boundary + malformed-cursor rejection,
+settings GET/PATCH + secret-shaped-key rejection, retention purge
+idempotency + real deletion + audit event).
+
 ## Not yet available
 
-- REST API (`/api/v1/analytics/*`) — Issue #621.
 - Admin dashboard UI (`/admin/analytics`) — Issue #622.
 - Geolocation enrichment — Issue #623.
-- Rollup/retention purge jobs — Issue #624.
+- Rollup job (retention purge itself already works — see §API above) — Issue #624.
 
 The `api.basePath`/navigation `path` in `module.ts` are pre-declared ahead
 of their landing issues (same convention `tenant_domain`'s descriptor

--- a/src/modules/visitor-analytics/application/analytics-queries.ts
+++ b/src/modules/visitor-analytics/application/analytics-queries.ts
@@ -1,0 +1,266 @@
+/**
+ * Aggregate analytics read queries (Issue #621, epic: visitor analytics
+ * #617-#624). All queries run inside the caller's own tenant-scoped
+ * transaction (`withTenant`) — RLS on `awcms_mini_visitor_sessions`/
+ * `awcms_mini_visit_events` is defense in depth on top of the explicit
+ * `tenant_id = ${tenantId}` filter every query below already carries.
+ *
+ * Computed directly from raw `visit_events`/`visitor_sessions` rows, not
+ * `awcms_mini_visitor_daily_rollups` — the rollup job (#624) hasn't
+ * landed yet, so that table is always empty today. Once #624 lands,
+ * `fetchAnalyticsSummary` is the function to switch to reading rollups
+ * for ranges old enough to be fully rolled up (see its own doc comment).
+ */
+import type { AnalyticsRange } from "../domain/analytics-range";
+
+export type RealtimeStats = {
+  onlineHumanCount: number;
+  onlineAdminCount: number;
+  onlinePublicCount: number;
+  onlineApiCount: number;
+  onlineWindowSeconds: number;
+  lastUpdatedAt: string;
+};
+
+export async function fetchRealtimeStats(
+  tx: Bun.SQL,
+  tenantId: string,
+  onlineWindowSeconds: number
+): Promise<RealtimeStats> {
+  const rows = (await tx`
+    SELECT
+      count(*) FILTER (WHERE is_human) AS online_human_count,
+      count(*) FILTER (WHERE area = 'admin') AS online_admin_count,
+      count(*) FILTER (WHERE area = 'public') AS online_public_count,
+      count(*) FILTER (WHERE area IN ('api', 'auth', 'setup')) AS online_api_count
+    FROM awcms_mini_visitor_sessions
+    WHERE tenant_id = ${tenantId}
+      AND last_seen_at >= now() - make_interval(secs => ${onlineWindowSeconds})
+  `) as {
+    online_human_count: string;
+    online_admin_count: string;
+    online_public_count: string;
+    online_api_count: string;
+  }[];
+
+  const row = rows[0];
+
+  return {
+    onlineHumanCount: Number(row?.online_human_count ?? 0),
+    onlineAdminCount: Number(row?.online_admin_count ?? 0),
+    onlinePublicCount: Number(row?.online_public_count ?? 0),
+    onlineApiCount: Number(row?.online_api_count ?? 0),
+    onlineWindowSeconds,
+    lastUpdatedAt: new Date().toISOString()
+  };
+}
+
+export type NamedCount = { name: string; count: number };
+
+async function topPathCounts(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  limit: number
+): Promise<NamedCount[]> {
+  const rows = (await tx`
+    SELECT path_sanitized AS name, count(*) AS count
+    FROM awcms_mini_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at >= ${start} AND human_status = 'human'
+    GROUP BY path_sanitized
+    ORDER BY count DESC, name ASC
+    LIMIT ${limit}
+  `) as { name: string; count: string }[];
+
+  return rows.map((row) => ({ name: row.name, count: Number(row.count) }));
+}
+
+async function topJsonFieldCounts(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  jsonColumn: "user_agent_parsed" | "geo",
+  jsonKey: "browserName" | "deviceType" | "countryCode",
+  limit: number
+): Promise<NamedCount[]> {
+  // `jsonColumn`/`jsonKey` are never user input — always one of the fixed
+  // literal values this file's own call sites pass — so interpolating
+  // them directly into the SQL text is safe (same convention
+  // `tests/integration/harness.ts`'s `resetDatabase` uses for a
+  // table-name list it built itself, never from request input).
+  // `tenantId`/`start`/`limit` remain real bound parameters via
+  // `tx.unsafe`'s `$1`/`$2`/`$3` placeholders — never string-concatenated.
+  const rows = (await tx.unsafe(
+    `SELECT ${jsonColumn}->>'${jsonKey}' AS name, count(*) AS count
+     FROM awcms_mini_visit_events
+     WHERE tenant_id = $1 AND occurred_at >= $2 AND human_status = 'human'
+       AND ${jsonColumn}->>'${jsonKey}' IS NOT NULL
+     GROUP BY name
+     ORDER BY count DESC, name ASC
+     LIMIT $3`,
+    [tenantId, start, limit]
+  )) as { name: string; count: string }[];
+
+  return rows.map((row) => ({ name: row.name, count: Number(row.count) }));
+}
+
+export async function fetchTopPaths(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  limit = 50
+): Promise<NamedCount[]> {
+  return topPathCounts(tx, tenantId, start, limit);
+}
+
+export async function fetchTopBrowsers(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  limit = 50
+): Promise<NamedCount[]> {
+  return topJsonFieldCounts(
+    tx,
+    tenantId,
+    start,
+    "user_agent_parsed",
+    "browserName",
+    limit
+  );
+}
+
+export async function fetchTopDevices(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  limit = 50
+): Promise<NamedCount[]> {
+  return topJsonFieldCounts(
+    tx,
+    tenantId,
+    start,
+    "user_agent_parsed",
+    "deviceType",
+    limit
+  );
+}
+
+export async function fetchTopCountries(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  limit = 50
+): Promise<NamedCount[]> {
+  return topJsonFieldCounts(tx, tenantId, start, "geo", "countryCode", limit);
+}
+
+export type AnalyticsSummary = {
+  range: AnalyticsRange;
+  humanUniqueVisitors: number;
+  humanPageviews: number;
+  botPageviews: number;
+  adminUniqueUsers: number;
+  publicUniqueVisitors: number;
+  topPaths: NamedCount[];
+  topBrowsers: NamedCount[];
+  topDevices: NamedCount[];
+  topCountries: NamedCount[];
+};
+
+export async function fetchAnalyticsSummary(
+  tx: Bun.SQL,
+  tenantId: string,
+  range: AnalyticsRange,
+  start: Date
+): Promise<AnalyticsSummary> {
+  const countRows = (await tx`
+    SELECT
+      count(DISTINCT visitor_session_id) FILTER (WHERE human_status = 'human') AS human_unique_visitors,
+      count(*) FILTER (WHERE human_status = 'human') AS human_pageviews,
+      count(*) FILTER (WHERE human_status = 'bot') AS bot_pageviews,
+      count(DISTINCT identity_id) FILTER (WHERE area = 'admin' AND identity_id IS NOT NULL) AS admin_unique_users,
+      count(DISTINCT visitor_session_id) FILTER (WHERE area = 'public') AS public_unique_visitors
+    FROM awcms_mini_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at >= ${start}
+  `) as {
+    human_unique_visitors: string;
+    human_pageviews: string;
+    bot_pageviews: string;
+    admin_unique_users: string;
+    public_unique_visitors: string;
+  }[];
+
+  const counts = countRows[0];
+
+  const [topPaths, topBrowsers, topDevices, topCountries] = await Promise.all([
+    fetchTopPaths(tx, tenantId, start, 10),
+    fetchTopBrowsers(tx, tenantId, start, 10),
+    fetchTopDevices(tx, tenantId, start, 10),
+    fetchTopCountries(tx, tenantId, start, 10)
+  ]);
+
+  return {
+    range,
+    humanUniqueVisitors: Number(counts?.human_unique_visitors ?? 0),
+    humanPageviews: Number(counts?.human_pageviews ?? 0),
+    botPageviews: Number(counts?.bot_pageviews ?? 0),
+    adminUniqueUsers: Number(counts?.admin_unique_users ?? 0),
+    publicUniqueVisitors: Number(counts?.public_unique_visitors ?? 0),
+    topPaths,
+    topBrowsers,
+    topDevices,
+    topCountries
+  };
+}
+
+export type SecurityView = {
+  range: AnalyticsRange;
+  botPageviews: number;
+  topBotReasons: NamedCount[];
+  botPageviewsByArea: NamedCount[];
+};
+
+export async function fetchSecurityView(
+  tx: Bun.SQL,
+  tenantId: string,
+  range: AnalyticsRange,
+  start: Date
+): Promise<SecurityView> {
+  const totalRows = (await tx`
+    SELECT count(*) AS bot_pageviews
+    FROM awcms_mini_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at >= ${start} AND human_status = 'bot'
+  `) as { bot_pageviews: string }[];
+
+  const reasonRows = (await tx`
+    SELECT s.bot_reason AS name, count(*) AS count
+    FROM awcms_mini_visit_events e
+    JOIN awcms_mini_visitor_sessions s ON s.id = e.visitor_session_id
+    WHERE e.tenant_id = ${tenantId} AND e.occurred_at >= ${start}
+      AND e.human_status = 'bot' AND s.bot_reason IS NOT NULL
+    GROUP BY s.bot_reason
+    ORDER BY count DESC, name ASC
+    LIMIT 20
+  `) as { name: string; count: string }[];
+
+  const areaRows = (await tx`
+    SELECT area AS name, count(*) AS count
+    FROM awcms_mini_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at >= ${start} AND human_status = 'bot'
+    GROUP BY area
+    ORDER BY count DESC, name ASC
+  `) as { name: string; count: string }[];
+
+  return {
+    range,
+    botPageviews: Number(totalRows[0]?.bot_pageviews ?? 0),
+    topBotReasons: reasonRows.map((row) => ({
+      name: row.name,
+      count: Number(row.count)
+    })),
+    botPageviewsByArea: areaRows.map((row) => ({
+      name: row.name,
+      count: Number(row.count)
+    }))
+  };
+}

--- a/src/modules/visitor-analytics/application/analytics-queries.ts
+++ b/src/modules/visitor-analytics/application/analytics-queries.ts
@@ -75,6 +75,11 @@ async function topPathCounts(
   return rows.map((row) => ({ name: row.name, count: Number(row.count) }));
 }
 
+/** The only two `jsonColumn` values `topJsonFieldCounts` may ever interpolate into SQL text. */
+const ALLOWED_JSON_COLUMNS = new Set(["user_agent_parsed", "geo"]);
+/** The only three `jsonKey` values `topJsonFieldCounts` may ever interpolate into SQL text. */
+const ALLOWED_JSON_KEYS = new Set(["browserName", "deviceType", "countryCode"]);
+
 async function topJsonFieldCounts(
   tx: Bun.SQL,
   tenantId: string,
@@ -90,6 +95,21 @@ async function topJsonFieldCounts(
   // table-name list it built itself, never from request input).
   // `tenantId`/`start`/`limit` remain real bound parameters via
   // `tx.unsafe`'s `$1`/`$2`/`$3` placeholders — never string-concatenated.
+  //
+  // Defense in depth (post-review hardening, PR #629): the TS union type
+  // above already prevents a *typed* caller from passing anything else,
+  // but a runtime assertion means a future caller that bypasses the type
+  // (a loose cast, a JS caller, a refactor that widens the parameter
+  // type) fails loudly instead of silently building unsafe SQL text.
+  if (
+    !ALLOWED_JSON_COLUMNS.has(jsonColumn) ||
+    !ALLOWED_JSON_KEYS.has(jsonKey)
+  ) {
+    throw new Error(
+      `topJsonFieldCounts: unexpected jsonColumn/jsonKey ("${jsonColumn}"/"${jsonKey}") — refusing to build SQL from an unvalidated identifier.`
+    );
+  }
+
   const rows = (await tx.unsafe(
     `SELECT ${jsonColumn}->>'${jsonKey}' AS name, count(*) AS count
      FROM awcms_mini_visit_events

--- a/src/modules/visitor-analytics/application/event-directory.ts
+++ b/src/modules/visitor-analytics/application/event-directory.ts
@@ -1,0 +1,31 @@
+/**
+ * Keyset-paginated `awcms_mini_visit_events` listing (Issue #621, epic:
+ * visitor analytics #617-#624). Ordered `occurred_at DESC, id DESC`.
+ */
+import type { VisitEventRow } from "../domain/analytics-response-shaping";
+import type { KeysetCursor } from "../../_shared/keyset-pagination";
+
+export const VISIT_EVENT_LIST_LIMIT = 50;
+
+export async function listVisitEvents(
+  tx: Bun.SQL,
+  tenantId: string,
+  cursor?: KeysetCursor
+): Promise<VisitEventRow[]> {
+  if (cursor) {
+    return (await tx`
+      SELECT * FROM awcms_mini_visit_events
+      WHERE tenant_id = ${tenantId}
+        AND (occurred_at, id) < (${cursor.createdAt}, ${cursor.id})
+      ORDER BY occurred_at DESC, id DESC
+      LIMIT ${VISIT_EVENT_LIST_LIMIT}
+    `) as VisitEventRow[];
+  }
+
+  return (await tx`
+    SELECT * FROM awcms_mini_visit_events
+    WHERE tenant_id = ${tenantId}
+    ORDER BY occurred_at DESC, id DESC
+    LIMIT ${VISIT_EVENT_LIST_LIMIT}
+  `) as VisitEventRow[];
+}

--- a/src/modules/visitor-analytics/application/retention-purge.ts
+++ b/src/modules/visitor-analytics/application/retention-purge.ts
@@ -1,0 +1,89 @@
+/**
+ * On-demand visitor analytics retention purge (Issue #621, epic: visitor
+ * analytics #617-#624), triggered via `POST /api/v1/analytics/retention/purge`.
+ * The scheduled job wrapper (`bun run analytics:retention:purge`, mirroring
+ * `logs:audit:purge`) is Issue #624's job — it will call this exact
+ * function rather than re-deriving the purge rules a second time.
+ *
+ * Three independent cutoffs, each from Issue #617's config
+ * (`VisitorAnalyticsConfig`):
+ *   1. `awcms_mini_visit_events` older than `eventRetentionDays` — hard
+ *      deleted.
+ *   2. `awcms_mini_visitor_sessions.ip_address`/`login_identifier_snapshot`
+ *      (the two genuinely "raw detail" columns) older than
+ *      `rawDetailRetentionDays` — cleared in place, row kept (device/
+ *      browser aggregate fields remain useful long after raw detail
+ *      should be gone).
+ *   3. `awcms_mini_visitor_sessions` rows older than `eventRetentionDays`
+ *      — hard deleted. Safe to run *after* step 1: a session's
+ *      `last_seen_at` is always >= every one of its own events'
+ *      `occurred_at` (the collector bumps `last_seen_at` at the same time
+ *      it inserts the triggering event, `application/collector.ts`), so
+ *      once a session is older than the event cutoff, every event that
+ *      referenced it (via `visit_events.visitor_session_id`) has already
+ *      been deleted in step 1 — the FK (no `ON DELETE` clause, i.e.
+ *      `RESTRICT`) is satisfied.
+ *   4. `awcms_mini_visitor_daily_rollups` older than
+ *      `rollupRetentionDays` — hard deleted (defensive; this table is
+ *      always empty until Issue #624's rollup job exists, but the purge
+ *      rule is written now so #624 doesn't need to touch this function).
+ */
+import type { VisitorAnalyticsConfig } from "../domain/visitor-analytics-config";
+
+export type RetentionPurgeResult = {
+  eventsDeleted: number;
+  sessionsRawDetailCleared: number;
+  sessionsDeleted: number;
+  rollupsDeleted: number;
+};
+
+function daysAgo(now: Date, days: number): Date {
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+export async function purgeVisitorAnalyticsData(
+  tx: Bun.SQL,
+  tenantId: string,
+  config: VisitorAnalyticsConfig,
+  now: Date
+): Promise<RetentionPurgeResult> {
+  const eventCutoff = daysAgo(now, config.eventRetentionDays);
+  const rawDetailCutoff = daysAgo(now, config.rawDetailRetentionDays);
+  const rollupCutoff = daysAgo(now, config.rollupRetentionDays)
+    .toISOString()
+    .slice(0, 10);
+
+  const deletedEvents = await tx`
+    DELETE FROM awcms_mini_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at < ${eventCutoff}
+    RETURNING id
+  `;
+
+  const clearedSessions = await tx`
+    UPDATE awcms_mini_visitor_sessions
+    SET ip_address = NULL, login_identifier_snapshot = NULL, updated_at = now()
+    WHERE tenant_id = ${tenantId}
+      AND last_seen_at < ${rawDetailCutoff}
+      AND (ip_address IS NOT NULL OR login_identifier_snapshot IS NOT NULL)
+    RETURNING id
+  `;
+
+  const deletedSessions = await tx`
+    DELETE FROM awcms_mini_visitor_sessions
+    WHERE tenant_id = ${tenantId} AND last_seen_at < ${eventCutoff}
+    RETURNING id
+  `;
+
+  const deletedRollups = await tx`
+    DELETE FROM awcms_mini_visitor_daily_rollups
+    WHERE tenant_id = ${tenantId} AND date < ${rollupCutoff}
+    RETURNING tenant_id
+  `;
+
+  return {
+    eventsDeleted: deletedEvents.length,
+    sessionsRawDetailCleared: clearedSessions.length,
+    sessionsDeleted: deletedSessions.length,
+    rollupsDeleted: deletedRollups.length
+  };
+}

--- a/src/modules/visitor-analytics/application/retention-purge.ts
+++ b/src/modules/visitor-analytics/application/retention-purge.ts
@@ -15,14 +15,24 @@
  *      browser aggregate fields remain useful long after raw detail
  *      should be gone).
  *   3. `awcms_mini_visitor_sessions` rows older than `eventRetentionDays`
- *      — hard deleted. Safe to run *after* step 1: a session's
- *      `last_seen_at` is always >= every one of its own events'
- *      `occurred_at` (the collector bumps `last_seen_at` at the same time
- *      it inserts the triggering event, `application/collector.ts`), so
- *      once a session is older than the event cutoff, every event that
- *      referenced it (via `visit_events.visitor_session_id`) has already
- *      been deleted in step 1 — the FK (no `ON DELETE` clause, i.e.
- *      `RESTRICT`) is satisfied.
+ *      — hard deleted, but only ones with no remaining `visit_events` row
+ *      (`NOT EXISTS`, post-review fix). A session's `last_seen_at` is
+ *      *usually* >= its newest event's `occurred_at`, but not always: the
+ *      collector's own write-throttle
+ *      (`application/collector.ts`'s `SESSION_UPDATE_THROTTLE_MS`, 30s)
+ *      deliberately skips the `last_seen_at` UPDATE on rapid repeat
+ *      requests from the same visitor while still inserting a fresh
+ *      event every time — so `last_seen_at` can trail the session's
+ *      newest event by up to ~30s. Relying on "session older than cutoff
+ *      implies its events are already gone" (the original version of
+ *      this comment) is therefore not a true invariant: a purge call
+ *      landing inside that ~30s straddle window could hit
+ *      `awcms_mini_visit_events.visitor_session_id`'s FK (no `ON DELETE`
+ *      clause, i.e. `RESTRICT`) and abort the whole transaction. The
+ *      `NOT EXISTS` guard below makes the delete self-defending instead
+ *      of depending on that timing assumption — a session with any
+ *      remaining event (regardless of why) is simply left for a later
+ *      purge run, never a hard failure.
  *   4. `awcms_mini_visitor_daily_rollups` older than
  *      `rollupRetentionDays` — hard deleted (defensive; this table is
  *      always empty until Issue #624's rollup job exists, but the purge
@@ -69,8 +79,12 @@ export async function purgeVisitorAnalyticsData(
   `;
 
   const deletedSessions = await tx`
-    DELETE FROM awcms_mini_visitor_sessions
-    WHERE tenant_id = ${tenantId} AND last_seen_at < ${eventCutoff}
+    DELETE FROM awcms_mini_visitor_sessions s
+    WHERE s.tenant_id = ${tenantId} AND s.last_seen_at < ${eventCutoff}
+      AND NOT EXISTS (
+        SELECT 1 FROM awcms_mini_visit_events e
+        WHERE e.visitor_session_id = s.id
+      )
     RETURNING id
   `;
 

--- a/src/modules/visitor-analytics/application/session-directory.ts
+++ b/src/modules/visitor-analytics/application/session-directory.ts
@@ -1,0 +1,35 @@
+/**
+ * Keyset-paginated `awcms_mini_visitor_sessions` listing (Issue #621,
+ * epic: visitor analytics #617-#624). Ordered `last_seen_at DESC, id
+ * DESC` — reuses `_shared/keyset-pagination.ts`'s generic `(timestamp,
+ * id)` cursor even though the sort column here is `last_seen_at`, not
+ * literally `created_at` (the cursor utility only encodes a Date+id
+ * pair, it has no column-name assumption baked in).
+ */
+import type { VisitorSessionRow } from "../domain/analytics-response-shaping";
+import type { KeysetCursor } from "../../_shared/keyset-pagination";
+
+export const VISITOR_SESSION_LIST_LIMIT = 50;
+
+export async function listVisitorSessions(
+  tx: Bun.SQL,
+  tenantId: string,
+  cursor?: KeysetCursor
+): Promise<VisitorSessionRow[]> {
+  if (cursor) {
+    return (await tx`
+      SELECT * FROM awcms_mini_visitor_sessions
+      WHERE tenant_id = ${tenantId}
+        AND (last_seen_at, id) < (${cursor.createdAt}, ${cursor.id})
+      ORDER BY last_seen_at DESC, id DESC
+      LIMIT ${VISITOR_SESSION_LIST_LIMIT}
+    `) as VisitorSessionRow[];
+  }
+
+  return (await tx`
+    SELECT * FROM awcms_mini_visitor_sessions
+    WHERE tenant_id = ${tenantId}
+    ORDER BY last_seen_at DESC, id DESC
+    LIMIT ${VISITOR_SESSION_LIST_LIMIT}
+  `) as VisitorSessionRow[];
+}

--- a/src/modules/visitor-analytics/domain/analytics-range.ts
+++ b/src/modules/visitor-analytics/domain/analytics-range.ts
@@ -1,0 +1,37 @@
+/**
+ * `range` query parameter validation for analytics aggregate endpoints
+ * (Issue #621, epic: visitor analytics #617-#624). Pure — matches the
+ * issue's exact four values, `24h|7d|30d|12m`.
+ */
+export const ANALYTICS_RANGES = ["24h", "7d", "30d", "12m"] as const;
+
+export type AnalyticsRange = (typeof ANALYTICS_RANGES)[number];
+
+export function isKnownAnalyticsRange(
+  value: string | null | undefined
+): value is AnalyticsRange {
+  return (ANALYTICS_RANGES as readonly string[]).includes(value ?? "");
+}
+
+/** `range=7d` (default) when the query param is omitted entirely. */
+export const DEFAULT_ANALYTICS_RANGE: AnalyticsRange = "7d";
+
+/** The start of the window for `range`, relative to `now`. Never throws. */
+export function resolveRangeStart(range: AnalyticsRange, now: Date): Date {
+  const start = new Date(now);
+
+  switch (range) {
+    case "24h":
+      start.setUTCHours(start.getUTCHours() - 24);
+      return start;
+    case "7d":
+      start.setUTCDate(start.getUTCDate() - 7);
+      return start;
+    case "30d":
+      start.setUTCDate(start.getUTCDate() - 30);
+      return start;
+    case "12m":
+      start.setUTCMonth(start.getUTCMonth() - 12);
+      return start;
+  }
+}

--- a/src/modules/visitor-analytics/domain/analytics-response-shaping.ts
+++ b/src/modules/visitor-analytics/domain/analytics-response-shaping.ts
@@ -1,0 +1,136 @@
+/**
+ * Raw-detail field omission for the `sessions`/`events` list endpoints
+ * (Issue #621, epic: visitor analytics #617-#624). Pure — the caller
+ * (route handler) decides `canSeeRawDetail` from whether the requester
+ * holds `visitor_analytics.raw_detail.read`; this module only shapes the
+ * response once that decision is made. Never the other way around —
+ * these functions must never themselves make an authorization decision.
+ */
+
+export type VisitorSessionRow = {
+  id: string;
+  visitor_key_hash: string;
+  identity_id: string | null;
+  login_identifier_snapshot: string | null;
+  is_authenticated: boolean;
+  area: string;
+  current_path: string | null;
+  first_seen_at: Date;
+  last_seen_at: Date;
+  ip_hash: string | null;
+  ip_address: string | null;
+  user_agent_hash: string | null;
+  browser_name: string | null;
+  browser_version_major: string | null;
+  os_name: string | null;
+  device_type: string | null;
+  is_human: boolean;
+  bot_reason: string | null;
+  country_code: string | null;
+  region: string | null;
+  city: string | null;
+  timezone: string | null;
+};
+
+export type VisitorSessionDto = Omit<
+  VisitorSessionRow,
+  | "ip_hash"
+  | "ip_address"
+  | "user_agent_hash"
+  | "login_identifier_snapshot"
+  | "first_seen_at"
+  | "last_seen_at"
+> & {
+  firstSeenAt: string;
+  lastSeenAt: string;
+  ipHash: string | null;
+  ipAddress: string | null;
+  userAgentHash: string | null;
+  loginIdentifierSnapshot: string | null;
+};
+
+export function shapeVisitorSession(
+  row: VisitorSessionRow,
+  canSeeRawDetail: boolean
+): VisitorSessionDto {
+  return {
+    id: row.id,
+    visitor_key_hash: row.visitor_key_hash,
+    identity_id: row.identity_id,
+    is_authenticated: row.is_authenticated,
+    area: row.area,
+    current_path: row.current_path,
+    firstSeenAt: row.first_seen_at.toISOString(),
+    lastSeenAt: row.last_seen_at.toISOString(),
+    browser_name: row.browser_name,
+    browser_version_major: row.browser_version_major,
+    os_name: row.os_name,
+    device_type: row.device_type,
+    is_human: row.is_human,
+    bot_reason: row.bot_reason,
+    country_code: row.country_code,
+    region: row.region,
+    city: row.city,
+    timezone: row.timezone,
+    loginIdentifierSnapshot: canSeeRawDetail
+      ? row.login_identifier_snapshot
+      : null,
+    ipHash: canSeeRawDetail ? row.ip_hash : null,
+    ipAddress: canSeeRawDetail ? row.ip_address : null,
+    userAgentHash: canSeeRawDetail ? row.user_agent_hash : null
+  };
+}
+
+export type VisitEventRow = {
+  id: string;
+  visitor_session_id: string | null;
+  identity_id: string | null;
+  occurred_at: Date;
+  method: string;
+  status_code: number | null;
+  area: string;
+  route_pattern: string | null;
+  path_sanitized: string;
+  referrer_domain: string | null;
+  duration_ms: number | null;
+  ip_hash: string | null;
+  user_agent_hash: string | null;
+  user_agent_parsed: Record<string, unknown>;
+  geo: Record<string, unknown>;
+  human_status: string;
+  correlation_id: string | null;
+};
+
+export type VisitEventDto = Omit<
+  VisitEventRow,
+  "ip_hash" | "user_agent_hash" | "occurred_at"
+> & {
+  occurredAt: string;
+  ipHash: string | null;
+  userAgentHash: string | null;
+};
+
+export function shapeVisitEvent(
+  row: VisitEventRow,
+  canSeeRawDetail: boolean
+): VisitEventDto {
+  return {
+    id: row.id,
+    visitor_session_id: row.visitor_session_id,
+    identity_id: row.identity_id,
+    occurredAt: row.occurred_at.toISOString(),
+    method: row.method,
+    status_code: row.status_code,
+    area: row.area,
+    route_pattern: row.route_pattern,
+    path_sanitized: row.path_sanitized,
+    referrer_domain: row.referrer_domain,
+    duration_ms: row.duration_ms,
+    user_agent_parsed: row.user_agent_parsed,
+    geo: row.geo,
+    human_status: row.human_status,
+    correlation_id: row.correlation_id,
+    ipHash: canSeeRawDetail ? row.ip_hash : null,
+    userAgentHash: canSeeRawDetail ? row.user_agent_hash : null
+  };
+}

--- a/src/modules/visitor-analytics/domain/analytics-response-shaping.ts
+++ b/src/modules/visitor-analytics/domain/analytics-response-shaping.ts
@@ -5,6 +5,13 @@
  * holds `visitor_analytics.raw_detail.read`; this module only shapes the
  * response once that decision is made. Never the other way around —
  * these functions must never themselves make an authorization decision.
+ *
+ * `*Row` types mirror the raw DB column names (snake_case, matching doc
+ * 10's TypeScript standard for a row shape) — never returned directly.
+ * `*Dto` types are the actual HTTP response shape and are fully
+ * camelCase (post-review fix, PR #629: the first version left several
+ * pass-through fields in snake_case, inconsistent with every other
+ * schema in the OpenAPI spec, e.g. `BlogPostItem`).
  */
 
 export type VisitorSessionRow = {
@@ -32,21 +39,29 @@ export type VisitorSessionRow = {
   timezone: string | null;
 };
 
-export type VisitorSessionDto = Omit<
-  VisitorSessionRow,
-  | "ip_hash"
-  | "ip_address"
-  | "user_agent_hash"
-  | "login_identifier_snapshot"
-  | "first_seen_at"
-  | "last_seen_at"
-> & {
+export type VisitorSessionDto = {
+  id: string;
+  visitorKeyHash: string;
+  identityId: string | null;
+  isAuthenticated: boolean;
+  area: string;
+  currentPath: string | null;
   firstSeenAt: string;
   lastSeenAt: string;
+  browserName: string | null;
+  browserVersionMajor: string | null;
+  osName: string | null;
+  deviceType: string | null;
+  isHuman: boolean;
+  botReason: string | null;
+  countryCode: string | null;
+  region: string | null;
+  city: string | null;
+  timezone: string | null;
+  loginIdentifierSnapshot: string | null;
   ipHash: string | null;
   ipAddress: string | null;
   userAgentHash: string | null;
-  loginIdentifierSnapshot: string | null;
 };
 
 export function shapeVisitorSession(
@@ -55,20 +70,20 @@ export function shapeVisitorSession(
 ): VisitorSessionDto {
   return {
     id: row.id,
-    visitor_key_hash: row.visitor_key_hash,
-    identity_id: row.identity_id,
-    is_authenticated: row.is_authenticated,
+    visitorKeyHash: row.visitor_key_hash,
+    identityId: row.identity_id,
+    isAuthenticated: row.is_authenticated,
     area: row.area,
-    current_path: row.current_path,
+    currentPath: row.current_path,
     firstSeenAt: row.first_seen_at.toISOString(),
     lastSeenAt: row.last_seen_at.toISOString(),
-    browser_name: row.browser_name,
-    browser_version_major: row.browser_version_major,
-    os_name: row.os_name,
-    device_type: row.device_type,
-    is_human: row.is_human,
-    bot_reason: row.bot_reason,
-    country_code: row.country_code,
+    browserName: row.browser_name,
+    browserVersionMajor: row.browser_version_major,
+    osName: row.os_name,
+    deviceType: row.device_type,
+    isHuman: row.is_human,
+    botReason: row.bot_reason,
+    countryCode: row.country_code,
     region: row.region,
     city: row.city,
     timezone: row.timezone,
@@ -101,11 +116,22 @@ export type VisitEventRow = {
   correlation_id: string | null;
 };
 
-export type VisitEventDto = Omit<
-  VisitEventRow,
-  "ip_hash" | "user_agent_hash" | "occurred_at"
-> & {
+export type VisitEventDto = {
+  id: string;
+  visitorSessionId: string | null;
+  identityId: string | null;
   occurredAt: string;
+  method: string;
+  statusCode: number | null;
+  area: string;
+  routePattern: string | null;
+  pathSanitized: string;
+  referrerDomain: string | null;
+  durationMs: number | null;
+  userAgentParsed: Record<string, unknown>;
+  geo: Record<string, unknown>;
+  humanStatus: string;
+  correlationId: string | null;
   ipHash: string | null;
   userAgentHash: string | null;
 };
@@ -116,20 +142,20 @@ export function shapeVisitEvent(
 ): VisitEventDto {
   return {
     id: row.id,
-    visitor_session_id: row.visitor_session_id,
-    identity_id: row.identity_id,
+    visitorSessionId: row.visitor_session_id,
+    identityId: row.identity_id,
     occurredAt: row.occurred_at.toISOString(),
     method: row.method,
-    status_code: row.status_code,
+    statusCode: row.status_code,
     area: row.area,
-    route_pattern: row.route_pattern,
-    path_sanitized: row.path_sanitized,
-    referrer_domain: row.referrer_domain,
-    duration_ms: row.duration_ms,
-    user_agent_parsed: row.user_agent_parsed,
+    routePattern: row.route_pattern,
+    pathSanitized: row.path_sanitized,
+    referrerDomain: row.referrer_domain,
+    durationMs: row.duration_ms,
+    userAgentParsed: row.user_agent_parsed,
     geo: row.geo,
-    human_status: row.human_status,
-    correlation_id: row.correlation_id,
+    humanStatus: row.human_status,
+    correlationId: row.correlation_id,
     ipHash: canSeeRawDetail ? row.ip_hash : null,
     userAgentHash: canSeeRawDetail ? row.user_agent_hash : null
   };

--- a/src/pages/api/v1/analytics/devices.ts
+++ b/src/pages/api/v1/analytics/devices.ts
@@ -1,0 +1,75 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import {
+  fetchTopBrowsers,
+  fetchTopDevices
+} from "../../../../modules/visitor-analytics/application/analytics-queries";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../../../modules/visitor-analytics/domain/analytics-range";
+
+const DASHBOARD_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+/** `GET /api/v1/analytics/devices?range=24h|7d|30d|12m` (Issue #621) — browser + device-type breakdown. */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const rangeParam = url.searchParams.get("range");
+  const range = rangeParam ?? DEFAULT_ANALYTICS_RANGE;
+
+  if (!isKnownAnalyticsRange(range)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "range must be one of 24h, 7d, 30d, 12m."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DASHBOARD_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const start = resolveRangeStart(range, now);
+    const [browsers, devices] = await Promise.all([
+      fetchTopBrowsers(tx, tenantId, start),
+      fetchTopDevices(tx, tenantId, start)
+    ]);
+
+    return ok({ range, browsers, devices });
+  });
+};

--- a/src/pages/api/v1/analytics/events.ts
+++ b/src/pages/api/v1/analytics/events.ts
@@ -1,0 +1,86 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import {
+  decodeKeysetCursor,
+  encodeKeysetCursor
+} from "../../../../modules/_shared/keyset-pagination";
+import {
+  listVisitEvents,
+  VISIT_EVENT_LIST_LIMIT
+} from "../../../../modules/visitor-analytics/application/event-directory";
+import { shapeVisitEvent } from "../../../../modules/visitor-analytics/domain/analytics-response-shaping";
+
+const EVENTS_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "events",
+  action: "read" as const
+};
+
+const RAW_DETAIL_PERMISSION_KEY = "visitor_analytics.raw_detail.read";
+
+/**
+ * `GET /api/v1/analytics/events` (Issue #621) — keyset-paginated, newest
+ * first. Raw detail (`ipHash`/`userAgentHash`) included only when the
+ * caller also holds `visitor_analytics.raw_detail.read`.
+ */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const cursorParam = url.searchParams.get("cursor");
+  const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+  if (cursorParam && !cursor) {
+    return fail(400, "VALIDATION_ERROR", "cursor is malformed.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      EVENTS_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const canSeeRawDetail = auth.grantedPermissionKeys.has(
+      RAW_DETAIL_PERMISSION_KEY
+    );
+
+    const rows = await listVisitEvents(tx, tenantId, cursor ?? undefined);
+    const events = rows.map((row) => shapeVisitEvent(row, canSeeRawDetail));
+
+    const nextCursor =
+      rows.length === VISIT_EVENT_LIST_LIMIT
+        ? encodeKeysetCursor(
+            rows[rows.length - 1]!.occurred_at,
+            rows[rows.length - 1]!.id
+          )
+        : null;
+
+    return ok({ events, nextCursor });
+  });
+};

--- a/src/pages/api/v1/analytics/locations.ts
+++ b/src/pages/api/v1/analytics/locations.ts
@@ -1,0 +1,74 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchTopCountries } from "../../../../modules/visitor-analytics/application/analytics-queries";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../../../modules/visitor-analytics/domain/analytics-range";
+
+const DASHBOARD_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/analytics/locations?range=24h|7d|30d|12m` (Issue #621) —
+ * country breakdown from `visit_events.geo->>'countryCode'`. Always empty
+ * until Issue #623 (geolocation enrichment) actually populates `geo` —
+ * not an error, just no data yet.
+ */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const rangeParam = url.searchParams.get("range");
+  const range = rangeParam ?? DEFAULT_ANALYTICS_RANGE;
+
+  if (!isKnownAnalyticsRange(range)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "range must be one of 24h, 7d, 30d, 12m."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DASHBOARD_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const start = resolveRangeStart(range, now);
+    const countries = await fetchTopCountries(tx, tenantId, start);
+
+    return ok({ range, countries });
+  });
+};

--- a/src/pages/api/v1/analytics/pages.ts
+++ b/src/pages/api/v1/analytics/pages.ts
@@ -1,0 +1,69 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchTopPaths } from "../../../../modules/visitor-analytics/application/analytics-queries";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../../../modules/visitor-analytics/domain/analytics-range";
+
+const DASHBOARD_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+/** `GET /api/v1/analytics/pages?range=24h|7d|30d|12m` (Issue #621) — top pages by human pageviews. */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const rangeParam = url.searchParams.get("range");
+  const range = rangeParam ?? DEFAULT_ANALYTICS_RANGE;
+
+  if (!isKnownAnalyticsRange(range)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "range must be one of 24h, 7d, 30d, 12m."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DASHBOARD_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const start = resolveRangeStart(range, now);
+    const pages = await fetchTopPaths(tx, tenantId, start);
+
+    return ok({ range, pages });
+  });
+};

--- a/src/pages/api/v1/analytics/realtime.ts
+++ b/src/pages/api/v1/analytics/realtime.ts
@@ -1,0 +1,58 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchRealtimeStats } from "../../../../modules/visitor-analytics/application/analytics-queries";
+import { resolveVisitorAnalyticsConfig } from "../../../../modules/visitor-analytics/domain/visitor-analytics-config";
+
+const REALTIME_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "realtime",
+  action: "read" as const
+};
+
+/** `GET /api/v1/analytics/realtime` (Issue #621) — online-now presence counts. */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const config = resolveVisitorAnalyticsConfig();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      REALTIME_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const stats = await fetchRealtimeStats(
+      tx,
+      tenantId,
+      config.onlineWindowSeconds
+    );
+
+    return ok(stats);
+  });
+};

--- a/src/pages/api/v1/analytics/retention/purge.ts
+++ b/src/pages/api/v1/analytics/retention/purge.ts
@@ -1,0 +1,132 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../modules/_shared/idempotency";
+import { purgeVisitorAnalyticsData } from "../../../../../modules/visitor-analytics/application/retention-purge";
+import { resolveVisitorAnalyticsConfig } from "../../../../../modules/visitor-analytics/domain/visitor-analytics-config";
+
+const PURGE_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "retention",
+  action: "purge" as const
+};
+
+const IDEMPOTENCY_SCOPE = "visitor_analytics_retention_purge";
+
+/**
+ * `POST /api/v1/analytics/retention/purge` (Issue #621) — on-demand
+ * purge using Issue #617's retention config
+ * (`VISITOR_ANALYTICS_EVENT_RETENTION_DAYS`/`_RAW_DETAIL_RETENTION_DAYS`/
+ * `_ROLLUP_RETENTION_DAYS`). Destructive, high-risk mutation: requires
+ * `Idempotency-Key` and is audited `critical`. See
+ * `application/retention-purge.ts` for the exact purge rules.
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ action: "retention_purge" });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+  const config = resolveVisitorAnalyticsConfig();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      PURGE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const result = await purgeVisitorAnalyticsData(tx, tenantId, config, now);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "visitor_analytics",
+      action: "retention_purged",
+      resourceType: "visitor_analytics_data",
+      resourceId: tenantId,
+      severity: "critical",
+      message: "Visitor analytics data purged past retention window.",
+      attributes: result,
+      correlationId
+    });
+
+    const successResponse = ok(result);
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+};

--- a/src/pages/api/v1/analytics/security.ts
+++ b/src/pages/api/v1/analytics/security.ts
@@ -1,0 +1,69 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchSecurityView } from "../../../../modules/visitor-analytics/application/analytics-queries";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../../../modules/visitor-analytics/domain/analytics-range";
+
+const DASHBOARD_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+/** `GET /api/v1/analytics/security?range=24h|7d|30d|12m` (Issue #621) — bot/crawler traffic breakdown. */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const rangeParam = url.searchParams.get("range");
+  const range = rangeParam ?? DEFAULT_ANALYTICS_RANGE;
+
+  if (!isKnownAnalyticsRange(range)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "range must be one of 24h, 7d, 30d, 12m."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DASHBOARD_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const start = resolveRangeStart(range, now);
+    const view = await fetchSecurityView(tx, tenantId, range, start);
+
+    return ok(view);
+  });
+};

--- a/src/pages/api/v1/analytics/sessions.ts
+++ b/src/pages/api/v1/analytics/sessions.ts
@@ -1,0 +1,89 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import {
+  decodeKeysetCursor,
+  encodeKeysetCursor
+} from "../../../../modules/_shared/keyset-pagination";
+import {
+  listVisitorSessions,
+  VISITOR_SESSION_LIST_LIMIT
+} from "../../../../modules/visitor-analytics/application/session-directory";
+import { shapeVisitorSession } from "../../../../modules/visitor-analytics/domain/analytics-response-shaping";
+
+const SESSIONS_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "sessions",
+  action: "read" as const
+};
+
+const RAW_DETAIL_PERMISSION_KEY = "visitor_analytics.raw_detail.read";
+
+/**
+ * `GET /api/v1/analytics/sessions` (Issue #621) — keyset-paginated,
+ * newest-active-first. Raw detail (`ipHash`/`ipAddress`/`userAgentHash`/
+ * `loginIdentifierSnapshot`) is included only when the caller also holds
+ * `visitor_analytics.raw_detail.read`, independent of `sessions.read`.
+ */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const cursorParam = url.searchParams.get("cursor");
+  const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+  if (cursorParam && !cursor) {
+    return fail(400, "VALIDATION_ERROR", "cursor is malformed.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      SESSIONS_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const canSeeRawDetail = auth.grantedPermissionKeys.has(
+      RAW_DETAIL_PERMISSION_KEY
+    );
+
+    const rows = await listVisitorSessions(tx, tenantId, cursor ?? undefined);
+    const sessions = rows.map((row) =>
+      shapeVisitorSession(row, canSeeRawDetail)
+    );
+
+    const nextCursor =
+      rows.length === VISITOR_SESSION_LIST_LIMIT
+        ? encodeKeysetCursor(
+            rows[rows.length - 1]!.last_seen_at,
+            rows[rows.length - 1]!.id
+          )
+        : null;
+
+    return ok({ sessions, nextCursor });
+  });
+};

--- a/src/pages/api/v1/analytics/settings.ts
+++ b/src/pages/api/v1/analytics/settings.ts
@@ -1,0 +1,155 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  fetchModuleSettingsView,
+  updateModuleSettings
+} from "../../../../modules/module-management/application/module-settings";
+import { validateModuleSettingsPatch } from "../../../../modules/module-management/domain/module-settings";
+
+const MODULE_KEY = "visitor_analytics";
+
+const READ_GUARD = {
+  moduleKey: MODULE_KEY,
+  activityCode: "settings",
+  action: "read" as const
+};
+
+const UPDATE_GUARD = {
+  moduleKey: MODULE_KEY,
+  activityCode: "settings",
+  action: "update" as const
+};
+
+/**
+ * `GET /api/v1/analytics/settings` (Issue #621) — a thin,
+ * `visitor_analytics`-permission-gated wrapper around Module Management's
+ * existing generic per-tenant settings storage (`awcms_mini_module_settings`,
+ * Issue #516), reusing its storage/validation rather than inventing a
+ * second mechanism. Distinct from the generic
+ * `GET /api/v1/tenant/modules/{moduleKey}/settings` (which requires
+ * `module_management.settings.read` — a different, broader permission)
+ * — this endpoint requires the module's own already-seeded
+ * `visitor_analytics.settings.read`/`.update` (migration 038) instead.
+ */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const view = await fetchModuleSettingsView(tx, tenantId, MODULE_KEY);
+
+    if (!view) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Module is not registered.");
+    }
+
+    return ok(view);
+  });
+};
+
+/**
+ * `PATCH /api/v1/analytics/settings` (Issue #621) — shallow JSON-merge
+ * patch, same semantics as the generic module-settings endpoint.
+ * `validateModuleSettingsPatch` rejects any secret-shaped key or value
+ * before this ever reaches storage (`400
+ * SETTINGS_SENSITIVE_KEY_REJECTED`/`SETTINGS_SECRET_SHAPED_VALUE_REJECTED`).
+ * Audited (`settings_updated`, diff of changed key *names* only, never
+ * values).
+ */
+export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const validation = validateModuleSettingsPatch(
+    await request.json().catch(() => null)
+  );
+
+  if (!validation.valid) {
+    return fail(400, validation.code, validation.message);
+  }
+
+  const patch = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      UPDATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const result = await updateModuleSettings(
+      tx,
+      tenantId,
+      MODULE_KEY,
+      patch,
+      auth.context.tenantUserId
+    );
+
+    if (result.outcome === "not_found") {
+      return fail(404, "RESOURCE_NOT_FOUND", "Module is not registered.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: MODULE_KEY,
+      action: "settings_updated",
+      resourceType: "module_settings",
+      resourceId: MODULE_KEY,
+      severity: "info",
+      message: "Visitor analytics settings updated.",
+      attributes: { diff: result.diff },
+      correlationId
+    });
+
+    return ok(result.view);
+  });
+};

--- a/src/pages/api/v1/analytics/summary.ts
+++ b/src/pages/api/v1/analytics/summary.ts
@@ -1,0 +1,69 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchAnalyticsSummary } from "../../../../modules/visitor-analytics/application/analytics-queries";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../../../modules/visitor-analytics/domain/analytics-range";
+
+const DASHBOARD_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+/** `GET /api/v1/analytics/summary?range=24h|7d|30d|12m` (Issue #621). */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const rangeParam = url.searchParams.get("range");
+  const range = rangeParam ?? DEFAULT_ANALYTICS_RANGE;
+
+  if (!isKnownAnalyticsRange(range)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "range must be one of 24h, 7d, 30d, 12m."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DASHBOARD_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const start = resolveRangeStart(range, now);
+    const summary = await fetchAnalyticsSummary(tx, tenantId, range, start);
+
+    return ok(summary);
+  });
+};

--- a/tests/integration/visitor-analytics-api.integration.test.ts
+++ b/tests/integration/visitor-analytics-api.integration.test.ts
@@ -1,0 +1,546 @@
+/**
+ * Integration tests for the visitor analytics API (Issue #621, epic:
+ * visitor analytics #617-#624) against a real PostgreSQL. Exercises the
+ * real handlers — auth guard, ABAC allow/deny, raw-detail gating,
+ * `range` validation, keyset pagination, settings secret-shaped-value
+ * rejection, and retention-purge idempotency + audit.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { GET as getRealtime } from "../../src/pages/api/v1/analytics/realtime";
+import { GET as getSummary } from "../../src/pages/api/v1/analytics/summary";
+import { GET as getSessions } from "../../src/pages/api/v1/analytics/sessions";
+import { GET as getEvents } from "../../src/pages/api/v1/analytics/events";
+import {
+  GET as getSettings,
+  PATCH as patchSettings
+} from "../../src/pages/api/v1/analytics/settings";
+import { POST as postPurge } from "../../src/pages/api/v1/analytics/retention/purge";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string };
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const loginIdentifier = `${tenantCode}-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId, token: login.body.data.token };
+}
+
+/** A second tenant_user in the SAME tenant, holding exactly `permissionKeys` (e.g. `["visitor_analytics.sessions.read"]`). Empty array = a real authenticated user with no analytics permission at all (ABAC-deny fixture). */
+async function provisionScopedTenantUser(
+  tenantId: string,
+  loginIdentifier: string,
+  permissionKeys: string[]
+): Promise<{ token: string }> {
+  const admin = getAdminSql();
+  const password = "integration-test-scoped-user-password";
+  const passwordHash = await Bun.password.hash(password);
+
+  await admin.begin(async (tx) => {
+    await tx.unsafe(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+    const profile = (await tx`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', 'Scoped User') RETURNING id
+    `) as { id: string }[];
+    const identity = (await tx`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profile[0]!.id}, ${loginIdentifier}, ${passwordHash})
+      RETURNING id
+    `) as { id: string }[];
+    const tenantUser = (await tx`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${tenantId}, ${identity[0]!.id}) RETURNING id
+    `) as { id: string }[];
+
+    if (permissionKeys.length > 0) {
+      const role = (await tx`
+        INSERT INTO awcms_mini_roles (tenant_id, role_code, role_name)
+        VALUES (${tenantId}, ${`scoped-${loginIdentifier}`}, 'Scoped Role')
+        RETURNING id
+      `) as { id: string }[];
+
+      for (const key of permissionKeys) {
+        const [moduleKey, activityCode, action] = key.split(".");
+        const permission = (await tx`
+          SELECT id FROM awcms_mini_permissions
+          WHERE module_key = ${moduleKey} AND activity_code = ${activityCode} AND action = ${action}
+        `) as { id: string }[];
+
+        await tx`
+          INSERT INTO awcms_mini_role_permissions (tenant_id, role_id, permission_id)
+          VALUES (${tenantId}, ${role[0]!.id}, ${permission[0]!.id})
+        `;
+      }
+
+      await tx`
+        INSERT INTO awcms_mini_access_assignments (tenant_id, tenant_user_id, role_id)
+        VALUES (${tenantId}, ${tenantUser[0]!.id}, ${role[0]!.id})
+      `;
+    }
+  });
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier, password },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { token: login.body.data.token };
+}
+
+function authHeaders(tenantId: string, token: string): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": tenantId,
+    authorization: `Bearer ${token}`
+  };
+}
+
+const HUMAN_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+
+async function seedSession(
+  tenantId: string,
+  overrides: Partial<{
+    visitorKeyHash: string;
+    area: string;
+    lastSeenAt: Date;
+    isHuman: boolean;
+    ipAddress: string | null;
+    loginIdentifierSnapshot: string | null;
+  }> = {}
+): Promise<string> {
+  const admin = getAdminSql();
+  const rows = await admin`
+    INSERT INTO awcms_mini_visitor_sessions
+      (tenant_id, visitor_key_hash, area, last_seen_at, is_human, ip_address,
+       ip_hash, user_agent_hash, login_identifier_snapshot, browser_name, device_type)
+    VALUES (
+      ${tenantId},
+      ${overrides.visitorKeyHash ?? `sha256:${crypto.randomUUID()}`},
+      ${overrides.area ?? "public"},
+      ${overrides.lastSeenAt ?? new Date()},
+      ${overrides.isHuman ?? true},
+      ${overrides.ipAddress ?? null},
+      'sha256:iphash',
+      'sha256:uahash',
+      ${overrides.loginIdentifierSnapshot ?? null},
+      'Chrome',
+      'desktop'
+    )
+    RETURNING id
+  `;
+  return (rows as { id: string }[])[0]!.id;
+}
+
+async function seedEvent(
+  tenantId: string,
+  sessionId: string,
+  overrides: Partial<{
+    occurredAt: Date;
+    area: string;
+    humanStatus: string;
+    pathSanitized: string;
+  }> = {}
+): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_visit_events
+      (tenant_id, visitor_session_id, method, area, path_sanitized,
+       human_status, occurred_at, user_agent_parsed)
+    VALUES (
+      ${tenantId}, ${sessionId}, 'GET',
+      ${overrides.area ?? "public"},
+      ${overrides.pathSanitized ?? "/news/hello"},
+      ${overrides.humanStatus ?? "human"},
+      ${overrides.occurredAt ?? new Date()},
+      ${JSON.stringify({ browserName: "Chrome", deviceType: "desktop" })}
+    )
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("visitor analytics API (Issue #621)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("requires a tenant header and a valid session (400/401)", async () => {
+    const noTenant = await invoke(getRealtime, {
+      path: "/api/v1/analytics/realtime"
+    });
+    expect(noTenant.status).toBe(400);
+
+    const b = await bootstrap();
+    const noAuth = await invoke(getRealtime, {
+      path: "/api/v1/analytics/realtime",
+      headers: { "x-awcms-mini-tenant-id": b.tenantId }
+    });
+    expect(noAuth.status).toBe(401);
+  });
+
+  test("ABAC default-deny: a user with no visitor_analytics permission gets 403 ACCESS_DENIED, never empty data", async () => {
+    const b = await bootstrap();
+    const scoped = await provisionScopedTenantUser(
+      b.tenantId,
+      "no-perms@example.com",
+      []
+    );
+    const headers = authHeaders(b.tenantId, scoped.token);
+
+    for (const invocation of [
+      () =>
+        invoke(getRealtime, { path: "/api/v1/analytics/realtime", headers }),
+      () => invoke(getSummary, { path: "/api/v1/analytics/summary", headers }),
+      () =>
+        invoke(getSessions, { path: "/api/v1/analytics/sessions", headers }),
+      () => invoke(getEvents, { path: "/api/v1/analytics/events", headers }),
+      () => invoke(getSettings, { path: "/api/v1/analytics/settings", headers })
+    ]) {
+      const result = await invocation();
+      expect(result.status).toBe(403);
+      expect((result.body as { error: { code: string } }).error.code).toBe(
+        "ACCESS_DENIED"
+      );
+    }
+  });
+
+  test("realtime: counts only sessions within the online window, by area/human", async () => {
+    const b = await bootstrap();
+    const now = new Date();
+    const stale = new Date(now.getTime() - 10 * 60 * 1000);
+
+    await seedSession(b.tenantId, {
+      area: "admin",
+      lastSeenAt: now,
+      isHuman: true
+    });
+    await seedSession(b.tenantId, {
+      area: "public",
+      lastSeenAt: now,
+      isHuman: true
+    });
+    await seedSession(b.tenantId, {
+      area: "public",
+      lastSeenAt: stale,
+      isHuman: true
+    });
+
+    const result = await invoke<{
+      data: {
+        onlineAdminCount: number;
+        onlinePublicCount: number;
+        onlineHumanCount: number;
+      };
+    }>(getRealtime, {
+      path: "/api/v1/analytics/realtime",
+      headers: authHeaders(b.tenantId, b.token)
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.onlineAdminCount).toBe(1);
+    expect(result.body.data.onlinePublicCount).toBe(1);
+    expect(result.body.data.onlineHumanCount).toBe(2);
+  });
+
+  test("summary: rejects an invalid range with 400 VALIDATION_ERROR", async () => {
+    const b = await bootstrap();
+    const result = await invoke(getSummary, {
+      path: "/api/v1/analytics/summary?range=1h",
+      headers: authHeaders(b.tenantId, b.token)
+    });
+    expect(result.status).toBe(400);
+    expect((result.body as { error: { code: string } }).error.code).toBe(
+      "VALIDATION_ERROR"
+    );
+  });
+
+  test("summary: computes human/bot pageview and unique-visitor counts within range", async () => {
+    const b = await bootstrap();
+    const session1 = await seedSession(b.tenantId, { area: "public" });
+    const session2 = await seedSession(b.tenantId, { area: "public" });
+
+    await seedEvent(b.tenantId, session1, {
+      humanStatus: "human",
+      pathSanitized: "/news/a"
+    });
+    await seedEvent(b.tenantId, session2, {
+      humanStatus: "human",
+      pathSanitized: "/news/a"
+    });
+    await seedEvent(b.tenantId, session1, {
+      humanStatus: "bot",
+      pathSanitized: "/news/b"
+    });
+
+    const result = await invoke<{
+      data: {
+        humanPageviews: number;
+        botPageviews: number;
+        humanUniqueVisitors: number;
+        topPaths: { name: string; count: number }[];
+      };
+    }>(getSummary, {
+      path: "/api/v1/analytics/summary?range=7d",
+      headers: authHeaders(b.tenantId, b.token)
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.data.humanPageviews).toBe(2);
+    expect(result.body.data.botPageviews).toBe(1);
+    expect(result.body.data.humanUniqueVisitors).toBe(2);
+    expect(result.body.data.topPaths[0]?.name).toBe("/news/a");
+    expect(result.body.data.topPaths[0]?.count).toBe(2);
+  });
+
+  test("sessions: raw detail fields are nulled without raw_detail.read, populated with it", async () => {
+    const b = await bootstrap();
+    await seedSession(b.tenantId, {
+      ipAddress: "203.0.113.10",
+      loginIdentifierSnapshot: "owner@example.com"
+    });
+
+    const withoutRawDetail = await provisionScopedTenantUser(
+      b.tenantId,
+      "sessions-only@example.com",
+      ["visitor_analytics.sessions.read"]
+    );
+    const withRawDetail = await provisionScopedTenantUser(
+      b.tenantId,
+      "sessions-plus-raw@example.com",
+      ["visitor_analytics.sessions.read", "visitor_analytics.raw_detail.read"]
+    );
+
+    const gated = await invoke<{
+      data: {
+        sessions: {
+          ipAddress: string | null;
+          loginIdentifierSnapshot: string | null;
+        }[];
+      };
+    }>(getSessions, {
+      path: "/api/v1/analytics/sessions",
+      headers: authHeaders(b.tenantId, withoutRawDetail.token)
+    });
+    expect(gated.status).toBe(200);
+    expect(gated.body.data.sessions[0]?.ipAddress).toBeNull();
+    expect(gated.body.data.sessions[0]?.loginIdentifierSnapshot).toBeNull();
+
+    const revealed = await invoke<{
+      data: {
+        sessions: {
+          ipAddress: string | null;
+          loginIdentifierSnapshot: string | null;
+        }[];
+      };
+    }>(getSessions, {
+      path: "/api/v1/analytics/sessions",
+      headers: authHeaders(b.tenantId, withRawDetail.token)
+    });
+    expect(revealed.status).toBe(200);
+    expect(revealed.body.data.sessions[0]?.ipAddress).toBe("203.0.113.10");
+    expect(revealed.body.data.sessions[0]?.loginIdentifierSnapshot).toBe(
+      "owner@example.com"
+    );
+  });
+
+  test("events: keyset pagination returns nextCursor and pages through all rows exactly once", async () => {
+    const b = await bootstrap();
+    const session = await seedSession(b.tenantId);
+
+    for (let i = 0; i < 55; i += 1) {
+      await seedEvent(b.tenantId, session, {
+        occurredAt: new Date(Date.now() - i * 1000),
+        pathSanitized: `/news/${i}`
+      });
+    }
+
+    const headers = authHeaders(b.tenantId, b.token);
+    const firstPage = await invoke<{
+      data: { events: { id: string }[]; nextCursor: string | null };
+    }>(getEvents, { path: "/api/v1/analytics/events", headers });
+
+    expect(firstPage.status).toBe(200);
+    expect(firstPage.body.data.events).toHaveLength(50);
+    expect(firstPage.body.data.nextCursor).not.toBeNull();
+
+    const secondPage = await invoke<{
+      data: { events: { id: string }[]; nextCursor: string | null };
+    }>(getEvents, {
+      path: `/api/v1/analytics/events?cursor=${encodeURIComponent(firstPage.body.data.nextCursor!)}`,
+      headers
+    });
+
+    expect(secondPage.status).toBe(200);
+    expect(secondPage.body.data.events).toHaveLength(5);
+    expect(secondPage.body.data.nextCursor).toBeNull();
+
+    const firstIds = new Set(firstPage.body.data.events.map((e) => e.id));
+    const secondIds = new Set(secondPage.body.data.events.map((e) => e.id));
+    expect([...firstIds].some((id) => secondIds.has(id))).toBe(false);
+  });
+
+  test("events: rejects a malformed cursor with 400 VALIDATION_ERROR", async () => {
+    const b = await bootstrap();
+    const result = await invoke(getEvents, {
+      path: "/api/v1/analytics/events?cursor=not-a-real-cursor",
+      headers: authHeaders(b.tenantId, b.token)
+    });
+    expect(result.status).toBe(400);
+    expect((result.body as { error: { code: string } }).error.code).toBe(
+      "VALIDATION_ERROR"
+    );
+  });
+
+  test("settings: GET returns a view even with no override yet, PATCH stores non-secret keys", async () => {
+    const b = await bootstrap();
+    const headers = authHeaders(b.tenantId, b.token);
+
+    const before = await invoke<{
+      data: { effective: Record<string, unknown> };
+    }>(getSettings, { path: "/api/v1/analytics/settings", headers });
+    expect(before.status).toBe(200);
+
+    const patched = await invoke<{
+      data: { effective: Record<string, unknown> };
+    }>(patchSettings, {
+      method: "PATCH",
+      path: "/api/v1/analytics/settings",
+      headers,
+      body: { dashboardLabel: "Visitor Insights" }
+    });
+    expect(patched.status).toBe(200);
+    expect(patched.body.data.effective.dashboardLabel).toBe("Visitor Insights");
+  });
+
+  test("settings: PATCH rejects a secret-shaped key", async () => {
+    const b = await bootstrap();
+    const result = await invoke(patchSettings, {
+      method: "PATCH",
+      path: "/api/v1/analytics/settings",
+      headers: authHeaders(b.tenantId, b.token),
+      body: { apiToken: "some-value" }
+    });
+    expect(result.status).toBe(400);
+  });
+
+  test("retention purge: requires Idempotency-Key, deletes old data, is idempotent, and is audited", async () => {
+    const b = await bootstrap();
+    const oldSession = await seedSession(b.tenantId, {
+      lastSeenAt: new Date(Date.now() - 400 * 24 * 60 * 60 * 1000)
+    });
+    await seedEvent(b.tenantId, oldSession, {
+      occurredAt: new Date(Date.now() - 400 * 24 * 60 * 60 * 1000)
+    });
+
+    const headers = authHeaders(b.tenantId, b.token);
+
+    const missingKey = await invoke(postPurge, {
+      method: "POST",
+      path: "/api/v1/analytics/retention/purge",
+      headers
+    });
+    expect(missingKey.status).toBe(400);
+    expect((missingKey.body as { error: { code: string } }).error.code).toBe(
+      "IDEMPOTENCY_REQUIRED"
+    );
+
+    const idempotencyKey = crypto.randomUUID();
+    const first = await invoke<{ data: { eventsDeleted: number } }>(postPurge, {
+      method: "POST",
+      path: "/api/v1/analytics/retention/purge",
+      headers: { ...headers, "idempotency-key": idempotencyKey }
+    });
+    expect(first.status).toBe(200);
+    expect(first.body.data.eventsDeleted).toBeGreaterThan(0);
+
+    const admin = getAdminSql();
+    const remainingEvents = await admin`
+      SELECT count(*)::int AS count FROM awcms_mini_visit_events WHERE tenant_id = ${b.tenantId}
+    `;
+    expect((remainingEvents as { count: number }[])[0]!.count).toBe(0);
+
+    const auditRows = await admin`
+      SELECT action, severity FROM awcms_mini_audit_events
+      WHERE tenant_id = ${b.tenantId} AND action = 'retention_purged'
+    `;
+    expect(auditRows).toHaveLength(1);
+    expect((auditRows as { severity: string }[])[0]!.severity).toBe("critical");
+
+    const replay = await invoke<{ data: { eventsDeleted: number } }>(
+      postPurge,
+      {
+        method: "POST",
+        path: "/api/v1/analytics/retention/purge",
+        headers: { ...headers, "idempotency-key": idempotencyKey }
+      }
+    );
+    expect(replay.status).toBe(200);
+    expect(replay.body.data.eventsDeleted).toBe(first.body.data.eventsDeleted);
+
+    const auditRowsAfterReplay = await admin`
+      SELECT id FROM awcms_mini_audit_events
+      WHERE tenant_id = ${b.tenantId} AND action = 'retention_purged'
+    `;
+    expect(auditRowsAfterReplay).toHaveLength(1);
+  });
+});

--- a/tests/integration/visitor-analytics-api.integration.test.ts
+++ b/tests/integration/visitor-analytics-api.integration.test.ts
@@ -543,4 +543,51 @@ suite("visitor analytics API (Issue #621)", () => {
     `;
     expect(auditRowsAfterReplay).toHaveLength(1);
   });
+
+  // Post-review regression test (PR #629): a session's last_seen_at can
+  // trail its newest event's occurred_at by up to the collector's ~30s
+  // write-throttle window (application/collector.ts's
+  // SESSION_UPDATE_THROTTLE_MS), so a session older than the event cutoff
+  // can still have a not-yet-deleted event referencing it. This must
+  // never abort the purge with a foreign key violation — the session is
+  // simply left in place for a later purge run instead.
+  test("retention purge: a session with a newer straddling event is left in place, never a foreign-key error", async () => {
+    const b = await bootstrap();
+    const eventRetentionDays = 90; // VISITOR_ANALYTICS_DEFAULTS.eventRetentionDays
+    const straddleSession = await seedSession(b.tenantId, {
+      // Session itself is past the event-retention cutoff...
+      lastSeenAt: new Date(
+        Date.now() - (eventRetentionDays + 1) * 24 * 60 * 60 * 1000
+      )
+    });
+    await seedEvent(b.tenantId, straddleSession, {
+      // ...but it still has one event INSIDE the retention window (the
+      // collector's write-throttle can leave last_seen_at stale like
+      // this in the real system).
+      occurredAt: new Date(Date.now() - 1000)
+    });
+
+    const idempotencyKey = crypto.randomUUID();
+    const result = await invoke<{
+      data: { sessionsDeleted: number; eventsDeleted: number };
+    }>(postPurge, {
+      method: "POST",
+      path: "/api/v1/analytics/retention/purge",
+      headers: {
+        ...authHeaders(b.tenantId, b.token),
+        "idempotency-key": idempotencyKey
+      }
+    });
+
+    // No FK violation / 500 — the purge completes successfully.
+    expect(result.status).toBe(200);
+    expect(result.body.data.eventsDeleted).toBe(0);
+    expect(result.body.data.sessionsDeleted).toBe(0);
+
+    const admin = getAdminSql();
+    const remainingSessions = await admin`
+      SELECT count(*)::int AS count FROM awcms_mini_visitor_sessions WHERE tenant_id = ${b.tenantId}
+    `;
+    expect((remainingSessions as { count: number }[])[0]!.count).toBe(1);
+  });
 });

--- a/tests/unit/visitor-analytics-range.test.ts
+++ b/tests/unit/visitor-analytics-range.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ANALYTICS_RANGES,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../src/modules/visitor-analytics/domain/analytics-range";
+
+describe("isKnownAnalyticsRange", () => {
+  test("accepts the four known ranges", () => {
+    for (const range of ANALYTICS_RANGES) {
+      expect(isKnownAnalyticsRange(range)).toBe(true);
+    }
+  });
+
+  test("rejects unknown/undefined/null values", () => {
+    expect(isKnownAnalyticsRange("1h")).toBe(false);
+    expect(isKnownAnalyticsRange(undefined)).toBe(false);
+    expect(isKnownAnalyticsRange(null)).toBe(false);
+    expect(isKnownAnalyticsRange("")).toBe(false);
+  });
+});
+
+describe("resolveRangeStart", () => {
+  const now = new Date("2026-07-10T12:00:00.000Z");
+
+  test("24h subtracts 24 hours", () => {
+    expect(resolveRangeStart("24h", now).toISOString()).toBe(
+      "2026-07-09T12:00:00.000Z"
+    );
+  });
+
+  test("7d subtracts 7 days", () => {
+    expect(resolveRangeStart("7d", now).toISOString()).toBe(
+      "2026-07-03T12:00:00.000Z"
+    );
+  });
+
+  test("30d subtracts 30 days", () => {
+    expect(resolveRangeStart("30d", now).toISOString()).toBe(
+      "2026-06-10T12:00:00.000Z"
+    );
+  });
+
+  test("12m subtracts 12 months", () => {
+    expect(resolveRangeStart("12m", now).toISOString()).toBe(
+      "2025-07-10T12:00:00.000Z"
+    );
+  });
+
+  test("never mutates the input date", () => {
+    const original = new Date(now);
+    resolveRangeStart("7d", now);
+    expect(now.toISOString()).toBe(original.toISOString());
+  });
+});

--- a/tests/unit/visitor-analytics-response-shaping.test.ts
+++ b/tests/unit/visitor-analytics-response-shaping.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  shapeVisitEvent,
+  shapeVisitorSession,
+  type VisitEventRow,
+  type VisitorSessionRow
+} from "../../src/modules/visitor-analytics/domain/analytics-response-shaping";
+
+const SESSION_ROW: VisitorSessionRow = {
+  id: "session-1",
+  visitor_key_hash: "sha256:abc",
+  identity_id: null,
+  login_identifier_snapshot: "owner@example.com",
+  is_authenticated: true,
+  area: "admin",
+  current_path: "/admin/dashboard",
+  first_seen_at: new Date("2026-07-10T00:00:00.000Z"),
+  last_seen_at: new Date("2026-07-10T00:05:00.000Z"),
+  ip_hash: "sha256:iphash",
+  ip_address: "203.0.113.10",
+  user_agent_hash: "sha256:uahash",
+  browser_name: "Chrome",
+  browser_version_major: "126",
+  os_name: "Windows",
+  device_type: "desktop",
+  is_human: true,
+  bot_reason: null,
+  country_code: null,
+  region: null,
+  city: null,
+  timezone: null
+};
+
+const EVENT_ROW: VisitEventRow = {
+  id: "event-1",
+  visitor_session_id: "session-1",
+  identity_id: null,
+  occurred_at: new Date("2026-07-10T00:05:00.000Z"),
+  method: "GET",
+  status_code: 200,
+  area: "admin",
+  route_pattern: null,
+  path_sanitized: "/admin/dashboard",
+  referrer_domain: null,
+  duration_ms: null,
+  ip_hash: "sha256:iphash",
+  user_agent_hash: "sha256:uahash",
+  user_agent_parsed: { browserName: "Chrome" },
+  geo: {},
+  human_status: "human",
+  correlation_id: "corr-1"
+};
+
+describe("shapeVisitorSession", () => {
+  test("omits raw-detail fields when canSeeRawDetail is false", () => {
+    const dto = shapeVisitorSession(SESSION_ROW, false);
+    expect(dto.ipHash).toBeNull();
+    expect(dto.ipAddress).toBeNull();
+    expect(dto.userAgentHash).toBeNull();
+    expect(dto.loginIdentifierSnapshot).toBeNull();
+    expect(dto.browser_name).toBe("Chrome");
+    expect(dto.area).toBe("admin");
+  });
+
+  test("includes raw-detail fields when canSeeRawDetail is true", () => {
+    const dto = shapeVisitorSession(SESSION_ROW, true);
+    expect(dto.ipHash).toBe("sha256:iphash");
+    expect(dto.ipAddress).toBe("203.0.113.10");
+    expect(dto.userAgentHash).toBe("sha256:uahash");
+    expect(dto.loginIdentifierSnapshot).toBe("owner@example.com");
+  });
+
+  test("always formats timestamps as ISO strings", () => {
+    const dto = shapeVisitorSession(SESSION_ROW, false);
+    expect(dto.firstSeenAt).toBe("2026-07-10T00:00:00.000Z");
+    expect(dto.lastSeenAt).toBe("2026-07-10T00:05:00.000Z");
+  });
+});
+
+describe("shapeVisitEvent", () => {
+  test("omits raw-detail fields when canSeeRawDetail is false", () => {
+    const dto = shapeVisitEvent(EVENT_ROW, false);
+    expect(dto.ipHash).toBeNull();
+    expect(dto.userAgentHash).toBeNull();
+    expect(dto.path_sanitized).toBe("/admin/dashboard");
+    expect(dto.human_status).toBe("human");
+  });
+
+  test("includes raw-detail fields when canSeeRawDetail is true", () => {
+    const dto = shapeVisitEvent(EVENT_ROW, true);
+    expect(dto.ipHash).toBe("sha256:iphash");
+    expect(dto.userAgentHash).toBe("sha256:uahash");
+  });
+
+  test("never omits non-raw parsed/aggregate fields regardless of raw-detail access", () => {
+    const withoutRaw = shapeVisitEvent(EVENT_ROW, false);
+    const withRaw = shapeVisitEvent(EVENT_ROW, true);
+    expect(withoutRaw.user_agent_parsed).toEqual(withRaw.user_agent_parsed);
+    expect(withoutRaw.area).toBe(withRaw.area);
+  });
+});

--- a/tests/unit/visitor-analytics-response-shaping.test.ts
+++ b/tests/unit/visitor-analytics-response-shaping.test.ts
@@ -59,7 +59,7 @@ describe("shapeVisitorSession", () => {
     expect(dto.ipAddress).toBeNull();
     expect(dto.userAgentHash).toBeNull();
     expect(dto.loginIdentifierSnapshot).toBeNull();
-    expect(dto.browser_name).toBe("Chrome");
+    expect(dto.browserName).toBe("Chrome");
     expect(dto.area).toBe("admin");
   });
 
@@ -83,8 +83,8 @@ describe("shapeVisitEvent", () => {
     const dto = shapeVisitEvent(EVENT_ROW, false);
     expect(dto.ipHash).toBeNull();
     expect(dto.userAgentHash).toBeNull();
-    expect(dto.path_sanitized).toBe("/admin/dashboard");
-    expect(dto.human_status).toBe("human");
+    expect(dto.pathSanitized).toBe("/admin/dashboard");
+    expect(dto.humanStatus).toBe("human");
   });
 
   test("includes raw-detail fields when canSeeRawDetail is true", () => {
@@ -96,7 +96,7 @@ describe("shapeVisitEvent", () => {
   test("never omits non-raw parsed/aggregate fields regardless of raw-detail access", () => {
     const withoutRaw = shapeVisitEvent(EVENT_ROW, false);
     const withRaw = shapeVisitEvent(EVENT_ROW, true);
-    expect(withoutRaw.user_agent_parsed).toEqual(withRaw.user_agent_parsed);
+    expect(withoutRaw.userAgentParsed).toEqual(withRaw.userAgentParsed);
     expect(withoutRaw.area).toBe(withRaw.area);
   });
 });


### PR DESCRIPTION
## Summary
Adds all eleven endpoints Issue #621 asks for, under `/api/v1/analytics`:

- `GET /realtime` (`realtime.read`) — online-now presence counts by area/human.
- `GET /summary|pages|devices|locations|security` (`dashboard.read`) — `range=24h|7d|30d|12m`, strictly validated (`400 VALIDATION_ERROR` otherwise). Computed directly from raw `visit_events`/`visitor_sessions` (rollup table is always empty until Issue #624).
- `GET /sessions` / `GET /events` (`sessions.read` / `events.read`) — keyset-paginated (limit 50). Raw detail (`ipHash`/`ipAddress`/`userAgentHash`/`loginIdentifierSnapshot`) is `null` unless the caller *also* holds `visitor_analytics.raw_detail.read`.
- `GET/PATCH /settings` (`settings.read`/`.update`) — thin wrapper reusing Module Management's existing generic per-tenant settings storage (Issue #516), gated by this module's own already-seeded permissions instead of `module_management.settings.*`.
- `POST /retention/purge` (`retention.purge`) — real purge logic (not a stub), using Issue #617's retention config as cutoffs. Requires `Idempotency-Key`, `critical`-severity audit event.

Every endpoint runs `authorizeInTransaction` (ABAC default-deny) before touching data — denial is always `403 ACCESS_DENIED`, never empty/zeroed analytics data. OpenAPI spec updated with all new paths, schemas (`AnalyticsRealtimeStats`, `AnalyticsSummary`, `VisitorSessionItem`, `VisitEventItem`, etc.), security, pagination, and error responses.

Out of scope per the issue: admin UI (#622), middleware collector changes (#620, already merged), rollup job implementation (#624 — `fetchAnalyticsSummary` reads raw events until then), geolocation enrichment (#623 — `locations` will populate once `geo` is written).

Closes #621

## Test plan
- [x] `bun run lint` / `check:docs` / `api:spec:check` / `typecheck`
- [x] `bun test` — 1705/1705 pass, including 13 new unit tests (`analytics-range`, `analytics-response-shaping`) and 11 new integration tests (`tests/integration/visitor-analytics-api.integration.test.ts`: auth guard 400/401, ABAC deny across every guarded endpoint, realtime counts, summary aggregation + range validation, raw-detail gating both directions, keyset pagination across a 55-row page boundary + malformed-cursor rejection, settings GET/PATCH + secret-shaped-key rejection, retention purge idempotency + real deletion + audit event)
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)