### PR TITLE
docs(news-portal): document full-online R2-only media architecture and SOP

### DIFF
--- a/.changeset/news-portal-r2-architecture-docs.md
+++ b/.changeset/news-portal-r2-architecture-docs.md
@@ -1,0 +1,29 @@
+---
+"awcms-mini": patch
+---
+
+Document the target full-online R2-only media architecture and SOP for
+the new `news_portal` epic (Issue #631, epic #631-#642 plus downstream
+#649 and the dependent `social-publishing` epic #643-#647) — no code,
+migration, or endpoint changes in this issue.
+
+Adds `docs/awcms-mini/news-portal/`: `full-online-r2-architecture.md`
+(scope/assumptions, the key decision to keep news media on a **separate**
+R2 bucket and credentials from `sync-storage`'s existing private object
+sync queue, the `NEWS_MEDIA_R2_*` env var naming convention, object key
+convention, upload flow diagrams, presigned URL lifecycle, MIME/
+extension/checksum validation order, CORS, custom domain, Cache-Control,
+credential rotation, and a practical mapping to ISO/IEC 27001, 27002,
+27005, 27017, 27018, 27701, 27034, ISO 22301, OWASP ASVS, and OWASP API
+Security Top 10), `r2-upload-sop.md`, `r2-security-checklist.md`,
+`r2-incident-response.md`, `r2-backup-lifecycle.md`, and
+`newsroom-user-guide.md`.
+
+Adds skill `.claude/skills/awcms-mini-news-portal/SKILL.md` summarizing
+the architecture decisions for follow-up issues #632-#642/#649, with a
+per-issue status table (#631 done, the rest not started with a scope
+summary each) so later issues don't need to re-read the full GitHub
+issue bodies. Registers the skill in `AGENTS.md` and
+`.claude/skills/README.md`, and links the new docs from
+`docs/awcms-mini/README.md` and `docs/awcms-mini/deployment-profiles.md`
+(explicit: this mode does not apply to offline/LAN deployments).

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -6,39 +6,40 @@ Skill Claude Code tingkat-proyek untuk AWCMS-Mini. Setiap skill meng-encode stan
 
 ## Katalog
 
-| Skill                                                  | Kapan dipakai                                                                         | Sumber docs                    |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------ |
-| `awcms-mini-implement-issue`                           | Orkestrator: kerjakan satu issue/sprint atomic end-to-end                             | 06, 11, 12                     |
-| `awcms-mini-new-module`                                | Scaffold modul baru di `src/modules/`                                                 | 10, 11                         |
-| `awcms-mini-module-management`                         | Kelola/konsumsi sistem Module Management (registry, lifecycle, settings, health)      | module-management/README.md    |
-| `awcms-mini-new-migration`                             | Buat/ubah migration SQL (tabel, index, RLS)                                           | 04, 10                         |
-| `awcms-mini-new-endpoint`                              | Tambah/ubah endpoint REST + OpenAPI                                                   | 05, 10                         |
-| `awcms-mini-new-event`                                 | Tambah/ubah domain event + AsyncAPI                                                   | 05                             |
-| `awcms-mini-idempotency`                               | Mutation high-risk anti double-submit                                                 | 10                             |
-| `awcms-mini-abac-guard`                                | Kontrol akses default-deny + RLS                                                      | 03, 10                         |
-| `awcms-mini-audit-log`                                 | Audit aksi high-risk + redaction                                                      | 03, 10                         |
-| `awcms-mini-observability`                             | Correlation ID otomatis, retensi/purge audit log, extension point log/audit           | 10, 16, 20                     |
-| `awcms-mini-new-migration` + `awcms-mini-new-endpoint` | Soft delete/restore/purge resource deletable                                          | 04, 05, 10, 16                 |
-| `awcms-mini-sensitive-data`                            | Normalize/hash/mask identifier sensitif                                               | 04                             |
-| `awcms-mini-sync-hmac`                                 | Sync push/pull bertanda HMAC + anti-replay                                            | 08, 10                         |
-| `awcms-mini-security-review`                           | Review keamanan modul                                                                 | 12, 13                         |
-| `awcms-mini-codeql-triage`                             | Triase & perbaiki temuan CodeQL code scanning (termasuk katalog false-positive)       | 20                             |
-| `awcms-mini-pr-review`                                 | Review pull request terhadap DoD                                                      | 09, 10, 12                     |
-| `awcms-mini-testing`                                   | Tulis test berlapis (unit→security)                                                   | 07                             |
-| `awcms-mini-browser-test`                              | E2E browser sungguhan (Playwright + Bun) — puncak piramida testing                    | 07, browser-test/SKILL.md      |
-| `awcms-mini-production-preflight`                      | Preflight & go-live readiness                                                         | 07, 12                         |
-| `awcms-mini-deploy`                                    | Pilih & jalankan profil deployment (LAN-first vs registry/Coolify)                    | 18, deploy-coolify.md          |
-| `awcms-mini-ui-screen`                                 | Implementasi layar/komponen UI sesuai design system                                   | 14, 15                         |
-| `awcms-mini-wizard-form`                               | Form multi-step (reusable wizard pattern)                                             | wizard-form-pattern.md         |
-| `awcms-mini-form-drafts`                               | Server-side draft persistence (resume lintas sesi/perangkat)                          | form-drafts/README.md          |
-| `awcms-mini-email`                                     | Kirim email transaksional (provider-neutral, template management, outbox)             | email/README.md                |
-| `awcms-mini-i18n`                                      | String UI `.po` gettext & konten multi-bahasa                                         | 14, 04, 19                     |
-| `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)                                     | 09                             |
-| `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                          | 07, 06                         |
-| `awcms-mini-blog-content`                              | Kerjakan bagian mana pun epic blog_content (Issue #537-#543)                          | blog-content/README.md         |
-| `awcms-mini-tenant-domain-routing`                     | Kerjakan bagian mana pun epic online public routing & tenant domain (Issue #556-#567) | tenant-domain-routing/SKILL.md |
-| `awcms-mini-auth-online-hardening`                     | Kerjakan bagian mana pun epic full-online auth security hardening (Issue #587-#593)   | auth-online-hardening/SKILL.md |
-| `awcms-mini-visitor-analytics`                         | Kerjakan bagian mana pun epic visitor analytics (Issue #617-#624)                     | visitor-analytics/SKILL.md     |
+| Skill                                                  | Kapan dipakai                                                                               | Sumber docs                    |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------- | ------------------------------ |
+| `awcms-mini-implement-issue`                           | Orkestrator: kerjakan satu issue/sprint atomic end-to-end                                   | 06, 11, 12                     |
+| `awcms-mini-new-module`                                | Scaffold modul baru di `src/modules/`                                                       | 10, 11                         |
+| `awcms-mini-module-management`                         | Kelola/konsumsi sistem Module Management (registry, lifecycle, settings, health)            | module-management/README.md    |
+| `awcms-mini-new-migration`                             | Buat/ubah migration SQL (tabel, index, RLS)                                                 | 04, 10                         |
+| `awcms-mini-new-endpoint`                              | Tambah/ubah endpoint REST + OpenAPI                                                         | 05, 10                         |
+| `awcms-mini-new-event`                                 | Tambah/ubah domain event + AsyncAPI                                                         | 05                             |
+| `awcms-mini-idempotency`                               | Mutation high-risk anti double-submit                                                       | 10                             |
+| `awcms-mini-abac-guard`                                | Kontrol akses default-deny + RLS                                                            | 03, 10                         |
+| `awcms-mini-audit-log`                                 | Audit aksi high-risk + redaction                                                            | 03, 10                         |
+| `awcms-mini-observability`                             | Correlation ID otomatis, retensi/purge audit log, extension point log/audit                 | 10, 16, 20                     |
+| `awcms-mini-new-migration` + `awcms-mini-new-endpoint` | Soft delete/restore/purge resource deletable                                                | 04, 05, 10, 16                 |
+| `awcms-mini-sensitive-data`                            | Normalize/hash/mask identifier sensitif                                                     | 04                             |
+| `awcms-mini-sync-hmac`                                 | Sync push/pull bertanda HMAC + anti-replay                                                  | 08, 10                         |
+| `awcms-mini-security-review`                           | Review keamanan modul                                                                       | 12, 13                         |
+| `awcms-mini-codeql-triage`                             | Triase & perbaiki temuan CodeQL code scanning (termasuk katalog false-positive)             | 20                             |
+| `awcms-mini-pr-review`                                 | Review pull request terhadap DoD                                                            | 09, 10, 12                     |
+| `awcms-mini-testing`                                   | Tulis test berlapis (unit→security)                                                         | 07                             |
+| `awcms-mini-browser-test`                              | E2E browser sungguhan (Playwright + Bun) — puncak piramida testing                          | 07, browser-test/SKILL.md      |
+| `awcms-mini-production-preflight`                      | Preflight & go-live readiness                                                               | 07, 12                         |
+| `awcms-mini-deploy`                                    | Pilih & jalankan profil deployment (LAN-first vs registry/Coolify)                          | 18, deploy-coolify.md          |
+| `awcms-mini-ui-screen`                                 | Implementasi layar/komponen UI sesuai design system                                         | 14, 15                         |
+| `awcms-mini-wizard-form`                               | Form multi-step (reusable wizard pattern)                                                   | wizard-form-pattern.md         |
+| `awcms-mini-form-drafts`                               | Server-side draft persistence (resume lintas sesi/perangkat)                                | form-drafts/README.md          |
+| `awcms-mini-email`                                     | Kirim email transaksional (provider-neutral, template management, outbox)                   | email/README.md                |
+| `awcms-mini-i18n`                                      | String UI `.po` gettext & konten multi-bahasa                                               | 14, 04, 19                     |
+| `awcms-mini-release`                                   | Rilis versi via Changesets (bump, CHANGELOG, tag)                                           | 09                             |
+| `awcms-mini-legacy-migration`                          | Migrasi data legacy aman (dry-run, backfill)                                                | 07, 06                         |
+| `awcms-mini-blog-content`                              | Kerjakan bagian mana pun epic blog_content (Issue #537-#543)                                | blog-content/README.md         |
+| `awcms-mini-tenant-domain-routing`                     | Kerjakan bagian mana pun epic online public routing & tenant domain (Issue #556-#567)       | tenant-domain-routing/SKILL.md |
+| `awcms-mini-auth-online-hardening`                     | Kerjakan bagian mana pun epic full-online auth security hardening (Issue #587-#593)         | auth-online-hardening/SKILL.md |
+| `awcms-mini-visitor-analytics`                         | Kerjakan bagian mana pun epic visitor analytics (Issue #617-#624)                           | visitor-analytics/SKILL.md     |
+| `awcms-mini-news-portal`                               | Kerjakan bagian mana pun epic news_portal full-online R2-only media (Issue #631-#642, #649) | news-portal/SKILL.md           |
 
 ## Katalog peningkatan (improvement/hardening)
 

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: awcms-mini-news-portal
+description: Kerjakan bagian mana pun dari epic news_portal AWCMS-Mini (Issue #631-#642, #649). Gunakan saat menambah/mengubah preset full-online R2-only, media object registry, presigned upload flow, R2 readiness checks, homepage composer, ad/video/quality-checklist berbasis media R2, tag linking, atau SEO/social preview `/news`. Merangkum keputusan arsitektur yang sudah dibuat (docs/awcms-mini/news-portal/) supaya issue lanjutan tidak mengulang/kontradiksi.
+---
+
+# AWCMS-Mini — News Portal (full-online R2-only media)
+
+Epic `news_portal` (#631-#642, #649) menambah lapisan editorial +
+media di atas `blog_content` (base module, sudah `active`) dan online
+public routing (`tenant_domain`, ADR-0009/ADR-0010), khusus untuk
+deployment **full-online** yang mengaktifkan mode **R2-only** untuk
+gambar berita. Epic lanjutan `social-publishing` (#643-#647) **bergantung**
+pada fondasi arsitektur epic ini (khususnya media registry #633 untuk
+gambar yang dibagikan ke platform sosial) tapi **bukan** bagian tabel
+status di bawah — lihat skill/dokumentasi terpisah begitu epic itu
+mulai dikerjakan.
+
+## Kapan pakai skill ini vs skill generik
+
+Skill ini melengkapi (bukan menggantikan) `awcms-mini-new-endpoint`,
+`awcms-mini-new-migration`, `awcms-mini-integration` (pola outbox/
+circuit breaker untuk R2, ADR-0006), `awcms-mini-idempotency` (mutation
+`confirm` upload), `awcms-mini-sensitive-data` (foto berpotensi PII),
+`awcms-mini-abac-guard`, dan `awcms-mini-blog-content` (model konten
+post/page/gallery/ads yang jadi konsumen media registry). Skill ini
+menyediakan konteks **cross-cutting epic spesifik** — terutama
+keputusan "R2-only, bucket terpisah dari sync-storage" yang wajib
+dipertahankan setiap issue.
+
+**Baca dulu** `docs/awcms-mini/news-portal/full-online-r2-architecture.md`
+sebelum mengerjakan issue mana pun di epic ini — dokumen itu (bukan
+skill ini) adalah sumber kebenaran arsitektur; skill ini merangkum
+status + pointer, bukan menduplikasi isinya.
+
+## Status per issue (jangan bangun ulang yang sudah ada)
+
+| Issue | Scope                                                                                                                        | Status                                               |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| #631  | Dokumentasi arsitektur full-online R2-only + SOP + security + IR + backup + user guide                                       | **Selesai** — lihat §Dokumen yang sudah ada di bawah |
+| #632  | Preset `news_portal_full_online_r2` (module descriptor/config gate)                                                          | Belum dikerjakan — lihat §632 di bawah               |
+| #633  | Tenant-scoped R2-only media object registry (schema + migration)                                                             | Belum dikerjakan — lihat §633 di bawah               |
+| #634  | Direct-to-R2 presigned upload flow (endpoint upload/confirm)                                                                 | Belum dikerjakan — lihat §634 di bawah               |
+| #635  | Config validation + readiness checks (`config:validate`/`security:readiness`/`production:preflight`) untuk R2 image delivery | Belum dikerjakan — lihat §635 di bawah               |
+| #636  | `blog_content` wajib referensi R2 media object untuk gambar berita saat mode aktif                                           | Belum dikerjakan — lihat §636 di bawah               |
+| #637  | Editorial homepage section composer `/news` dengan render R2-only                                                            | Belum dikerjakan — lihat §637 di bawah               |
+| #638  | Preset placement iklan news portal dengan validasi gambar R2-only                                                            | Belum dikerjakan — lihat §638 di bawah               |
+| #639  | Content block `video_news` dengan thumbnail R2 wajib                                                                         | Belum dikerjakan — lihat §639 di bawah               |
+| #640  | Content quality checklist publishing dengan syarat gambar R2                                                                 | Belum dikerjakan — lihat §640 di bawah               |
+| #641  | Automatic internal tag linking untuk konten post/news                                                                        | Belum dikerjakan — lihat §641 di bawah               |
+| #642  | Public social share buttons di halaman artikel `/news`                                                                       | Belum dikerjakan — lihat §642 di bawah               |
+| #649  | SEO + social preview metadata lengkap di halaman artikel `/news`                                                             | Belum dikerjakan — lihat §649 di bawah               |
+
+Urutan dependency yang disarankan (dari objective masing-masing issue):
+631 → 632 → 633 → 634 → 635 (readiness butuh #632-#634 ada untuk
+divalidasi) → 636 (butuh #633 registry) → 637/638/639/640 (butuh #636,
+bisa paralel satu sama lain) → 641 (independen, hanya butuh
+`blog_content` taxonomies yang sudah ada) → 642/649 (butuh #636 untuk
+gambar R2 yang valid dipakai preview sosial, bisa paralel).
+
+## Yang sudah ada — pakai ulang, jangan re-derive
+
+### Dokumen arsitektur (Issue #631, `docs/awcms-mini/news-portal/`)
+
+Enam dokumen, semua docs-only (tidak ada kode/migration/endpoint di
+issue ini):
+
+- **`full-online-r2-architecture.md`** — dokumen utama. Berisi:
+  ruang lingkup full-online-only (§1), keputusan **bucket R2 terpisah
+  dari `sync-storage`** (§2 — lihat §Keputusan kunci di bawah), lima
+  prinsip inti tidak bisa dinegosiasi (§3), konvensi env var
+  `NEWS_MEDIA_R2_*` (§4, **belum** ada di `.env.example`/doc 18 — itu
+  tugas #632/#633), model data konseptual media registry (§5), konvensi
+  object key (§6), dua diagram alur upload (§7), lifecycle presigned
+  URL (§8), urutan validasi MIME/ekstensi/checksum (§9), CORS (§10),
+  custom domain (§11), Cache-Control (§12), rotasi kredensial (§13),
+  diagram trust boundary (§14), dan pemetaan kepatuhan penuh ke
+  ISO/IEC 27001/27002/27005/27017/27018/27701/27034, ISO 22301, OWASP
+  ASVS, OWASP API Security Top 10 (§15).
+- **`r2-upload-sop.md`** — SOP operasional Jalur A (direct-to-R2,
+  disarankan) dan Jalur B (server-streaming tanpa temp file lokal),
+  urutan validasi, penanganan error, troubleshooting operator.
+- **`r2-security-checklist.md`** — checklist siap-pakai (validasi,
+  object key, presigned URL, CORS, custom domain/cache, kredensial,
+  readiness gates, monitoring) + contoh kebijakan API token R2
+  least-privilege. §7 checklist ini eksplisit menyatakan **belum ada**
+  check nyata di `config:validate`/`security:readiness` untuk news
+  media sampai #635 mengimplementasikannya — jangan klaim readiness
+  sudah ditegakkan sebelum #635 selesai.
+- **`r2-incident-response.md`** — runbook Detect/Contain/Eradicate/
+  Recover/Post-incident untuk tiga skenario: presigned URL bocor,
+  object exposure publik, upload berbahaya.
+- **`r2-backup-lifecycle.md`** — lifecycle objek `pending` (TTL default
+  60 menit), retention policy per klasifikasi data, deteksi objek
+  `orphaned`, strategi backup (replikasi/versioning — pilihan operator,
+  bukan mandat tunggal), kontinuitas (RPO/RTO), privasi/minimisasi.
+- **`newsroom-user-guide.md`** — panduan editor/jurnalis (bukan
+  developer): cara upload, format/ukuran didukung, pesan error umum,
+  praktik terbaik privasi/atribusi, ke mana gambar dipakai.
+
+Test: tidak ada (docs-only, tidak ada acceptance criteria berupa
+kode/test di issue #631). Validasi: `bun run lint`, `bun run check:docs`,
+`bun run build`.
+
+### Keputusan kunci #1 — bucket R2 terpisah dari `sync-storage` (WAJIB dipertahankan)
+
+`src/modules/sync-storage/` sudah memakai R2 sejak Issue 6.3/#436
+(`R2_ENABLED`/`R2_ACCOUNT_ID`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`/
+`R2_BUCKET`) sebagai **object queue privat** untuk sinkronisasi
+offline/LAN (lampiran/receipt, machine-to-machine via HMAC). News
+portal media adalah kebutuhan yang **fundamental berbeda** — publik,
+diakses browser, custom domain, CORS untuk direct-upload. **Jangan
+pernah** menyatukan keduanya ke bucket/kredensial yang sama:
+
+- Bucket berbeda mencegah kesalahan konfigurasi publik (CORS/custom
+  domain) di satu fungsi membocorkan objek privat fungsi lain.
+- Kredensial berbeda membatasi blast radius — kompromi token media
+  publik (bucket yang memang sudah publik) tidak pernah memberi akses
+  tulis ke objek sync privat, dan sebaliknya.
+- Konvensi penamaan env var **`NEWS_MEDIA_R2_*`** (bukan `R2_*` yang
+  sudah dipakai) — lihat `full-online-r2-architecture.md` §4 untuk
+  daftar lengkap yang wajib diikuti implementor persis apa adanya.
+- Cloudflare **account** boleh sama (satu akun, dua bucket) — yang
+  wajib terpisah adalah bucket dan API token, bukan akun.
+
+Issue #632/#633 **wajib** menambahkan validasi eksplisit bahwa
+`NEWS_MEDIA_R2_BUCKET` ≠ `R2_BUCKET` (dan kredensial keduanya berbeda)
+di `config:validate`/`security:readiness` — jangan hanya
+mendokumentasikan tanpa menegakkan (lihat `r2-security-checklist.md` §7
+untuk kontrak lengkap yang wajib dipenuhi #635).
+
+### Keputusan kunci #2 — tidak ada fallback lokal, tidak ada temp file
+
+Mode ini (bila `NEWS_MEDIA_R2_ENABLED=true`) **tidak pernah** menulis
+bytes gambar ke `LOCAL_STORAGE_PATH`/disk lokal server sebagai
+pengganti R2 — baik sebagai fallback kegagalan maupun sebagai file
+sementara di tengah proses upload (`full-online-r2-architecture.md`
+§3.3/§3.4, `r2-upload-sop.md` §2/§3). Ini kebalikan dari `sync-storage`
+(yang memang menyimpan lokal dulu, upload R2 belakangan via dispatcher
+— desain yang benar untuk kasus offline-first-nya). Implementor #634
+**wajib** memverifikasi tidak ada `Bun.write(tempPath, ...)`/
+`fs.writeFile` perantara di jalur upload manapun sebelum PR dianggap
+selesai.
+
+### Keputusan kunci #3 — object key tidak pernah berisi PII/nama file asli
+
+Format wajib: `news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}` — `uuid`
+dari `crypto.randomUUID()`, `ext` **diturunkan dari MIME tervalidasi**
+(bukan ekstensi asli client). `original_filename` tetap disimpan
+sebagai kolom metadata terpisah untuk tampilan, tidak pernah masuk key
+(`full-online-r2-architecture.md` §6). Implementor #633 (schema) dan
+#634 (endpoint) wajib mengikuti format ini persis.
+
+### Keputusan kunci #4 — status `pending`/`confirmed` tidak mengontrol akses storage
+
+Residual risk yang sudah didokumentasikan dan **wajib** terus
+dipertahankan setiap issue lanjutan: begitu objek ter-PUT sukses ke R2,
+ia langsung reachable publik lewat custom domain — status Postgres
+`pending` **tidak** memblokir pembacaan storage-level
+(`full-online-r2-architecture.md` §8). Mitigasi: object key tidak bisa
+ditebak (Keputusan #3), konten editorial tidak pernah menunjuk objek
+`pending` (hanya `confirmed`), dan lifecycle job membersihkan objek
+`pending` basi (`r2-backup-lifecycle.md` §2, `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`
+default 60 menit). Jangan mengimplementasikan kontrol yang mengasumsikan
+status Postgres sudah cukup untuk mencegah akses publik — bila
+implementor #634 menemukan cara menegakkan ACL per-objek R2 yang nyata,
+itu peningkatan yang harus didokumentasikan sebagai penggantian
+keputusan ini, bukan diam-diam diasumsikan sudah ada.
+
+### Keputusan kunci #5 — `image/svg+xml` dilarang default
+
+MIME allow-list default (`full-online-r2-architecture.md` §4/§9):
+`image/jpeg, image/png, image/webp, image/gif`. SVG sengaja tidak
+termasuk karena risiko XSS (script tersemat). Mengizinkannya butuh
+pipeline sanitasi khusus dan keputusan terpisah — bukan sekadar
+menambah ke allow-list di issue mana pun.
+
+## §632 — Preset `news_portal_full_online_r2` (belum dikerjakan)
+
+Ringkasan scope dari objective issue: menambah preset yang
+mengkonfigurasi AWCMS-Mini untuk news portal full-online, gambar
+hanya di R2. Implementor **wajib**:
+
+- Memakai env var persis sesuai `full-online-r2-architecture.md` §4
+  (`NEWS_MEDIA_R2_*`), menambahkannya ke `.env.example` dan
+  `18_configuration_env_reference.md` (belum ada di kedua tempat itu
+  sampai issue ini).
+- Preset ini **tidak** mengubah default deployment offline/LAN/base
+  generik apa pun — hanya aktif untuk tenant/deployment yang eksplisit
+  mengaktifkannya (§1 arsitektur).
+- Perbarui baris status tabel di atas menjadi **Selesai** dan tambahkan
+  subbagian `### §632 — ...` (pola sama subbagian lain di bawah) begitu
+  selesai — jangan hanya mengubah kata "Belum dikerjakan" tanpa
+  merangkum keputusan konkret yang dibuat.
+
+## §633 — Media object registry (belum dikerjakan)
+
+Ringkasan scope: tabel tenant-scoped R2-only media registry dipakai
+`blog_content`, homepage section, galeri, ads, gambar SEO, thumbnail
+video. Implementor **wajib** mengikuti bentuk konseptual
+`full-online-r2-architecture.md` §5 (kolom, tidak ada binary),
+konvensi object key §6, dan migration lewat skill
+`awcms-mini-new-migration` (RLS `ENABLE`+`FORCE`, pola sama tabel
+tenant-scoped lain).
+
+## §634 — Direct-to-R2 presigned upload flow (belum dikerjakan)
+
+Ringkasan scope: endpoint upload presigned + confirm (Jalur A) dan/atau
+server-streaming (Jalur B) sesuai `r2-upload-sop.md` §2/§3. Implementor
+**wajib**: `Idempotency-Key` untuk langkah `confirm` (skill
+`awcms-mini-idempotency`), panggilan R2 di luar DB transaction
+(ADR-0006), circuit breaker + timeout (pola sama `object-storage`
+breaker `sync-storage` sudah pakai), validasi berlapis persis urutan
+`full-online-r2-architecture.md` §9.
+
+## §635 — Readiness checks (belum dikerjakan)
+
+Ringkasan scope: `config:validate`, `security:readiness`,
+`production:preflight` untuk R2 image delivery. Kontrak lengkap yang
+wajib dipenuhi: `r2-security-checklist.md` §7 (termasuk penegakan
+`NEWS_MEDIA_R2_BUCKET` ≠ `R2_BUCKET`, kredensial berbeda, SVG tidak di
+allow-list kecuali override eksplisit). Implementor **wajib**
+memperbarui `r2-security-checklist.md` §7 begitu check nyata ditulis
+(ganti "belum ada" jadi nama fungsi/test).
+
+## §636 — `blog_content` wajib referensi R2 media (belum dikerjakan)
+
+Ringkasan scope: featured image, block gallery, gambar SEO, dan
+surface gambar blog/news lain **wajib** menunjuk baris
+`status='confirmed'` di media registry (#633) ketika mode R2-only aktif
+— menerapkan Keputusan kunci #4 di atas ke `blog_content` yang sudah
+ada (yang saat ini, sebelum issue ini, memakai `featuredMediaId` sebagai
+UUID longgar tanpa FK dan URL bebas `isAbsoluteHttpUrl` untuk gallery —
+lihat `src/modules/blog-content/README.md` §Media/Gallery). Implementor
+**wajib** membaca subbagian itu untuk memahami perilaku sebelum issue
+ini (tidak ada FK, tidak ada media library nyata) yang akan diganti.
+
+## §637-#640, #642, #649 — konsumsi media registry (belum dikerjakan)
+
+Ringkasan objective per issue (detail lengkap ada di body issue
+GitHub masing-masing, cek `gh issue view <n>` bila butuh acceptance
+criteria penuh):
+
+- **#637** — homepage section composer `/news` dengan render R2-only
+  (gambar section harus dari media registry, bukan URL bebas).
+- **#638** — preset placement iklan dengan validasi gambar R2-only
+  (memperluas `awcms_mini_blog_ads`'s `image_url` yang saat ini bebas
+  URL http(s) — lihat `blog-content` README §Ads).
+- **#639** — content block `video_news` baru dengan thumbnail R2 wajib
+  (thumbnail, bukan video itu sendiri, yang wajib R2 — video hosting
+  eksternal seperti YouTube/embed kemungkinan tetap di luar cakupan R2,
+  cek body issue untuk detail persis sebelum implementasi).
+- **#640** — content quality checklist publishing dengan syarat gambar
+  R2 (mis. featured image wajib ada + confirmed sebelum status
+  `published` diizinkan).
+- **#642** — social share buttons publik di `/news` dengan canonical
+  URL aman + Open Graph/Twitter Card + privacy-conscious.
+- **#649** — SEO + social preview metadata lengkap (title/excerpt/
+  canonical/gambar R2 terverifikasi) untuk crawler share.
+
+Semua issue ini **wajib** mengonsumsi media registry (#633) dan validasi
+`confirmed`-only (#636) — bukan re-derive validasi URL/MIME sendiri.
+
+## §641 — Automatic internal tag linking (belum dikerjakan)
+
+Ringkasan scope: auto-linking tag/taxonomy di dalam konten post/news
+memakai tag/taxonomy yang **sudah ada** (`blog_content`'s
+`awcms_mini_blog_terms`), sambil menjaga kontrol editorial, keamanan
+SEO, aksesibilitas, dan keamanan rendering. **Tidak terkait R2/media**
+secara langsung — item ini ada di epic yang sama karena sama-sama
+bagian pengalaman editorial `news_portal`, tapi tidak bergantung pada
+Keputusan kunci #1-#5 di atas. Implementor wajib tetap memakai whitelist
+renderer yang sama (`content-block-rendering.ts`) — auto-linking tidak
+boleh membuka jalur raw-HTML baru (lihat `blog-content` README
+§Rendering publik tetap aman dari XSS).
+
+## Prinsip yang wajib dipertahankan di setiap issue lanjutan
+
+1. **Full-online-only, opt-in eksplisit** — tidak ada perilaku epic ini
+   yang aktif default untuk deployment yang tidak eksplisit mengaktifkan
+   preset (#632). Offline/LAN tidak boleh terpengaruh sama sekali.
+2. **R2-only untuk binary, Postgres untuk metadata** — tidak ada kolom
+   binary baru di tabel manapun epic ini menyentuh.
+3. **Tidak ada fallback filesystem lokal, tidak ada temp file lokal** —
+   lihat Keputusan kunci #2.
+4. **Bucket + kredensial R2 media terpisah dari `sync-storage`** — lihat
+   Keputusan kunci #1. Ini bukan saran, ini penegakan wajib di
+   `config:validate`/`security:readiness` (#635).
+5. **Object key: UUID + tanggal + tenant, tidak pernah nama file/PII** —
+   lihat Keputusan kunci #3.
+6. **Status Postgres bukan kontrol akses storage** — lihat Keputusan
+   kunci #4, jangan berasumsi sebaliknya di kode/dokumentasi baru.
+7. **SVG dilarang default** — lihat Keputusan kunci #5.
+8. **Konten editorial hanya boleh menunjuk media `confirmed`** — dari
+   #636 dan seterusnya; jangan re-derive aturan URL bebas lama.
+
+## Referensi
+
+- `docs/awcms-mini/news-portal/full-online-r2-architecture.md` — arsitektur lengkap + pemetaan kepatuhan.
+- `docs/awcms-mini/news-portal/r2-upload-sop.md` — SOP upload.
+- `docs/awcms-mini/news-portal/r2-security-checklist.md` — checklist keamanan.
+- `docs/awcms-mini/news-portal/r2-incident-response.md` — runbook insiden.
+- `docs/awcms-mini/news-portal/r2-backup-lifecycle.md` — backup/lifecycle/retensi.
+- `docs/awcms-mini/news-portal/newsroom-user-guide.md` — panduan editor.
+- `src/modules/sync-storage/README.md` — R2 usage yang sudah ada (bucket terpisah, Keputusan kunci #1).
+- `src/modules/blog-content/README.md` §Media/Gallery, §Ads — perilaku sebelum #636 mengubahnya.
+- `docs/adr/0006-offline-first-sync-outbox.md` — provider eksternal opsional/di luar transaksi.
+- `docs/awcms-mini/deployment-profiles.md` §News portal — ringkasan per profil deployment.
+- `AGENTS.md` skill table.

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -207,10 +207,22 @@ tenant-scoped lain).
 Ringkasan scope: endpoint upload presigned + confirm (Jalur A) dan/atau
 server-streaming (Jalur B) sesuai `r2-upload-sop.md` §2/§3. Implementor
 **wajib**: `Idempotency-Key` untuk langkah `confirm` (skill
-`awcms-mini-idempotency`), panggilan R2 di luar DB transaction
-(ADR-0006), circuit breaker + timeout (pola sama `object-storage`
-breaker `sync-storage` sudah pakai), validasi berlapis persis urutan
-`full-online-r2-architecture.md` §9.
+`awcms-mini-idempotency`), audit event formal untuk `confirm`
+sukses/gagal (skill `awcms-mini-audit-log`, bukan sekadar correlation-ID
+logging), panggilan R2 di luar DB transaction (ADR-0006), circuit
+breaker + timeout (pola sama `object-storage` breaker `sync-storage`
+sudah pakai), validasi berlapis persis urutan
+`full-online-r2-architecture.md` §9. **Titik paling kritis (temuan
+security-auditor #631, sudah diperbaiki di dokumen arsitektur)**:
+langkah `confirm` Jalur A HARUS melakukan `GET` penuh objek dari R2
+(bukan `HEAD` saja) untuk menjalankan MIME sniffing dari magic bytes
+dan menghitung checksum server-side dari isi objek — `HEAD` hanya
+membuktikan sesuatu ter-upload, bukan apa yang ter-upload, dan
+membandingkan checksum aktual dari `HEAD`/ETag terhadap klaim client
+adalah pemeriksaan self-referential yang tidak menutup upload konten
+berbahaya berkedok gambar. Tambahkan test integrasi yang meng-upload
+payload HTML/JS berkedok `.jpg` dan membuktikan `confirm` menolaknya
+sebelum menganggap implementasi ini benar.
 
 ## §635 — Readiness checks (belum dikerjakan)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ AWCMS-Mini menyediakan **skill Claude Code tingkat-proyek** yang meng-encode sta
 | Kerjakan bagian mana pun epic blog_content (Issue #537-#543)           | `awcms-mini-blog-content`          |
 | Epic online public routing & tenant domain (Issue #556-#567)           | `awcms-mini-tenant-domain-routing` |
 | Epic visitor analytics (Issue #617-#624)                               | `awcms-mini-visitor-analytics`     |
+| Epic news_portal full-online R2-only media (Issue #631-#642, #649)     | `awcms-mini-news-portal`           |
 
 **Peningkatan (audit & hardening artefak yang sudah ada):**
 
@@ -174,6 +175,13 @@ flowchart LR
   VA --> EP
   VA --> UI2
   VA --> SD
+  II --> NP[news-portal]
+  NP --> MIG
+  NP --> EP
+  NP --> UI2
+  NP --> SD
+  NP --> INT
+  NP --> IDEM
 ```
 
 Skill merujuk `docs/awcms-mini/*` sebagai sumber kebenaran; bila standar berubah, perbarui doc **dan** skill terkait.

--- a/docs/awcms-mini/README.md
+++ b/docs/awcms-mini/README.md
@@ -116,20 +116,21 @@ Dokumen dikelompokkan mengikuti alur pengembangan agar mudah diimplementasi.
 
 ### Lapisan E — Operasi & referensi
 
-|  No | File                                        | Isi                                                                                                    |
-| --: | ------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-|   8 | `08_sop_operasional_user_guide.md`          | SOP operasional dan user guide                                                                         |
-|  19 | `19_glossary_terminology.md`                | Glossary & terminologi lintas dokumen                                                                  |
-|  20 | `20_threat_model_security_architecture.md`  | Threat model (STRIDE), trust boundary, kontrol keamanan berlapis (dokumen base, bukan contoh domain)   |
-|   – | `database-migrations.md`                    | Panduan runner migrasi PostgreSQL Bun-native                                                           |
-|   – | `deployment-profiles.md`                    | Profil deployment (development/staging/production/offline-LAN) dan model dua-peran basis data          |
-|   – | `deploy-coolify.md`                         | Panduan deploy Coolify: single-VPS, multi-aplikasi, opsi PostgreSQL, checklist keamanan (Issue #462)   |
-|   – | `derived-application-guide.md`              | Panduan membangun aplikasi turunan di atas base (9 langkah + 5 contoh ilustratif + checklist keamanan) |
-|   – | `examples/minimal-domain-module.md`         | Contoh konkret satu modul domain minimal (Issue #463)                                                  |
-|   – | `examples/wizard-form-pattern.md`           | Reusable multi-step wizard form pattern: komponen, helper, pola i18n (Issue #479)                      |
-|   – | `examples/wizard-derived-module-example.md` | Contoh pemakaian wizard end-to-end pada modul domain turunan (Issue #482)                              |
-|   – | `derived-app-pilot-plan.md`                 | Rencana pilot aplikasi turunan pertama — rekomendasi AWPOS (Issue #465)                                |
-|   – | `../../openapi/` dan `../../asyncapi/`      | Baseline kontrak OpenAPI/AsyncAPI dan validator `api:spec:check`                                       |
+|  No | File                                              | Isi                                                                                                                                           |
+| --: | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+|   8 | `08_sop_operasional_user_guide.md`                | SOP operasional dan user guide                                                                                                                |
+|  19 | `19_glossary_terminology.md`                      | Glossary & terminologi lintas dokumen                                                                                                         |
+|  20 | `20_threat_model_security_architecture.md`        | Threat model (STRIDE), trust boundary, kontrol keamanan berlapis (dokumen base, bukan contoh domain)                                          |
+|   – | `database-migrations.md`                          | Panduan runner migrasi PostgreSQL Bun-native                                                                                                  |
+|   – | `deployment-profiles.md`                          | Profil deployment (development/staging/production/offline-LAN) dan model dua-peran basis data                                                 |
+|   – | `deploy-coolify.md`                               | Panduan deploy Coolify: single-VPS, multi-aplikasi, opsi PostgreSQL, checklist keamanan (Issue #462)                                          |
+|   – | `derived-application-guide.md`                    | Panduan membangun aplikasi turunan di atas base (9 langkah + 5 contoh ilustratif + checklist keamanan)                                        |
+|   – | `examples/minimal-domain-module.md`               | Contoh konkret satu modul domain minimal (Issue #463)                                                                                         |
+|   – | `examples/wizard-form-pattern.md`                 | Reusable multi-step wizard form pattern: komponen, helper, pola i18n (Issue #479)                                                             |
+|   – | `examples/wizard-derived-module-example.md`       | Contoh pemakaian wizard end-to-end pada modul domain turunan (Issue #482)                                                                     |
+|   – | `derived-app-pilot-plan.md`                       | Rencana pilot aplikasi turunan pertama — rekomendasi AWPOS (Issue #465)                                                                       |
+|   – | `news-portal/full-online-r2-architecture.md` dkk. | Arsitektur full-online R2-only media berita, SOP upload, security checklist, incident response, backup/lifecycle, panduan editor (Issue #631) |
+|   – | `../../openapi/` dan `../../asyncapi/`            | Baseline kontrak OpenAPI/AsyncAPI dan validator `api:spec:check`                                                                              |
 
 ### Architecture Decision Records
 

--- a/docs/awcms-mini/deployment-profiles.md
+++ b/docs/awcms-mini/deployment-profiles.md
@@ -259,6 +259,43 @@ ringkasan per profil:
   job aman dijalankan di profil offline/LAN sekalipun (operasi database
   lokal murni, tidak pernah memanggil provider eksternal).
 
+## News portal full-online R2-only media (opsional, Issue #631)
+
+Epic `news_portal` (Issue #631-#642, #649) menambah mode **full-online
+R2-only** untuk gambar berita — mandat "gambar hanya di Cloudflare R2,
+tidak pernah di filesystem lokal" **hanya berlaku bila mode ini
+diaktifkan secara eksplisit**. Issue #631 (dokumentasi arsitektur,
+selesai) mendefinisikan seluruh keputusan; Issue #632-#635 (implementasi
+preset/registry/upload/readiness, belum dikerjakan) yang benar-benar
+menambahkan env var `NEWS_MEDIA_R2_*` ke `.env.example`/doc 18 — lihat
+`docs/awcms-mini/news-portal/full-online-r2-architecture.md` §4 untuk
+konvensi penamaan lengkap dan
+`.claude/skills/awcms-mini-news-portal/SKILL.md` untuk status per issue.
+
+- **offline/LAN & development**: biarkan `NEWS_MEDIA_R2_ENABLED` tidak
+  di-set (default, begitu #632 mengimplementasikannya). Mode ini
+  **tidak berlaku** untuk offline/LAN — bukan sekadar default mati,
+  tapi memang di luar cakupan penggunaan mode ini sama sekali (lihat
+  `full-online-r2-architecture.md` §1).
+- **production (online)**, hanya bila operator memang menjalankan
+  portal berita publik dengan kredensial R2 aktif: aktifkan preset
+  (Issue #632) dan pastikan bucket + kredensial R2 media **berbeda**
+  dari `R2_BUCKET`/`R2_*` yang sudah dipakai `sync-storage` (§Storage di
+  atas) — ini bukan rekomendasi, tapi penegakan wajib di
+  `config:validate`/`security:readiness` begitu Issue #635 selesai
+  (lihat `docs/awcms-mini/news-portal/r2-security-checklist.md` §7).
+  Alasan pemisahan bucket: `sync-storage`'s R2 usage adalah object
+  queue **privat** untuk sinkronisasi offline/LAN, sedangkan media
+  berita **publik** by design (custom domain, CORS) — menyatukan
+  keduanya berisiko membocorkan objek sync privat lewat konfigurasi
+  publik yang ditujukan untuk media berita.
+- **Tidak ada fallback lokal**: berbeda dari `STORAGE_DRIVER=local`
+  (default base generik) yang tetap didukung penuh untuk kebutuhan lain,
+  mode R2-only news media secara eksplisit **melarang** fallback
+  filesystem lokal untuk gambar berita — kegagalan upload R2 gagal
+  secara eksplisit ke editor, bukan diam-diam ditulis ke
+  `LOCAL_STORAGE_PATH`.
+
 ## Cara menjalankan tiap profil
 
 ### development
@@ -569,3 +606,6 @@ profil non-development, termasuk offline/LAN (doc 18: "backup lokal").
 - [`visitor-analytics.md`](visitor-analytics.md) — panduan lengkap mode
   offline/LAN vs online, privacy-first default, retensi, dan pemetaan
   kepatuhan modul visitor analytics.
+- [`news-portal/full-online-r2-architecture.md`](news-portal/full-online-r2-architecture.md)
+  — arsitektur full-online R2-only media berita, SOP upload, security
+  checklist, incident response, backup/lifecycle, dan panduan editor.

--- a/docs/awcms-mini/news-portal/full-online-r2-architecture.md
+++ b/docs/awcms-mini/news-portal/full-online-r2-architecture.md
@@ -290,16 +290,47 @@ Catatan implementasi wajib untuk Issue #634:
 
 ## 9. Validasi MIME, ekstensi, dan checksum
 
-Urutan validasi wajib (server-side, sebelum objek dianggap `confirmed`):
+**Kedua jalur (§7) wajib menjalankan urutan validasi yang SAMA sebelum
+objek dianggap `confirmed` — tidak ada jalur pintas untuk Jalur A.**
+`HEAD` request (eksistensi/`Content-Length`/ETag) TIDAK PERNAH cukup
+untuk menaikkan status ke `confirmed`, karena `HEAD` tidak membaca isi
+objek — ia hanya membuktikan _sesuatu_ ter-upload, bukan _apa_ yang
+ter-upload. Presigned PUT S3-compatible juga tidak memverifikasi
+`Content-Type` yang dikirim client saat PUT terhadap apa pun yang
+disetujui server saat inisiasi upload — client bebas mem-PUT payload
+apa pun (mis. HTML/JS yang diberi nama/checksum seolah gambar) ke URL
+presigned yang sama. Karena itu langkah `confirm` WAJIB melakukan
+**ranged `GET`** (bukan `HEAD`) untuk membaca isi objek langsung dari
+R2, pada kedua jalur:
 
-1. **Ukuran** — tolak lebih awal (dari `Content-Length` atau saat stream
-   melampaui `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`) sebelum membaca isi file
-   — mencegah pemborosan CPU/bandwidth untuk file yang pasti ditolak
-   (juga mitigasi OWASP API4 "unrestricted resource consumption", §15).
-2. **MIME sniffing dari magic bytes**, bukan `Content-Type` header
-   client atau ekstensi nama file — header/ekstensi client adalah input
-   tidak tepercaya yang mudah dipalsukan. Allow-list default
+1. **Ukuran** — tolak lebih awal (dari `Content-Length` klaim awal atau
+   saat stream melampaui `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`) sebelum
+   membaca isi file, mencegah pemborosan CPU/bandwidth untuk file yang
+   pasti ditolak (mitigasi OWASP API4 "unrestricted resource
+   consumption", §15). **Residual risk pada Jalur A**: presigned PUT
+   (bukan presigned POST) tidak mendukung pembatasan ukuran di level
+   signature R2 — client secara teknis bisa mem-PUT byte lebih banyak
+   dari yang diklaim saat inisiasi. Mitigasi wajib: langkah `confirm`
+   membaca `Content-Length` sebenarnya dari R2 (`HEAD` sebagai
+   pengecekan cepat sebelum `GET`) dan menolak (`REJECTED` + jadwalkan
+   penghapusan objek) bila melebihi `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES` —
+   lapisan reaktif menyusul lapisan preventif ini; bandwidth yang
+   sudah terpakai untuk objek yang akhirnya ditolak adalah risiko yang
+   **diterima secara eksplisit** (sama pola dengan §8's residual risk
+   soal status Postgres vs akses storage-level), bukan diklaim sudah
+   tertutup penuh. Implementasi yang lebih kuat (opsional, di luar
+   cakupan epic ini): presigned **POST** dengan policy condition
+   `content-length-range`, yang menolak PUT berlebih di level R2
+   sebelum data sampai ke bucket sama sekali.
+2. **MIME sniffing dari magic bytes**, dijalankan terhadap isi objek
+   hasil ranged `GET` di atas — **bukan** `Content-Type` header client,
+   bukan ekstensi nama file, dan bukan checksum yang diklaim client
+   (ketiganya adalah input tidak tepercaya yang mudah
+   dipalsukan/self-referential). Allow-list default
    `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` (§4): JPEG, PNG, WebP, GIF.
+   Mismatch antara MIME yang diklaim saat inisiasi dan MIME hasil
+   sniffing berarti `REJECTED`, objek dijadwalkan penghapusan, dan
+   baris metadata tidak pernah naik status ke `confirmed`.
 3. **`image/svg+xml` sengaja TIDAK diizinkan** secara default — SVG bisa
    membawa `<script>`/event handler dan dieksekusi sebagai HTML oleh
    sebagian browser bila disajikan dengan `Content-Type` yang salah
@@ -310,17 +341,24 @@ Urutan validasi wajib (server-side, sebelum objek dianggap `confirmed`):
    dari ekstensi asli — menutup celah "file dengan MIME benar tapi
    ekstensi berbahaya (`.php.jpg`, `.jpg.exe`)" karena ekstensi asli
    tidak pernah dipercaya sama sekali.
-5. **Checksum SHA-256** — client mengirim checksum yang diklaim saat
-   inisiasi upload (Jalur A) atau server menghitung on-the-fly saat
-   streaming (Jalur B); langkah `confirm`/akhir stream membandingkan
-   checksum aktual objek di R2 (dari `HEAD`/hasil hashing stream)
-   terhadap yang diklaim — mismatch berarti `REJECTED`, baris metadata
-   tidak pernah naik status ke `confirmed`, dan objek di R2 (bila
-   sempat ter-upload di Jalur A) dijadwalkan pembersihan (bukan
-   dibiarkan `pending` selamanya — `r2-backup-lifecycle.md`).
-6. Empat langkah di atas adalah **defense in depth** yang berurutan —
+5. **Checksum SHA-256** — dihitung **server-side dari isi objek yang
+   benar-benar dibaca di langkah 2** (Jalur A: server menyelesaikan
+   `GET` penuh objek untuk menghitung digest, dibatasi
+   `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES` dari langkah 1, bukan hanya
+   membaca beberapa byte pertama untuk sniffing; Jalur B: server sudah
+   menghitung on-the-fly saat streaming). Checksum yang diklaim client
+   saat inisiasi (Jalur A) **hanya dipakai sebagai deteksi korupsi
+   transport** (bandingkan dua nilai yang sama-sama dihitung dari byte
+   yang benar-benar diterima server) — **tidak pernah** menjadi
+   satu-satunya bukti validasi konten/MIME, karena nilai itu
+   self-referential terhadap klaim client sendiri. Mismatch berarti
+   `REJECTED`, baris metadata tidak pernah naik status ke `confirmed`,
+   dan objek di R2 dijadwalkan pembersihan (bukan dibiarkan `pending`
+   selamanya — `r2-backup-lifecycle.md`).
+6. Lima langkah di atas adalah **defense in depth** yang berurutan —
    satu langkah gagal berarti seluruh upload ditolak, tidak ada
-   "sebagian lolos".
+   "sebagian lolos", dan tidak ada langkah yang dilewati hanya karena
+   sebuah jalur (A vs B) "sudah dipercaya lebih aman".
 
 ## 10. Konfigurasi CORS
 

--- a/docs/awcms-mini/news-portal/full-online-r2-architecture.md
+++ b/docs/awcms-mini/news-portal/full-online-r2-architecture.md
@@ -1,0 +1,602 @@
+# News Portal — Full-Online R2-Only Media Architecture
+
+Dokumen ini adalah **fondasi arsitektur** untuk epic `news-portal` (Issue
+#631-#642, #649) dan prasyarat untuk epic `social-publishing` (Issue
+#643-#647). Issue ini (**#631**) murni dokumentasi — tidak ada
+implementasi kode/migration/endpoint. Setiap issue lanjutan **wajib**
+membaca dokumen ini sebelum mengubah perilaku media/gambar berita, dan
+**wajib** mempertahankan keputusan di sini kecuali ada ADR baru yang
+secara eksplisit menggantikannya.
+
+Ringkasan status per issue: lihat
+`.claude/skills/awcms-mini-news-portal/SKILL.md`.
+
+## 1. Ruang lingkup & asumsi — full-online only
+
+**Ini bukan aturan untuk semua deployment.** Seluruh dokumen di
+`docs/awcms-mini/news-portal/` mengasumsikan **mode full-online R2-only**
+untuk gambar berita — deployment publik yang tersambung internet secara
+permanen dan sudah punya kredensial Cloudflare R2 aktif.
+
+- **TIDAK berlaku untuk offline/LAN** (doc 18 §Profil per-environment,
+  `deployment-profiles.md`). Deployment offline/LAN yang tidak pernah
+  mengaktifkan mode ini **tidak terpengaruh sama sekali** oleh epic ini —
+  tidak ada perubahan default, tidak ada migrasi yang mengubah perilaku
+  penyimpanan media yang sudah ada untuk deployment yang tidak
+  mengaktifkan preset ini (lihat Issue #632, yang akan menambah preset
+  `news_portal_full_online_r2` sebagai opsi eksplisit, bukan default
+  baru untuk seluruh base).
+- **TIDAK berlaku untuk modul lain.** `sync-storage`'s R2 usage (§2 di
+  bawah) tetap berjalan seperti sebelumnya — epic ini tidak mengubah
+  `awcms_mini_object_sync_queue`, dispatcher, atau env var `R2_*` yang
+  sudah ada.
+- Prasyarat produk: `blog_content` (base module, sudah `active`) dan
+  online public routing (`tenant_domain`, ADR-0009/ADR-0010) sudah
+  tersedia — news portal adalah lapisan editorial + media di atas
+  keduanya, bukan modul yang berdiri sendiri dari nol.
+- Setiap dokumen di folder ini yang menyebut "wajib"/"dilarang" berarti
+  **wajib/dilarang untuk mode full-online R2-only**, bukan untuk base
+  generik AWCMS-Mini secara keseluruhan.
+
+## 2. Hubungan dengan `sync-storage`'s R2 usage yang sudah ada — bucket terpisah
+
+`src/modules/sync-storage/` **sudah** memakai Cloudflare R2 sejak Issue
+6.3/#436 (`R2_ENABLED`, `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`,
+`R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, lihat
+`src/modules/sync-storage/README.md` §Scope — Issue 6.3 dan §Dispatcher).
+Ini bisa disalahpahami sebagai "R2 sudah ada, tinggal pakai bucket yang
+sama" — **keputusan arsitektural eksplisit di sini: JANGAN.** News
+portal media **wajib** memakai bucket R2 dan kredensial R2 yang
+**terpisah** dari `sync-storage`, dengan alasan konkret:
+
+| Aspek                    | `sync-storage`'s R2 usage (sudah ada)                                                             | News portal media (epic ini)                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Tujuan                   | Object queue **privat** untuk sinkronisasi antar-node offline/LAN (lampiran, receipt, file lokal) | Media **publik** yang memang harus bisa diakses siapa pun lewat CDN/custom domain                           |
+| Siapa yang menulis objek | Node sync (HMAC machine-to-machine) via dispatcher internal                                       | Editor/jurnalis (bearer session) via presigned upload atau server-streaming                                 |
+| Akses publik             | **Tidak pernah** — tidak ada custom domain, tidak ada CORS, tidak ada Cache-Control publik        | **By design** — custom domain, CORS untuk direct-upload dari browser, Cache-Control agresif untuk CDN       |
+| Isi objek                | Bisa berupa dokumen bisnis sensitif tenant (bukan cuma gambar)                                    | Gambar berita saja (MIME allow-list ketat, §9)                                                              |
+| Model ancaman dominan    | Kebocoran data bisnis privat bila bucket/CORS misconfigured jadi publik                           | Presigned URL bocor, object publik yang tidak diinginkan, upload berbahaya (§13, `r2-incident-response.md`) |
+| Rotasi kredensial        | Independen — rotasi tidak boleh mengganggu media publik                                           | Independen — rotasi/leak kredensial ini **tidak boleh** memberi akses ke objek sync privat                  |
+
+Konsekuensi konkret: **satu bucket publik yang salah konfigurasi CORS/
+custom domain tidak pernah bisa membocorkan objek sync privat**, dan
+**kompromi kredensial media publik (blast radius terbatas ke bucket yang
+memang sudah publik) tidak pernah memberi akses ke objek sync privat**.
+Sebaliknya, kompromi kredensial sync tidak pernah memberi akses tulis ke
+bucket media publik. Ini adalah penerapan langsung prinsip **least
+privilege** dan **segregation of duties** (lihat §15 ISO/IEC 27001 A.5.15,
+27017 CLD 6.3.1).
+
+Cloudflare account **boleh sama** (satu akun Cloudflare, dua bucket) —
+yang wajib terpisah adalah **bucket** dan **API token/kredensial R2**,
+bukan akun. Operator yang ingin isolasi lebih kuat (mis. akun Cloudflare
+terpisah per fungsi) tetap didukung karena konvensi env var di §4 tidak
+mengasumsikan akun yang sama.
+
+## 3. Prinsip inti (tidak bisa dinegosiasi issue lanjutan)
+
+1. **R2-only untuk binary gambar berita.** Setiap gambar berita
+   (featured image, gallery block, ad image, video thumbnail, SEO/social
+   preview image) **wajib** disimpan sebagai objek di bucket R2 media
+   berita — tidak ada jalur penyimpanan binary lain yang sah dalam mode
+   ini.
+2. **PostgreSQL hanya metadata.** Tabel media registry (dirancang Issue
+   #633) **tidak pernah** menyimpan bytes gambar — hanya `object_key`,
+   MIME, ukuran, checksum, dimensi, status, dan atribusi. Tidak ada kolom
+   `bytea`/`text` yang menampung gambar mentah atau base64 apa pun.
+3. **Tidak ada fallback filesystem lokal.** Bila upload ke R2 gagal
+   dalam mode ini, permintaan **gagal secara eksplisit** (error jelas ke
+   editor) — sistem **tidak pernah** diam-diam menulis ke
+   `LOCAL_STORAGE_PATH` sebagai pengganti. Ini kebalikan dari
+   `sync-storage` (yang memang punya "objek tetap lokal dulu, upload R2
+   belakangan" sebagai desain — lihat README modul itu) karena di mode
+   ini R2 **adalah** satu-satunya tempat penyimpanan yang sah, bukan
+   cadangan opsional.
+4. **Tidak ada file sementara di disk lokal server.** Baik jalur
+   direct-to-R2 maupun jalur server-streaming (§7) tidak pernah menulis
+   bytes gambar ke disk lokal server aplikasi — bukan hanya "dihapus
+   setelah dipakai", tapi memang tidak pernah ditulis sama sekali.
+5. **Default deny sebelum tervalidasi.** Objek tidak dianggap "media
+   berita sah" sampai lolos validasi MIME+ekstensi+checksum+ukuran (§9)
+   DAN baris metadata `confirmed` tercatat di Postgres — konten yang
+   direferensikan editorial (post, gallery, ads, video thumbnail) hanya
+   boleh menunjuk media berstatus `confirmed`.
+
+## 4. Konvensi environment variable (rencana penamaan, belum diimplementasikan)
+
+**Penting:** var di bawah **belum ada** di `.env.example`/
+`18_configuration_env_reference.md` — issue ini murni dokumentasi.
+Issue #632 (preset) dan #633 (registry) adalah yang benar-benar
+menambahkannya ke `.env.example`/doc 18/`scripts/validate-env.ts`. Nama
+di sini adalah **konvensi yang wajib diikuti** implementasi supaya tidak
+ada issue lanjutan yang menciptakan skema penamaan lain atau (lebih
+buruk) menimpakan arti baru ke `R2_*` yang sudah dipakai `sync-storage`.
+
+Prefix **`NEWS_MEDIA_R2_`** — sengaja berbeda dari `R2_*` generik
+(§2, disambiguasi eksplisit dari bucket sync):
+
+| Var (rencana)                                | Wajib bila   | Default                                     | Catatan                                                                                        |
+| -------------------------------------------- | ------------ | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `NEWS_MEDIA_R2_ENABLED`                      | –            | `false`                                     | Master switch mode R2-only news media. Bagian dari preset #632.                                |
+| `NEWS_MEDIA_R2_ACCOUNT_ID`                   | bila enabled | –                                           | Boleh sama dengan `R2_ACCOUNT_ID` (satu akun Cloudflare) atau berbeda (§2).                    |
+| `NEWS_MEDIA_R2_ACCESS_KEY_ID`                | bila enabled | –                                           | Token least-privilege terpisah dari `R2_ACCESS_KEY_ID` — **wajib** berbeda (§2, §13).          |
+| `NEWS_MEDIA_R2_SECRET_ACCESS_KEY`            | bila enabled | –                                           | Idem.                                                                                          |
+| `NEWS_MEDIA_R2_BUCKET`                       | bila enabled | –                                           | **Wajib** berbeda dari `R2_BUCKET` (§2) — divalidasi tidak sama saat `config:validate` (#635). |
+| `NEWS_MEDIA_R2_PUBLIC_BASE_URL`              | bila enabled | –                                           | Custom domain publik (§11), mis. `https://media.contoh-berita.id`. Harus HTTPS absolut.        |
+| `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` | –            | `300`                                       | TTL presigned PUT (§8). Bukan TTL baca — baca selalu publik lewat custom domain.               |
+| `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`             | –            | `10485760` (10 MiB)                         | Batas ukuran per file (§9).                                                                    |
+| `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`           | –            | `image/jpeg,image/png,image/webp,image/gif` | Allow-list MIME (§9) — **tidak termasuk** `image/svg+xml` (§9 alasan).                         |
+| `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`          | –            | `60`                                        | Batas usia objek `pending` sebelum dibersihkan lifecycle job (`r2-backup-lifecycle.md`).       |
+
+Implementor (#632/#633/#634) wajib memakai nama ini persis — jangan
+memilih nama lain "yang mirip" tanpa memperbarui tabel ini.
+
+## 5. Model data konseptual — media registry (rencana untuk Issue #633)
+
+Bentuk metadata target (bukan DDL final — Issue #633 yang menulis
+migration sebenarnya, mengikuti skill `awcms-mini-new-migration`):
+
+```text
+awcms_mini_news_media_objects (tenant-scoped, RLS ENABLE+FORCE)
+- id                 uuid PK
+- tenant_id          uuid FK -> awcms_mini_tenants
+- object_key         text UNIQUE (per tenant)   -- §6
+- original_filename  text                       -- hanya untuk tampilan, TIDAK pernah masuk object_key (§6)
+- mime_type          text                       -- hasil validasi server (§9), bukan input mentah client
+- byte_size          bigint
+- checksum_sha256    text
+- width_px/height_px integer, nullable           -- diisi bila server bisa membaca dimensi gambar
+- purpose            text  -- featured|gallery|ad|video_thumbnail|seo_share
+- status             text  -- pending|confirmed|orphaned|deleted (soft delete, doc 05)
+- alt_text           text, nullable              -- aksesibilitas (doc 14), wajib diisi sebelum publish (Issue #636/#640)
+- uploaded_by         uuid FK -> awcms_mini_identities
+- created_at, confirmed_at, deleted_at, deleted_by
+```
+
+Catatan desain yang wajib dipertahankan:
+
+- **Tidak ada kolom binary apa pun** (§3.2) — pelanggaran ini adalah
+  regresi kritis bila terjadi di issue mana pun.
+- **`status='pending'` bukan jaminan objek tidak bisa diakses publik** —
+  lihat §8 residual risk. Jangan berasumsi baris Postgres mengontrol
+  akses storage-level.
+- Konten editorial (`blog_content`'s `featuredMediaId`, block `gallery`,
+  dsb.) **harus** menunjuk baris `status='confirmed'` di tabel ini
+  ketika mode R2-only aktif — inilah yang diterapkan Issue #636 (bukan
+  issue ini).
+
+## 6. Konvensi object key
+
+Format wajib:
+
+```text
+news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}
+```
+
+- `tenantId` — UUID tenant (bukan `tenantCode` yang human-readable) —
+  konsisten dengan isolasi ABAC/RLS berbasis UUID di seluruh repo, dan
+  menghindari kebocoran slug tenant yang bisa ditebak lewat pola key.
+- `{yyyy}/{mm}` — partisi tanggal upload, memudahkan lifecycle
+  rule/retensi per periode (`r2-backup-lifecycle.md`) tanpa perlu daftar
+  objek penuh.
+- `{uuid}` — `crypto.randomUUID()` (Bun-native, konsisten dengan
+  konvensi ID lain di repo) — **satu-satunya** komponen yang
+  mengidentifikasi file secara unik. Objek key **tidak pernah**
+  menyertakan nama file asli, judul artikel, atau teks apa pun yang
+  disediakan client — mencegah path traversal, karakter tidak aman,
+  kebocoran informasi lewat URL (mis. nama file berisi nama orang), dan
+  membuat key tidak bisa ditebak (mitigasi tambahan untuk §8 residual
+  risk).
+- `{ext}` — **diturunkan dari MIME type yang sudah divalidasi server**
+  (§9: `image/jpeg`→`.jpg`, `image/png`→`.png`, `image/webp`→`.webp`,
+  `image/gif`→`.gif`), **bukan** dari ekstensi asli file client. Ini
+  menutup celah spoofing "file.jpg yang sebenarnya berisi PHP/HTML".
+
+`original_filename` tetap disimpan (kolom metadata terpisah, §5) untuk
+ditampilkan ke editor ("photo-lapangan.jpg") tanpa pernah memengaruhi
+key penyimpanan.
+
+## 7. Alur upload — direct-to-R2 atau server-streaming, tanpa temp file lokal
+
+Dua jalur yang sah (implementasi konkret: Issue #634). Keduanya
+**dilarang** menulis bytes gambar ke disk lokal server aplikasi.
+
+```mermaid
+sequenceDiagram
+  participant Editor as Editor (browser)
+  participant API as AWCMS-Mini API
+  participant R2 as Cloudflare R2
+
+  rect rgb(235,245,255)
+  note over Editor,R2: Jalur A — Direct-to-R2 (disarankan, default)
+  Editor->>API: POST /news-media/uploads (mime, size, checksum client)
+  API->>API: Validasi shape + kuota + izin (ABAC)
+  API->>R2: Generate presigned PUT (object_key baru, TTL pendek §8)
+  API-->>Editor: presignedUrl + objectKey
+  Editor->>R2: PUT langsung (bytes tidak pernah lewat server AWCMS-Mini)
+  Editor->>API: POST /news-media/{objectKey}/confirm (checksum, size aktual)
+  API->>R2: HEAD objectKey (verifikasi eksistensi, ETag, size)
+  API->>API: Insert/UPDATE metadata status=confirmed (Idempotency-Key)
+  end
+```
+
+```mermaid
+sequenceDiagram
+  participant Editor as Editor / integrasi lain
+  participant API as AWCMS-Mini API
+  participant R2 as Cloudflare R2
+
+  rect rgb(255,245,235)
+  note over Editor,R2: Jalur B — Server-streaming (saat direct-to-R2 tidak memungkinkan)
+  Editor->>API: POST /news-media/uploads (multipart/form-data, streamed)
+  API->>API: Validasi header MIME + size limit dari stream (§9), TANPA fs.write sementara
+  API->>R2: Streaming PUT (ReadableStream diteruskan langsung ke Bun.S3Client, bukan buffer disk)
+  API->>API: Hitung checksum on-the-fly saat stream lewat, cocokkan post-hoc
+  API-->>Editor: metadata confirmed (satu round-trip, tidak ada langkah confirm terpisah)
+  end
+```
+
+Catatan implementasi wajib untuk Issue #634:
+
+- Jalur A adalah **default yang disarankan** — beban bandwidth upload
+  tidak pernah melewati server aplikasi, konsisten dengan prinsip "tidak
+  ada temp file lokal" secara struktural (server tidak pernah memegang
+  bytes-nya sama sekali).
+- Jalur B **tetap harus** streaming murni (Bun `ReadableStream`/
+  `Request.body` diteruskan langsung ke client R2, bukan
+  `await request.arrayBuffer()` lalu simpan ke variabel besar dan bukan
+  `Bun.write(tempPath, ...)` — validasi ukuran harus memotong stream
+  begitu `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES` terlampaui, bukan menunggu
+  keseluruhan body diterima dulu).
+- `confirm` (Jalur A) adalah **mutation high-risk** (mendaftarkan media
+  yang akan tampil publik) — wajib `Idempotency-Key` (skill
+  `awcms-mini-idempotency`) supaya retry client tidak membuat baris
+  metadata duplikat untuk `object_key` yang sama.
+- Pemanggilan R2 (presign, HEAD, PUT streaming) **tidak pernah** di
+  dalam DB transaction (ADR-0006) — pola yang sama dengan
+  `object-dispatch.ts`'s CLAIM/UPLOAD/FINALIZE tiga-fase, walau di sini
+  urutannya terbalik (validasi dulu, lalu upload, baru commit metadata)
+  karena upload diinisiasi langsung oleh user request, bukan dispatcher
+  latar belakang.
+
+## 8. Lifecycle & expiry presigned URL
+
+- **Presigned upload (PUT) TTL pendek** — default
+  `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS=300` (5 menit). Cukup untuk
+  satu upload interaktif, terlalu pendek untuk berguna bagi URL yang
+  bocor lama setelah di-generate.
+- **Presigned URL tidak benar-benar "single-use"** secara protokol S3/R2
+  — valid sampai TTL habis, siapa pun yang memegang URL bisa PUT ke situ
+  selama TTL belum lewat. Mitigasi: TTL pendek + `object_key` per-upload
+  yang baru (tidak pernah reuse presigned URL untuk key yang sama) +
+  langkah `confirm` yang memverifikasi checksum aktual (menolak upload
+  yang isinya beda dari yang diklaim, sekalipun URL-nya valid).
+- **Tidak ada presigned URL untuk GET/baca.** Gambar berita memang
+  publik by design — pembacaan selalu lewat custom domain publik (§11),
+  bukan presigned GET. Ini menyederhanakan model: hanya jalur upload
+  yang perlu proteksi TTL, jalur baca tidak punya "kredensial" untuk
+  bocor sama sekali.
+- **Residual risk yang wajib didokumentasikan setiap issue lanjutan**:
+  begitu PUT sukses ke `object_key` yang valid, objek itu **langsung
+  reachable publik** lewat custom domain (bucket publik tidak menegakkan
+  ACL per-objek berbasis status Postgres) — status `pending` di
+  Postgres **tidak memblokir** akses storage-level. Mitigasi berlapis:
+  (1) `object_key` tidak bisa ditebak (UUID, §6), (2) konten editorial
+  tidak pernah menunjuk objek `pending` (§5), (3) objek `pending` yang
+  tidak pernah di-`confirm` dibersihkan otomatis setelah
+  `NEWS_MEDIA_R2_PENDING_TTL_MINUTES` (`r2-backup-lifecycle.md` §Lifecycle
+  objek pending). Lihat juga `r2-incident-response.md` §Public object
+  exposure.
+
+## 9. Validasi MIME, ekstensi, dan checksum
+
+Urutan validasi wajib (server-side, sebelum objek dianggap `confirmed`):
+
+1. **Ukuran** — tolak lebih awal (dari `Content-Length` atau saat stream
+   melampaui `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`) sebelum membaca isi file
+   — mencegah pemborosan CPU/bandwidth untuk file yang pasti ditolak
+   (juga mitigasi OWASP API4 "unrestricted resource consumption", §15).
+2. **MIME sniffing dari magic bytes**, bukan `Content-Type` header
+   client atau ekstensi nama file — header/ekstensi client adalah input
+   tidak tepercaya yang mudah dipalsukan. Allow-list default
+   `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` (§4): JPEG, PNG, WebP, GIF.
+3. **`image/svg+xml` sengaja TIDAK diizinkan** secara default — SVG bisa
+   membawa `<script>`/event handler dan dieksekusi sebagai HTML oleh
+   sebagian browser bila disajikan dengan `Content-Type` yang salah
+   (vektor XSS well-known). Mengizinkan SVG di masa depan membutuhkan
+   pipeline sanitasi khusus (di luar cakupan epic ini) dan keputusan
+   eksplisit terpisah, bukan sekadar menambah ke allow-list.
+4. **Ekstensi object key diturunkan dari MIME tervalidasi** (§6), bukan
+   dari ekstensi asli — menutup celah "file dengan MIME benar tapi
+   ekstensi berbahaya (`.php.jpg`, `.jpg.exe`)" karena ekstensi asli
+   tidak pernah dipercaya sama sekali.
+5. **Checksum SHA-256** — client mengirim checksum yang diklaim saat
+   inisiasi upload (Jalur A) atau server menghitung on-the-fly saat
+   streaming (Jalur B); langkah `confirm`/akhir stream membandingkan
+   checksum aktual objek di R2 (dari `HEAD`/hasil hashing stream)
+   terhadap yang diklaim — mismatch berarti `REJECTED`, baris metadata
+   tidak pernah naik status ke `confirmed`, dan objek di R2 (bila
+   sempat ter-upload di Jalur A) dijadwalkan pembersihan (bukan
+   dibiarkan `pending` selamanya — `r2-backup-lifecycle.md`).
+6. Empat langkah di atas adalah **defense in depth** yang berurutan —
+   satu langkah gagal berarti seluruh upload ditolak, tidak ada
+   "sebagian lolos".
+
+## 10. Konfigurasi CORS
+
+Bucket media berita butuh CORS untuk Jalur A (§7) karena browser editor
+melakukan PUT langsung ke R2 dari origin admin AWCMS-Mini:
+
+```json
+[
+  {
+    "AllowedOrigins": ["https://admin.contoh-berita.id"],
+    "AllowedMethods": ["PUT"],
+    "AllowedHeaders": ["content-type", "content-md5"],
+    "MaxAgeSeconds": 300
+  }
+]
+```
+
+Prinsip:
+
+- `AllowedOrigins` **wajib** daftar eksplisit origin admin tenant
+  (`APP_URL`/custom domain admin) — **tidak pernah** `"*"`. Wildcard
+  origin pada bucket yang menerima PUT berarti origin mana pun bisa
+  memicu upload memakai presigned URL yang bocor ke halaman lain (CSRF
+  gaya storage).
+- `AllowedMethods` hanya `PUT` (dan `OPTIONS` preflight implisit) — bucket
+  ini tidak butuh CORS untuk `GET` karena pembacaan publik lewat custom
+  domain tidak melalui fetch cross-origin browser dengan credential apa
+  pun yang perlu diverifikasi CORS untuk sekadar menampilkan `<img>`.
+- Bucket **sync-storage** (§2) tidak butuh CORS sama sekali — tidak ada
+  browser yang pernah PUT langsung ke bucket itu. Jangan menyalin
+  konfigurasi CORS ini ke bucket sync.
+
+## 11. Custom domain R2 & public image base URL
+
+- `NEWS_MEDIA_R2_PUBLIC_BASE_URL` (§4) — domain kustom yang di-mapping
+  operator ke bucket R2 media (fitur "Custom Domains" Cloudflare R2),
+  bukan URL `r2.dev` bawaan (yang tidak stabil untuk produksi dan tidak
+  mendukung caching/branding kustom).
+- URL publik akhir sebuah objek = `{NEWS_MEDIA_R2_PUBLIC_BASE_URL}/{object_key}`
+  — API/UI **tidak pernah** menyimpan URL absolut penuh sebagai sumber
+  kebenaran di kolom terpisah (hindari drift bila base URL berubah);
+  selalu derive dari `object_key` + config saat render, pola yang sama
+  dengan `resolveCanonicalUrl`'s pendekatan "derive, don't duplicate" di
+  `blog-content`.
+- Domain kustom ini **berbeda** dari `PUBLIC_PLATFORM_ROOT_DOMAIN`/
+  tenant domain routing (epic #555) — satu untuk media statis, satu
+  untuk routing halaman HTML tenant. Boleh subdomain dari domain yang
+  sama (mis. `media.` vs domain utama) tapi secara konfigurasi
+  independen.
+- TLS/HTTPS wajib untuk domain kustom ini — gambar berita yang disajikan
+  lewat HTTP polos akan memicu mixed-content warning pada halaman
+  `/news` yang sudah HTTPS.
+
+## 12. Strategi Cache-Control
+
+- Objek media berita **immutable per key** (§6: key baru untuk setiap
+  upload, tidak pernah menimpa key yang sama dengan konten berbeda) —
+  jadi aman memakai Cache-Control agresif:
+  `Cache-Control: public, max-age=31536000, immutable` (1 tahun) di
+  level objek R2 saat upload (bukan di level custom domain saja).
+- Karena objek immutable, "mengganti gambar" berarti **upload objek
+  baru** (key baru) dan memperbarui referensi (`featuredMediaId`, dsb.)
+  ke key baru — bukan overwrite key lama. Ini juga menutup risiko cache
+  poisoning (CDN/browser tidak pernah menyajikan versi lama dari key
+  yang "diubah" karena key yang diubah selalu baru).
+- Objek `pending` yang belum `confirmed` **tidak perlu** Cache-Control
+  berbeda — mereka seharusnya tidak pernah direferensikan tempat publik
+  mana pun sebelum `confirmed` (§5), jadi cache header-nya tidak relevan
+  secara praktis, tapi tetap diberi header yang sama saat upload (objek
+  R2 tidak punya cara murah untuk "memperbarui header nanti" tanpa
+  menulis ulang objek).
+
+## 13. Kredensial R2 — rotasi & least privilege
+
+Ringkasan (detail penuh + langkah operasional: `r2-security-checklist.md`
+§Kredensial):
+
+- API token R2 untuk media berita **wajib** dibatasi ke **satu bucket**
+  (`NEWS_MEDIA_R2_BUCKET`) — Cloudflare R2 API token mendukung scoping
+  per-bucket; jangan pernah memakai token "Account API Token" bergaya
+  admin penuh untuk kredensial yang disuntik ke environment aplikasi.
+- Rotasi terjadwal (rekomendasi: 90 hari, atau segera setelah insiden —
+  `r2-incident-response.md`) tanpa downtime: buat token baru → update
+  env var → restart/redeploy → cabut token lama, bukan cabut lalu buat
+  (mencegah window tanpa kredensial valid).
+- Least privilege: token hanya perlu `Object Read & Write` untuk bucket
+  media (upload dari server pada Jalur B, HEAD verifikasi pada Jalur A)
+  — tidak pernah butuh permission administratif bucket (delete bucket,
+  ubah CORS/lifecycle policy lewat API token yang sama yang disuntik ke
+  runtime aplikasi; perubahan konfigurasi bucket itu sendiri dilakukan
+  operator lewat dashboard/Terraform terpisah, bukan oleh aplikasi saat
+  runtime).
+
+## 14. Diagram trust boundary
+
+```mermaid
+flowchart LR
+  subgraph Browser["Browser editor (tidak tepercaya sebagian)"]
+    U[Editor]
+  end
+  subgraph App["AWCMS-Mini app (tepercaya)"]
+    API[API /news-media/*]
+    PG[(PostgreSQL — metadata only)]
+  end
+  subgraph R2Media["R2 bucket media berita (publik-baca)"]
+    Obj[(Objek gambar, immutable per key)]
+  end
+  subgraph R2Sync["R2 bucket sync-storage (privat, TERPISAH — §2)"]
+    ObjSync[(Objek sync privat)]
+  end
+
+  U -- "1 presigned PUT / streaming (§7)" --> API
+  API -- "2 generate presign / stream" --> R2Media
+  U -. "3 PUT langsung (Jalur A)" .-> R2Media
+  API -- "4 metadata confirmed" --> PG
+  R2Media -- "5 GET publik lewat custom domain (§11)" --> Public[Pembaca publik /news]
+  API -. "kredensial & bucket berbeda, tidak pernah bersinggungan" .-> R2Sync
+```
+
+## 15. Pemetaan kepatuhan
+
+Pemetaan level-praktis: bagian dokumen mana yang menutup kontrol mana.
+Bukan tabel kosong — setiap baris merujuk keputusan konkret di atas.
+
+### ISO/IEC 27001:2022 Annex A
+
+| Kontrol Annex A                           | Implementasi                                                                                                                            |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **A.5.15 Kontrol akses**                  | Presigned upload di-generate hanya untuk identity dengan permission `news_media.upload` (rencana Issue #633/#634), tidak pernah publik. |
+| **A.5.23 Keamanan layanan cloud**         | §2 — segregasi bucket/kredensial per fungsi (media publik vs sync privat), §13 least-privilege token per bucket.                        |
+| **A.8.10 Penghapusan informasi**          | §8/§12 objek `pending` kedaluwarsa dibersihkan; `r2-backup-lifecycle.md` §Retention untuk penghapusan objek `deleted`.                  |
+| **A.8.12 Pencegahan kebocoran data**      | §10 CORS allow-list eksplisit (bukan wildcard); §2 bucket terpisah mencegah kebocoran objek sync privat lewat konfigurasi publik.       |
+| **A.8.24 Kriptografi**                    | §9 checksum SHA-256 wajib untuk integritas; TLS wajib untuk custom domain (§11) dan komunikasi ke R2 API.                               |
+| **A.8.25 Siklus hidup pengembangan aman** | §9 urutan validasi defense-in-depth wajib diimplementasikan sebelum kode upload ditulis (ISO 27034, lihat di bawah).                    |
+| **A.5.30 Kesiapan TIK untuk kontinuitas** | §16/22301 di bawah — tidak ada fallback lokal berarti kesiapan R2 sendiri jadi kritis; lihat `r2-backup-lifecycle.md`.                  |
+| **A.5.34 Privasi dan perlindungan PII**   | §5 minimisasi metadata, §6 object key tidak pernah berisi nama file/PII; `r2-backup-lifecycle.md` §Privasi.                             |
+
+### ISO/IEC 27002:2022
+
+Panduan implementasi untuk kontrol Annex A yang sama di atas sudah
+tercermin di level desain, bukan hanya kebijakan tertulis: A.5.23
+(layanan cloud) diwujudkan sebagai pemisahan bucket/kredensial yang
+ditegakkan lewat env var terpisah (§4) — bukan konvensi penamaan yang
+bisa dilupakan; A.8.25 (SDLC aman) diwujudkan sebagai urutan validasi
+eksplisit (§9) yang harus diimplementasikan sebelum endpoint upload
+sendiri ditulis, bukan ditambahkan belakangan sebagai perbaikan.
+
+### ISO/IEC 27005:2023 (manajemen risiko)
+
+Risiko utama yang diidentifikasi epic ini dan perlakuannya:
+
+| Risiko                                                         | Perlakuan                                                                                                                                                                      |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Presigned upload URL bocor                                     | **Mitigasi** — TTL pendek (§8), checksum verification di `confirm`, tidak pernah presigned untuk GET.                                                                          |
+| Objek publik tidak diinginkan (upload salah / bucket publik)   | **Mitigasi + risiko residual diterima** — key tidak bisa ditebak (§6), status Postgres tidak mengontrol storage-level access (§8, diterima secara eksplisit, bukan diabaikan). |
+| Upload berbahaya (MIME spoofing, file besar, SVG XSS)          | **Mitigasi** — §9 validasi berlapis, SVG dilarang default.                                                                                                                     |
+| Kompromi kredensial media memberi akses ke bucket sync privat  | **Dihindari (avoidance)** — §2 bucket/token terpisah secara struktural, bukan mitigasi setelah fakta.                                                                          |
+| Ketergantungan penuh pada ketersediaan R2 (tidak ada fallback) | **Diterima sebagai trade-off eksplisit** dari mandat "R2-only, full-online" — lihat §16 ISO 22301.                                                                             |
+
+### ISO/IEC 27017:2023 (kontrol keamanan cloud)
+
+- **CLD 6.3.1 (segregasi di lingkungan virtual bersama)** — §2: bucket
+  terpisah adalah wujud segregasi antar-fungsi dalam akun cloud yang
+  sama.
+- **CLD 9.5.1 (penghapusan aset pelanggan layanan cloud)** — §8/§12,
+  `r2-backup-lifecycle.md`: kebijakan lifecycle eksplisit untuk objek
+  yang tidak lagi dibutuhkan.
+- **CLD 12.1.5 (keamanan operasional administrator)** — §13: rotasi
+  kredensial dan larangan token administratif penuh di runtime aplikasi.
+- **Model tanggung jawab bersama**: Cloudflare bertanggung jawab atas
+  keamanan fisik/infrastruktur R2 dan enforcement CORS/custom domain
+  yang dikonfigurasi; AWCMS-Mini bertanggung jawab atas konfigurasi
+  (CORS §10, lifecycle §12) dan validasi aplikasi (§9). Dokumen ini
+  tidak berasumsi Cloudflare menyediakan kontrol yang tidak
+  didokumentasikan publik oleh mereka.
+
+### ISO/IEC 27018:2023 (perlindungan PII di cloud publik)
+
+Gambar berita bisa memuat wajah/individu yang bisa diidentifikasi
+(bukan hanya "gambar generik") — R2 di sini berperan sebagai penyimpan
+data yang berpotensi PII visual:
+
+- **Minimisasi** — §5/§6: tidak ada PII tekstual (nama, deskripsi
+  pribadi) yang dipaksa masuk metadata/object key; `alt_text` diisi
+  editor secara sadar (bisa memilih deskripsi netral).
+- **Pembatasan tujuan** — objek media berita hanya dipakai untuk tampilan
+  editorial yang direferensikan eksplisit (§5 `purpose` enum), tidak ada
+  pemrosesan sekunder (mis. face recognition) di scope epic ini.
+- **Transparansi** — `newsroom-user-guide.md` §Privasi mengingatkan
+  editor untuk memperhatikan consent/privasi subjek foto sebelum
+  publish (kontrol prosedural, bukan teknis — didokumentasikan secara
+  eksplisit, bukan diasumsikan).
+
+### ISO/IEC 27701:2019 (PIMS)
+
+AWCMS-Mini berperan sebagai **PII controller** untuk tenant sendiri
+(bukan processor pihak ketiga — R2 adalah sub-processor infrastruktur,
+bukan penerima data untuk tujuan lain):
+
+- **7.4 Minimisasi PII** — §5/§6 (di atas).
+- **7.9 Penghapusan PII** — `r2-backup-lifecycle.md` §Retention/§Purge:
+  siklus hapus metadata (soft delete) + objek fisik R2 setelah masa
+  tenggang.
+- **6.2 Kondisi pemrosesan** — media hanya diproses untuk tujuan
+  editorial yang dideklarasikan (`purpose`), tidak untuk profiling.
+
+### ISO/IEC 27034 (keamanan aplikasi)
+
+Dokumen ini **adalah** artefak normatif SDLC aman untuk fitur upload
+sebelum kode ditulis (ONF — Organizational Normative Framework, level
+praktis): §9 mendefinisikan Application Security Control yang wajib ada
+sebelum endpoint `POST /news-media/uploads` diimplementasikan (Issue
+#634), bukan checklist yang ditambahkan setelah kode selesai. Threat
+model lengkap tetap di `20_threat_model_security_architecture.md` —
+issue lanjutan yang mengimplementasikan upload API wajib menambah
+subbagian "Standar tambahan dipicu epic news-portal" di dokumen itu,
+mengikuti pola epic-epic sebelumnya (lihat subbagian visitor-analytics/
+auth-online-hardening di dokumen yang sama).
+
+### ISO 22301 (kontinuitas bisnis)
+
+- **Trade-off eksplisit**: mandat "R2-only, tidak ada fallback lokal"
+  (§3) berarti ketersediaan R2 = ketersediaan upload gambar berita baru.
+  Ini **diterima secara sadar**, bukan diabaikan — konten teks/artikel
+  tetap bisa dipublikasikan tanpa gambar (gambar bukan syarat mutlak
+  `blog_content`'s post), dan gambar yang **sudah** ter-upload tetap
+  bisa dibaca (custom domain publik R2 independen dari ketersediaan
+  aplikasi AWCMS-Mini itu sendiri — R2 melayani langsung, tidak lewat
+  proxy aplikasi).
+- **RTO/RPO untuk media**: lihat `r2-backup-lifecycle.md` §Kontinuitas —
+  strategi replikasi/backup objek dan target waktu pemulihan.
+- **Komunikasi insiden**: `r2-incident-response.md` §Roles & escalation.
+
+### OWASP ASVS (level L1/L2 relevan)
+
+| Kontrol ASVS                                             | Implementasi                                                                                                   |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| **V12.1/V12.4 (validasi file upload, penyimpanan file)** | §9 urutan validasi MIME/ekstensi/checksum/ukuran; §3 penyimpanan di luar filesystem aplikasi (object storage). |
+| **V4.1/V4.2 (kontrol akses fungsi/data)**                | Presigned upload hanya untuk identity berizin (§15 A.5.15); tenant-scoped melalui `object_key` prefix (§6).    |
+| **V9.1 (komunikasi TLS)**                                | §11 HTTPS wajib untuk custom domain dan panggilan API R2.                                                      |
+| **V14.3 (konfigurasi aman by default)**                  | Semua `NEWS_MEDIA_R2_*` default aman (§4): mode nonaktif default, SVG tidak diizinkan default.                 |
+| **V3.x (manajemen token/kredensial sesi setara)**        | Presigned URL diperlakukan setara bearer credential jangka pendek (§8) — tidak pernah dicatat penuh di log.    |
+
+### OWASP API Security Top 10 (2023)
+
+| Risiko                                              | Kontrol                                                                                                                            |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **API1 Broken Object Level Authorization**          | `object_key` tenant-scoped + tidak bisa ditebak (§6); endpoint upload/confirm wajib cek tenant context (ABAC).                     |
+| **API3 Broken Object Property Level Authorization** | Field metadata yang boleh diisi client dibatasi (mime/size/checksum diklaim, bukan status/id — status hanya diubah server).        |
+| **API4 Unrestricted Resource Consumption**          | §9 langkah 1 (batas ukuran ditegakkan sebelum baca isi file), `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`.                                    |
+| **API7 Server Side Request Forgery**                | Endpoint upload tidak pernah mengambil URL dari input client untuk di-fetch server-side — hanya menerima bytes/stream langsung.    |
+| **API8 Security Misconfiguration**                  | §10 CORS allow-list eksplisit; §13 token least-privilege per bucket; readiness check (`r2-security-checklist.md`) sebelum go-live. |
+| **API9 Improper Inventory Management**              | Tabel media registry (§5) adalah inventaris eksplisit setiap objek yang pernah diklaim dipakai — bukan asumsi implisit.            |
+| **API10 Unsafe Consumption of APIs**                | Panggilan ke R2 API timeout-bounded + circuit breaker (pola sama `object-storage` breaker yang sudah ada di `sync-storage`).       |
+
+## 16. Peta issue lanjutan
+
+| Issue                 | Bagian dokumen ini yang diimplementasikan                                                      |
+| --------------------- | ---------------------------------------------------------------------------------------------- |
+| #632                  | §4 env var + preset `news_portal_full_online_r2`, §1 gating full-online                        |
+| #633                  | §5 media registry schema, §6 object key generator                                              |
+| #634                  | §7 alur upload, §8 presigned URL, §9 validasi                                                  |
+| #635                  | §13 readiness (`config:validate`/`security:readiness`/`production:preflight`)                  |
+| #636                  | §5 "konten editorial wajib menunjuk media confirmed" diterapkan ke `blog_content`              |
+| #637-#640, #642, #649 | Konsumsi media registry untuk fitur editorial spesifik (lihat skill untuk ringkasan per issue) |
+
+## 17. Referensi
+
+- `docs/awcms-mini/news-portal/r2-upload-sop.md` — SOP operasional upload.
+- `docs/awcms-mini/news-portal/r2-security-checklist.md` — checklist keamanan siap-pakai.
+- `docs/awcms-mini/news-portal/r2-incident-response.md` — runbook insiden.
+- `docs/awcms-mini/news-portal/r2-backup-lifecycle.md` — backup/lifecycle/retensi.
+- `docs/awcms-mini/news-portal/newsroom-user-guide.md` — panduan editor.
+- `.claude/skills/awcms-mini-news-portal/SKILL.md` — status per issue.
+- `src/modules/sync-storage/README.md` — R2 usage yang sudah ada (§2).
+- `docs/adr/0006-offline-first-sync-outbox.md` — prinsip provider eksternal opsional/di luar transaksi.
+- `docs/awcms-mini/deployment-profiles.md` §News portal — ringkasan per profil deployment.
+- `docs/awcms-mini/18_configuration_env_reference.md` §Storage — konvensi `R2_*` yang sudah ada.
+- `docs/awcms-mini/20_threat_model_security_architecture.md` — threat model dasar (subbagian epic ini menyusul di Issue #635).

--- a/docs/awcms-mini/news-portal/newsroom-user-guide.md
+++ b/docs/awcms-mini/news-portal/newsroom-user-guide.md
@@ -1,0 +1,117 @@
+# News Portal — Newsroom User Guide
+
+Panduan untuk editor/jurnalis yang mengunggah gambar berita di admin
+AWCMS-Mini, mode **full-online R2-only** (lihat
+[`full-online-r2-architecture.md`](full-online-r2-architecture.md) §1 —
+panduan ini berlaku ketika deployment tenant Anda menggunakan mode ini;
+tanyakan ke administrator sistem bila tidak yakin). Dokumen ini
+menjelaskan **apa yang dialami editor**, bukan detail implementasi —
+untuk SOP teknis lihat [`r2-upload-sop.md`](r2-upload-sop.md).
+
+> **Catatan status**: layar upload gambar itu sendiri belum
+> diimplementasikan pada saat dokumen ini ditulis (Issue #631,
+> docs-only) — panduan ini menjelaskan **perilaku target** yang akan
+> berlaku setelah Issue #632-#634 selesai. Bagian yang bergantung pada
+> UI konkret ditandai jelas di bawah.
+
+## 1. Mengapa gambar berita disimpan berbeda
+
+Semua gambar berita di mode ini disimpan di **Cloudflare R2**, bukan di
+server aplikasi. Bagi editor, ini berarti:
+
+- Upload gambar sedikit berbeda dari "attach file biasa" — ada langkah
+  tambahan di balik layar (upload langsung ke penyimpanan, lalu
+  konfirmasi), tapi dari sisi UI tetap satu aksi "pilih file → upload".
+- Setelah gambar berhasil diunggah dan dikonfirmasi, gambar tersebut
+  **tidak bisa diganti isinya** — mengganti gambar berarti mengunggah
+  file baru dan memilihnya ulang, bukan "menimpa" file lama.
+- Tidak ada opsi "simpan ke folder lokal server" — bila upload ke R2
+  gagal (mis. jaringan/penyimpanan sedang bermasalah), sistem akan
+  menampilkan error dengan jelas, bukan diam-diam menyimpan ke tempat
+  lain.
+
+## 2. Cara mengunggah gambar berita (alur target)
+
+1. Buka editor post/halaman/iklan yang mendukung gambar (featured image,
+   galeri, iklan, thumbnail video).
+2. Pilih "Unggah gambar" → pilih file dari perangkat Anda.
+3. Sistem memvalidasi format dan ukuran file **sebelum** upload selesai
+   — Anda akan melihat pesan error langsung bila file tidak didukung.
+4. Tunggu hingga progres upload selesai dan status berubah menjadi
+   "Terkonfirmasi"/"Confirmed". Gambar yang belum terkonfirmasi
+   **belum** akan tampil di halaman publik.
+5. Isi teks alternatif (`alt text`)/keterangan gambar — wajib untuk
+   aksesibilitas dan SEO (lihat §5 di bawah).
+
+## 3. Format dan ukuran file yang didukung
+
+- Format yang didukung: **JPEG, PNG, WebP, GIF**.
+- **SVG tidak didukung** untuk gambar berita — ini bukan keterbatasan
+  sementara, tapi keputusan keamanan (file SVG bisa menyembunyikan
+  kode berbahaya). Bila Anda punya logo/ilustrasi vektor, konversi ke
+  PNG/WebP terlebih dahulu sebelum mengunggah.
+- Ukuran maksimum per file: **10 MB** (default — administrator sistem
+  Anda bisa mengubah batas ini; tanyakan bila Anda rutin bekerja dengan
+  file lebih besar, mis. foto resolusi sangat tinggi).
+
+## 4. Pesan error umum dan artinya
+
+| Pesan/gejala                                                 | Artinya                                                                                               | Yang harus dilakukan                                                                              |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| "Format file tidak didukung"                                 | File bukan JPEG/PNG/WebP/GIF, atau namanya berekstensi gambar tapi isinya bukan gambar sungguhan.     | Pastikan file benar-benar gambar dengan salah satu format yang didukung, ekspor ulang bila perlu. |
+| "Ukuran file terlalu besar"                                  | File melebihi batas maksimum (§3).                                                                    | Kompres/resize gambar sebelum mengunggah ulang.                                                   |
+| "Link unggah kedaluwarsa"/upload gagal setelah lama menunggu | Proses upload memakan waktu lebih lama dari batas waktu link unggah (biasanya karena koneksi lambat). | Coba unggah ulang dari awal — link unggah tidak bisa "dilanjutkan", harus mengulang.              |
+| Gambar sukses terunggah tapi tidak muncul di artikel         | Kemungkinan status belum "Terkonfirmasi" — proses konfirmasi gagal/belum selesai.                     | Tunggu sebentar dan refresh; bila tetap tidak muncul, hubungi administrator sistem.               |
+
+## 5. Praktik terbaik untuk editor
+
+- **Selalu isi `alt text`/teks alternatif** — pembaca yang memakai
+  pembaca layar dan mesin pencari sama-sama bergantung pada teks ini,
+  bukan gambar itu sendiri.
+- **Perhatikan privasi subjek foto** — sebelum mengunggah foto yang
+  memuat wajah/individu yang bisa dikenali, pastikan sudah sesuai
+  kebijakan editorial redaksi Anda soal consent/privasi (sistem tidak
+  secara otomatis memfilter ini — ini keputusan editorial, bukan
+  teknis).
+- **Beri atribusi/kredit foto** sesuai kebijakan redaksi (mis. di
+  keterangan gambar) — sistem tidak memaksakan format kredit tertentu.
+- **Jangan gunakan nama file yang mengandung informasi sensitif**
+  (mis. nama lengkap narasumber di nama file) — meskipun sistem tidak
+  memakai nama file asli untuk penyimpanan (§6 dokumen arsitektur), nama
+  file tetap terlihat oleh sesama editor di daftar unggahan.
+- **Gambar yang sudah dipublikasikan idealnya tidak dihapus** —
+  konsisten dengan sifat berita sebagai arsip publik; bila gambar perlu
+  diganti karena kesalahan, unggah gambar baru dan perbarui artikel,
+  daripada menghapus riwayat.
+
+## 6. Ke mana gambar Anda akan tampil
+
+Satu gambar yang diunggah bisa dipakai di berbagai tempat, tergantung
+bagaimana Anda memasangnya di editor:
+
+- **Featured image** — gambar utama artikel, tampil di halaman detail
+  dan daftar artikel.
+- **Galeri** — beberapa gambar dalam satu blok galeri di dalam artikel.
+- **Thumbnail video** — gambar sampul untuk blok video berita.
+- **Gambar iklan** — dipasang oleh admin/pengelola iklan, mengikuti
+  aturan validasi yang sama.
+- **Gambar preview media sosial (SEO/Open Graph)** — gambar yang tampil
+  saat artikel dibagikan ke media sosial/aplikasi chat.
+
+Setiap penggunaan di atas melewati validasi yang sama (§3) — tidak ada
+"jalur pintas" untuk salah satu jenis penggunaan.
+
+## 7. Bila Anda mencurigai sesuatu yang tidak beres
+
+Bila Anda melihat gambar yang jelas tidak diunggah oleh siapa pun di
+redaksi Anda, gambar yang tampil sebelum seharusnya dipublikasikan,
+atau menerima link unggah yang terasa mencurigakan — laporkan ke
+administrator sistem Anda segera. Administrator sistem mengikuti
+prosedur di [`r2-incident-response.md`](r2-incident-response.md).
+
+## 8. Referensi untuk administrator sistem
+
+- `full-online-r2-architecture.md` — arsitektur lengkap.
+- `r2-upload-sop.md` — SOP teknis alur upload.
+- `r2-security-checklist.md` — checklist keamanan.
+- `r2-incident-response.md` — respons insiden.

--- a/docs/awcms-mini/news-portal/r2-backup-lifecycle.md
+++ b/docs/awcms-mini/news-portal/r2-backup-lifecycle.md
@@ -1,0 +1,149 @@
+# News Portal — R2 Backup, Lifecycle & Retention
+
+Kebijakan backup, lifecycle objek, retensi, dan privasi/minimisasi data
+untuk media berita R2-only di mode **full-online** (lihat
+[`full-online-r2-architecture.md`](full-online-r2-architecture.md) §1 —
+**tidak berlaku** untuk offline/LAN). Berbeda dari PostgreSQL (yang
+punya `deploy/backup/backup-postgres.sh` dan konvensi soft delete doc
+05), R2 di sini menyimpan **satu-satunya salinan** bytes gambar berita
+(§3 arsitektur: "PostgreSQL hanya metadata") — kebijakan backup/lifecycle
+untuk R2 karena itu sama pentingnya dengan backup database, bukan
+pelengkap opsional.
+
+## 1. Mengapa ini kritis — R2 adalah satu-satunya salinan
+
+Karena mandat R2-only (tidak ada fallback filesystem lokal, §3
+arsitektur), kehilangan objek di R2 berarti **kehilangan gambar berita
+secara permanen** — tidak ada salinan lokal untuk dipulihkan. Ini
+konsekuensi langsung dari trade-off yang diterima secara eksplisit di
+§16 (ISO 22301) `full-online-r2-architecture.md`. Kebijakan di dokumen
+ini adalah mitigasi untuk trade-off tersebut.
+
+## 2. Lifecycle objek `pending`
+
+- Objek berstatus `pending` (belum melewati langkah `confirm`/validasi
+  penuh — lihat `full-online-r2-architecture.md` §5/§9) **wajib**
+  dibersihkan otomatis setelah `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`
+  (default 60 menit) — baik baris metadata (hard delete, bukan soft
+  delete, karena baris `pending` bukan "resource" yang pernah dipakai
+  siapa pun) maupun objek fisik di R2.
+- Job pembersihan ini mengikuti pola job terjadwal yang sudah ada di
+  repo (`sync:objects:dispatch`, `analytics:purge`, dsb. — lihat
+  `deployment-profiles.md` §Job registry lainnya): idempoten, aman
+  dijalankan berulang, tidak menjadi dependency kritis alur upload itu
+  sendiri (ADR-0006 — pembersihan adalah housekeeping, bukan bagian
+  jalur upload sinkron).
+- Implementor job ini (di luar cakupan Issue #631, kemungkinan bagian
+  dari #633/#634) **wajib** menghapus objek fisik R2 **dan** baris
+  metadata dalam urutan yang aman terhadap kegagalan parsial: hapus
+  objek R2 dulu, baru hapus baris metadata (bila proses gagal di
+  tengah, baris metadata `pending` basi tetap ada untuk retry
+  berikutnya — kebalikan urutan ini bisa meninggalkan objek R2 yatim
+  tanpa jejak metadata untuk retry).
+
+## 3. Retention policy per klasifikasi data
+
+| Klasifikasi                                                   | Retensi                                                                                                                | Alasan                                                                                                                                                                       |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Objek `pending` (belum confirmed)                             | `NEWS_MEDIA_R2_PENDING_TTL_MINUTES` (default 60 menit)                                                                 | Belum pernah jadi bagian konten publik — risiko exposure lebih besar dari manfaat menyimpan lama (§8 arsitektur).                                                            |
+| Objek `confirmed` yang direferensikan konten aktif            | Tidak terbatas (aset editorial, bagian arsip berita)                                                                   | Berita yang sudah publish adalah aset jangka panjang — sama prinsip immutability posted document (doc 05).                                                                   |
+| Objek `confirmed` yang tidak lagi direferensikan (`orphaned`) | Masa tenggang minimum 30 hari sebelum hapus fisik, dapat dikonfigurasi operator                                        | Memberi jendela waktu untuk membatalkan penghapusan tidak sengaja (mis. draft yang direvisi lalu gambar lama "kehilangan" referensi sementara) sebelum penghapusan permanen. |
+| Baris metadata `deleted` (soft delete)                        | Baris tetap ada (audit trail) sesuai konvensi soft delete doc 05; objek fisik R2 dihapus setelah masa tenggang di atas | Konsisten dengan pola soft delete resource lain — `deleted_at`/`deleted_by` di baris metadata, bukan penghapusan baris itu sendiri.                                          |
+
+Retensi lebih pendek untuk data yang lebih berisiko (`pending`) dan
+lebih panjang untuk aset yang sudah jadi bagian konten publik —
+prinsip yang sama dipakai `visitor-analytics.md` (retensi bertingkat
+sesuai sensitivitas/nilai data).
+
+## 4. Deteksi objek `orphaned`
+
+Objek `confirmed` menjadi kandidat `orphaned` ketika tidak ada lagi
+referensi aktif dari `blog_content` (post/page/ads/gallery/video
+thumbnail) atau surface news-portal lain (Issue #637-#640, #649) yang
+menunjuknya. Implementasi konkret (di luar cakupan Issue #631):
+
+- Job periodik membandingkan `object_key` berstatus `confirmed` terhadap
+  seluruh titik referensi yang diketahui (bukan hanya `featuredMediaId`
+  — juga block `gallery`/`video_news`, `ad.imageUrl` versi R2-only, SEO
+  share image) — daftar titik referensi ini **wajib** diperbarui setiap
+  kali issue lanjutan (#637-#640, #642, #649) menambah surface baru yang
+  bisa menunjuk media registry, supaya deteksi orphan tidak pernah
+  salah menandai objek yang sebenarnya masih dipakai.
+- Objek yang tidak ditemukan di titik referensi mana pun selama masa
+  tenggang (§3) ditandai `orphaned`, lalu dihapus fisik setelah masa
+  tenggang berakhir tanpa referensi baru muncul.
+
+## 5. Strategi backup (di luar retensi lifecycle di atas)
+
+R2 tidak punya mekanisme point-in-time-restore native yang setara
+`pg_dump`/WAL PostgreSQL. Strategi yang direkomendasikan (dipilih
+operator sesuai skala, bukan mandat tunggal — didokumentasikan di sini
+sebagai opsi, implementasi konkret di luar cakupan Issue #631):
+
+1. **Replikasi terjadwal ke bucket/region sekunder** — job periodik
+   (pola sama `sync:objects:dispatch`) menyalin objek `confirmed` baru
+   ke bucket cadangan (bisa provider R2 lain/region lain, atau S3-
+   compatible lain) — memberi RPO setara interval job (mis. harian).
+2. **Cloudflare R2 bucket versioning** (bila tersedia di rencana/plan
+   operator) — melindungi dari penghapusan/overwrite tidak sengaja,
+   walau §12 arsitektur sudah membuat overwrite key yang sama secara
+   praktis tidak pernah terjadi by design (immutable per key).
+3. **Minimal**: backup metadata PostgreSQL (`deploy/backup/*`, sudah
+   ada) memastikan operator setidaknya tahu **objek mana** yang pernah
+   ada (`object_key`, checksum, ukuran) sekalipun bytes-nya hilang —
+   memungkinkan re-upload manual dari sumber asli (arsip redaksi) bila
+   diperlukan, walau ini bukan pengganti backup bytes itu sendiri.
+
+Operator **wajib** memilih minimal satu dari (1)/(2) untuk deployment
+production yang menganggap arsip gambar berita sebagai aset penting
+jangka panjang — dokumen ini tidak mewajibkan salah satu secara
+spesifik karena trade-off biaya/kompleksitas berbeda per skala operator,
+tapi **mewajibkan keputusan eksplisit dicatat** (bukan dibiarkan tanpa
+strategi backup sama sekali, mengingat §1 di atas).
+
+## 6. Kontinuitas (ISO 22301)
+
+- **RPO (Recovery Point Objective)** untuk media: bergantung strategi
+  §5 yang dipilih operator — replikasi harian berarti RPO ≤ 24 jam untuk
+  objek yang hilang di antara siklus replikasi.
+- **RTO (Recovery Time Objective)**: pembacaan gambar publik yang sudah
+  ter-upload **tidak bergantung** pada ketersediaan aplikasi AWCMS-Mini
+  (custom domain R2 melayani langsung) — RTO untuk _pembacaan_ gambar
+  yang sudah ada secara praktis mendekati RTO Cloudflare R2 itu sendiri
+  (di luar kendali aplikasi). RTO untuk _upload baru_ bergantung pada
+  ketersediaan R2 API — tidak ada fallback (§3 arsitektur, trade-off
+  diterima).
+- **Rencana komunikasi** saat R2 outage berkepanjangan: editorial tetap
+  bisa mempublikasikan artikel teks tanpa gambar baru (gambar bukan
+  syarat mutlak publish, lihat `blog_content`), operator mengomunikasikan
+  status ke redaksi lewat kanal operasional yang sudah ada (di luar
+  cakupan dokumen ini).
+
+## 7. Privasi & minimisasi data
+
+- **Object key tidak pernah berisi PII** (§6 arsitektur) — hanya UUID +
+  partisi tanggal + tenant ID.
+- **Metadata minimal** — tabel registry (§5 arsitektur) hanya menyimpan
+  field teknis (MIME, ukuran, checksum, dimensi) dan atribusi
+  operasional (`uploaded_by`, timestamp) — tidak ada field bebas yang
+  mendorong penyimpanan data pribadi berlebih di luar `alt_text`
+  (yang memang untuk aksesibilitas, diisi sadar oleh editor).
+- **EXIF/metadata tersemat pada file gambar** (mis. GPS lokasi
+  pengambilan foto dari kamera/HP) **direkomendasikan** dibersihkan
+  sebelum/saat upload — ini **belum diimplementasikan** (di luar cakupan
+  Issue #631/#634 saat ini) dan dicatat di sini sebagai kontrol yang
+  wajib dipertimbangkan implementor #634 atau issue hardening lanjutan,
+  bukan diklaim sudah ada.
+- **Right-to-erasure/hapus permintaan subjek** — mengikuti alur soft
+  delete → hard delete masa tenggang yang sama (§3) yang sudah ada untuk
+  penghapusan reguler; tidak ada mekanisme percepatan khusus permintaan
+  privasi di scope epic ini (dicatat sebagai keterbatasan, bukan
+  diabaikan).
+
+## 8. Referensi
+
+- `full-online-r2-architecture.md` §16 (ISO 22301), §15 (ISO 27018/27701).
+- `r2-security-checklist.md` §Monitoring & audit.
+- `r2-incident-response.md` §Object exposure publik.
+- `deploy/backup/README.md` — backup PostgreSQL yang sudah ada (metadata saja).
+- `docs/awcms-mini/visitor-analytics.md` §Retensi — pola retensi bertingkat yang direplikasi di sini.

--- a/docs/awcms-mini/news-portal/r2-incident-response.md
+++ b/docs/awcms-mini/news-portal/r2-incident-response.md
@@ -149,9 +149,16 @@ checksum yang selalu mismatch (indikasi automated probing/scanning).
 
 ### Contain
 
-- Validasi berlapis (§9 arsitektur) **sudah** mencegah file berbahaya
-  pernah mencapai status `confirmed`/tereferensi publik — langkah
-  containment tambahan adalah **operasional**, bukan teknis-darurat:
+- Validasi berlapis (§9 arsitektur) — termasuk `GET` penuh + MIME
+  sniffing dari magic bytes saat `confirm`, bukan `HEAD` saja — dirancang
+  untuk mencegah file berbahaya mencapai status `confirmed`/tereferensi
+  publik **selama implementasi benar-benar menjalankan `GET`+sniffing di
+  KEDUA jalur** (§9: tidak ada jalur pintas untuk Jalur A). Ini adalah
+  kontrol yang wajib diverifikasi ada di kode (mis. lewat test integrasi
+  yang meng-upload payload HTML/JS berkedok `.jpg`), bukan diasumsikan
+  otomatis benar hanya karena didokumentasikan. Langkah containment
+  tambahan berikut tetap **operasional**, bukan pengganti kontrol
+  teknis di atas:
   - Objek yang tertolak validasi tetap ter-upload sementara ke R2 pada
     Jalur A (client PUT duluan, confirm menyusul) — pastikan lifecycle
     job (`r2-backup-lifecycle.md`) membersihkannya, jangan biarkan

--- a/docs/awcms-mini/news-portal/r2-incident-response.md
+++ b/docs/awcms-mini/news-portal/r2-incident-response.md
@@ -1,0 +1,196 @@
+# News Portal — R2 Incident Response
+
+Runbook insiden untuk media berita R2-only di mode **full-online**
+(lihat [`full-online-r2-architecture.md`](full-online-r2-architecture.md)
+§1 untuk asumsi — **tidak berlaku** untuk offline/LAN, yang tidak
+mengaktifkan mode ini). Mencakup tiga skenario yang diminta Issue #631:
+presigned URL bocor, object exposure publik, dan upload berbahaya.
+Struktur mengikuti Detect → Contain → Eradicate → Recover → Post-incident,
+konsisten dengan doc 20 §Batasan dan pola respons insiden lain di repo.
+
+## 0. Peran & eskalasi
+
+| Peran                           | Tanggung jawab dalam insiden ini                                                    |
+| ------------------------------- | ----------------------------------------------------------------------------------- |
+| Operator/on-call                | Deteksi awal, eksekusi containment (rotasi kredensial, hapus objek), eskalasi.      |
+| Admin tenant                    | Keputusan take-down konten publik yang terpengaruh, komunikasi ke editorial.        |
+| Pemilik platform (multi-tenant) | Keputusan bila insiden lintas-tenant (kredensial platform-wide, mis. rotasi masal). |
+
+Semua rotasi kredensial darurat dan tindakan penghapusan objek massal
+**wajib** dicatat sebagai audit event `critical` (skill
+`awcms-mini-audit-log`) dengan `correlationId` yang menghubungkan
+seluruh langkah insiden untuk investigasi pasca-insiden.
+
+## 1. Presigned upload URL bocor
+
+**Contoh pemicu**: presigned URL ikut ter-log di layanan pihak ketiga
+(browser devtools network log yang di-screenshot dan dibagikan, proxy
+korporat yang mencatat URL penuh, dsb.) sebelum TTL habis.
+
+### Detect
+
+- Presigned URL yang sama dipakai untuk PUT dari IP/User-Agent yang
+  jelas berbeda dari sesi editor yang menginisiasi (bila logging
+  request R2 tersedia di sisi operator/Cloudflare).
+- Objek `pending` dengan checksum yang tidak pernah cocok dengan
+  klaim manapun dari sesi yang sah (indikasi seseorang mencoba PUT
+  konten berbeda ke key yang bocor).
+
+### Contain
+
+1. **Tunggu TTL habis** (default 5 menit,
+   `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS`) — presigned URL R2/S3
+   tidak bisa dicabut manual sebelum TTL, jadi mitigasi utama adalah TTL
+   pendek by design (`full-online-r2-architecture.md` §8).
+2. Bila objek terlanjur ter-PUT dengan konten tidak sah oleh pemegang
+   URL bocor: object key tersebut **tidak pernah** dianggap `confirmed`
+   kecuali checksum-nya cocok klaim asli (§9 arsitektur) — pastikan
+   baris metadata tetap `pending`/`rejected`, jangan pernah manual-force
+   `confirmed`.
+3. Hapus objek fisik dari R2 langsung (di luar jalur aplikasi normal,
+   akses admin R2) bila isinya terbukti tidak sah.
+
+### Eradicate
+
+- Tidak perlu rotasi kredensial R2 untuk skenario ini **kecuali** URL
+  yang bocor ternyata membawa informasi kredensial (bukan sekadar
+  presigned URL biasa) — presigned URL yang benar tidak pernah
+  menyertakan secret key mentah di dalamnya (hanya signature turunan),
+  jadi kebocoran presigned URL saja **tidak** mengharuskan rotasi
+  `NEWS_MEDIA_R2_SECRET_ACCESS_KEY`.
+
+### Recover
+
+- Editor mengulang upload dari langkah inisiasi (object key baru,
+  presigned URL baru).
+
+### Post-incident
+
+- Catat di audit log: siapa yang menginisiasi upload asli, kapan URL
+  diperkirakan bocor, tindakan containment.
+- Bila pola berulang untuk identity/tenant yang sama → evaluasi apakah
+  TTL perlu diperpendek lebih lanjut untuk tenant tersebut, atau
+  edukasi operasional ke editor (`newsroom-user-guide.md`).
+
+## 2. Object exposure publik (bucket/objek yang tidak seharusnya publik)
+
+**Contoh pemicu**: objek `pending`/belum layak publish ternyata
+diakses lewat custom domain publik sebelum `confirmed` (§8 arsitektur —
+ini **residual risk yang sudah diketahui**, bukan bug baru: status
+Postgres tidak mengontrol akses storage-level R2). Atau: kesalahan
+konfigurasi CORS/bucket policy membuat bucket **sync-storage** yang
+seharusnya privat menjadi bisa diakses publik (skenario lintas-modul,
+lihat `full-online-r2-architecture.md` §2).
+
+### Detect
+
+- Laporan eksternal (mis. gambar yang belum dipublikasikan terlihat di
+  URL publik) atau audit rutin (`r2-security-checklist.md` §Monitoring).
+- Pemindaian berkala: bandingkan daftar `object_key` yang `confirmed`
+  DAN direferensikan konten publik (`blog_content`) terhadap objek yang
+  benar-benar reachable di custom domain — objek reachable yang tidak
+  ada di kedua himpunan itu adalah kandidat exposure yang tidak
+  diinginkan (`pending` lama, atau upload gagal `confirm`).
+
+### Contain
+
+1. **Bucket media berita**: karena publik-by-design, "object exposure"
+   di sini secara spesifik berarti objek `pending`/tidak sah yang
+   ter-expose sebelum waktunya — hapus objek fisik langsung dari R2
+   (bukan sekadar ubah status Postgres, karena §8 sudah menegaskan
+   status Postgres tidak mengontrol akses storage).
+2. **Bucket sync-storage jadi publik (skenario lintas-modul, lebih
+   serius)**: segera perbaiki konfigurasi bucket (cabut public access/
+   custom domain yang salah pasang) di dashboard R2 — ini pelanggaran
+   terhadap §2 arsitektur (segregasi bucket) dan **wajib** dianggap
+   insiden kebocoran data tenant (bukan sekadar media), eskalasi ke
+   pemilik platform.
+3. Rotasi kredensial bucket yang terpengaruh (§`r2-security-checklist.md`
+   §Kredensial) bila ada indikasi kredensial itu sendiri yang bocor
+   (bukan hanya kesalahan konfigurasi).
+
+### Eradicate
+
+- Perbaiki root cause: kesalahan konfigurasi CORS/custom domain (§10/§11
+  arsitektur) atau bug yang membuat objek `pending` tidak pernah
+  dibersihkan lifecycle job (`r2-backup-lifecycle.md`).
+- Bila root cause adalah bug aplikasi (mis. `confirm` gagal tapi objek
+  tetap ter-upload dan tidak pernah dibersihkan) — perbaikan kode masuk
+  issue tersendiri, bukan bagian dokumentasi ini.
+
+### Recover
+
+- Verifikasi ulang seluruh checklist §CORS/§Custom domain di
+  `r2-security-checklist.md` untuk bucket yang terpengaruh.
+- Jalankan ulang `bun run security:readiness` setelah perbaikan.
+
+### Post-incident
+
+- Dokumentasikan sebagai risiko residual yang **terealisasi** (bukan
+  lagi hanya "diterima secara teoretis" — lihat §15 ISO 27005 di
+  `full-online-r2-architecture.md`) — evaluasi apakah mitigasi
+  (`NEWS_MEDIA_R2_PENDING_TTL_MINUTES`) perlu diperketat.
+
+## 3. Upload berbahaya
+
+**Contoh pemicu**: percobaan upload file dengan MIME dipalsukan
+(mis. payload berbahaya di-rename `.jpg`), file SVG berisi script,
+file berukuran ekstrem (zip-bomb-style), atau percobaan berulang dengan
+checksum yang selalu mismatch (indikasi automated probing/scanning).
+
+### Detect
+
+- Tingkat penolakan validasi (§9 arsitektur) yang tidak wajar tinggi
+  dari satu identity/IP dalam jendela waktu pendek.
+- Percobaan upload MIME di luar allow-list (termasuk `image/svg+xml`)
+  berulang.
+- Checksum mismatch berulang dari identity yang sama pada `confirm`
+  (indikasi mencoba menukar isi objek setelah klaim awal).
+
+### Contain
+
+- Validasi berlapis (§9 arsitektur) **sudah** mencegah file berbahaya
+  pernah mencapai status `confirmed`/tereferensi publik — langkah
+  containment tambahan adalah **operasional**, bukan teknis-darurat:
+  - Objek yang tertolak validasi tetap ter-upload sementara ke R2 pada
+    Jalur A (client PUT duluan, confirm menyusul) — pastikan lifecycle
+    job (`r2-backup-lifecycle.md`) membersihkannya, jangan biarkan
+    menumpuk.
+  - Bila pola indikasi serangan aktif (bukan kesalahan pengguna biasa),
+    pertimbangkan menonaktifkan sementara `news_media.upload` untuk
+    identity yang bersangkutan (ABAC, aksi manual admin) sambil
+    investigasi.
+- Rate limiting endpoint upload (di luar cakupan dokumentasi ini secara
+  spesifik — ikuti pola rate limit yang sudah ada di `lib/security/
+rate-limit.ts` untuk endpoint sensitif lain) direkomendasikan sebagai
+  kontrol tambahan saat Issue #634 mengimplementasikan endpoint ini.
+
+### Eradicate
+
+- Tidak ada "pembersihan sistem" khusus diperlukan bila validasi
+  berfungsi seperti dirancang (file berbahaya tidak pernah confirmed/
+  publik) — fokus eradication adalah memastikan **tidak ada** celah di
+  urutan validasi (§9) yang terlewat untuk kasus spesifik yang memicu
+  insiden ini (mis. tipe file baru yang lolos sniffing MIME karena bug).
+
+### Recover
+
+- Tidak ada dampak ke konten publik yang sudah ter-_confirmed_ (validasi
+  berlapis mencegah file berbahaya pernah mencapai status itu).
+
+### Post-incident
+
+- Tambahkan signature/MIME baru ke daftar yang diblokir bila ditemukan
+  teknik baru yang nyaris lolos, sebagai follow-up issue tersendiri
+  (bukan revisi diam-diam ke dokumen arsitektur).
+- Catat sebagai audit event `critical` bila identity tertentu
+  dinonaktifkan sementara (§Contain di atas).
+
+## 4. Referensi
+
+- `full-online-r2-architecture.md` §8 (residual risk presigned URL/public
+  object), §9 (validasi), §15 (pemetaan ISO 27005 risiko).
+- `r2-security-checklist.md` §Monitoring & audit.
+- `r2-backup-lifecycle.md` §Lifecycle objek pending.
+- `SECURITY.md` (repo root) — kebijakan pelaporan kerentanan umum.
+- `.claude/skills/awcms-mini-audit-log/SKILL.md` — pola audit event.

--- a/docs/awcms-mini/news-portal/r2-security-checklist.md
+++ b/docs/awcms-mini/news-portal/r2-security-checklist.md
@@ -10,18 +10,32 @@ alasannya.
 ## 1. Validasi upload
 
 - [ ] Ukuran file ditolak **sebelum** membaca isi file bila melebihi
-      `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES` (arsitektur §9 langkah 1).
-- [ ] MIME divalidasi dari **magic bytes**, bukan `Content-Type` header
-      client atau ekstensi nama file (§9 langkah 2).
+      `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES` (arsitektur §9 langkah 1); untuk
+      Jalur A, `confirm` juga menolak reaktif via `Content-Length`
+      sebenarnya dari `HEAD` (residual risk presigned PUT yang diterima
+      secara eksplisit, §9 langkah 1).
+- [ ] `confirm` melakukan **`GET` penuh objek dari R2, bukan `HEAD`
+      saja**, sebelum status boleh naik ke `confirmed` — pada KEDUA
+      jalur (§9: "kedua jalur wajib menjalankan urutan validasi yang
+      sama"). `HEAD` sendirian (eksistensi/`Content-Length`/ETag) tidak
+      pernah menjadi dasar `confirmed`.
+- [ ] MIME divalidasi dari **magic bytes hasil `GET` di atas**, bukan
+      `Content-Type` header client, ekstensi nama file, atau checksum
+      yang diklaim client (§9 langkah 2).
 - [ ] `image/svg+xml` **tidak** ada di allow-list default (§9 langkah 3)
       — mengizinkannya butuh keputusan terpisah + pipeline sanitasi.
 - [ ] Ekstensi object key **diturunkan** dari MIME tervalidasi, bukan
       dari input client (§6/§9 langkah 4).
-- [ ] Checksum SHA-256 aktual dicocokkan terhadap checksum yang diklaim
-      sebelum status naik ke `confirmed` (§9 langkah 5).
-- [ ] Tidak ada jalur yang melewati salah satu dari empat validasi di
-      atas untuk kategori file/purpose apa pun (§9 langkah 6 — defense
-      in depth, tanpa pengecualian diam-diam).
+- [ ] Checksum SHA-256 dihitung **server-side dari isi objek** yang
+      benar-benar dibaca saat `confirm` (bukan hanya dibandingkan
+      terhadap `Content-Length`/ETag) sebelum status naik ke
+      `confirmed`; checksum yang diklaim client hanya dipakai sebagai
+      deteksi korupsi transport, tidak pernah sebagai satu-satunya
+      bukti validasi konten (§9 langkah 5).
+- [ ] Tidak ada jalur yang melewati salah satu dari validasi di atas
+      untuk kategori file/purpose apa pun (§9 langkah 6 — defense in
+      depth, tanpa pengecualian diam-diam, dan tanpa jalur yang
+      "dipercaya lebih aman" hanya karena upload-nya direct-to-R2).
 
 ## 2. Object key & penyimpanan
 
@@ -148,8 +162,12 @@ biarkan dokumen ini menyiratkan check sudah ada padahal belum
 
 ## 8. Monitoring & audit
 
-- [ ] Setiap `confirm` (sukses/gagal) dicatat lewat correlation ID
-      terstruktur (pola `sync_storage.object_dispatch.*` yang sudah ada).
+- [ ] Setiap `confirm` (sukses/gagal) menulis **audit event formal**
+      lewat skill `awcms-mini-audit-log` (bukan hanya correlation-ID
+      logging aplikasi biasa, pola `sync_storage.object_dispatch.*`) —
+      ini mutation high-risk yang menaikkan status metadata ke
+      `confirmed` (§7 arsitektur), sama kelas dengan aksi lain yang
+      wajib audit di doc 03/10.
 - [ ] Percobaan checksum-mismatch berulang dari identity/IP yang sama
       dalam jendela waktu pendek memicu perhatian operator (lihat
       `r2-incident-response.md` §Malicious upload untuk ambang & respons).

--- a/docs/awcms-mini/news-portal/r2-security-checklist.md
+++ b/docs/awcms-mini/news-portal/r2-security-checklist.md
@@ -1,0 +1,166 @@
+# News Portal — R2 Security Checklist
+
+Checklist siap-pakai untuk implementor (Issue #632-#635) dan operator
+sebelum mengaktifkan mode **full-online R2-only** untuk gambar berita
+(lihat [`full-online-r2-architecture.md`](full-online-r2-architecture.md)
+§1 untuk asumsi full-online-only — checklist ini **tidak berlaku** untuk
+offline/LAN). Setiap item merujuk bagian arsitektur yang menjelaskan
+alasannya.
+
+## 1. Validasi upload
+
+- [ ] Ukuran file ditolak **sebelum** membaca isi file bila melebihi
+      `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES` (arsitektur §9 langkah 1).
+- [ ] MIME divalidasi dari **magic bytes**, bukan `Content-Type` header
+      client atau ekstensi nama file (§9 langkah 2).
+- [ ] `image/svg+xml` **tidak** ada di allow-list default (§9 langkah 3)
+      — mengizinkannya butuh keputusan terpisah + pipeline sanitasi.
+- [ ] Ekstensi object key **diturunkan** dari MIME tervalidasi, bukan
+      dari input client (§6/§9 langkah 4).
+- [ ] Checksum SHA-256 aktual dicocokkan terhadap checksum yang diklaim
+      sebelum status naik ke `confirmed` (§9 langkah 5).
+- [ ] Tidak ada jalur yang melewati salah satu dari empat validasi di
+      atas untuk kategori file/purpose apa pun (§9 langkah 6 — defense
+      in depth, tanpa pengecualian diam-diam).
+
+## 2. Object key & penyimpanan
+
+- [ ] Format object key = `news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}`
+      (arsitektur §6) — `tenantId` UUID, bukan `tenantCode`.
+- [ ] Object key **tidak pernah** menyertakan nama file asli/input teks
+      bebas client (§6).
+- [ ] `original_filename` disimpan hanya sebagai metadata tampilan,
+      terpisah dari object key (§5/§6).
+- [ ] Tidak ada kolom binary (`bytea`, base64 text besar, dsb.) di tabel
+      metadata mana pun (§3.2/§5 arsitektur).
+- [ ] Tidak ada jalur kode yang menulis bytes gambar ke
+      `LOCAL_STORAGE_PATH`/disk lokal server sebagai fallback (§3.3/§3.4).
+
+## 3. Presigned URL
+
+- [ ] TTL presigned upload PUT = `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS`,
+      default pendek (300 detik) (arsitektur §8).
+- [ ] Tidak ada presigned URL untuk **GET**/baca — pembacaan selalu lewat
+      custom domain publik (§8/§11).
+- [ ] Langkah `confirm` memverifikasi eksistensi + checksum aktual
+      sebelum status `confirmed` (§7/§9) — presigned URL yang valid
+      tidak otomatis berarti kontennya sah.
+- [ ] Presigned URL **tidak pernah** dicatat penuh di log aplikasi
+      (perlakukan setara bearer credential jangka pendek, ASVS V3.x).
+
+## 4. CORS
+
+- [ ] `AllowedOrigins` bucket media berita = daftar eksplisit origin
+      admin tenant — **tidak pernah** `"*"` (arsitektur §10).
+- [ ] `AllowedMethods` hanya `PUT` (+ preflight) — tidak ada `GET`/`DELETE`
+      lewat CORS untuk bucket ini.
+- [ ] Konfigurasi CORS bucket media **tidak** disalin ke bucket
+      `sync-storage` — bucket itu tidak butuh CORS sama sekali (§2/§10).
+
+## 5. Custom domain & Cache-Control
+
+- [ ] `NEWS_MEDIA_R2_PUBLIC_BASE_URL` HTTPS absolut, custom domain R2
+      (bukan `*.r2.dev`) (arsitektur §11).
+- [ ] URL publik objek selalu di-derive dari `object_key` + base URL saat
+      render — tidak disimpan sebagai kolom URL absolut terpisah (§11).
+- [ ] Objek diberi `Cache-Control: public, max-age=31536000, immutable`
+      saat upload (arsitektur §12).
+- [ ] Mengganti gambar = upload objek/key baru, bukan overwrite key lama
+      (§12 — mencegah cache poisoning).
+
+## 6. Kredensial R2 — least privilege & rotasi
+
+- [ ] `NEWS_MEDIA_R2_BUCKET` **berbeda** dari `R2_BUCKET` (bucket
+      `sync-storage`) — divalidasi tidak sama saat `config:validate`
+      (arsitektur §2/§4).
+- [ ] `NEWS_MEDIA_R2_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` **berbeda** dari
+      `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` (§2/§13).
+- [ ] API token R2 media berita di-scope ke **satu bucket** saja, bukan
+      "Account API Token" administratif penuh (§13).
+- [ ] Token yang disuntik ke runtime aplikasi **tidak** punya permission
+      administratif bucket (ubah CORS/lifecycle/hapus bucket) — hanya
+      `Object Read & Write` (§13).
+- [ ] Rotasi terjadwal (rekomendasi 90 hari) mengikuti urutan: buat token
+      baru → update env → redeploy → cabut token lama (§13, tanpa
+      downtime, tanpa window tanpa kredensial valid).
+- [ ] Rotasi darurat (pasca-insiden) mengikuti
+      [`r2-incident-response.md`](r2-incident-response.md), bukan jadwal
+      rutin.
+
+### Contoh kebijakan API token R2 (least privilege, ilustratif)
+
+```json
+{
+  "token_name": "news-media-r2-app-token",
+  "permission_groups": ["Object Read & Write"],
+  "resources": {
+    "com.cloudflare.edge.r2.bucket.<account-id>_<news-media-bucket>": "*"
+  },
+  "not_allowed": [
+    "Bucket delete",
+    "Bucket CORS/lifecycle configuration",
+    "Account-level R2 administration"
+  ]
+}
+```
+
+Konfigurasi bucket (CORS, lifecycle, custom domain) tetap dilakukan
+operator lewat dashboard/Terraform terpisah dengan kredensial admin
+terpisah — **tidak pernah** lewat token yang sama yang disuntik ke
+`NEWS_MEDIA_R2_ACCESS_KEY_ID` runtime aplikasi.
+
+## 7. Readiness gates (`config:validate` / `security:readiness` / `production:preflight`)
+
+Acceptance criteria Issue #631 mensyaratkan readiness checklist ini
+merujuk tiga command yang sudah ada di repo — status saat ini (Issue
+#631, docs-only): **belum ada check khusus news media** di ketiganya;
+Issue #635 ("Add Cloudflare R2 image delivery readiness checks") adalah
+yang mengimplementasikannya. Kontrak yang wajib dipenuhi Issue #635:
+
+- **`bun run config:validate`** (shape-only, `scripts/validate-env.ts`)
+  wajib menambah:
+  - Bila `NEWS_MEDIA_R2_ENABLED=true`: `NEWS_MEDIA_R2_ACCOUNT_ID`,
+    `_ACCESS_KEY_ID`, `_SECRET_ACCESS_KEY`, `_BUCKET`,
+    `_PUBLIC_BASE_URL` wajib terisi (pola sama `checkR2Config` yang
+    sudah ada untuk `R2_*`).
+  - `NEWS_MEDIA_R2_BUCKET` ≠ `R2_BUCKET` (bila keduanya aktif) — gagal
+    validasi bila sama (§2 penegakan, bukan hanya dokumentasi).
+  - `NEWS_MEDIA_R2_PUBLIC_BASE_URL` harus URL HTTPS absolut.
+- **`bun run security:readiness`** (safety/severity, cross-field) wajib
+  menambah pengecekan **critical**:
+  - Bucket media dan bucket sync tidak sama (redundan dengan
+    `config:validate` sebagai defense in depth, pola yang sama dipakai
+    check lain di repo yang menduplikasi validasi shape+safety).
+  - Kredensial media berbeda dari kredensial sync.
+  - `image/svg+xml` tidak ada di `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`
+    kecuali operator eksplisit override (warning bila di-override, tidak
+    pernah default-on).
+- **`bun run production:preflight`** — tidak butuh tahap baru (sudah
+  menjalankan `config:validate` dan `security:readiness` sebagai bagian
+  urutannya, doc 18) — cukup pastikan kedua check di atas benar-benar
+  terpanggil dari urutan yang sudah ada, tidak membuat jalur pintas
+  terpisah.
+
+Implementor #635 **wajib** memperbarui bagian ini (ganti "belum ada"
+menjadi nama fungsi/test nyata) begitu check-nya ditulis — jangan
+biarkan dokumen ini menyiratkan check sudah ada padahal belum
+(konsisten dengan status "Belum dikerjakan" di skill).
+
+## 8. Monitoring & audit
+
+- [ ] Setiap `confirm` (sukses/gagal) dicatat lewat correlation ID
+      terstruktur (pola `sync_storage.object_dispatch.*` yang sudah ada).
+- [ ] Percobaan checksum-mismatch berulang dari identity/IP yang sama
+      dalam jendela waktu pendek memicu perhatian operator (lihat
+      `r2-incident-response.md` §Malicious upload untuk ambang & respons).
+- [ ] Rotasi kredensial (§6) dicatat sebagai audit event high-risk
+      (skill `awcms-mini-audit-log`), bukan hanya perubahan env var yang
+      tidak terlacak.
+
+## 9. Referensi
+
+- `full-online-r2-architecture.md` — arsitektur & pemetaan kepatuhan lengkap.
+- `r2-upload-sop.md` — alur operasional upload.
+- `r2-incident-response.md` — respons insiden.
+- `r2-backup-lifecycle.md` — retensi dan lifecycle objek.
+- `.claude/skills/awcms-mini-security-hardening/SKILL.md` — audit OWASP/ASVS/ISO tingkat repo.

--- a/docs/awcms-mini/news-portal/r2-upload-sop.md
+++ b/docs/awcms-mini/news-portal/r2-upload-sop.md
@@ -41,17 +41,39 @@ checksumSha256, purpose }`. Server memvalidasi **shape saja** di
    transit lewat server AWCMS-Mini di langkah ini.
 5. **Confirm** — client memanggil
    `POST /api/v1/news-media/{objectKey}/confirm` dengan
-   `Idempotency-Key` (mutation high-risk, skill `awcms-mini-idempotency`).
-   Server:
-   - `HEAD` objek di R2 — pastikan benar-benar ada (client tidak bisa
-     "confirm" objek yang gagal ter-upload).
-   - Bandingkan `Content-Length`/ETag/checksum aktual terhadap yang
-     diklaim di langkah 1.
-   - Cocok → `status='confirmed'`, `confirmed_at=now()`.
-   - Tidak cocok → `status` tetap `pending` (atau `rejected` bila
-     implementasi memilih state eksplisit), response error jelas ke
-     client, dan objek dijadwalkan pembersihan
-     (`r2-backup-lifecycle.md` §Lifecycle objek pending).
+   `Idempotency-Key` (mutation high-risk, skill `awcms-mini-idempotency`,
+   dan **wajib menulis audit event lewat skill `awcms-mini-audit-log`**
+   baik sukses maupun gagal — bukan sekadar correlation-ID logging
+   biasa, karena ini menaikkan status metadata ke `confirmed` yang
+   dipakai untuk keputusan "boleh direferensikan konten publik").
+   Server (`HEAD` SAJA TIDAK PERNAH CUKUP di sini — lihat
+   `full-online-r2-architecture.md` §9):
+   - `HEAD` objek di R2 sebagai pengecekan cepat — pastikan benar-benar
+     ada dan `Content-Length`-nya tidak melebihi
+     `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES` (client tidak bisa "confirm" objek
+     yang gagal ter-upload atau yang lebih besar dari batas — lihat §9
+     arsitektur soal residual risk ukuran di Jalur A).
+   - **`GET` penuh objek** (dibatasi ukuran yang sudah divalidasi di
+     atas) — bukan `HEAD` saja — untuk (a) menjalankan MIME sniffing
+     dari magic bytes terhadap isi objek yang sebenarnya, dan
+     (b) menghitung checksum SHA-256 **server-side dari byte yang
+     benar-benar diterima**, bukan mempercayai `Content-Length`/ETag
+     semata.
+   - Bandingkan MIME hasil sniffing terhadap allow-list DAN terhadap
+     `mimeType` yang diklaim di langkah 1; bandingkan checksum
+     server-side terhadap `checksumSha256` yang diklaim di langkah 1
+     (mismatch checksum di sini hanya mendeteksi korupsi transport —
+     keputusan MIME/konten selalu dari hasil sniffing, tidak pernah
+     dari klaim client).
+   - Semua cocok → `status='confirmed'`, `confirmed_at=now()`.
+   - Tidak cocok (MIME sniffing gagal allow-list, MIME tidak sama
+     dengan klaim, checksum tidak cocok, atau ukuran melebihi batas) →
+     `status` tetap `pending` (atau `rejected` bila implementasi
+     memilih state eksplisit), response error jelas ke client, dan
+     objek dijadwalkan pembersihan (`r2-backup-lifecycle.md` §Lifecycle
+     objek pending) — **objek yang MIME-nya tidak lolos sniffing tidak
+     pernah dibiarkan reachable publik di bawah status apa pun selain
+     dijadwalkan hapus.**
 6. **TTL kedaluwarsa sebelum confirm** — bila `confirm` dipanggil setelah
    `expiresAt`, server menolak dan editor harus mengulang dari langkah 1
    (object key baru, presigned URL baru — presigned URL lama tidak
@@ -102,29 +124,32 @@ tegasnya adalah **disk lokal**, bukan memori proses.
 
 ```mermaid
 flowchart TD
-  A[Terima request upload] --> B{Ukuran <= batas?}
-  B -- Tidak --> R1[Tolak — 413/400, tanpa proses lanjut]
-  B -- Ya --> C{MIME magic-bytes di allow-list?}
-  C -- Tidak --> R2[Tolak — 415, termasuk SVG]
+  A[confirm dipanggil] --> H{HEAD: objek ada & Content-Length <= batas?}
+  H -- Tidak --> R1[Tolak — 404/413, jadwalkan pembersihan bila ada objek]
+  H -- Ya --> G[GET penuh objek dari R2 — bukan HEAD saja]
+  G --> C{MIME magic-bytes hasil sniffing di allow-list & = klaim?}
+  C -- Tidak --> R2[Tolak — 415, termasuk SVG; jadwalkan pembersihan objek]
   C -- Ya --> D[Turunkan ekstensi dari MIME tervalidasi]
-  D --> E{Checksum aktual = checksum diklaim?}
+  D --> E{Checksum server-side dari isi objek = checksum diklaim?}
   E -- Tidak --> R3[Tolak, jadwalkan pembersihan objek]
   E -- Ya --> F[status = confirmed]
 ```
 
 Tidak ada jalur "lolos sebagian" — kegagalan pada langkah mana pun
 menghentikan seluruh proses, konsisten dengan prinsip default-deny (§3
-arsitektur).
+arsitektur). **`HEAD` sendirian tidak pernah menjadi dasar `confirmed`**
+— lihat `full-online-r2-architecture.md` §9 untuk kenapa ranged/full
+`GET` wajib pada kedua jalur.
 
 ## 5. Penanganan error & rollback
 
-| Skenario                                       | Penanganan                                                                                                                                                                                                    |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PUT ke R2 gagal (network/timeout, Jalur A)     | Client melihat error dari R2 langsung; baris metadata tetap `pending`, dibersihkan oleh lifecycle job.                                                                                                        |
-| `confirm` dipanggil tapi objek tidak ada di R2 | `HEAD` gagal → `404`, metadata tetap `pending` (tidak pernah naik jadi `confirmed` tanpa objek nyata).                                                                                                        |
-| Checksum mismatch saat `confirm`               | Tolak eksplisit, metadata tidak `confirmed`; lihat `r2-incident-response.md` bila polanya berulang/mencurigakan (indikasi upload berbahaya).                                                                  |
-| Retry `confirm` dengan `Idempotency-Key` sama  | Idempotent — request kedua mengembalikan hasil pertama, tidak membuat baris duplikat.                                                                                                                         |
-| R2 mengalami outage saat upload                | Gagal eksplisit ke editor (§3 arsitektur — tidak ada fallback lokal); circuit breaker provider mencegah percobaan berulang membebani R2 yang sedang down (pola sama `object-storage` breaker `sync-storage`). |
+| Skenario                                                                                                  | Penanganan                                                                                                                                                                                                    |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PUT ke R2 gagal (network/timeout, Jalur A)                                                                | Client melihat error dari R2 langsung; baris metadata tetap `pending`, dibersihkan oleh lifecycle job.                                                                                                        |
+| `confirm` dipanggil tapi objek tidak ada di R2                                                            | `HEAD` gagal → `404`, metadata tetap `pending` (tidak pernah naik jadi `confirmed` tanpa objek nyata).                                                                                                        |
+| MIME sniffing hasil `GET` tidak cocok allow-list/klaim, atau checksum server-side mismatch saat `confirm` | Tolak eksplisit, metadata tidak `confirmed`, objek dijadwalkan pembersihan; lihat `r2-incident-response.md` bila polanya berulang/mencurigakan (indikasi upload berbahaya).                                   |
+| Retry `confirm` dengan `Idempotency-Key` sama                                                             | Idempotent — request kedua mengembalikan hasil pertama, tidak membuat baris duplikat.                                                                                                                         |
+| R2 mengalami outage saat upload                                                                           | Gagal eksplisit ke editor (§3 arsitektur — tidak ada fallback lokal); circuit breaker provider mencegah percobaan berulang membebani R2 yang sedang down (pola sama `object-storage` breaker `sync-storage`). |
 
 ## 6. Troubleshooting operator
 

--- a/docs/awcms-mini/news-portal/r2-upload-sop.md
+++ b/docs/awcms-mini/news-portal/r2-upload-sop.md
@@ -1,0 +1,151 @@
+# News Portal — R2 Upload SOP
+
+Standard operating procedure untuk alur upload gambar berita di mode
+**full-online R2-only** (lihat
+[`full-online-r2-architecture.md`](full-online-r2-architecture.md) §1
+untuk asumsi lengkap — dokumen ini **tidak berlaku** untuk offline/LAN).
+Ditujukan untuk implementor (Issue #634) dan operator yang perlu
+memahami/mendiagnosis alur upload nyata.
+
+## 1. Prasyarat sebelum SOP ini bisa dijalankan
+
+- `NEWS_MEDIA_R2_ENABLED=true` dan seluruh var wajib terisi (lihat
+  `full-online-r2-architecture.md` §4).
+- `bun run config:validate` lulus (rencana Issue #632/#635 — validasi
+  shape env var termasuk memastikan `NEWS_MEDIA_R2_BUCKET` ≠ `R2_BUCKET`).
+- `bun run security:readiness` lulus untuk kontrol khusus news media
+  (rencana Issue #635) — lihat
+  [`r2-security-checklist.md`](r2-security-checklist.md) §Readiness.
+- Identity pemanggil punya permission `news_media.upload` (rencana Issue
+  #633) — ABAC default-deny seperti endpoint lain.
+
+## 2. Jalur A — Direct-to-R2 (disarankan)
+
+Diagram alur lengkap: `full-online-r2-architecture.md` §7. Langkah
+operasional:
+
+1. **Inisiasi** — client (admin UI) memanggil
+   `POST /api/v1/news-media/uploads` dengan `{ mimeType, byteSize,
+checksumSha256, purpose }`. Server memvalidasi **shape saja** di
+   langkah ini (belum ada bytes untuk divalidasi isinya) — `mimeType`
+   harus salah satu allow-list (`full-online-r2-architecture.md` §9),
+   `byteSize` ≤ `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`.
+2. **Generate object key baru** (§6 arsitektur) dan baris metadata
+   `status='pending'`.
+3. **Generate presigned PUT URL** dengan TTL
+   `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` (default 300 detik).
+   Response ke client: `{ objectKey, presignedUrl, expiresAt }` — **tidak
+   pernah** menyertakan kredensial R2 mentah, hanya URL yang sudah
+   ditandatangani.
+4. **Client PUT langsung** ke `presignedUrl` — bytes gambar tidak pernah
+   transit lewat server AWCMS-Mini di langkah ini.
+5. **Confirm** — client memanggil
+   `POST /api/v1/news-media/{objectKey}/confirm` dengan
+   `Idempotency-Key` (mutation high-risk, skill `awcms-mini-idempotency`).
+   Server:
+   - `HEAD` objek di R2 — pastikan benar-benar ada (client tidak bisa
+     "confirm" objek yang gagal ter-upload).
+   - Bandingkan `Content-Length`/ETag/checksum aktual terhadap yang
+     diklaim di langkah 1.
+   - Cocok → `status='confirmed'`, `confirmed_at=now()`.
+   - Tidak cocok → `status` tetap `pending` (atau `rejected` bila
+     implementasi memilih state eksplisit), response error jelas ke
+     client, dan objek dijadwalkan pembersihan
+     (`r2-backup-lifecycle.md` §Lifecycle objek pending).
+6. **TTL kedaluwarsa sebelum confirm** — bila `confirm` dipanggil setelah
+   `expiresAt`, server menolak dan editor harus mengulang dari langkah 1
+   (object key baru, presigned URL baru — presigned URL lama tidak
+   pernah diperpanjang).
+
+## 3. Jalur B — Server-streaming (tanpa temp file lokal)
+
+Dipakai saat direct-to-R2 dari browser tidak memungkinkan (mis. import
+terprogram lewat integrasi lain yang tidak berjalan di browser). Detail
+larangan temp file: `full-online-r2-architecture.md` §3.4/§7.
+
+1. Client mengirim `POST /api/v1/news-media/uploads` sebagai
+   `multipart/form-data` atau raw body streamed.
+2. Server membaca **stream**, bukan buffer penuh:
+   - Validasi `Content-Length` terhadap `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`
+     dari header lebih dulu (tolak cepat tanpa membaca body sama sekali
+     bila header sudah melebihi batas).
+   - Bila `Content-Length` tidak ada/tidak bisa dipercaya, hitung byte
+     yang sudah lewat secara kumulatif saat streaming dan **potong
+     koneksi** begitu melampaui batas — jangan menunggu EOF dulu.
+   - MIME disniff dari beberapa byte pertama stream (magic bytes),
+     bukan header `Content-Type` client.
+3. Stream yang sudah divalidasi partial-nya diteruskan **langsung** ke
+   `Bun.S3Client`'s write API (streaming PUT) — tidak ada
+   `Bun.write(tempPath, ...)`, tidak ada `fs.writeFile` perantara, tidak
+   ada variabel yang menampung seluruh isi file di memori server untuk
+   file besar (bila memungkinkan secara teknis; lihat catatan performa
+   di bawah).
+4. Checksum dihitung on-the-fly saat byte lewat (hashing incremental),
+   dibandingkan terhadap checksum yang diklaim client di akhir stream.
+5. Sukses → metadata langsung `confirmed` (tidak ada langkah `confirm`
+   terpisah karena server sudah melihat seluruh isi file sendiri).
+   Gagal (checksum mismatch/validasi MIME gagal di tengah jalan) →
+   objek yang sudah ter-upload sebagian/penuh ke R2 dijadwalkan
+   pembersihan, response error ke client.
+
+**Catatan performa/implementasi (Issue #634):** bila runtime Bun/`Bun.S3Client`
+tidak mendukung streaming upload tanpa mem-buffer penuh di memori untuk
+kasus tertentu, implementor wajib mendokumentasikan batasan itu secara
+eksplisit di README modul (bukan mengklaim "no temp file" secara
+membabi-buta) — batas ukuran (§`NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`, default
+10 MiB) dipilih cukup kecil justru supaya buffering in-memory (bila
+benar-benar tak terhindarkan secara teknis) tetap aman untuk resource
+server, sebagai pengganti "tidak pernah menyentuh disk" — larangan
+tegasnya adalah **disk lokal**, bukan memori proses.
+
+## 4. Urutan validasi (ringkasan dari arsitektur §9)
+
+```mermaid
+flowchart TD
+  A[Terima request upload] --> B{Ukuran <= batas?}
+  B -- Tidak --> R1[Tolak — 413/400, tanpa proses lanjut]
+  B -- Ya --> C{MIME magic-bytes di allow-list?}
+  C -- Tidak --> R2[Tolak — 415, termasuk SVG]
+  C -- Ya --> D[Turunkan ekstensi dari MIME tervalidasi]
+  D --> E{Checksum aktual = checksum diklaim?}
+  E -- Tidak --> R3[Tolak, jadwalkan pembersihan objek]
+  E -- Ya --> F[status = confirmed]
+```
+
+Tidak ada jalur "lolos sebagian" — kegagalan pada langkah mana pun
+menghentikan seluruh proses, konsisten dengan prinsip default-deny (§3
+arsitektur).
+
+## 5. Penanganan error & rollback
+
+| Skenario                                       | Penanganan                                                                                                                                                                                                    |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PUT ke R2 gagal (network/timeout, Jalur A)     | Client melihat error dari R2 langsung; baris metadata tetap `pending`, dibersihkan oleh lifecycle job.                                                                                                        |
+| `confirm` dipanggil tapi objek tidak ada di R2 | `HEAD` gagal → `404`, metadata tetap `pending` (tidak pernah naik jadi `confirmed` tanpa objek nyata).                                                                                                        |
+| Checksum mismatch saat `confirm`               | Tolak eksplisit, metadata tidak `confirmed`; lihat `r2-incident-response.md` bila polanya berulang/mencurigakan (indikasi upload berbahaya).                                                                  |
+| Retry `confirm` dengan `Idempotency-Key` sama  | Idempotent — request kedua mengembalikan hasil pertama, tidak membuat baris duplikat.                                                                                                                         |
+| R2 mengalami outage saat upload                | Gagal eksplisit ke editor (§3 arsitektur — tidak ada fallback lokal); circuit breaker provider mencegah percobaan berulang membebani R2 yang sedang down (pola sama `object-storage` breaker `sync-storage`). |
+
+## 6. Troubleshooting operator
+
+- **"Upload gagal berulang untuk semua editor"** → cek
+  `bun run security:readiness`/kredensial R2 belum kedaluwarsa/rotasi
+  (`r2-security-checklist.md` §Rotasi), cek circuit breaker
+  `object-storage`/media provider belum dalam status open berkepanjangan.
+- **"Gambar sukses upload tapi tidak muncul di halaman publik"** →
+  periksa status metadata (`pending` vs `confirmed`) — kemungkinan
+  langkah `confirm` belum dipanggil/gagal; periksa juga apakah
+  `NEWS_MEDIA_R2_PUBLIC_BASE_URL` custom domain sudah benar dan
+  propagasi DNS/TLS-nya selesai.
+- **"Editor melaporkan link upload kedaluwarsa"** → normal bila TTL
+  presigned URL (default 5 menit) terlampaui sebelum PUT selesai
+  (koneksi lambat) — editor mengulang dari langkah inisiasi, bukan
+  memakai ulang presigned URL lama.
+
+## 7. Referensi
+
+- `full-online-r2-architecture.md` — arsitektur lengkap, konvensi, dan pemetaan kepatuhan.
+- `r2-security-checklist.md` — checklist keamanan sebelum go-live.
+- `r2-incident-response.md` — bila ditemukan pola upload mencurigakan.
+- `.claude/skills/awcms-mini-idempotency/SKILL.md` — pola `Idempotency-Key`.
+- `.claude/skills/awcms-mini-integration/SKILL.md` — timeout/circuit breaker provider eksternal.


### PR DESCRIPTION
## Summary

Foundation issue for the new news-portal epic (#631-#642, #649). Adds the target architecture, upload SOP, security checklist, incident response plan, backup/lifecycle policy, and newsroom user guide for Cloudflare R2-only news image storage in full-online deployments. Also adds the `awcms-mini-news-portal` skill to track per-issue decisions across the epic so later issues don't re-derive this context.

Docs added under `docs/awcms-mini/news-portal/`:
- `full-online-r2-architecture.md`
- `r2-upload-sop.md`
- `r2-security-checklist.md`
- `r2-incident-response.md`
- `r2-backup-lifecycle.md`
- `newsroom-user-guide.md`

Key design decision: news media R2 bucket/credentials (`NEWS_MEDIA_R2_*`, planned) must be **separate** from the existing `sync-storage` module's `R2_*` (private object-sync queue) — different trust boundary (public vs. private), different blast radius on credential compromise, independent rotation. Documented in `full-online-r2-architecture.md` §2 and enforced by later issues (#635) via `config:validate`/`security:readiness`.

Out of scope (per issue): upload API implementation, R2 client code, legacy media import, offline/LAN image storage — all deferred to later issues in this epic.

## Test plan

- [x] `bun run lint` — pass.
- [x] `bun run check:docs` — pass (mermaid, internal links, naming all valid).
- [x] `bun run build` — pass.
- Docs-only change; no code/migration/test surface to exercise.

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)