### PR TITLE
feat(visitor-analytics): add trusted online geolocation enrichment

### DIFF
--- a/.changeset/visitor-analytics-geo-enrichment.md
+++ b/.changeset/visitor-analytics-geo-enrichment.md
@@ -1,0 +1,16 @@
+---
+"awcms-mini": minor
+---
+
+Add trusted online geolocation enrichment (Issue #623, epic: visitor
+analytics #617-#624) — country code from Cloudflare's `CF-IPCountry`
+header, gated behind both `VISITOR_ANALYTICS_GEO_ENABLED` and
+`VISITOR_ANALYTICS_TRUST_CLOUDFLARE`, never an external network call.
+`GET /api/v1/analytics/locations` now returns real data for deployments
+that opt in. Also hardens `resolveAnalyticsClientIp` against ambiguous
+multi-value `X-Forwarded-For`/`CF-Connecting-IP` headers (fail-safe with
+a warning log, matching the tenant-domain-routing epic's
+`X-Forwarded-Host` handling) and fixes a latent bug where
+`user_agent_parsed`/`geo` jsonb columns were written via
+`JSON.stringify(...)::jsonb`, which silently made every later read of
+those columns return a raw JSON string instead of a parsed object.

--- a/.claude/skills/awcms-mini-visitor-analytics/SKILL.md
+++ b/.claude/skills/awcms-mini-visitor-analytics/SKILL.md
@@ -31,7 +31,7 @@ spesifik** yang menjembatani beberapa issue sekaligus.
 | #619  | Visitor identity, user-agent, human/bot classification helpers | **Selesai** — lihat §Domain helpers di bawah |
 | #620  | Middleware telemetry collection (admin + public)               | **Selesai** — lihat §Collector di bawah      |
 | #621  | Analytics API + OpenAPI contract (`/api/v1/analytics`)         | **Selesai** — lihat §API di bawah            |
-| #623  | Trusted online geolocation enrichment                          | Belum dikerjakan                             |
+| #623  | Trusted online geolocation enrichment                          | **Selesai** — lihat §Geo enrichment di bawah |
 | #622  | Admin visitor analytics dashboard UI (`/admin/analytics`)      | Belum dikerjakan                             |
 | #624  | Rollup job, retention purge job, readiness checks, docs pass   | Belum dikerjakan                             |
 
@@ -314,10 +314,58 @@ analytics kosong/nol diam-diam.
   (selalu kosong sampai job rollup #624 ada).
 
 Test: `tests/unit/visitor-analytics-{range,response-shaping}.test.ts`,
-`tests/integration/visitor-analytics-api.integration.test.ts` (11 test:
+`tests/integration/visitor-analytics-api.integration.test.ts` (13 test:
 auth guard, ABAC deny lintas endpoint, realtime, summary+range validation,
-raw-detail gating dua arah, keyset pagination 55-row, settings GET/PATCH +
-secret-key rejection, retention purge idempotency+delete+audit).
+raw-detail gating dua arah, keyset pagination 55-row, FK-straddle purge,
+geo/jsonb object shape lewat API nyata, settings GET/PATCH + secret-key
+rejection, retention purge idempotency+delete+audit).
+
+### Geo enrichment (Issue #623, `domain/geo-enrichment.ts`)
+
+Country code saja, dari header Cloudflare `CF-IPCountry` — **tidak
+pernah** external network call. Gate ganda: `VISITOR_ANALYTICS_GEO_ENABLED`
+**dan** `VISITOR_ANALYTICS_TRUST_CLOUDFLARE` harus `true` keduanya;
+salah satu `false` → semua field `null`. Region/city/timezone selalu
+`null` di issue ini (belum ada local GeoIP DB, out of scope).
+
+`src/middleware.ts` panggil `resolveGeoEnrichment` di samping
+`resolveAnalyticsClientIp`, hasilnya masuk `collectVisitorTelemetry`'s
+field baru `geo` (Issue #620's `collector.ts` di-extend, bukan file
+baru) — ditulis ke `visitor_sessions.country_code/region/city/timezone`
+DAN `visit_events.geo` (shape sama yang sudah dibaca
+`fetchTopCountries`, Issue #621 — `GET /api/v1/analytics/locations`
+otomatis dapat data nyata begitu geo enrichment aktif, tanpa ubah sisi
+API).
+
+**Hardening ambiguous-header** (`domain/client-ip.ts`, issue ini juga):
+`resolveAnalyticsClientIp` sekarang menolak `X-Forwarded-For`/
+`CF-Connecting-IP` yang punya >1 nilai comma-separated (anomali, log
+warning, fallback ke sumber berikutnya — sama persis pola
+`X-Forwarded-Host` di `public-host-tenant-resolver.ts`, epic
+tenant-domain-routing). Proxy tepercaya yang benar wajib **overwrite**,
+bukan **append**, header ini (kontrak sama `PUBLIC_TRUST_PROXY`, doc 18)
+— jadi proxy yang dikonfigurasi benar tidak pernah menghasilkan >1 nilai
+di sini juga.
+
+**Temuan post-review issue ini — bug jsonb laten sejak #620**:
+`collector.ts`'s `user_agent_parsed`/`geo` sebelumnya ditulis via
+`JSON.stringify(...)::jsonb` — bytes yang tersimpan identik dengan
+`${object}::jsonb`, TAPI Bun.SQL men-decode SELECT berikutnya dari
+kolom itu sebagai raw JSON **string**, bukan object ter-parse (lihat
+memory `bun-sql-jsonb-stringify-trap` untuk bukti empiris lengkap).
+Ini diam-diam memengaruhi response `GET /api/v1/analytics/events`'s
+`userAgentParsed`/`geo` sejak #621 rilis. **Wajib dipertahankan issue
+lanjutan**: selalu bind object JS polos sebagai parameter query untuk
+kolom jsonb (`${plainObject}::jsonb`), jangan pernah
+`JSON.stringify()` dulu — cek `grep -rn "JSON.stringify.*::jsonb"` di
+modul manapun yang disentuh sebelum menganggap kolom jsonb "sudah
+benar".
+
+Test: `tests/unit/visitor-analytics-{client-ip,geo-enrichment}.test.ts`,
+`tests/integration/visitor-analytics-collector.integration.test.ts`
+(geo tertulis ke session+event, geo kosong tetap null),
+`tests/integration/visitor-analytics-api.integration.test.ts` (geo/
+userAgentParsed object nyata lewat `/events` dan `/locations`).
 
 ## Prinsip yang wajib dipertahankan di setiap issue lanjutan
 

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -445,6 +445,29 @@ tabel ini.
 | `VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS`     | –     | `730`   | –        | Retensi rollup agregat — wajib integer positif bila diisi                                                                                                     |
 | `VISITOR_ANALYTICS_HASH_SALT`                 | –     | `""`    | Ya       | Salt fingerprint visitor pseudonymous (Issue #619) — jangan isi nilai asli di sini                                                                            |
 
+> **Peringatan operasional — `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`:** hanya
+> nyalakan flag ini bila deployment benar-benar **hanya** bisa dijangkau
+> lewat edge Cloudflare (mis. origin di-firewall ke rentang IP
+> Cloudflare). Flag ini mempercayai `CF-Connecting-IP` **dan**
+> `CF-IPCountry` sekaligus — kalau origin masih bisa diakses langsung,
+> klien mana pun bisa memalsukan kedua header itu dan meracuni data IP
+> serta geolokasi di analytics. Sama seperti `VISITOR_ANALYTICS_TRUST_PROXY`,
+> ini adalah asumsi operasional/infrastruktur, bukan sesuatu yang bisa
+> divalidasi dari kode aplikasi.
+
+**Kontrak operasional `VISITOR_ANALYTICS_TRUST_PROXY` /
+`VISITOR_ANALYTICS_TRUST_CLOUDFLARE`** mengikuti kontrak yang sama
+dengan `PUBLIC_TRUST_PROXY`/`X-Forwarded-Host` di atas: proxy tepercaya
+**wajib menimpa (overwrite)** header `X-Forwarded-For`/`CF-Connecting-IP`/
+`CF-IPCountry` secara penuh di setiap request, tidak pernah
+append/forward nilai dari klien. `resolveAnalyticsClientIp`
+(`src/modules/visitor-analytics/domain/client-ip.ts`) secara sengaja
+**tidak** menebak-nebak mana yang tepercaya kalau salah satu header itu
+berisi beberapa nilai comma-separated saat runtime — kejadian itu
+dicatat sebagai anomali (log warning) dan gagal aman (fallback ke
+sumber berikutnya / `null`), persis seperti perilaku resolver Issue
+#559 untuk `X-Forwarded-Host`.
+
 Aturan validasi (`checkVisitorAnalyticsConfig`): `VISITOR_ANALYTICS_MODE`
 bila diisi wajib salah satu dari `VISITOR_ANALYTICS_MODES` (`basic` |
 `detailed`); empat var retensi/jendela di atas bila diisi wajib integer

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,6 +16,7 @@ import { resolveVisitorAnalyticsConfig } from "./modules/visitor-analytics/domai
 import { determineArea } from "./modules/visitor-analytics/domain/request-area";
 import { resolveVisitorKey } from "./modules/visitor-analytics/domain/visitor-key";
 import { resolveAnalyticsClientIp } from "./modules/visitor-analytics/domain/client-ip";
+import { resolveGeoEnrichment } from "./modules/visitor-analytics/domain/geo-enrichment";
 import {
   collectVisitorTelemetry,
   shouldCollectRequest
@@ -192,6 +193,10 @@ export async function collectRequestAnalytics(
       trustProxy: config.trustProxy,
       trustCloudflare: config.trustCloudflare
     });
+    const geo = resolveGeoEnrichment(context.request, {
+      geoEnabled: config.geoEnabled,
+      trustCloudflare: config.trustCloudflare
+    });
 
     await collectVisitorTelemetry({
       sql,
@@ -206,7 +211,8 @@ export async function collectRequestAnalytics(
       userAgent: context.request.headers.get("user-agent"),
       referrerHeader: context.request.headers.get("referer"),
       isAuthenticated,
-      identityId
+      identityId,
+      geo
     });
   } catch (error) {
     log("warning", "visitor_analytics.middleware.failed", {

--- a/src/modules/visitor-analytics/README.md
+++ b/src/modules/visitor-analytics/README.md
@@ -67,7 +67,15 @@ aggregates, keyset-paginated sessions/events, settings, and on-demand
 retention purge (see §API below). First issue exposing this module's data
 through authenticated APIs.
 
-Issue #623: trusted online geolocation enrichment.
+Issue #623 (`domain/geo-enrichment.ts`, hardened `domain/client-ip.ts`):
+optional country-code enrichment from Cloudflare's `CF-IPCountry` header,
+gated behind both `VISITOR_ANALYTICS_GEO_ENABLED` and
+`VISITOR_ANALYTICS_TRUST_CLOUDFLARE` — never an external network call
+(see §Geo enrichment below). Also hardens `resolveAnalyticsClientIp`
+against ambiguous multi-value forwarded headers. **First issue that
+populates `visitor_sessions.country_code`/`visit_events.geo` with a real
+value** — `/api/v1/analytics/locations` (Issue #621) has real data from
+here on for deployments that opt in.
 
 Issue #622: admin visitor analytics dashboard UI at `/admin/analytics`.
 
@@ -335,10 +343,55 @@ pagination across a 55-row page boundary + malformed-cursor rejection,
 settings GET/PATCH + secret-shaped-key rejection, retention purge
 idempotency + real deletion + audit event).
 
+## Geo enrichment (Issue #623, `domain/geo-enrichment.ts`)
+
+Country code only, from Cloudflare's `CF-IPCountry` header — never an
+external network call (binding constraint). Gated behind **both**
+`VISITOR_ANALYTICS_GEO_ENABLED` and `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`;
+either flag off returns all-null. Region/city/timezone always stay
+`null` in this issue — no local/offline GeoIP database is configured
+(out of scope: "Paid GeoIP integration"); a future issue can add one
+without changing this function's signature.
+
+`src/middleware.ts` calls `resolveGeoEnrichment` alongside
+`resolveAnalyticsClientIp` and passes the result into
+`collectVisitorTelemetry`'s new `geo` field, which
+`application/collector.ts` writes to both
+`awcms_mini_visitor_sessions.country_code`/`region`/`city`/`timezone`
+and `awcms_mini_visit_events.geo` (jsonb `{countryCode, region, city,
+timezone}` — the same shape `application/analytics-queries.ts`'s
+`fetchTopCountries` already reads via `geo->>'countryCode'`, so
+`GET /api/v1/analytics/locations` (Issue #621) starts returning real
+data the moment a deployment opts in, with no change needed on the API
+side).
+
+**Ambiguous-header hardening** (`domain/client-ip.ts`, also this issue):
+`resolveAnalyticsClientIp` now treats a forwarded header (`X-Forwarded-For`
+or `CF-Connecting-IP`) carrying more than one comma-separated value as an
+anomaly — logs a warning and falls through to the next source, exactly
+as if that trust flag were `false` for this one request, mirroring
+`lib/tenant/public-host-tenant-resolver.ts`'s `X-Forwarded-Host` handling
+in the tenant-domain-routing epic. A correctly-configured trusted proxy
+must _overwrite_, never _append to_, these headers (same operational
+contract as `PUBLIC_TRUST_PROXY`, doc 18), so a real trusted proxy never
+produces more than one value here either — this is not a functional
+regression for any correctly-configured deployment.
+
+**Post-review fix, this issue**: `application/collector.ts`'s
+`user_agent_parsed`/`geo` jsonb writes previously built the value with
+`JSON.stringify(...)` before an explicit `::jsonb` cast — this stores
+byte-identical rows, but Bun.SQL then decodes every later `SELECT` of
+that column as a raw JSON **string**, not a parsed object (a real,
+previously-undetected bug since Issue #620, silently affecting
+`GET /api/v1/analytics/events`'s `userAgentParsed`/`geo` response fields
+since Issue #621 — see the memory note `bun-sql-jsonb-stringify-trap` for
+the full empirical writeup). Fixed by binding the plain object directly
+as the query parameter instead. Regression-tested both at the collector
+level and through the real HTTP `/events`/`/locations` response shape.
+
 ## Not yet available
 
 - Admin dashboard UI (`/admin/analytics`) — Issue #622.
-- Geolocation enrichment — Issue #623.
 - Rollup job (retention purge itself already works — see §API above) — Issue #624.
 
 The `api.basePath`/navigation `path` in `module.ts` are pre-declared ahead

--- a/src/modules/visitor-analytics/application/collector.ts
+++ b/src/modules/visitor-analytics/application/collector.ts
@@ -40,6 +40,7 @@ import {
   hashUserAgent,
   hashVisitorKey
 } from "../domain/visitor-key";
+import type { GeoEnrichment } from "../domain/geo-enrichment";
 import type { VisitorAnalyticsConfig } from "../domain/visitor-analytics-config";
 
 /**
@@ -92,6 +93,8 @@ export type CollectVisitorTelemetryInput = {
   isAuthenticated: boolean;
   /** Server-derived from the caller's own authenticated session — see file header note. */
   identityId: string | null;
+  /** Resolved by the caller from trusted headers only (Issue #623's `resolveGeoEnrichment`) — always all-null when geo enrichment is disabled/untrusted. */
+  geo: GeoEnrichment;
 };
 
 type SessionRow = { id: string; last_seen_at: string };
@@ -122,6 +125,7 @@ async function upsertVisitorSession(
     isAuthenticated: boolean;
     identityId: string | null;
     onlineWindowSeconds: number;
+    geo: GeoEnrichment;
   }
 ): Promise<string> {
   const existingRows = (await tx`
@@ -157,6 +161,10 @@ async function upsertVisitorSession(
             browser_version_major = ${input.parsedUserAgent.browserVersionMajor},
             os_name = ${input.parsedUserAgent.osName},
             device_type = ${input.parsedUserAgent.deviceType},
+            country_code = ${input.geo.countryCode},
+            region = ${input.geo.region},
+            city = ${input.geo.city},
+            timezone = ${input.geo.timezone},
             updated_at = now()
         WHERE id = ${existing.id}
       `;
@@ -177,14 +185,15 @@ async function upsertVisitorSession(
       (tenant_id, visitor_key_hash, identity_id, login_identifier_snapshot,
        is_authenticated, area, current_path, ip_hash, ip_address,
        user_agent_hash, browser_name, browser_version_major, os_name,
-       device_type, is_human, bot_reason)
+       device_type, is_human, bot_reason, country_code, region, city, timezone)
     VALUES (
       ${input.tenantId}, ${input.visitorKeyHash}, ${input.identityId}, null,
       ${input.isAuthenticated}, ${input.area}, ${input.pathSanitized},
       ${input.ipHash}, ${input.rawIpAddress}, ${input.userAgentHash},
       ${input.parsedUserAgent.browserName}, ${input.parsedUserAgent.browserVersionMajor},
       ${input.parsedUserAgent.osName}, ${input.parsedUserAgent.deviceType},
-      ${input.isHuman}, ${input.botReason}
+      ${input.isHuman}, ${input.botReason}, ${input.geo.countryCode},
+      ${input.geo.region}, ${input.geo.city}, ${input.geo.timezone}
     )
     RETURNING id
   `) as { id: string }[];
@@ -216,7 +225,8 @@ export async function collectVisitorTelemetry(
     userAgent,
     referrerHeader,
     isAuthenticated,
-    identityId
+    identityId,
+    geo
   } = input;
 
   try {
@@ -258,15 +268,39 @@ export async function collectVisitorTelemetry(
           botReason: sessionHumanity.botReason,
           isAuthenticated,
           identityId,
-          onlineWindowSeconds: config.onlineWindowSeconds
+          onlineWindowSeconds: config.onlineWindowSeconds,
+          geo
         });
 
-        const userAgentParsed = JSON.stringify({
+        // Post-review fix (Issue #623): pass a plain JS object as the
+        // query parameter, never a pre-`JSON.stringify`'d string. Bun.SQL
+        // only decodes a `jsonb` column back into a parsed object on
+        // SELECT when the matching INSERT parameter was itself passed as
+        // an object (its own driver auto-serializes it and tags the
+        // round trip accordingly) — `${JSON.stringify(x)}::jsonb` stores
+        // the exact same bytes in Postgres, but every later SELECT of
+        // that column then comes back as a raw JSON **string**, not an
+        // object, breaking `VisitEventRow.user_agent_parsed`/`geo`'s own
+        // `Record<string, unknown>` type (verified empirically — see the
+        // regression tests in
+        // `tests/integration/visitor-analytics-collector.integration.test.ts`).
+        // This was a latent bug in `user_agent_parsed` since Issue #620
+        // (it happened not to matter yet — no endpoint read that column
+        // back before Issue #621's `GET /api/v1/analytics/events`, which
+        // this fix also silently repairs) and would have reproduced for
+        // `geo` the moment this issue wrote a non-empty value to it.
+        const userAgentParsed = {
           browserName: parsedUserAgent.browserName,
           browserVersionMajor: parsedUserAgent.browserVersionMajor,
           osName: parsedUserAgent.osName,
           deviceType: parsedUserAgent.deviceType
-        });
+        };
+        const geoJson = {
+          countryCode: geo.countryCode,
+          region: geo.region,
+          city: geo.city,
+          timezone: geo.timezone
+        };
 
         await tx`
           INSERT INTO awcms_mini_visit_events
@@ -276,7 +310,7 @@ export async function collectVisitorTelemetry(
           VALUES (
             ${tenantId}, ${sessionId}, ${identityId}, ${method}, ${statusCode},
             ${area}, ${pathSanitized}, ${referrerDomain}, ${ipHash}, ${userAgentHash},
-            ${userAgentParsed}::jsonb, '{}'::jsonb, ${humanStatus}, ${correlationId}
+            ${userAgentParsed}::jsonb, ${geoJson}::jsonb, ${humanStatus}, ${correlationId}
           )
         `;
       },

--- a/src/modules/visitor-analytics/domain/client-ip.ts
+++ b/src/modules/visitor-analytics/domain/client-ip.ts
@@ -1,34 +1,86 @@
 /**
- * Client IP resolution for visitor analytics (Issue #620, epic: visitor
- * analytics #617-#624). Pure — a distinct, more conservative sibling of
- * `lib/security/rate-limit.ts`'s `resolveClientIp` (which trusts
- * `X-Forwarded-For` unconditionally for rate-limit-key purposes). This
- * one only ever trusts a forwarded header when the deployment has
- * explicitly opted in via `VISITOR_ANALYTICS_TRUST_PROXY`/
- * `VISITOR_ANALYTICS_TRUST_CLOUDFLARE` (Issue #617's config gate) — same
- * principle as `PUBLIC_TRUST_PROXY` in the tenant-domain-routing epic:
- * never trust a spoofable client-supplied header without a trusted proxy
- * in front that actually overwrites it.
+ * Client IP resolution for visitor analytics (Issue #620, hardened
+ * Issue #623, epic: visitor analytics #617-#624). Pure — a distinct,
+ * more conservative sibling of `lib/security/rate-limit.ts`'s
+ * `resolveClientIp` (which trusts `X-Forwarded-For` unconditionally for
+ * rate-limit-key purposes). This one only ever trusts a forwarded header
+ * when the deployment has explicitly opted in via
+ * `VISITOR_ANALYTICS_TRUST_PROXY`/`VISITOR_ANALYTICS_TRUST_CLOUDFLARE`
+ * (Issue #617's config gate) — same principle as `PUBLIC_TRUST_PROXY` in
+ * the tenant-domain-routing epic: never trust a spoofable client-supplied
+ * header without a trusted proxy in front that actually overwrites it.
  *
  * Returns `null` (never a fake "unknown" placeholder) when no IP is
  * resolvable — `null` correctly hashes to nothing and stores as SQL
  * `NULL` in `ip_hash`/`ip_address`, rather than a meaningless-but-real-
  * looking hash of the literal string `"unknown"`.
+ *
+ * Ambiguous-header fail-safe (Issue #623 acceptance criterion): a
+ * forwarded header carrying more than one comma-separated value is
+ * treated as an anomaly, not "just proxy chaining" — this codebase has
+ * no "N trusted hops" configuration to anchor a "take the Nth value from
+ * the right" rule on (same reasoning
+ * `lib/tenant/public-host-tenant-resolver.ts`'s `extractHostHeader` uses
+ * for `X-Forwarded-Host`), so an ambiguous header is logged as a warning
+ * and never trusted, falling through to the next source in the chain
+ * exactly as if that trust flag were `false` for this one request.
  */
+import { log } from "../../../lib/logging/logger";
+
+/** `null` if the header is absent/blank, the single value if unambiguous, `null` (with a warning logged) if it carries more than one comma-separated value. */
+function extractSingleTrustedHeaderValue(
+  request: Request,
+  headerName: string,
+  warningEvent: string
+): string | null {
+  const raw = request.headers.get(headerName);
+
+  if (!raw || raw.trim().length === 0) {
+    return null;
+  }
+
+  const parts = raw
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  if (parts.length === 1) {
+    return parts[0] as string;
+  }
+
+  if (parts.length > 1) {
+    log("warning", warningEvent, {
+      valueCount: parts.length,
+      // Not a secret, but capped defensively — an anomaly report, not a
+      // place to let an attacker-sized header balloon log storage.
+      firstValuePreview: parts[0]?.slice(0, 100)
+    });
+  }
+
+  return null;
+}
+
 export function resolveAnalyticsClientIp(
   request: Request,
   clientAddress: string | undefined,
   trustConfig: { trustProxy: boolean; trustCloudflare: boolean }
 ): string | null {
   if (trustConfig.trustCloudflare) {
-    const cfIp = request.headers.get("cf-connecting-ip")?.trim();
+    const cfIp = extractSingleTrustedHeaderValue(
+      request,
+      "cf-connecting-ip",
+      "visitor_analytics.client_ip.cf_connecting_ip_multi_value"
+    );
     if (cfIp) return cfIp;
   }
 
   if (trustConfig.trustProxy) {
-    const forwardedFor = request.headers.get("x-forwarded-for");
-    const first = forwardedFor?.split(",")[0]?.trim();
-    if (first) return first;
+    const forwardedFor = extractSingleTrustedHeaderValue(
+      request,
+      "x-forwarded-for",
+      "visitor_analytics.client_ip.x_forwarded_for_multi_value"
+    );
+    if (forwardedFor) return forwardedFor;
   }
 
   return clientAddress?.trim() || null;

--- a/src/modules/visitor-analytics/domain/geo-enrichment.ts
+++ b/src/modules/visitor-analytics/domain/geo-enrichment.ts
@@ -1,0 +1,67 @@
+/**
+ * Trusted online geolocation enrichment (Issue #623, epic: visitor
+ * analytics #617-#624). Pure — reads only already-present, trusted
+ * request headers; never makes an external network call (binding
+ * constraint, issue's own "Out of scope"/security notes — no third-party
+ * geolocation API is ever called from the request path).
+ *
+ * Country code only, from Cloudflare's `CF-IPCountry` header, and only
+ * when both `VISITOR_ANALYTICS_GEO_ENABLED` and
+ * `VISITOR_ANALYTICS_TRUST_CLOUDFLARE` are `true` — Cloudflare's free
+ * tier reliably provides country via that header; region/city/timezone
+ * require either Cloudflare's paid IP Geolocation add-on (different,
+ * non-standard headers, not implemented here) or a local/offline GeoIP
+ * database (also not implemented here — out of scope per the issue,
+ * "Paid GeoIP integration"). Those three fields are always `null` until
+ * a later issue adds one of those trusted sources; this is a documented
+ * gap, not a bug — `resolveGeoEnrichment` never fabricates a value.
+ *
+ * BINDING: never used for authorization, rate-limiting, or tenant
+ * resolution — analytics-only, same rule `domain/user-agent.ts`'s
+ * human/bot classification follows.
+ */
+export type GeoEnrichment = {
+  countryCode: string | null;
+  region: string | null;
+  city: string | null;
+  timezone: string | null;
+};
+
+const EMPTY_GEO: GeoEnrichment = {
+  countryCode: null,
+  region: null,
+  city: null,
+  timezone: null
+};
+
+/**
+ * Cloudflare's `CF-IPCountry` is a 2-letter ISO 3166-1 alpha-2 code, or
+ * one of a small set of non-country sentinels (`XX` unknown, `T1` Tor
+ * exit node, `EU` region-only edge case) — all of those are still a
+ * short alphanumeric code, so this only guards against something
+ * obviously not a country-code-shaped value ever being stored (e.g. an
+ * empty string, or a header some misbehaving intermediary stuffed with
+ * unrelated text).
+ */
+const COUNTRY_CODE_PATTERN = /^[A-Z0-9]{2,3}$/i;
+
+function normalizeCountryCode(raw: string | null): string | null {
+  if (!raw) return null;
+
+  const trimmed = raw.trim().toUpperCase();
+
+  return COUNTRY_CODE_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+export function resolveGeoEnrichment(
+  request: Request,
+  config: { geoEnabled: boolean; trustCloudflare: boolean }
+): GeoEnrichment {
+  if (!config.geoEnabled || !config.trustCloudflare) {
+    return EMPTY_GEO;
+  }
+
+  const countryCode = normalizeCountryCode(request.headers.get("cf-ipcountry"));
+
+  return { ...EMPTY_GEO, countryCode };
+}

--- a/tests/integration/visitor-analytics-api.integration.test.ts
+++ b/tests/integration/visitor-analytics-api.integration.test.ts
@@ -25,6 +25,7 @@ import { GET as getRealtime } from "../../src/pages/api/v1/analytics/realtime";
 import { GET as getSummary } from "../../src/pages/api/v1/analytics/summary";
 import { GET as getSessions } from "../../src/pages/api/v1/analytics/sessions";
 import { GET as getEvents } from "../../src/pages/api/v1/analytics/events";
+import { GET as getLocations } from "../../src/pages/api/v1/analytics/locations";
 import {
   GET as getSettings,
   PATCH as patchSettings
@@ -194,20 +195,27 @@ async function seedEvent(
     area: string;
     humanStatus: string;
     pathSanitized: string;
+    geo: Record<string, unknown>;
   }> = {}
 ): Promise<void> {
   const admin = getAdminSql();
+  // Bind the plain object as the parameter (never `JSON.stringify` it
+  // first) — see [[bun-sql-jsonb-stringify-trap]]: a stringified param
+  // makes every later SELECT of this column return a raw JSON string
+  // instead of a parsed object, even though the stored bytes are
+  // identical either way.
   await admin`
     INSERT INTO awcms_mini_visit_events
       (tenant_id, visitor_session_id, method, area, path_sanitized,
-       human_status, occurred_at, user_agent_parsed)
+       human_status, occurred_at, user_agent_parsed, geo)
     VALUES (
       ${tenantId}, ${sessionId}, 'GET',
       ${overrides.area ?? "public"},
       ${overrides.pathSanitized ?? "/news/hello"},
       ${overrides.humanStatus ?? "human"},
       ${overrides.occurredAt ?? new Date()},
-      ${JSON.stringify({ browserName: "Chrome", deviceType: "desktop" })}
+      ${{ browserName: "Chrome", deviceType: "desktop" }}::jsonb,
+      ${overrides.geo ?? {}}::jsonb
     )
   `;
 }
@@ -449,6 +457,49 @@ suite("visitor analytics API (Issue #621)", () => {
     expect((result.body as { error: { code: string } }).error.code).toBe(
       "VALIDATION_ERROR"
     );
+  });
+
+  test("events/locations: geo and user_agent_parsed come back as real nested objects, not JSON strings", async () => {
+    // Regression test for [[bun-sql-jsonb-stringify-trap]] (Issue #623):
+    // proves the fix through the actual HTTP response shape, not just a
+    // direct DB read.
+    const b = await bootstrap();
+    const session = await seedSession(b.tenantId, { area: "public" });
+    await seedEvent(b.tenantId, session, {
+      geo: { countryCode: "ID", region: null, city: null, timezone: null }
+    });
+
+    const eventsResult = await invoke<{
+      data: {
+        events: {
+          geo: { countryCode: string | null };
+          userAgentParsed: { browserName: string | null };
+        }[];
+      };
+    }>(getEvents, {
+      path: "/api/v1/analytics/events",
+      headers: authHeaders(b.tenantId, b.token)
+    });
+
+    expect(eventsResult.status).toBe(200);
+    const event = eventsResult.body.data.events[0]!;
+    expect(typeof event.geo).toBe("object");
+    expect(event.geo.countryCode).toBe("ID");
+    expect(typeof event.userAgentParsed).toBe("object");
+    expect(event.userAgentParsed.browserName).toBe("Chrome");
+
+    const locationsResult = await invoke<{
+      data: { countries: { name: string; count: number }[] };
+    }>(getLocations, {
+      path: "/api/v1/analytics/locations",
+      headers: authHeaders(b.tenantId, b.token)
+    });
+
+    expect(locationsResult.status).toBe(200);
+    expect(locationsResult.body.data.countries).toContainEqual({
+      name: "ID",
+      count: 1
+    });
   });
 
   test("settings: GET returns a view even with no override yet, PATCH stores non-secret keys", async () => {

--- a/tests/integration/visitor-analytics-collector.integration.test.ts
+++ b/tests/integration/visitor-analytics-collector.integration.test.ts
@@ -21,6 +21,15 @@ import {
 import { collectVisitorTelemetry } from "../../src/modules/visitor-analytics/application/collector";
 import { VISITOR_ANALYTICS_DEFAULTS } from "../../src/modules/visitor-analytics/domain/visitor-analytics-config";
 import { generateVisitorKey } from "../../src/modules/visitor-analytics/domain/visitor-key";
+import type { GeoEnrichment } from "../../src/modules/visitor-analytics/domain/geo-enrichment";
+
+/** Geo enrichment is disabled by default (Issue #623) — every existing test here predates that issue and never opted in. */
+const EMPTY_GEO: GeoEnrichment = {
+  countryCode: null,
+  region: null,
+  city: null,
+  timezone: null
+};
 
 const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
 const HUMAN_UA =
@@ -81,7 +90,8 @@ suite("collectVisitorTelemetry", () => {
       userAgent: HUMAN_UA,
       referrerHeader: "https://www.google.com/search?q=x",
       isAuthenticated: false,
-      identityId: null
+      identityId: null,
+      geo: EMPTY_GEO
     });
 
     const sessions = await fetchSessions();
@@ -129,7 +139,8 @@ suite("collectVisitorTelemetry", () => {
       userAgent: HUMAN_UA,
       referrerHeader: null,
       isAuthenticated: false,
-      identityId: null
+      identityId: null,
+      geo: EMPTY_GEO
     });
 
     const events = await fetchEvents();
@@ -153,7 +164,8 @@ suite("collectVisitorTelemetry", () => {
       userAgent: BOT_UA,
       referrerHeader: null,
       isAuthenticated: false,
-      identityId: null
+      identityId: null,
+      geo: EMPTY_GEO
     });
 
     const sessions = await fetchSessions();
@@ -180,7 +192,8 @@ suite("collectVisitorTelemetry", () => {
       userAgent: HUMAN_UA,
       referrerHeader: null,
       isAuthenticated: false,
-      identityId: null
+      identityId: null,
+      geo: EMPTY_GEO
     });
 
     const sessions = await fetchSessions();
@@ -204,7 +217,8 @@ suite("collectVisitorTelemetry", () => {
       userAgent: HUMAN_UA,
       referrerHeader: null,
       isAuthenticated: false,
-      identityId: null
+      identityId: null,
+      geo: EMPTY_GEO
     });
 
     await collectVisitorTelemetry({
@@ -220,7 +234,8 @@ suite("collectVisitorTelemetry", () => {
       userAgent: HUMAN_UA,
       referrerHeader: null,
       isAuthenticated: false,
-      identityId: null
+      identityId: null,
+      geo: EMPTY_GEO
     });
 
     const sessions = await fetchSessions();
@@ -247,7 +262,8 @@ suite("collectVisitorTelemetry", () => {
       userAgent: HUMAN_UA,
       referrerHeader: null,
       isAuthenticated: false,
-      identityId: null
+      identityId: null,
+      geo: EMPTY_GEO
     });
 
     // Simulate the session going stale beyond the online window (real
@@ -274,7 +290,8 @@ suite("collectVisitorTelemetry", () => {
       userAgent: HUMAN_UA,
       referrerHeader: null,
       isAuthenticated: false,
-      identityId: null
+      identityId: null,
+      geo: EMPTY_GEO
     });
 
     const sessions = await fetchSessions();
@@ -301,7 +318,8 @@ suite("collectVisitorTelemetry", () => {
         userAgent: HUMAN_UA,
         referrerHeader: null,
         isAuthenticated: false,
-        identityId: null
+        identityId: null,
+        geo: EMPTY_GEO
       })
     ).resolves.toBeUndefined();
 
@@ -326,7 +344,8 @@ suite("collectVisitorTelemetry", () => {
         userAgent: HUMAN_UA,
         referrerHeader: null,
         isAuthenticated: false,
-        identityId: null
+        identityId: null,
+        geo: EMPTY_GEO
       })
     ).resolves.toBeUndefined();
 
@@ -369,7 +388,8 @@ suite("collectVisitorTelemetry", () => {
       userAgent: HUMAN_UA,
       referrerHeader: null,
       isAuthenticated: true,
-      identityId
+      identityId,
+      geo: EMPTY_GEO
     });
 
     const sessions = await fetchSessions();
@@ -380,5 +400,69 @@ suite("collectVisitorTelemetry", () => {
     expect(sessions[0]!.is_authenticated).toBe(true);
     expect(events[0]!.identity_id).toBe(identityId);
     expect(events[0]!.area).toBe("admin");
+  });
+
+  test("geo enrichment (Issue #623) is written to both the session and the event", async () => {
+    const sql = getTestSql();
+    const geo: GeoEnrichment = {
+      countryCode: "ID",
+      region: null,
+      city: null,
+      timezone: null
+    };
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-10",
+      config: VISITOR_ANALYTICS_DEFAULTS,
+      method: "GET",
+      rawPath: "/news",
+      statusCode: 200,
+      visitorKey: generateVisitorKey(),
+      ipAddress: "203.0.113.90",
+      userAgent: HUMAN_UA,
+      referrerHeader: null,
+      isAuthenticated: false,
+      identityId: null,
+      geo
+    });
+
+    const sessions = await fetchSessions();
+    const events = await fetchEvents();
+
+    expect(sessions[0]!.country_code).toBe("ID");
+    expect((events[0]!.geo as { countryCode: string | null }).countryCode).toBe(
+      "ID"
+    );
+  });
+
+  test("empty geo enrichment leaves session country_code null and event geo fields null", async () => {
+    const sql = getTestSql();
+
+    await collectVisitorTelemetry({
+      sql,
+      tenantId: TENANT_A,
+      correlationId: "corr-11",
+      config: VISITOR_ANALYTICS_DEFAULTS,
+      method: "GET",
+      rawPath: "/news",
+      statusCode: 200,
+      visitorKey: generateVisitorKey(),
+      ipAddress: "203.0.113.91",
+      userAgent: HUMAN_UA,
+      referrerHeader: null,
+      isAuthenticated: false,
+      identityId: null,
+      geo: EMPTY_GEO
+    });
+
+    const sessions = await fetchSessions();
+    const events = await fetchEvents();
+
+    expect(sessions[0]!.country_code).toBeNull();
+    expect(
+      (events[0]!.geo as { countryCode: string | null }).countryCode
+    ).toBeNull();
   });
 });

--- a/tests/unit/visitor-analytics-client-ip.test.ts
+++ b/tests/unit/visitor-analytics-client-ip.test.ts
@@ -17,7 +17,24 @@ describe("resolveAnalyticsClientIp", () => {
     ).toBe("198.51.100.1");
   });
 
-  test("trusts X-Forwarded-For only when trustProxy is true", () => {
+  test("trusts a single-value X-Forwarded-For only when trustProxy is true", () => {
+    const request = requestWithHeaders({ "x-forwarded-for": "203.0.113.9" });
+    expect(
+      resolveAnalyticsClientIp(request, "198.51.100.1", {
+        trustProxy: true,
+        trustCloudflare: false
+      })
+    ).toBe("203.0.113.9");
+  });
+
+  // Issue #623 acceptance criterion: "If multiple conflicting forwarded
+  // values exist, prefer fail-safe behavior... without trusting ambiguous
+  // data" — this repo has no "N trusted hops" config to pick the right
+  // position from (same reasoning as X-Forwarded-Host in
+  // public-host-tenant-resolver.ts), and doc 18's operational contract
+  // for a trusted proxy is "overwrite, never append", so a real trusted
+  // proxy never produces more than one value here either.
+  test("an ambiguous multi-value X-Forwarded-For fails safe (falls back to clientAddress, never trusts any of the values)", () => {
     const request = requestWithHeaders({
       "x-forwarded-for": "203.0.113.9, 10.0.0.1"
     });
@@ -26,7 +43,19 @@ describe("resolveAnalyticsClientIp", () => {
         trustProxy: true,
         trustCloudflare: false
       })
-    ).toBe("203.0.113.9");
+    ).toBe("198.51.100.1");
+  });
+
+  test("an ambiguous multi-value CF-Connecting-IP fails safe the same way", () => {
+    const request = requestWithHeaders({
+      "cf-connecting-ip": "203.0.113.42, 203.0.113.43"
+    });
+    expect(
+      resolveAnalyticsClientIp(request, "198.51.100.1", {
+        trustProxy: false,
+        trustCloudflare: true
+      })
+    ).toBe("198.51.100.1");
   });
 
   test("trusts CF-Connecting-IP only when trustCloudflare is true, taking priority over X-Forwarded-For", () => {

--- a/tests/unit/visitor-analytics-geo-enrichment.test.ts
+++ b/tests/unit/visitor-analytics-geo-enrichment.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveGeoEnrichment } from "../../src/modules/visitor-analytics/domain/geo-enrichment";
+
+function requestWithHeaders(headers: Record<string, string>): Request {
+  return new Request("http://internal.invalid/", { headers });
+}
+
+describe("resolveGeoEnrichment", () => {
+  test("returns all-null when geoEnabled is false, even with a trusted Cloudflare header present", () => {
+    const request = requestWithHeaders({ "cf-ipcountry": "ID" });
+    const result = resolveGeoEnrichment(request, {
+      geoEnabled: false,
+      trustCloudflare: true
+    });
+    expect(result).toEqual({
+      countryCode: null,
+      region: null,
+      city: null,
+      timezone: null
+    });
+  });
+
+  test("returns all-null when trustCloudflare is false, even with geoEnabled true", () => {
+    const request = requestWithHeaders({ "cf-ipcountry": "ID" });
+    const result = resolveGeoEnrichment(request, {
+      geoEnabled: true,
+      trustCloudflare: false
+    });
+    expect(result.countryCode).toBeNull();
+  });
+
+  test("extracts the country code from CF-IPCountry when both flags are enabled", () => {
+    const request = requestWithHeaders({ "cf-ipcountry": "id" });
+    const result = resolveGeoEnrichment(request, {
+      geoEnabled: true,
+      trustCloudflare: true
+    });
+    expect(result.countryCode).toBe("ID");
+  });
+
+  test("region/city/timezone always stay null (no local GeoIP database in this issue)", () => {
+    const request = requestWithHeaders({ "cf-ipcountry": "US" });
+    const result = resolveGeoEnrichment(request, {
+      geoEnabled: true,
+      trustCloudflare: true
+    });
+    expect(result.region).toBeNull();
+    expect(result.city).toBeNull();
+    expect(result.timezone).toBeNull();
+  });
+
+  test("accepts Cloudflare's non-country sentinel codes (XX unknown, T1 Tor, EU region)", () => {
+    for (const code of ["XX", "T1", "EU"]) {
+      const request = requestWithHeaders({ "cf-ipcountry": code });
+      const result = resolveGeoEnrichment(request, {
+        geoEnabled: true,
+        trustCloudflare: true
+      });
+      expect(result.countryCode).toBe(code);
+    }
+  });
+
+  test("rejects a header value that doesn't look like a country code", () => {
+    const request = requestWithHeaders({
+      "cf-ipcountry": "<script>alert(1)</script>"
+    });
+    const result = resolveGeoEnrichment(request, {
+      geoEnabled: true,
+      trustCloudflare: true
+    });
+    expect(result.countryCode).toBeNull();
+  });
+
+  test("returns null countryCode when the header is absent", () => {
+    const request = requestWithHeaders({});
+    const result = resolveGeoEnrichment(request, {
+      geoEnabled: true,
+      trustCloudflare: true
+    });
+    expect(result.countryCode).toBeNull();
+  });
+
+  test("never makes an external network call (pure header read only)", () => {
+    // No fetch/network API is imported or referenced anywhere in
+    // geo-enrichment.ts — this test documents the binding constraint
+    // rather than mocking a call that structurally cannot happen.
+    const request = requestWithHeaders({ "cf-ipcountry": "ID" });
+    expect(() =>
+      resolveGeoEnrichment(request, { geoEnabled: true, trustCloudflare: true })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `domain/geo-enrichment.ts`: country code from Cloudflare's `CF-IPCountry` header, gated behind **both** `VISITOR_ANALYTICS_GEO_ENABLED` and `VISITOR_ANALYTICS_TRUST_CLOUDFLARE` — never an external network call. Region/city/timezone stay `null` (no local GeoIP database in this issue, out of scope per the issue's own "Paid GeoIP integration" exclusion).
- Wires it into `src/middleware.ts`/`application/collector.ts`, writing to `awcms_mini_visitor_sessions.country_code/region/city/timezone` and `awcms_mini_visit_events.geo`. `GET /api/v1/analytics/locations` (already-merged Issue #621) now returns real data for deployments that opt in — no API-side change needed.
- Hardens `domain/client-ip.ts`'s `resolveAnalyticsClientIp` against ambiguous multi-value `X-Forwarded-For`/`CF-Connecting-IP` headers: more than one comma-separated value is now treated as an anomaly (logged as a warning, falls through to the next source), mirroring the tenant-domain-routing epic's `X-Forwarded-Host` handling. A correctly-configured trusted proxy must *overwrite*, never *append to*, these headers (same operational contract as `PUBLIC_TRUST_PROXY`, doc 18) — not a functional regression for any real deployment.
- **Bonus fix found while testing**: `collector.ts`'s `user_agent_parsed`/`geo` jsonb writes used `JSON.stringify(...)::jsonb`, which stores byte-identical rows to binding the object directly but makes Bun.SQL decode every later `SELECT` of that column as a raw JSON *string* instead of a parsed object. This silently affected `GET /api/v1/analytics/events`'s `userAgentParsed`/`geo` response fields since Issue #621 (a real, previously-undetected bug). Fixed by binding the plain object directly; regression-tested both at the collector level and through the actual HTTP response shape.

Closes #623

## Test plan
- [x] `bun run lint` / `check:docs` / `typecheck`
- [x] `bun test` — 1719/1719 pass, including new unit tests (`geo-enrichment`, hardened `client-ip`) and new/updated integration tests (geo written to both session+event, empty geo stays null, FK-straddle purge regression carried over from #621, and a new regression proving `geo`/`userAgentParsed` come back as real objects through the actual `/events` and `/locations` HTTP endpoints)
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)