### PR TITLE
feat(news-portal): add full-online R2-only news portal preset

### DIFF
--- a/.changeset/news-portal-full-online-r2-preset.md
+++ b/.changeset/news-portal-full-online-r2-preset.md
@@ -1,0 +1,41 @@
+---
+"awcms-mini": minor
+---
+
+Add the `news_portal_full_online_r2` tenant module preset (Issue #632,
+epic `news_portal` #631-#642/#649) — the first concrete implementation
+step after Issue #631's architecture documentation.
+
+New module `news_portal` (`src/modules/news-portal/`, minimal descriptor
+only — no permissions/navigation/API/settings yet), a new tenant module
+preset `news_portal_full_online_r2` (bundling `blog_content` +
+`tenant_domain` + `visitor_analytics` + `module_management` +
+`identity_access` + `news_portal`, `module-management/domain/module-presets.ts`),
+and its activation readiness gate: `applyNewsPortalFullOnlineR2Preset`
+(`news-portal/application/apply-news-portal-preset.ts`) is the sanctioned
+entry point, requiring `NEWS_PORTAL_ENABLED=true`,
+`NEWS_PORTAL_PROFILE=full_online_r2`, and complete `NEWS_MEDIA_R2_*`
+config kept separate from `sync-storage`'s own `R2_*` credentials/bucket
+(enforced, not just documented) before delegating to the existing generic
+`applyModulePreset`. Every activation attempt (rejected or applied) is
+audited.
+
+New env vars (`.env.example`, doc 18 §News portal): `NEWS_PORTAL_ENABLED`,
+`NEWS_PORTAL_PROFILE`, and the `NEWS_MEDIA_R2_*` family
+(`ENABLED`/`ACCOUNT_ID`/`ACCESS_KEY_ID`/`SECRET_ACCESS_KEY`/`BUCKET`/
+`PUBLIC_BASE_URL`/`PRESIGNED_UPLOAD_TTL_SECONDS`/`MAX_UPLOAD_BYTES`/
+`ALLOWED_MIME_TYPES`/`PENDING_TTL_MINUTES`) — deliberately namespaced
+`NEWS_MEDIA_R2_*` rather than reusing `sync-storage`'s `R2_*` names (see
+architecture doc §2/§4 and `.claude/skills/awcms-mini-news-portal/SKILL.md`
+§632 for the full naming-reconciliation rationale). No new
+`DEPLOYMENT_PROFILE`/`BLOG_PUBLIC_ROUTE_MODE`/`BLOG_PUBLIC_BASE_PATH` env
+vars were added — those concepts already exist as other mechanisms
+(per-tenant `blog_content` settings, `PUBLIC_CANONICAL_BASE_PATH`, or
+simply don't exist as a real need in this repo's per-feature-flag
+convention).
+
+`bun run config:validate` and `bun run security:readiness` both cover the
+new preset's config (shape, conditional-required vars, and hard
+separation from `sync-storage`'s R2 config). No schema/migration changes
+in this issue — no local filesystem upload fallback exists or was added
+(structurally guarded by a new test, not a runtime flag).

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -37,7 +37,7 @@ status + pointer, bukan menduplikasi isinya.
 | Issue | Scope                                                                                                                        | Status                                               |
 | ----- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | #631  | Dokumentasi arsitektur full-online R2-only + SOP + security + IR + backup + user guide                                       | **Selesai** — lihat §Dokumen yang sudah ada di bawah |
-| #632  | Preset `news_portal_full_online_r2` (module descriptor/config gate)                                                          | Belum dikerjakan — lihat §632 di bawah               |
+| #632  | Preset `news_portal_full_online_r2` (module descriptor/config gate)                                                          | **Selesai** — lihat §632 di bawah                    |
 | #633  | Tenant-scoped R2-only media object registry (schema + migration)                                                             | Belum dikerjakan — lihat §633 di bawah               |
 | #634  | Direct-to-R2 presigned upload flow (endpoint upload/confirm)                                                                 | Belum dikerjakan — lihat §634 di bawah               |
 | #635  | Config validation + readiness checks (`config:validate`/`security:readiness`/`production:preflight`) untuk R2 image delivery | Belum dikerjakan — lihat §635 di bawah               |
@@ -68,8 +68,9 @@ issue ini):
   ruang lingkup full-online-only (§1), keputusan **bucket R2 terpisah
   dari `sync-storage`** (§2 — lihat §Keputusan kunci di bawah), lima
   prinsip inti tidak bisa dinegosiasi (§3), konvensi env var
-  `NEWS_MEDIA_R2_*` (§4, **belum** ada di `.env.example`/doc 18 — itu
-  tugas #632/#633), model data konseptual media registry (§5), konvensi
+  `NEWS_MEDIA_R2_*` (§4 — **diimplementasikan Issue #632**: sudah ada di
+  `.env.example`/doc 18/`scripts/validate-env.ts`), model data konseptual
+  media registry (§5), konvensi
   object key (§6), dua diagram alur upload (§7), lifecycle presigned
   URL (§8), urutan validasi MIME/ekstensi/checksum (§9), CORS (§10),
   custom domain (§11), Cache-Control (§12), rotasi kredensial (§13),
@@ -82,10 +83,10 @@ issue ini):
 - **`r2-security-checklist.md`** — checklist siap-pakai (validasi,
   object key, presigned URL, CORS, custom domain/cache, kredensial,
   readiness gates, monitoring) + contoh kebijakan API token R2
-  least-privilege. §7 checklist ini eksplisit menyatakan **belum ada**
-  check nyata di `config:validate`/`security:readiness` untuk news
-  media sampai #635 mengimplementasikannya — jangan klaim readiness
-  sudah ditegakkan sebelum #635 selesai.
+  least-privilege. §7 checklist ini awalnya menyatakan belum ada check
+  nyata sampai #635 — **diperbarui**: shape/separation/SVG checks sudah
+  landed lewat Issue #632 (lebih awal dari rencana semula); sisa untuk
+  #633/#634/#635 hanya check level schema registry/endpoint upload.
 - **`r2-incident-response.md`** — runbook Detect/Contain/Eradicate/
   Recover/Post-incident untuk tiga skenario: presigned URL bocor,
   object exposure publik, upload berbahaya.
@@ -122,11 +123,17 @@ pernah** menyatukan keduanya ke bucket/kredensial yang sama:
 - Cloudflare **account** boleh sama (satu akun, dua bucket) — yang
   wajib terpisah adalah bucket dan API token, bukan akun.
 
-Issue #632/#633 **wajib** menambahkan validasi eksplisit bahwa
-`NEWS_MEDIA_R2_BUCKET` ≠ `R2_BUCKET` (dan kredensial keduanya berbeda)
-di `config:validate`/`security:readiness` — jangan hanya
-mendokumentasikan tanpa menegakkan (lihat `r2-security-checklist.md` §7
-untuk kontrak lengkap yang wajib dipenuhi #635).
+**Ditegakkan (bukan hanya didokumentasikan) sejak Issue #632**:
+`findNewsMediaR2SeparationViolations`
+(`news-portal/domain/news-media-r2-config.ts`) membandingkan
+`NEWS_MEDIA_R2_BUCKET`/`_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` terhadap
+`R2_BUCKET`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` milik
+`sync-storage`, dipanggil dari `config:validate`
+(`checkNewsMediaR2SeparationFromSyncR2`, gagal boot bila sama) DAN
+`security:readiness` (`checkNewsPortalFullOnlineR2PresetReady`, critical)
+— lihat `r2-security-checklist.md` §7 untuk kontrak lengkap dan apa yang
+masih tersisa untuk #633/#634/#635 (schema/endpoint-level checks, bukan
+shape/separation ini).
 
 ### Keputusan kunci #2 — tidak ada fallback lokal, tidak ada temp file
 
@@ -174,23 +181,160 @@ termasuk karena risiko XSS (script tersemat). Mengizinkannya butuh
 pipeline sanitasi khusus dan keputusan terpisah — bukan sekadar
 menambah ke allow-list di issue mana pun.
 
-## §632 — Preset `news_portal_full_online_r2` (belum dikerjakan)
+## §632 — Preset `news_portal_full_online_r2` (Selesai)
 
-Ringkasan scope dari objective issue: menambah preset yang
-mengkonfigurasi AWCMS-Mini untuk news portal full-online, gambar
-hanya di R2. Implementor **wajib**:
+Implementasi lengkap: `src/modules/news-portal/` (module baru, minimal —
+lihat "Kenapa modul baru" di bawah), preset
+`news_portal_full_online_r2` di `module-management/domain/module-presets.ts`,
+readiness gate di `application/apply-news-portal-preset.ts`,
+`.env.example`, `18_configuration_env_reference.md` §News portal,
+`scripts/validate-env.ts`, `scripts/security-readiness.ts`. Tiga
+rekonsiliasi penamaan berikut **mengikat** issue #633-#649 lanjutan —
+jangan investigasi ulang, jangan pakai nama lain dari body issue #632
+yang sudah dilihat bertentangan berikut ini.
 
-- Memakai env var persis sesuai `full-online-r2-architecture.md` §4
-  (`NEWS_MEDIA_R2_*`), menambahkannya ke `.env.example` dan
-  `18_configuration_env_reference.md` (belum ada di kedua tempat itu
-  sampai issue ini).
-- Preset ini **tidak** mengubah default deployment offline/LAN/base
-  generik apa pun — hanya aktif untuk tenant/deployment yang eksplisit
-  mengaktifkannya (§1 arsitektur).
-- Perbarui baris status tabel di atas menjadi **Selesai** dan tambahkan
-  subbagian `### §632 — ...` (pola sama subbagian lain di bawah) begitu
-  selesai — jangan hanya mengubah kata "Belum dikerjakan" tanpa
-  merangkum keputusan konkret yang dibuat.
+### Rekonsiliasi #1 — env var R2 pakai `NEWS_MEDIA_R2_*`, BUKAN nama dari body issue #632
+
+Body issue #632 menulis `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`/
+`CLOUDFLARE_ACCOUNT_ID`/`R2_NEWS_IMAGE_*` — ini SENGAJA tidak diikuti.
+`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` adalah nama PERSIS yang sudah
+dipakai `sync-storage` (Issue #436); mengikutinya akan membuat dua fitur
+berbagi kredensial yang sama, tepat risiko yang Keputusan kunci #1 (di
+atas) dirancang mencegah. Dipakai sebagai gantinya: konvensi
+`NEWS_MEDIA_R2_*` PERSIS sesuai `full-online-r2-architecture.md` §4 —
+`NEWS_MEDIA_R2_ENABLED`, `_ACCOUNT_ID`, `_ACCESS_KEY_ID`,
+`_SECRET_ACCESS_KEY`, `_BUCKET`, `_PUBLIC_BASE_URL`,
+`_PRESIGNED_UPLOAD_TTL_SECONDS`, `_MAX_UPLOAD_BYTES`,
+`_ALLOWED_MIME_TYPES`, `_PENDING_TTL_MINUTES`. **Catatan**: dokumen §4
+TIDAK punya `NEWS_MEDIA_R2_CUSTOM_DOMAIN` terpisah (§11-nya menyatakan
+`_PUBLIC_BASE_URL` SUDAH mencakup custom domain) — implementor #633/#634
+jangan menambah var `_CUSTOM_DOMAIN` terpisah tanpa keputusan eksplisit
+baru. Resolver: `src/modules/news-portal/domain/news-media-r2-config.ts`
+(`resolveNewsMediaR2Config`, `findMissingNewsMediaR2Vars`,
+`findNewsMediaR2SeparationViolations`, `allowsSvgMimeType`).
+
+### Rekonsiliasi #2 — tidak ada `DEPLOYMENT_PROFILE`/`BLOG_PUBLIC_ROUTE_MODE`/`BLOG_PUBLIC_BASE_PATH` baru
+
+Body issue #632 menulis ketiga var ini seolah baru. Investigasi
+membuktikan:
+
+- `DEPLOYMENT_PROFILE` **tidak ada di kode sama sekali** (hanya narasi
+  `deployment-profiles.md`) — TIDAK ditambahkan. Konvensi repo ini adalah
+  flag independen per-fitur (`R2_ENABLED`, `EMAIL_ENABLED`,
+  `VISITOR_ANALYTICS_ENABLED`, dst), bukan satu enum sentral. "Full-online"
+  untuk preset ini dinyatakan lewat **dua var baru yang sempit**:
+  `NEWS_PORTAL_ENABLED` (master switch preset ini sendiri) dan
+  `NEWS_PORTAL_PROFILE` (saat ini hanya nilai valid `full_online_r2`) —
+  digabung dengan `NEWS_MEDIA_R2_ENABLED` yang sudah ada. Tiga flag
+  independen yang harus SEKALIGUS `true`/cocok, bukan satu master switch.
+- `BLOG_PUBLIC_ROUTE_MODE=domain_default` di body issue **bukan** env var
+  baru — string `"domain_default"` itu adalah nilai `PUBLIC_ROUTE_MODES`
+  yang SUDAH ADA di `blog_content`'s per-tenant module setting
+  `publicRouteMode` (`blog-content/application/public-route-settings.ts`,
+  Issue #564), sudah default ke situ untuk setiap tenant hari ini. TIDAK
+  ditambahkan env var baru untuk ini — preset #632 hanya
+  MEREKOMENDASIKAN (dokumentasi, bukan mekanisme baru) tenant
+  membiarkannya di default `"domain_default"` dan mengatur kolom
+  `route_mode` (`canonical`/`legacy_blog`) milik
+  `awcms_mini_tenant_domains` (Issue #557, per-domain, BUKAN per-tenant
+  global) ke `"canonical"` lewat API tenant-domain yang sudah ada
+  (#562) untuk domain yang dipakai news portal.
+- `BLOG_PUBLIC_BASE_PATH` di body issue juga bukan var baru — itu
+  `PUBLIC_CANONICAL_BASE_PATH` (Issue #556) yang sudah ada, default
+  `/news`. TIDAK ditambahkan var baru.
+
+Detail lengkap ada di komentar header
+`src/modules/news-portal/domain/news-portal-preset-readiness.ts`.
+
+### Rekonsiliasi #3 — preset name BUKAN reuse dari preset `news_portal` yang sudah ada
+
+`module-management/domain/module-presets.ts` SUDAH punya preset bernama
+`"news_portal"` (Issue #565, epic #555 — "online website + editorial
+approval workflow", TIDAK terkait R2/media sama sekali). Preset baru
+issue ini bernama **`news_portal_full_online_r2`** — nama yang BERBEDA,
+BUKAN rename/merge dari yang sudah ada. Keduanya hidup berdampingan di
+`MODULE_PRESETS`; lihat komentar `// NOTE:` tepat di atas entry
+`news_portal_full_online_r2` di file itu.
+
+### Kenapa modul baru `news_portal` diregistrasi sekarang (bukan ditunda)
+
+`src/modules/news-portal/module.ts` — module baru, minimal (tanpa
+`permissions`/`navigation`/`api`/`settings`/`jobs`/`health`, sama pola
+`visitor_analytics` sebelum fitur nyatanya ada). Diregistrasi sekarang
+karena preset butuh module key nyata untuk enable/disable (pola sama
+`tenant_domain`, Issue #558, register descriptor duluan sebelum
+resolver/routes/admin UI). **PENTING**: `dependencies` HANYA
+`["tenant_admin", "identity_access"]` — SENGAJA TIDAK menyertakan
+`blog_content`/`tenant_domain`/`visitor_analytics` walau hubungan
+konseptual "layer di atas" itu benar (dijelaskan di `description`
+descriptor). Percobaan pertama menambahkan mereka sebagai
+`dependencies` nyata memecahkan 3 test integrasi yang sudah ada
+(`blog-content-public-news.integration.test.ts` disable blog_content
+gagal 409, `module-presets.integration.test.ts`'s online_website test)
+karena setiap tenant baru punya SEMUA module enabled by default —
+`news_portal` yang enabled-by-default lalu memblokir disable
+blog_content/tenant_domain/visitor_analytics SELAMANYA lewat
+`MODULE_REVERSE_DEPENDENCY_ACTIVE`. Implementor #633+ **jangan**
+menambahkan dependency itu lagi tanpa memikirkan ulang konsekuensi ini —
+urutan enable di dalam SATU preset application sudah cukup dijamin oleh
+`enabledModuleKeys`'s urutan + `planEnableOrder`, tidak perlu dependency
+permanen di graph.
+
+### Readiness gate — WAJIB lewat `applyNewsPortalFullOnlineR2Preset`
+
+`src/modules/news-portal/application/apply-news-portal-preset.ts`
+adalah SATU-SATUNYA jalur yang sah untuk mengaktifkan preset ini — ia
+menjalankan `evaluateNewsPortalFullOnlineR2Readiness` (env: harus
+`NEWS_PORTAL_ENABLED=true`, `NEWS_PORTAL_PROFILE=full_online_r2`,
+`NEWS_MEDIA_R2_*` lengkap DAN terpisah dari `R2_*` sync-storage) sebelum
+memanggil `applyModulePreset` generik, dan mengaudit baik penolakan
+(`news_portal_preset_activation_rejected`, warning) maupun keberhasilan
+(`news_portal_preset_activated`, info) — keduanya via
+`recordAuditEvent`, `moduleKey: "news_portal"`. Generic
+`applyModulePreset` module-management **tidak tahu apa-apa** soal R2 —
+ia tidak boleh diimpor modul domain manapun (lihat header comment
+`module-presets.ts` sendiri) — jadi gate ini TIDAK bisa dipindah ke sana;
+ia hidup sebagai wrapper terpisah. Belum ada endpoint HTTP yang memanggil
+`applyModulePreset`/wrapper ini sama sekali (issue lanjutan/setup wizard).
+
+### Tidak ada flag "local fallback" sungguhan
+
+Acceptance criteria issue minta "readiness gagal bila local upload
+diaktifkan" — TIDAK diimplementasikan sebagai flag runtime
+(`NEWS_MEDIA_LOCAL_FALLBACK_ENABLED` dkk) karena mode ini secara
+struktural tidak punya jalur local-upload untuk didisable. Sebagai
+gantinya: `tests/unit/news-portal-no-local-fallback.test.ts` — test
+struktural yang grep seluruh `src/modules/news-portal/**` mencari
+`Bun.write`/`fs.writeFile`/`LOCAL_STORAGE_PATH`/dst, gagal loud begitu
+PR manapun (#634 khususnya) menambah jalur itu.
+
+### File yang dibuat/diubah (referensi cepat)
+
+- `src/modules/news-portal/module.ts`, `domain/news-media-r2-config.ts`,
+  `domain/news-portal-preset-readiness.ts`,
+  `application/apply-news-portal-preset.ts`.
+- `src/modules/index.ts`,
+  `src/modules/module-management/domain/module-presets.ts` (preset entry
+  - `ModulePresetName` union).
+- `scripts/validate-env.ts`
+  (`checkNewsPortalProfileConfig`/`checkNewsMediaR2Config`/
+  `checkNewsMediaR2SeparationFromSyncR2`/`isHttpsAbsoluteUrl`),
+  `scripts/security-readiness.ts`
+  (`checkNewsPortalFullOnlineR2PresetReady`/`checkNewsMediaR2SvgNotAllowed`).
+- `.env.example`, `18_configuration_env_reference.md` §News portal,
+  `full-online-r2-architecture.md` §4 (status diperbarui),
+  `r2-security-checklist.md` §7 (status diperbarui — sebagian besar
+  kontrak yang tadinya dijadwalkan #635 sudah terpenuhi #632; sisa untuk
+  #633/#634/#635 hanya check yang butuh tabel registry/endpoint upload
+  nyata).
+- Test: `tests/unit/news-media-r2-config.test.ts`,
+  `tests/unit/news-portal-preset-readiness.test.ts`,
+  `tests/unit/news-portal-no-local-fallback.test.ts`,
+  `tests/modules/news-portal-module.test.ts`,
+  `tests/integration/news-portal-preset.integration.test.ts`; diperbarui:
+  `tests/unit/module-presets.test.ts`,
+  `tests/integration/module-presets.integration.test.ts`,
+  `tests/foundation.test.ts` (module count 13→14).
 
 ## §633 — Media object registry (belum dikerjakan)
 

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -129,7 +129,11 @@ pernah** menyatukan keduanya ke bucket/kredensial yang sama:
 `NEWS_MEDIA_R2_BUCKET`/`_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` terhadap
 `R2_BUCKET`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` milik
 `sync-storage`, dipanggil dari `config:validate`
-(`checkNewsMediaR2SeparationFromSyncR2`, gagal boot bila sama) DAN
+(`checkNewsMediaR2SeparationFromSyncR2`, gagal `bun run config:validate`/
+gate CI-deploy bila sama — **bukan** penegakan boot-time otomatis di
+server; `config:validate`/`security:readiness` adalah script CLI mandiri
+yang tidak dipanggil dari `src/server.ts`, sama seperti seluruh keluarga
+check lain di `validate-env.ts`) DAN
 `security:readiness` (`checkNewsPortalFullOnlineR2PresetReady`, critical)
 — lihat `r2-security-checklist.md` §7 untuk kontrak lengkap dan apa yang
 masih tersisa untuk #633/#634/#635 (schema/endpoint-level checks, bukan
@@ -296,6 +300,43 @@ ia tidak boleh diimpor modul domain manapun (lihat header comment
 `module-presets.ts` sendiri) — jadi gate ini TIDAK bisa dipindah ke sana;
 ia hidup sebagai wrapper terpisah. Belum ada endpoint HTTP yang memanggil
 `applyModulePreset`/wrapper ini sama sekali (issue lanjutan/setup wizard).
+
+**PENTING untuk issue lanjutan yang menambah endpoint/setup-wizard
+pertama yang memanggil preset ini (temuan reviewer+security-auditor
+PR #651, keduanya PASS tapi dengan catatan mengikat)**:
+
+1. `applyModulePreset(tx, tenantId, actor, "news_portal_full_online_r2")`
+   dipanggil langsung (melewati wrapper) hari ini **akan** mengaktifkan
+   preset TANPA readiness gate dan TANPA audit event — generic engine-nya
+   tidak tahu preset ini butuh gate. Inert hari ini (tidak ada caller sama
+   sekali), tapi begitu issue lanjutan menambah caller apa pun ke
+   `applyModulePreset`, WAJIB memastikan literal string
+   `"news_portal_full_online_r2"` hanya pernah lewat
+   `applyNewsPortalFullOnlineR2Preset`, tidak pernah dipanggil generic
+   function-nya langsung — tambahkan test struktural (pola sama
+   `news-portal-no-local-fallback.test.ts`) yang men-grep memastikan ini,
+   jangan cuma mengandalkan disiplin code review.
+2. `applyModulePreset`/wrapper ini **tidak melakukan ABAC/permission check
+   sendiri** (by design, sama pola `enableTenantModule`/
+   `disableTenantModule` — tanggung jawab pemanggil). Issue pertama yang
+   menambah endpoint HTTP/halaman admin untuk mengaktifkan preset ini
+   WAJIB menambah `authorizeInTransaction` (skill `awcms-mini-abac-guard`)
+   dan mendaftarkan endpoint itu di OpenAPI — jangan asumsikan wrapper ini
+   "sudah aman" karena sudah ada readiness+audit, itu bukan pengganti
+   lapisan otorisasi.
+3. Readiness/audit gate ini bersifat **global per-deployment** (baca env
+   var, bukan state module per-tenant) — ia tidak memverifikasi bahwa
+   `blog_content`/`tenant_domain`/`visitor_analytics` masih benar-benar
+   `tenantEnabled=true` untuk tenant yang preset-nya sedang aktif (lihat
+   §"Kenapa modul baru... dependencies HANYA..." di atas — ini sengaja,
+   supaya `news_portal` bisa jadi leaf yang bisa di-disable). Konsekuensi:
+   seorang admin tenant bisa mengaktifkan preset ini lalu belakangan
+   men-disable `blog_content` untuk tenant itu tanpa terblokir apa pun,
+   dan readiness check tetap melaporkan "ready" walau tenant itu
+   fungsionalnya tidak bisa lagi menyajikan berita. Begitu #633/#634
+   menambah API/health nyata yang dikonsumsi operator/end-user, tambahkan
+   pemeriksaan tenant-scoped terpisah (bukan cuma env-level) sebelum
+   mengklaim tenant tersebut "ready".
 
 ### Tidak ada flag "local fallback" sungguhan
 

--- a/.env.example
+++ b/.env.example
@@ -249,6 +249,49 @@ VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS=730
 # Kosong di file ini secara sengaja; jangan isi dengan nilai rahasia asli.
 VISITOR_ANALYTICS_HASH_SALT=
 
+# News portal — full-online R2-only preset (opsional, Issue #632, epic
+# `news_portal` #631-#642/#649, modul `news_portal`). Dua flag di bawah
+# adalah master switch preset ini sendiri — TIDAK terkait
+# DEPLOYMENT_PROFILE (var itu tidak ada di repo ini, lihat
+# docs/awcms-mini/news-portal/full-online-r2-architecture.md dan
+# `.claude/skills/awcms-mini-news-portal/SKILL.md` §632 untuk alasan
+# lengkap kenapa tidak ditambahkan). Aktivasi preset
+# `news_portal_full_online_r2` WAJIB lewat
+# `applyNewsPortalFullOnlineR2Preset` (src/modules/news-portal/application/
+# apply-news-portal-preset.ts), yang menegakkan ketiga syarat di bawah
+# SEKALIGUS terpenuhinya NEWS_MEDIA_R2_* (blok berikutnya) sebelum
+# mengizinkan aktivasi.
+NEWS_PORTAL_ENABLED=false
+# Wajib "full_online_r2" (satu-satunya nilai valid hari ini) bila
+# NEWS_PORTAL_ENABLED=true.
+# NEWS_PORTAL_PROFILE=full_online_r2
+
+# News media R2-only storage (opsional, Issue #632, konvensi penamaan
+# `NEWS_MEDIA_R2_*` dari Issue #631 architecture doc §4 — SENGAJA BUKAN
+# `R2_*` yang sudah dipakai sync-storage di atas: bucket dan kredensial di
+# bawah ini WAJIB berbeda dari R2_ACCOUNT_ID/R2_ACCESS_KEY_ID/
+# R2_SECRET_ACCESS_KEY/R2_BUCKET — `bun run config:validate` dan
+# `bun run security:readiness` menolak konfigurasi yang menyamakan
+# keduanya). Media berita ini publik-by-design (custom domain, tanpa
+# presigned GET) — beda total dari object queue privat sync-storage.
+# Tidak ada fallback filesystem lokal dalam mode ini (lihat README modul
+# `news-portal` dan architecture doc §3).
+NEWS_MEDIA_R2_ENABLED=false
+# Wajib diisi hanya bila NEWS_MEDIA_R2_ENABLED=true; jangan isi dengan
+# kredensial asli di file ini, dan jangan pernah menyamakan dengan
+# R2_ACCOUNT_ID/R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY/R2_BUCKET di atas.
+# NEWS_MEDIA_R2_ACCOUNT_ID=
+# NEWS_MEDIA_R2_ACCESS_KEY_ID=
+# NEWS_MEDIA_R2_SECRET_ACCESS_KEY=
+# NEWS_MEDIA_R2_BUCKET=
+# NEWS_MEDIA_R2_PUBLIC_BASE_URL=
+NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS=300
+NEWS_MEDIA_R2_MAX_UPLOAD_BYTES=10485760
+# image/svg+xml sengaja TIDAK termasuk default (risiko XSS) — lihat
+# architecture doc §9 sebelum menambahkannya.
+NEWS_MEDIA_R2_ALLOWED_MIME_TYPES=image/jpeg,image/png,image/webp,image/gif
+NEWS_MEDIA_R2_PENDING_TTL_MINUTES=60
+
 # Provider eksternal opsional (default off) — base tidak menetapkan provider
 # tertentu; aplikasi turunan menambah flag provider-nya sendiri di sini
 # (lihat contoh domain retail/POS di doc 18 §Provider CRM/AI analyst).

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -505,6 +505,56 @@ pernah baca `process.env.VISITOR_ANALYTICS_*` langsung) dan lulus
 BERSIH pada konfigurasi default (semua var tidak di-set) — hanya
 `critical` yang memblokir go-live.
 
+### News portal — full-online R2-only preset (opsional, Issue #632, epic `news_portal` #631-#642/#649)
+
+Modul `news_portal` (`src/modules/news-portal/`). Preset tenant module
+`news_portal_full_online_r2` (`module-management/domain/module-presets.ts`)
+mengaktifkan `blog_content`+`tenant_domain`+`visitor_analytics`+`news_portal`
+untuk profil news portal full-online, gambar berita **hanya** di Cloudflare
+R2. Aktivasi WAJIB lewat `applyNewsPortalFullOnlineR2Preset`
+(`news-portal/application/apply-news-portal-preset.ts`), yang menegakkan
+readiness gate di bawah sebelum menjalankan `applyModulePreset` generik —
+lihat `.claude/skills/awcms-mini-news-portal/SKILL.md` §632 untuk keputusan
+arsitektur lengkap (termasuk kenapa TIDAK ada var `DEPLOYMENT_PROFILE`/
+`BLOG_PUBLIC_ROUTE_MODE`/`BLOG_PUBLIC_BASE_PATH` baru — dua yang terakhir
+sudah ada sebagai konsep lain: `blog_content`'s per-tenant module setting
+`publicRouteMode` dan `PUBLIC_CANONICAL_BASE_PATH` di atas).
+
+| Var                                          | Wajib        | Default                                     | Sensitif | Fungsi                                                                                        |
+| -------------------------------------------- | ------------ | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `NEWS_PORTAL_ENABLED`                        | –            | `false`                                     | –        | Master switch preset `news_portal_full_online_r2` itu sendiri                                 |
+| `NEWS_PORTAL_PROFILE`                        | bila enabled | –                                           | –        | Wajib `full_online_r2` (satu-satunya nilai valid hari ini)                                    |
+| `NEWS_MEDIA_R2_ENABLED`                      | –            | `false`                                     | –        | Master switch mode R2-only news media                                                         |
+| `NEWS_MEDIA_R2_ACCOUNT_ID`                   | bila enabled | –                                           | –        | Boleh sama dengan `R2_ACCOUNT_ID` (satu akun Cloudflare) atau berbeda                         |
+| `NEWS_MEDIA_R2_ACCESS_KEY_ID`                | bila enabled | –                                           | Ya       | WAJIB berbeda dari `R2_ACCESS_KEY_ID` — ditegakkan `config:validate`/`security:readiness`     |
+| `NEWS_MEDIA_R2_SECRET_ACCESS_KEY`            | bila enabled | –                                           | Ya       | WAJIB berbeda dari `R2_SECRET_ACCESS_KEY` — ditegakkan `config:validate`/`security:readiness` |
+| `NEWS_MEDIA_R2_BUCKET`                       | bila enabled | –                                           | –        | WAJIB berbeda dari `R2_BUCKET` — ditegakkan `config:validate`/`security:readiness`            |
+| `NEWS_MEDIA_R2_PUBLIC_BASE_URL`              | bila enabled | –                                           | –        | Custom domain publik (HTTPS absolut), mis. `https://media.contoh-berita.id`                   |
+| `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` | –            | `300`                                       | –        | TTL presigned PUT upload (bukan TTL baca — baca selalu publik)                                |
+| `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`             | –            | `10485760` (10 MiB)                         | –        | Batas ukuran per file                                                                         |
+| `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`           | –            | `image/jpeg,image/png,image/webp,image/gif` | –        | Allow-list MIME — `image/svg+xml` sengaja tidak termasuk default (risiko XSS)                 |
+| `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`          | –            | `60`                                        | –        | Batas usia objek `pending` sebelum dibersihkan lifecycle job (Issue #633 lanjutan)            |
+
+`bun run config:validate` (`checkNewsPortalProfileConfig`,
+`checkNewsMediaR2Config`, `checkNewsMediaR2SeparationFromSyncR2`) menolak
+boot bila `NEWS_PORTAL_PROFILE` bukan nilai yang dikenal, bila
+`NEWS_MEDIA_R2_ENABLED=true` tapi var wajib di atas hilang, ATAU bila
+`NEWS_MEDIA_R2_BUCKET`/`_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` sama persis
+dengan `R2_BUCKET`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` milik
+sync-storage (Issue #631 architecture doc §2). `bun run security:readiness`
+(`checkNewsPortalFullOnlineR2PresetReady`, critical;
+`checkNewsMediaR2SvgNotAllowed`, warning) menilai kombinasi penuh syarat
+aktivasi preset dan memperingatkan bila allow-list MIME di-override untuk
+mengizinkan `image/svg+xml`.
+
+Tidak ada var `FILE_STORAGE_DRIVER`/`LOCAL_FILE_UPLOADS_ENABLED`/
+`LOCAL_MEDIA_STORAGE_ENABLED` di sini — mode ini secara struktural tidak
+punya opsi fallback filesystem lokal untuk gambar berita sama sekali
+(bukan flag yang di-set `false`, karena tidak ada kode jalur upload
+lokal untuk media berita yang perlu dimatikan — lihat
+`tests/unit/news-portal-no-local-fallback.test.ts` dan architecture doc
+§3.3-3.4).
+
 ### Provider CRM (opsional) — contoh domain retail/POS
 
 | Var                    | Wajib      | Default | Sensitif | Fungsi             |
@@ -615,6 +665,11 @@ VISITOR_ANALYTICS_MODE=basic
 VISITOR_ANALYTICS_RAW_IP_ENABLED=false
 VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED=false
 VISITOR_ANALYTICS_GEO_ENABLED=false
+
+# News portal — full-online R2-only preset (opsional — Issue #632, epic
+# `news_portal`). Tidak di-set sama sekali = preset tidak aktif.
+NEWS_PORTAL_ENABLED=false
+NEWS_MEDIA_R2_ENABLED=false
 
 # Provider opsional (default off) — contoh domain retail/POS
 STARSENDER_ENABLED=false

--- a/docs/awcms-mini/news-portal/full-online-r2-architecture.md
+++ b/docs/awcms-mini/news-portal/full-online-r2-architecture.md
@@ -102,31 +102,35 @@ mengasumsikan akun yang sama.
    direferensikan editorial (post, gallery, ads, video thumbnail) hanya
    boleh menunjuk media berstatus `confirmed`.
 
-## 4. Konvensi environment variable (rencana penamaan, belum diimplementasikan)
+## 4. Konvensi environment variable
 
-**Penting:** var di bawah **belum ada** di `.env.example`/
-`18_configuration_env_reference.md` — issue ini murni dokumentasi.
-Issue #632 (preset) dan #633 (registry) adalah yang benar-benar
-menambahkannya ke `.env.example`/doc 18/`scripts/validate-env.ts`. Nama
-di sini adalah **konvensi yang wajib diikuti** implementasi supaya tidak
-ada issue lanjutan yang menciptakan skema penamaan lain atau (lebih
-buruk) menimpakan arti baru ke `R2_*` yang sudah dipakai `sync-storage`.
+**Status: diimplementasikan oleh Issue #632.** Var di bawah sudah ada di
+`.env.example` dan `18_configuration_env_reference.md` §News portal,
+ditegakkan `scripts/validate-env.ts` (`checkNewsPortalProfileConfig`,
+`checkNewsMediaR2Config`, `checkNewsMediaR2SeparationFromSyncR2`) dan
+`scripts/security-readiness.ts` (`checkNewsPortalFullOnlineR2PresetReady`,
+`checkNewsMediaR2SvgNotAllowed`), dan diresolusi oleh
+`src/modules/news-portal/domain/news-media-r2-config.ts`
+(`resolveNewsMediaR2Config`). Nama di sini tetap **konvensi wajib**
+persis apa adanya untuk implementor lanjutan (#633/#634) — jangan
+menciptakan skema penamaan lain atau menimpakan arti baru ke `R2_*` yang
+sudah dipakai `sync-storage`.
 
 Prefix **`NEWS_MEDIA_R2_`** — sengaja berbeda dari `R2_*` generik
 (§2, disambiguasi eksplisit dari bucket sync):
 
-| Var (rencana)                                | Wajib bila   | Default                                     | Catatan                                                                                        |
-| -------------------------------------------- | ------------ | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `NEWS_MEDIA_R2_ENABLED`                      | –            | `false`                                     | Master switch mode R2-only news media. Bagian dari preset #632.                                |
-| `NEWS_MEDIA_R2_ACCOUNT_ID`                   | bila enabled | –                                           | Boleh sama dengan `R2_ACCOUNT_ID` (satu akun Cloudflare) atau berbeda (§2).                    |
-| `NEWS_MEDIA_R2_ACCESS_KEY_ID`                | bila enabled | –                                           | Token least-privilege terpisah dari `R2_ACCESS_KEY_ID` — **wajib** berbeda (§2, §13).          |
-| `NEWS_MEDIA_R2_SECRET_ACCESS_KEY`            | bila enabled | –                                           | Idem.                                                                                          |
-| `NEWS_MEDIA_R2_BUCKET`                       | bila enabled | –                                           | **Wajib** berbeda dari `R2_BUCKET` (§2) — divalidasi tidak sama saat `config:validate` (#635). |
-| `NEWS_MEDIA_R2_PUBLIC_BASE_URL`              | bila enabled | –                                           | Custom domain publik (§11), mis. `https://media.contoh-berita.id`. Harus HTTPS absolut.        |
-| `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` | –            | `300`                                       | TTL presigned PUT (§8). Bukan TTL baca — baca selalu publik lewat custom domain.               |
-| `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`             | –            | `10485760` (10 MiB)                         | Batas ukuran per file (§9).                                                                    |
-| `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`           | –            | `image/jpeg,image/png,image/webp,image/gif` | Allow-list MIME (§9) — **tidak termasuk** `image/svg+xml` (§9 alasan).                         |
-| `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`          | –            | `60`                                        | Batas usia objek `pending` sebelum dibersihkan lifecycle job (`r2-backup-lifecycle.md`).       |
+| Var                                          | Wajib bila   | Default                                     | Catatan                                                                                                                                                                                                                                                              |
+| -------------------------------------------- | ------------ | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEWS_MEDIA_R2_ENABLED`                      | –            | `false`                                     | Master switch mode R2-only news media. Bagian dari preset #632.                                                                                                                                                                                                      |
+| `NEWS_MEDIA_R2_ACCOUNT_ID`                   | bila enabled | –                                           | Boleh sama dengan `R2_ACCOUNT_ID` (satu akun Cloudflare) atau berbeda (§2).                                                                                                                                                                                          |
+| `NEWS_MEDIA_R2_ACCESS_KEY_ID`                | bila enabled | –                                           | Token least-privilege terpisah dari `R2_ACCESS_KEY_ID` — **wajib** berbeda (§2, §13).                                                                                                                                                                                |
+| `NEWS_MEDIA_R2_SECRET_ACCESS_KEY`            | bila enabled | –                                           | Idem.                                                                                                                                                                                                                                                                |
+| `NEWS_MEDIA_R2_BUCKET`                       | bila enabled | –                                           | **Wajib** berbeda dari `R2_BUCKET` (§2) — divalidasi tidak sama saat `config:validate`/`security:readiness` (diimplementasikan #632, bukan #635 — #635 masih menambah check readiness lain di luar separation ini, mis. MIME sniffing/checksum runtime enforcement). |
+| `NEWS_MEDIA_R2_PUBLIC_BASE_URL`              | bila enabled | –                                           | Custom domain publik (§11), mis. `https://media.contoh-berita.id`. Harus HTTPS absolut.                                                                                                                                                                              |
+| `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` | –            | `300`                                       | TTL presigned PUT (§8). Bukan TTL baca — baca selalu publik lewat custom domain.                                                                                                                                                                                     |
+| `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`             | –            | `10485760` (10 MiB)                         | Batas ukuran per file (§9).                                                                                                                                                                                                                                          |
+| `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`           | –            | `image/jpeg,image/png,image/webp,image/gif` | Allow-list MIME (§9) — **tidak termasuk** `image/svg+xml` (§9 alasan).                                                                                                                                                                                               |
+| `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`          | –            | `60`                                        | Batas usia objek `pending` sebelum dibersihkan lifecycle job (`r2-backup-lifecycle.md`).                                                                                                                                                                             |
 
 Implementor (#632/#633/#634) wajib memakai nama ini persis — jangan
 memilih nama lain "yang mirip" tanpa memperbarui tabel ini.

--- a/docs/awcms-mini/news-portal/r2-security-checklist.md
+++ b/docs/awcms-mini/news-portal/r2-security-checklist.md
@@ -125,40 +125,45 @@ terpisah — **tidak pernah** lewat token yang sama yang disuntik ke
 
 ## 7. Readiness gates (`config:validate` / `security:readiness` / `production:preflight`)
 
-Acceptance criteria Issue #631 mensyaratkan readiness checklist ini
-merujuk tiga command yang sudah ada di repo — status saat ini (Issue
-#631, docs-only): **belum ada check khusus news media** di ketiganya;
-Issue #635 ("Add Cloudflare R2 image delivery readiness checks") adalah
-yang mengimplementasikannya. Kontrak yang wajib dipenuhi Issue #635:
+**Status: diimplementasikan oleh Issue #632** (lebih awal dari rencana
+semula #635 — #632's acceptance criteria sendiri mensyaratkan
+"`bun run config:validate` mencakup preset ini" dan
+"`bun run security:readiness` mencakup preset ini", jadi shape+separation
+checks di bawah landed bersamaan dengan preset itu sendiri, bukan
+menunggu #635):
 
-- **`bun run config:validate`** (shape-only, `scripts/validate-env.ts`)
-  wajib menambah:
-  - Bila `NEWS_MEDIA_R2_ENABLED=true`: `NEWS_MEDIA_R2_ACCOUNT_ID`,
-    `_ACCESS_KEY_ID`, `_SECRET_ACCESS_KEY`, `_BUCKET`,
-    `_PUBLIC_BASE_URL` wajib terisi (pola sama `checkR2Config` yang
-    sudah ada untuk `R2_*`).
-  - `NEWS_MEDIA_R2_BUCKET` ≠ `R2_BUCKET` (bila keduanya aktif) — gagal
-    validasi bila sama (§2 penegakan, bukan hanya dokumentasi).
-  - `NEWS_MEDIA_R2_PUBLIC_BASE_URL` harus URL HTTPS absolut.
-- **`bun run security:readiness`** (safety/severity, cross-field) wajib
-  menambah pengecekan **critical**:
-  - Bucket media dan bucket sync tidak sama (redundan dengan
-    `config:validate` sebagai defense in depth, pola yang sama dipakai
-    check lain di repo yang menduplikasi validasi shape+safety).
-  - Kredensial media berbeda dari kredensial sync.
-  - `image/svg+xml` tidak ada di `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`
-    kecuali operator eksplisit override (warning bila di-override, tidak
-    pernah default-on).
+- **`bun run config:validate`** (shape-only, `scripts/validate-env.ts`):
+  - `checkNewsPortalProfileConfig` — `NEWS_PORTAL_PROFILE` bila diisi
+    wajib `full_online_r2`.
+  - `checkNewsMediaR2Config` — bila `NEWS_MEDIA_R2_ENABLED=true`:
+    `NEWS_MEDIA_R2_ACCOUNT_ID`, `_ACCESS_KEY_ID`, `_SECRET_ACCESS_KEY`,
+    `_BUCKET`, `_PUBLIC_BASE_URL` wajib terisi (pola sama `checkR2Config`
+    untuk `R2_*`) DAN `_PUBLIC_BASE_URL` wajib URL HTTPS absolut.
+  - `checkNewsMediaR2SeparationFromSyncR2` — `NEWS_MEDIA_R2_BUCKET`/
+    `_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` ≠ `R2_BUCKET`/`R2_ACCESS_KEY_ID`/
+    `R2_SECRET_ACCESS_KEY` (§2 penegakan nyata, gagal boot bila sama —
+    bukan hanya dokumentasi).
+- **`bun run security:readiness`** (`scripts/security-readiness.ts`):
+  - `checkNewsPortalFullOnlineR2PresetReady` (**critical**) — menilai
+    kombinasi penuh syarat aktivasi preset (`NEWS_PORTAL_ENABLED`,
+    `NEWS_PORTAL_PROFILE`, kelengkapan+separasi `NEWS_MEDIA_R2_*`) lewat
+    `evaluateNewsPortalFullOnlineR2Readiness`
+    (`src/modules/news-portal/domain/news-portal-preset-readiness.ts`).
+  - `checkNewsMediaR2SvgNotAllowed` (**warning**) — `image/svg+xml` tidak
+    ada di `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` kecuali operator eksplisit
+    override.
 - **`bun run production:preflight`** — tidak butuh tahap baru (sudah
   menjalankan `config:validate` dan `security:readiness` sebagai bagian
-  urutannya, doc 18) — cukup pastikan kedua check di atas benar-benar
-  terpanggil dari urutan yang sudah ada, tidak membuat jalur pintas
-  terpisah.
+  urutannya, doc 18); kedua check di atas otomatis ikut terpanggil.
 
-Implementor #635 **wajib** memperbarui bagian ini (ganti "belum ada"
-menjadi nama fungsi/test nyata) begitu check-nya ditulis — jangan
-biarkan dokumen ini menyiratkan check sudah ada padahal belum
-(konsisten dengan status "Belum dikerjakan" di skill).
+**Masih terbuka untuk #633/#634/#635** (di luar cakupan #632): tidak ada
+check di atas yang menyentuh tabel media registry itu sendiri (objek
+`pending` basi, orphaned object detection — `r2-backup-lifecycle.md` §2)
+atau perilaku runtime endpoint upload (MIME sniffing dari magic bytes,
+checksum server-side dari isi objek — §9 arsitektur) karena tabel/endpoint
+itu belum ada. Implementor #633/#634/#635 **wajib** memperbarui bagian ini
+lagi begitu check readiness baru yang relevan ke schema/endpoint tersebut
+ditulis.
 
 ## 8. Monitoring & audit
 

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -49,6 +49,8 @@ import {
   checkTurnstileConfig
 } from "./validate-env";
 import { resolveVisitorAnalyticsConfig } from "../src/modules/visitor-analytics/domain/visitor-analytics-config";
+import { allowsSvgMimeType } from "../src/modules/news-portal/domain/news-media-r2-config";
+import { evaluateNewsPortalFullOnlineR2Readiness } from "../src/modules/news-portal/domain/news-portal-preset-readiness";
 
 export type CheckSeverity = "critical" | "warning" | "info";
 export type CheckStatus = "pass" | "fail";
@@ -1616,6 +1618,100 @@ export function checkLoginRateLimitImplemented(): SecurityCheckResult {
 }
 
 // ---------------------------------------------------------------------------
+// 12. News portal full-online R2-only preset readiness (critical/warning —
+//     Issue #632, epic `news_portal` #631-#642/#649)
+// ---------------------------------------------------------------------------
+
+/**
+ * Critical: once a tenant/deployment has opted in (`NEWS_PORTAL_ENABLED=true`),
+ * every activation precondition (`NEWS_PORTAL_PROFILE=full_online_r2`,
+ * complete `NEWS_MEDIA_R2_*` config, config separated from sync-storage's
+ * own `R2_*`) must hold — reuses
+ * `evaluateNewsPortalFullOnlineR2Readiness` (domain, pure) rather than
+ * re-deriving the same checks a second way. Passes trivially when the
+ * feature isn't opted into at all (the default for every existing
+ * offline/LAN or non-news deployment).
+ */
+export function checkNewsPortalFullOnlineR2PresetReady(
+  env: NodeJS.ProcessEnv = process.env
+): SecurityCheckResult {
+  const name = "News portal full-online R2-only preset readiness (Issue #632)";
+  const severity: CheckSeverity = "critical";
+
+  if (env.NEWS_PORTAL_ENABLED !== "true") {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence:
+        'NEWS_PORTAL_ENABLED is not "true" — the news_portal_full_online_r2 preset is not in use.'
+    };
+  }
+
+  const readiness = evaluateNewsPortalFullOnlineR2Readiness(env);
+
+  if (readiness.ready) {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence:
+        "NEWS_PORTAL_ENABLED=true, NEWS_PORTAL_PROFILE=full_online_r2, and NEWS_MEDIA_R2_* config is complete and separated from sync-storage's R2_* config."
+    };
+  }
+
+  return {
+    name,
+    severity,
+    status: "fail",
+    evidence: readiness.detail.join(" ")
+  };
+}
+
+/**
+ * Warning (not critical): `image/svg+xml` is excluded from the default
+ * `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` allow-list on purpose (SVG can embed
+ * `<script>`/event handlers — architecture doc §9). An operator CAN
+ * override the allow-list to include it, but that should be a deliberate,
+ * reviewed decision paired with a sanitization pipeline — not an
+ * accidental broadening. This check flags the override, it does not block
+ * go-live on its own.
+ */
+export function checkNewsMediaR2SvgNotAllowed(
+  env: NodeJS.ProcessEnv = process.env
+): SecurityCheckResult {
+  const name = "News media R2 allow-list excludes image/svg+xml by default";
+  const severity: CheckSeverity = "warning";
+
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence:
+        'NEWS_MEDIA_R2_ENABLED is not "true" — no MIME allow-list in effect.'
+    };
+  }
+
+  if (allowsSvgMimeType(env)) {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence:
+        "NEWS_MEDIA_R2_ALLOWED_MIME_TYPES includes image/svg+xml — verify this is a deliberate override paired with a real SVG sanitization pipeline, not an accidental broadening of the default allow-list (XSS risk via embedded <script>/event handlers)."
+    };
+  }
+
+  return {
+    name,
+    severity,
+    status: "pass",
+    evidence: "NEWS_MEDIA_R2_ALLOWED_MIME_TYPES does not include image/svg+xml."
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Out-of-scope items — printed as their own report section, never silently
 // dropped.
 // ---------------------------------------------------------------------------
@@ -1688,6 +1784,8 @@ export async function runSecurityReadinessChecks(): Promise<
     checkVisitorAnalyticsGeoTrustedSourceReady(),
     checkVisitorAnalyticsRetentionOrderingReady(),
     checkVisitorAnalyticsHashSaltReady(),
+    checkNewsPortalFullOnlineR2PresetReady(),
+    checkNewsMediaR2SvgNotAllowed(),
     await checkErrorsDontLeakStackTraces(),
     await checkSecurityHeadersPresent(),
     checkLoginRateLimitImplemented()

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -129,6 +129,25 @@
  *     (`parsePositiveInt`). No conditional cross-field requirement exists
  *     yet (unlike EMAIL_PROVIDER/TENANT_DOMAIN_DNS_PROVIDER) — geolocation
  *     enrichment provider config lands in a later issue (#623).
+ * 11. News portal full-online R2-only preset (Issue #632, epic `news_portal`
+ *     #631-#642/#649): if NEWS_PORTAL_PROFILE is set, it must be one of
+ *     `NEWS_PORTAL_PROFILES` (currently only "full_online_r2") —
+ *     `../src/modules/news-portal/domain/news-portal-preset-readiness`. If
+ *     NEWS_MEDIA_R2_ENABLED === "true", NEWS_MEDIA_R2_ACCOUNT_ID,
+ *     NEWS_MEDIA_R2_ACCESS_KEY_ID, NEWS_MEDIA_R2_SECRET_ACCESS_KEY,
+ *     NEWS_MEDIA_R2_BUCKET, and NEWS_MEDIA_R2_PUBLIC_BASE_URL must all be
+ *     set (`../src/modules/news-portal/domain/news-media-r2-config`) —
+ *     mirrors the R2_ENABLED conditional check above (item 3), deliberately
+ *     namespaced `NEWS_MEDIA_R2_*` rather than reusing `R2_*` (see that
+ *     file's header comment: news-portal media is a public bucket, wholly
+ *     separate from sync-storage's private object queue — Issue #631
+ *     architecture doc §2). Regardless of NEWS_MEDIA_R2_ENABLED, if BOTH a
+ *     NEWS_MEDIA_R2_* var and its `sync-storage` R2_* counterpart
+ *     (BUCKET/ACCESS_KEY_ID/SECRET_ACCESS_KEY) are set and equal, validation
+ *     fails — this is enforced at config:validate as a hard boot-time
+ *     failure, not merely a security:readiness warning, because sharing a
+ *     credential between a private sync queue and a public media bucket is
+ *     never a valid configuration in this repo, not just a risky one.
  *
  * Never prints actual secret values — only which variable name is
  * missing/invalid (doc 18: "Var wajib hilang → gagal start dengan pesan
@@ -172,6 +191,14 @@ import {
   VISITOR_ANALYTICS_MODES,
   VISITOR_ANALYTICS_POSITIVE_INT_VARS
 } from "../src/modules/visitor-analytics/domain/visitor-analytics-config";
+import {
+  findNewsMediaR2SeparationViolations,
+  NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED
+} from "../src/modules/news-portal/domain/news-media-r2-config";
+import {
+  isKnownNewsPortalProfile,
+  NEWS_PORTAL_PROFILES
+} from "../src/modules/news-portal/domain/news-portal-preset-readiness";
 
 export type EnvCheckResult = {
   name: string;
@@ -216,6 +243,15 @@ function isKnownPublicTenantResolutionMode(
 
 function isSet(value: string | undefined): boolean {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+/** `NEWS_MEDIA_R2_PUBLIC_BASE_URL` must be an absolute HTTPS URL — news media is public-by-design (architecture doc §11), never `r2.dev` over plain HTTP in a real deployment. */
+function isHttpsAbsoluteUrl(value: string): boolean {
+  try {
+    return new URL(value.trim()).protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -847,6 +883,116 @@ export function checkVisitorAnalyticsConfig(
   return results;
 }
 
+/**
+ * News portal full-online R2-only preset (Issue #632, epic `news_portal`
+ * #631-#642/#649). `NEWS_PORTAL_PROFILE` shape check first, then
+ * `NEWS_MEDIA_R2_*` conditional-required-vars (mirrors `checkR2Config`
+ * exactly, different namespace), then the hard separation-from-sync-R2
+ * check (Keputusan kunci #1 — never a warning, always a boot-blocking
+ * failure when violated).
+ */
+export function checkNewsPortalProfileConfig(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult {
+  const name = "NEWS_PORTAL_PROFILE";
+  const raw = env.NEWS_PORTAL_PROFILE;
+
+  if (!isSet(raw)) {
+    return {
+      name,
+      status: "pass",
+      detail: `${name} is not set — the news_portal_full_online_r2 preset is not requested.`
+    };
+  }
+
+  if (isKnownNewsPortalProfile((raw as string).trim())) {
+    return {
+      name,
+      status: "pass",
+      detail: `${name} is a known profile (${(raw as string).trim()}).`
+    };
+  }
+
+  return {
+    name,
+    status: "fail",
+    detail: `${name} must be one of ${NEWS_PORTAL_PROFILES.join(", ")}; got "${(raw as string).trim()}".`
+  };
+}
+
+export function checkNewsMediaR2Config(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult[] {
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") {
+    return [
+      {
+        name: "News media R2 credentials (conditional on NEWS_MEDIA_R2_ENABLED)",
+        status: "pass",
+        detail:
+          'NEWS_MEDIA_R2_ENABLED is not "true" — news media R2 credentials not required.'
+      }
+    ];
+  }
+
+  const results: EnvCheckResult[] = NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED.map(
+    (name) => {
+      if (isSet(env[name])) {
+        return { name, status: "pass", detail: `${name} is set.` };
+      }
+
+      return {
+        name,
+        status: "fail",
+        detail: `NEWS_MEDIA_R2_ENABLED=true but ${name} is missing or empty.`
+      };
+    }
+  );
+
+  const publicBaseUrlName = "NEWS_MEDIA_R2_PUBLIC_BASE_URL";
+  const publicBaseUrl = env.NEWS_MEDIA_R2_PUBLIC_BASE_URL;
+
+  if (isSet(publicBaseUrl)) {
+    results.push(
+      isHttpsAbsoluteUrl(publicBaseUrl as string)
+        ? {
+            name: `${publicBaseUrlName} (format)`,
+            status: "pass",
+            detail: `${publicBaseUrlName} is an absolute HTTPS URL.`
+          }
+        : {
+            name: `${publicBaseUrlName} (format)`,
+            status: "fail",
+            detail: `${publicBaseUrlName} must be an absolute HTTPS URL (news media is public-by-design — architecture doc §11); got "${(publicBaseUrl as string).trim()}".`
+          }
+    );
+  }
+
+  return results;
+}
+
+export function checkNewsMediaR2SeparationFromSyncR2(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult {
+  const name =
+    "News media R2 bucket/credentials separated from sync-storage's R2_*";
+  const violations = findNewsMediaR2SeparationViolations(env);
+
+  if (violations.length === 0) {
+    return {
+      name,
+      status: "pass",
+      detail:
+        "No NEWS_MEDIA_R2_* value is equal to its sync-storage R2_* counterpart."
+    };
+  }
+
+  return {
+    name,
+    status: "fail",
+    detail: `NEWS_MEDIA_R2_* must never share a bucket/credential with sync-storage's R2_* config (Issue #631 architecture doc §2): ${violations.join(", ")}.`
+  };
+}
+
 export function runEnvValidation(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -862,7 +1008,10 @@ export function runEnvValidation(
     ...checkGoogleOidcConfig(env),
     ...checkSsoConfig(env),
     ...checkOnlineAuthSecurityConfig(env),
-    ...checkVisitorAnalyticsConfig(env)
+    ...checkVisitorAnalyticsConfig(env),
+    checkNewsPortalProfileConfig(env),
+    ...checkNewsMediaR2Config(env),
+    checkNewsMediaR2SeparationFromSyncR2(env)
   ];
 }
 

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -5,6 +5,7 @@ import { formDraftsModule } from "./form-drafts/module";
 import { identityAccessModule } from "./identity-access/module";
 import { loggingModule } from "./logging/module";
 import { moduleManagementModule } from "./module-management/module";
+import { newsPortalModule } from "./news-portal/module";
 import { profileIdentityModule } from "./profile-identity/module";
 import { reportingModule } from "./reporting/module";
 import { syncStorageModule } from "./sync-storage/module";
@@ -26,7 +27,8 @@ export const modules: ModuleDescriptor[] = [
   moduleManagementModule,
   blogContentModule,
   tenantDomainModule,
-  visitorAnalyticsModule
+  visitorAnalyticsModule,
+  newsPortalModule
 ];
 
 export function getModuleByKey(

--- a/src/modules/module-management/domain/module-presets.ts
+++ b/src/modules/module-management/domain/module-presets.ts
@@ -70,7 +70,12 @@ import type { ModuleDescriptor } from "../../_shared/module-contract";
 import type { ModuleTenantState } from "./tenant-module-lifecycle";
 
 export type ModulePresetName =
-  "online_website" | "news_portal" | "saas_online" | "pos_lan" | "minimal";
+  | "online_website"
+  | "news_portal"
+  | "news_portal_full_online_r2"
+  | "saas_online"
+  | "pos_lan"
+  | "minimal";
 
 export type ModulePresetDefinition = {
   name: ModulePresetName;
@@ -104,6 +109,32 @@ export const MODULE_PRESETS: readonly ModulePresetDefinition[] = [
       "email",
       "reporting",
       "workflow"
+    ]
+  },
+  // NOTE: "news_portal" above (Issue #565, epic #555) and
+  // "news_portal_full_online_r2" below (Issue #632, epic `news_portal`
+  // #631-#642/#649) are deliberately DIFFERENT preset names for
+  // DIFFERENT concepts — "news_portal" is "online website + editorial
+  // approval workflow" (no R2/media requirement at all), while
+  // "news_portal_full_online_r2" is the full-online, R2-only-media
+  // editorial+news profile. Do not merge/rename either one to "fix" the
+  // apparent naming overlap — a tenant using the plain `news_portal`
+  // preset is not required to have any NEWS_MEDIA_R2_* config, and this
+  // preset's own activation is gated (see
+  // `news-portal/application/apply-news-portal-preset.ts`) in a way
+  // `news_portal` above is not.
+  {
+    name: "news_portal_full_online_r2",
+    label: "News portal (full-online, R2-only media)",
+    description:
+      "Full-online public news portal profile: blog_content + tenant_domain + visitor_analytics editorial/media stack, with news images stored exclusively in Cloudflare R2 (bucket/credentials kept separate from sync_storage's own R2_* config, Issue #631 architecture doc §2). Activation MUST go through `applyNewsPortalFullOnlineR2Preset` (`news-portal/application/apply-news-portal-preset.ts`), never this generic `applyModulePreset` directly with this name — that wrapper runs the readiness gate (`news-portal/domain/news-portal-preset-readiness.ts`: NEWS_PORTAL_ENABLED=true, NEWS_PORTAL_PROFILE=full_online_r2, complete+separated NEWS_MEDIA_R2_* config) this generic engine has no way to enforce (it never imports concrete domain modules — see this file's own header comment).",
+    enabledModuleKeys: [
+      "blog_content",
+      "tenant_domain",
+      "visitor_analytics",
+      "module_management",
+      "identity_access",
+      "news_portal"
     ]
   },
   {

--- a/src/modules/news-portal/README.md
+++ b/src/modules/news-portal/README.md
@@ -1,0 +1,104 @@
+# News Portal
+
+Modul untuk epic `news_portal` (Issue #631-#642, #649) — lapisan
+editorial + media full-online, R2-only di atas `blog_content` (base
+module, sudah `active`) dan online public routing (`tenant_domain`).
+
+## Scope Issue #632 (status saat ini — satu-satunya yang sudah dikerjakan)
+
+Modul ini **baru berisi**:
+
+- Module descriptor (`module.ts`) — key `news_portal`, tanpa
+  `permissions`/`navigation`/`api`/`settings`/`jobs`/`health` (belum ada
+  fitur nyata yang membutuhkannya).
+- Preset tenant module `news_portal_full_online_r2`
+  (`../module-management/domain/module-presets.ts`) yang membundel
+  `blog_content` + `tenant_domain` + `visitor_analytics` +
+  `module_management` + `identity_access` + `news_portal`.
+- Config gate R2-only (`domain/news-media-r2-config.ts`) dan readiness
+  gate aktivasi preset (`domain/news-portal-preset-readiness.ts`).
+- Sanctioned entry point aktivasi preset
+  (`application/apply-news-portal-preset.ts`) — **satu-satunya** jalur
+  yang boleh dipakai untuk mengaktifkan preset ini (lihat komentar
+  header file itu).
+
+**Belum ada** (issue lanjutan di epic yang sama): media object registry
+/ schema (#633), endpoint upload presigned R2 (#634), integrasi
+`blog_content` mewajibkan media R2 `confirmed` (#636), homepage
+composer/ads/video/quality-checklist/tag-linking/social-share/SEO
+(#637-#642, #649).
+
+## Kenapa modul ini diregistrasi sekarang, dependencies minimal
+
+Lihat komentar panjang di `module.ts` dan
+`.claude/skills/awcms-mini-news-portal/SKILL.md` §632 untuk alasan
+lengkap. Ringkas: `dependencies` HANYA `["tenant_admin",
+"identity_access"]` — SENGAJA tidak menyertakan
+`blog_content`/`tenant_domain`/`visitor_analytics` walau relasi
+konseptual "layer di atas" itu nyata, karena menjadikannya dependency
+graph nyata memblokir disable ketiga module itu untuk SETIAP tenant
+(setiap module enabled by default) lewat
+`MODULE_REVERSE_DEPENDENCY_ACTIVE` — regresi nyata yang sempat memecah
+test integrasi yang sudah ada sebelum diperbaiki.
+
+## Konvensi penamaan env var — `NEWS_MEDIA_R2_*`, bukan `R2_*`
+
+`src/modules/sync-storage/` sudah memakai `R2_ENABLED`/`R2_ACCOUNT_ID`/
+`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`/`R2_BUCKET` sebagai object
+queue **privat** untuk sinkronisasi offline/LAN. News media R2 adalah
+kebutuhan **publik** yang fundamental berbeda (custom domain, CORS
+direct-upload) — bucket dan kredensialnya WAJIB terpisah total, memakai
+prefix `NEWS_MEDIA_R2_*` (lihat
+`docs/awcms-mini/news-portal/full-online-r2-architecture.md` §2/§4).
+`findNewsMediaR2SeparationViolations`
+(`domain/news-media-r2-config.ts`) menegakkan ini secara eksplisit di
+`bun run config:validate`/`bun run security:readiness` — konfigurasi
+yang menyamakan bucket/kredensial keduanya gagal boot/gagal go-live,
+bukan hanya diperingatkan.
+
+## Aktivasi preset
+
+```ts
+import { applyNewsPortalFullOnlineR2Preset } from "./application/apply-news-portal-preset";
+
+const result = await applyNewsPortalFullOnlineR2Preset(
+  tx,
+  tenantId,
+  actorTenantUserId,
+  process.env
+);
+```
+
+Menolak (tanpa mengubah state module apa pun) kecuali SEMUA berikut
+benar:
+
+- `NEWS_PORTAL_ENABLED=true`
+- `NEWS_PORTAL_PROFILE=full_online_r2`
+- `NEWS_MEDIA_R2_ENABLED=true` dan lima var wajibnya
+  (`NEWS_MEDIA_R2_ACCOUNT_ID`/`_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY`/
+  `_BUCKET`/`_PUBLIC_BASE_URL`) terisi
+- `NEWS_MEDIA_R2_BUCKET`/`_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` berbeda
+  dari `R2_BUCKET`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`
+  sync-storage
+
+Setiap keputusan (tolak maupun sukses) diaudit
+(`news_portal_preset_activation_rejected`/`news_portal_preset_activated`,
+`moduleKey: "news_portal"`).
+
+## Tidak ada fallback filesystem lokal
+
+Mode ini tidak pernah punya opsi menyimpan gambar berita ke disk lokal
+server — bukan flag yang dimatikan, tapi memang tidak ada kode jalur
+itu. `tests/unit/news-portal-no-local-fallback.test.ts` menegakkan ini
+secara struktural (grep source tree), gagal loud begitu PR manapun
+menambah jalur tulis lokal untuk media berita.
+
+## Referensi
+
+- `.claude/skills/awcms-mini-news-portal/SKILL.md` — status penuh epic +
+  keputusan arsitektur.
+- `docs/awcms-mini/news-portal/full-online-r2-architecture.md` —
+  arsitektur R2-only lengkap.
+- `docs/awcms-mini/18_configuration_env_reference.md` §News portal.
+- `src/modules/sync-storage/README.md` — R2 usage yang sudah ada
+  (bucket privat, terpisah dari modul ini).

--- a/src/modules/news-portal/application/apply-news-portal-preset.ts
+++ b/src/modules/news-portal/application/apply-news-portal-preset.ts
@@ -1,0 +1,131 @@
+/**
+ * Sanctioned entry point for activating the `news_portal_full_online_r2`
+ * module preset (Issue #632, epic `news_portal`). Wraps
+ * `module-management/application/module-presets.ts`'s generic
+ * `applyModulePreset` with a readiness gate this preset's activation
+ * requires (`domain/news-portal-preset-readiness.ts`) — the generic
+ * engine deliberately has zero knowledge of R2/media (it only ever
+ * receives plain `ModuleDescriptor[]` data, never imports a concrete
+ * domain module — see `module-management/domain/module-presets.ts`'s own
+ * header comment), so this gate cannot live there without breaking that
+ * separation.
+ *
+ * IMPORTANT for future callers (#633 onward, any future setup-wizard/API
+ * step that lets an operator apply a preset): call
+ * `applyNewsPortalFullOnlineR2Preset` for this specific preset name, never
+ * `applyModulePreset(tx, tenantId, actor, "news_portal_full_online_r2")`
+ * directly — the generic function has no way to enforce this gate itself.
+ * As of this issue nothing calls `applyModulePreset` from any HTTP route
+ * (module-presets.ts's own header comment: "no HTTP route in this issue")
+ * so there is no real bypass surface in production today; this comment
+ * exists to keep it that way.
+ */
+import { recordAuditEvent } from "../../logging/application/audit-log";
+import { applyModulePreset } from "../../module-management/application/module-presets";
+import type { ApplyModulePresetResult } from "../../module-management/application/module-presets";
+import { evaluateNewsPortalFullOnlineR2Readiness } from "../domain/news-portal-preset-readiness";
+
+export const NEWS_PORTAL_FULL_ONLINE_R2_PRESET_NAME =
+  "news_portal_full_online_r2";
+
+export type ApplyNewsPortalFullOnlineR2PresetResult =
+  | ({ outcome: "applied" } & Omit<
+      Extract<ApplyModulePresetResult, { outcome: "applied" }>,
+      "outcome"
+    >)
+  | {
+      outcome: "rejected";
+      code: "NEWS_PORTAL_PRESET_NOT_READY";
+      reasons: string[];
+      detail: string[];
+    }
+  | {
+      outcome: "rejected";
+      code: "MODULE_PRESET_NOT_FOUND";
+      reasons: string[];
+      detail: string[];
+    };
+
+/**
+ * Evaluates readiness first (pure, no I/O); on failure, records an audit
+ * event (`news_portal_preset_activation_rejected`, severity `warning` —
+ * this is a "security readiness decision" per skill
+ * `awcms-mini-audit-log`) and returns rejected WITHOUT touching any module
+ * enable/disable state. On success, delegates to the existing, generic
+ * `applyModulePreset` (which itself audits each individual module
+ * enable/disable — see `module-management/application/module-presets.ts`)
+ * and additionally records one more audit event confirming the gate
+ * passed, so "why was this tenant allowed into full-online R2-only mode"
+ * is answerable from the audit log alone, not just inferred from module
+ * enable events.
+ */
+export async function applyNewsPortalFullOnlineR2Preset(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  env: NodeJS.ProcessEnv = process.env,
+  correlationId?: string | null
+): Promise<ApplyNewsPortalFullOnlineR2PresetResult> {
+  const readiness = evaluateNewsPortalFullOnlineR2Readiness(env);
+
+  if (!readiness.ready) {
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId,
+      moduleKey: "news_portal",
+      action: "news_portal_preset_activation_rejected",
+      resourceType: "tenant_module_preset",
+      resourceId: NEWS_PORTAL_FULL_ONLINE_R2_PRESET_NAME,
+      severity: "warning",
+      message: `Activation of preset "${NEWS_PORTAL_FULL_ONLINE_R2_PRESET_NAME}" blocked: ${readiness.reasons.join(", ")}.`,
+      attributes: { reasons: readiness.reasons, detail: readiness.detail },
+      correlationId: correlationId ?? undefined
+    });
+
+    return {
+      outcome: "rejected",
+      code: "NEWS_PORTAL_PRESET_NOT_READY",
+      reasons: readiness.reasons,
+      detail: readiness.detail
+    };
+  }
+
+  const result = await applyModulePreset(
+    tx,
+    tenantId,
+    actorTenantUserId,
+    NEWS_PORTAL_FULL_ONLINE_R2_PRESET_NAME,
+    correlationId
+  );
+
+  if (result.outcome === "applied") {
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId,
+      moduleKey: "news_portal",
+      action: "news_portal_preset_activated",
+      resourceType: "tenant_module_preset",
+      resourceId: NEWS_PORTAL_FULL_ONLINE_R2_PRESET_NAME,
+      severity: "info",
+      message: `Preset "${NEWS_PORTAL_FULL_ONLINE_R2_PRESET_NAME}" activated (full-online R2-only readiness gate passed).`,
+      attributes: {
+        changes: result.changes.length,
+        skipped: result.skipped.length
+      },
+      correlationId: correlationId ?? undefined
+    });
+
+    return result;
+  }
+
+  // Generic engine only rejects with MODULE_PRESET_NOT_FOUND, which can't
+  // actually happen here (the preset name is a compile-time constant
+  // registered in MODULE_PRESETS) — but propagate faithfully rather than
+  // assert/throw, matching this repo's "never silently swallow" convention.
+  return {
+    outcome: "rejected",
+    code: "MODULE_PRESET_NOT_FOUND",
+    reasons: [result.code],
+    detail: [result.message]
+  };
+}

--- a/src/modules/news-portal/domain/news-media-r2-config.ts
+++ b/src/modules/news-portal/domain/news-media-r2-config.ts
@@ -1,0 +1,217 @@
+/**
+ * `NEWS_MEDIA_R2_*` configuration gate (Issue #632, epic `news_portal`
+ * #631-#642/#649). Pure — no `process.env` reads here; callers
+ * (`scripts/validate-env.ts`, `scripts/security-readiness.ts`,
+ * `application/apply-news-portal-preset.ts`) pass in whatever `env` they
+ * were given. Same split as `visitor-analytics/domain/visitor-analytics-config.ts`
+ * and `email/domain/email-config.ts`.
+ *
+ * ## Naming — a deliberate deviation from Issue #632's own body text
+ *
+ * Issue #632's body literally lists `CLOUDFLARE_ACCOUNT_ID`,
+ * `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_NEWS_IMAGE_BUCKET`,
+ * `R2_NEWS_IMAGE_PUBLIC_BASE_URL`, etc. **This file intentionally does
+ * NOT use those names.** `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` are the
+ * EXACT names `sync-storage` already uses (`object-storage-uploader.ts`,
+ * Issue #436) for its own, unrelated, *private* object queue bucket. Reusing
+ * them here would make news-portal media and sync-storage share literally
+ * the same credential — precisely the single-point-of-compromise risk
+ * Issue #631's architecture doc was written to prevent (see
+ * `docs/awcms-mini/news-portal/full-online-r2-architecture.md` §2,
+ * "Keputusan kunci #1" in `.claude/skills/awcms-mini-news-portal/SKILL.md`).
+ *
+ * Every var below instead follows §4 of that document EXACTLY as written
+ * there (`NEWS_MEDIA_R2_*` prefix) — this is the authoritative source, not
+ * the issue body. Note the architecture doc's §4 table does NOT include a
+ * separate `NEWS_MEDIA_R2_CUSTOM_DOMAIN` var (§11 clarifies
+ * `NEWS_MEDIA_R2_PUBLIC_BASE_URL` already IS the custom-domain URL) — this
+ * file follows the doc, not a broader reading of the issue body.
+ */
+
+export const NEWS_MEDIA_R2_DEFAULT_ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif"
+] as const;
+
+/** SVG is deliberately excluded by default — see architecture doc §9 (XSS via embedded `<script>`). */
+export const NEWS_MEDIA_R2_DISALLOWED_MIME_TYPE_DEFAULT = "image/svg+xml";
+
+export const NEWS_MEDIA_R2_DEFAULTS = {
+  enabled: false,
+  presignedUploadTtlSeconds: 300,
+  maxUploadBytes: 10_485_760,
+  allowedMimeTypes: [...NEWS_MEDIA_R2_DEFAULT_ALLOWED_MIME_TYPES] as string[],
+  pendingTtlMinutes: 60
+} as const;
+
+/**
+ * Required only when `NEWS_MEDIA_R2_ENABLED=true` — mirrors
+ * `R2_REQUIRED_WHEN_ENABLED` in `scripts/validate-env.ts` (the existing
+ * `sync-storage` R2 conditional check), same shape, different var names,
+ * one extra key (`NEWS_MEDIA_R2_PUBLIC_BASE_URL` — news media is public by
+ * design, sync-storage's bucket never is, so it has no public-base-URL
+ * concept at all).
+ */
+export const NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED = [
+  "NEWS_MEDIA_R2_ACCOUNT_ID",
+  "NEWS_MEDIA_R2_ACCESS_KEY_ID",
+  "NEWS_MEDIA_R2_SECRET_ACCESS_KEY",
+  "NEWS_MEDIA_R2_BUCKET",
+  "NEWS_MEDIA_R2_PUBLIC_BASE_URL"
+] as const;
+
+export type NewsMediaR2Config = {
+  enabled: boolean;
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+  publicBaseUrl: string;
+  presignedUploadTtlSeconds: number;
+  maxUploadBytes: number;
+  allowedMimeTypes: string[];
+  pendingTtlMinutes: number;
+};
+
+function isSet(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (!isSet(value)) return fallback;
+  return value === "true";
+}
+
+/** `undefined` when unset/blank/non-positive-integer — never throws, never NaN. */
+export function parsePositiveInt(
+  value: string | undefined
+): number | undefined {
+  if (!isSet(value)) return undefined;
+
+  const trimmed = (value as string).trim();
+
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  const parsed = Number.parseInt(trimmed, 10);
+
+  return parsed > 0 ? parsed : undefined;
+}
+
+function parseMimeList(value: string | undefined): string[] {
+  if (!isSet(value)) return [...NEWS_MEDIA_R2_DEFAULTS.allowedMimeTypes];
+
+  return (value as string)
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Resolves the full config from `env`, falling back to
+ * `NEWS_MEDIA_R2_DEFAULTS` for anything unset/malformed. Never throws —
+ * malformed values are reported by `checkNewsMediaR2Config`
+ * (`scripts/validate-env.ts`), not here.
+ */
+export function resolveNewsMediaR2Config(
+  env: NodeJS.ProcessEnv = process.env
+): NewsMediaR2Config {
+  return {
+    enabled: parseBoolean(
+      env.NEWS_MEDIA_R2_ENABLED,
+      NEWS_MEDIA_R2_DEFAULTS.enabled
+    ),
+    accountId: env.NEWS_MEDIA_R2_ACCOUNT_ID ?? "",
+    accessKeyId: env.NEWS_MEDIA_R2_ACCESS_KEY_ID ?? "",
+    secretAccessKey: env.NEWS_MEDIA_R2_SECRET_ACCESS_KEY ?? "",
+    bucket: env.NEWS_MEDIA_R2_BUCKET ?? "",
+    publicBaseUrl: env.NEWS_MEDIA_R2_PUBLIC_BASE_URL ?? "",
+    presignedUploadTtlSeconds:
+      parsePositiveInt(env.NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS) ??
+      NEWS_MEDIA_R2_DEFAULTS.presignedUploadTtlSeconds,
+    maxUploadBytes:
+      parsePositiveInt(env.NEWS_MEDIA_R2_MAX_UPLOAD_BYTES) ??
+      NEWS_MEDIA_R2_DEFAULTS.maxUploadBytes,
+    allowedMimeTypes: parseMimeList(env.NEWS_MEDIA_R2_ALLOWED_MIME_TYPES),
+    pendingTtlMinutes:
+      parsePositiveInt(env.NEWS_MEDIA_R2_PENDING_TTL_MINUTES) ??
+      NEWS_MEDIA_R2_DEFAULTS.pendingTtlMinutes
+  };
+}
+
+export function isNewsMediaR2Enabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return resolveNewsMediaR2Config(env).enabled;
+}
+
+/**
+ * Required keys missing/empty when `NEWS_MEDIA_R2_ENABLED=true`. Empty
+ * array when disabled (nothing required) or fully configured.
+ */
+export function findMissingNewsMediaR2Vars(
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") return [];
+
+  return NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED.filter(
+    (name) => !isSet(env[name])
+  );
+}
+
+/**
+ * Keputusan kunci #1 (`.claude/skills/awcms-mini-news-portal/SKILL.md`,
+ * architecture doc §2): news-media R2 bucket/credentials MUST be separate
+ * from `sync-storage`'s own `R2_*` vars (Issue #436). Compares whichever
+ * of the two pairs is actually set — an unset `sync-storage` R2 var never
+ * produces a false "collision" (both sides empty-string would otherwise
+ * look "equal").
+ */
+export type NewsMediaR2SeparationViolation =
+  | "bucket_shared_with_sync_r2"
+  | "access_key_id_shared_with_sync_r2"
+  | "secret_access_key_shared_with_sync_r2";
+
+export function findNewsMediaR2SeparationViolations(
+  env: NodeJS.ProcessEnv = process.env
+): NewsMediaR2SeparationViolation[] {
+  const violations: NewsMediaR2SeparationViolation[] = [];
+
+  const newsBucket = env.NEWS_MEDIA_R2_BUCKET;
+  const syncBucket = env.R2_BUCKET;
+  if (isSet(newsBucket) && isSet(syncBucket) && newsBucket === syncBucket) {
+    violations.push("bucket_shared_with_sync_r2");
+  }
+
+  const newsAccessKeyId = env.NEWS_MEDIA_R2_ACCESS_KEY_ID;
+  const syncAccessKeyId = env.R2_ACCESS_KEY_ID;
+  if (
+    isSet(newsAccessKeyId) &&
+    isSet(syncAccessKeyId) &&
+    newsAccessKeyId === syncAccessKeyId
+  ) {
+    violations.push("access_key_id_shared_with_sync_r2");
+  }
+
+  const newsSecretAccessKey = env.NEWS_MEDIA_R2_SECRET_ACCESS_KEY;
+  const syncSecretAccessKey = env.R2_SECRET_ACCESS_KEY;
+  if (
+    isSet(newsSecretAccessKey) &&
+    isSet(syncSecretAccessKey) &&
+    newsSecretAccessKey === syncSecretAccessKey
+  ) {
+    violations.push("secret_access_key_shared_with_sync_r2");
+  }
+
+  return violations;
+}
+
+/** `true` when the configured allow-list contains the disallowed-by-default SVG MIME type. */
+export function allowsSvgMimeType(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return resolveNewsMediaR2Config(env).allowedMimeTypes.includes(
+    NEWS_MEDIA_R2_DISALLOWED_MIME_TYPE_DEFAULT
+  );
+}

--- a/src/modules/news-portal/domain/news-portal-preset-readiness.ts
+++ b/src/modules/news-portal/domain/news-portal-preset-readiness.ts
@@ -1,0 +1,143 @@
+/**
+ * Readiness gate for the `news_portal_full_online_r2` module preset
+ * (Issue #632, epic `news_portal` #631-#642/#649). Pure — no I/O, no
+ * `process.env` reads here (same split as
+ * `visitor-analytics/domain/visitor-analytics-config.ts`).
+ *
+ * ## Naming reconciliation #1 — no new global `DEPLOYMENT_PROFILE` var
+ *
+ * Issue #632's body illustrates `DEPLOYMENT_PROFILE=full_online` as if it
+ * were an existing/needed env var. It is neither: `grep`ing this repo
+ * finds zero references outside narrative docs
+ * (`docs/awcms-mini/deployment-profiles.md`). This repo's established
+ * config pattern is independent, per-feature flags (`R2_ENABLED`,
+ * `EMAIL_ENABLED`, `VISITOR_ANALYTICS_ENABLED`, ...) — never one central
+ * deployment-mode enum every module has to branch on. Introducing a new
+ * global master switch here would be the first of its kind and would
+ * duplicate/compete with those flags instead of composing with them.
+ *
+ * Instead, "full-online" for THIS preset is expressed as two new,
+ * narrowly-scoped vars (`NEWS_PORTAL_ENABLED` and `NEWS_PORTAL_PROFILE`,
+ * this module's own master switch + profile selector) combined with the
+ * already-existing `NEWS_MEDIA_R2_ENABLED` (news-media-r2-config.ts). Three
+ * independent flags that all have to agree, not one central enum.
+ *
+ * ## Naming reconciliation #2 — no new `BLOG_PUBLIC_ROUTE_MODE` var
+ *
+ * Issue #632's body also lists `BLOG_PUBLIC_ROUTE_MODE=domain_default`.
+ * That string is not a new concept — it is the EXISTING
+ * `blog_content` module setting `publicRouteMode`
+ * (`blog-content/application/public-route-settings.ts`,
+ * `PUBLIC_ROUTE_MODES = ["domain_default", "disabled"]`, Issue #564),
+ * already defaulting to `"domain_default"` today for every tenant. It is a
+ * per-tenant `awcms_mini_module_settings` value (written via
+ * `PATCH /api/v1/tenant/modules/blog_content/settings`), not an env var —
+ * introducing an env var of the same name would create two competing
+ * sources of truth for one concept. This preset recommends (documents,
+ * does not enforce via a new mechanism) that a tenant activating
+ * `news_portal_full_online_r2` leaves `blog_content`'s `publicRouteMode`
+ * at its default `"domain_default"` and sets the relevant
+ * `awcms_mini_tenant_domains` row's existing `route_mode` column
+ * (`tenant-domain/domain/tenant-domain-validation.ts`,
+ * `canonical` | `legacy_blog`, Issue #557) to `"canonical"` via the
+ * existing tenant-domain API (#562) — two already-existing, independent
+ * mechanisms, not a third new one.
+ *
+ * `BLOG_PUBLIC_BASE_PATH` in the issue body is, similarly, just
+ * `PUBLIC_CANONICAL_BASE_PATH` (Issue #556,
+ * `blog-content/application/public-route-settings.ts`), already
+ * defaulting to `/news` — no new var needed for it either.
+ */
+import {
+  findMissingNewsMediaR2Vars,
+  findNewsMediaR2SeparationViolations,
+  isNewsMediaR2Enabled
+} from "./news-media-r2-config";
+
+export const NEWS_PORTAL_PROFILES = ["full_online_r2"] as const;
+export type NewsPortalProfile = (typeof NEWS_PORTAL_PROFILES)[number];
+
+export function isKnownNewsPortalProfile(
+  value: string | undefined
+): value is NewsPortalProfile {
+  return (NEWS_PORTAL_PROFILES as readonly string[]).includes(value ?? "");
+}
+
+export type NewsPortalPresetReadinessReason =
+  | "news_portal_disabled"
+  | "profile_not_full_online_r2"
+  | "news_media_r2_disabled"
+  | "news_media_r2_config_incomplete"
+  | "news_media_r2_shares_sync_storage_bucket_or_credentials";
+
+export type NewsPortalPresetReadinessResult = {
+  ready: boolean;
+  reasons: NewsPortalPresetReadinessReason[];
+  /** Human-readable evidence, one entry per failing/relevant check — for audit `attributes`/report output. */
+  detail: string[];
+};
+
+/**
+ * The one concrete, checkable signal this preset uses to decide "is this
+ * deployment genuinely full-online R2-only" — see reconciliation #1
+ * above. All three of `NEWS_PORTAL_ENABLED=true`,
+ * `NEWS_PORTAL_PROFILE=full_online_r2`, and `NEWS_MEDIA_R2_ENABLED=true`
+ * must hold, AND the R2 config itself must be complete and separated from
+ * `sync-storage`'s own R2 bucket/credentials (Keputusan kunci #1).
+ *
+ * Out of scope by design (see SKILL.md/architecture doc §3.3-3.4): there is
+ * no "local upload fallback enabled" flag to check here, because no such
+ * flag/code path exists anywhere in this repo — this mode has structurally
+ * no local-fallback option to disable. `tests/unit/news-portal-no-local-fallback.test.ts`
+ * guards this by asserting no such code path gets introduced later,
+ * instead of this function checking a flag that would otherwise have to be
+ * invented just to be checked.
+ */
+export function evaluateNewsPortalFullOnlineR2Readiness(
+  env: NodeJS.ProcessEnv = process.env
+): NewsPortalPresetReadinessResult {
+  const reasons: NewsPortalPresetReadinessReason[] = [];
+  const detail: string[] = [];
+
+  if (env.NEWS_PORTAL_ENABLED !== "true") {
+    reasons.push("news_portal_disabled");
+    detail.push(
+      'NEWS_PORTAL_ENABLED is not "true" — the news_portal_full_online_r2 preset requires it explicitly (opt-in, never a default).'
+    );
+  }
+
+  const profile = env.NEWS_PORTAL_PROFILE;
+  if (!isKnownNewsPortalProfile(profile)) {
+    reasons.push("profile_not_full_online_r2");
+    detail.push(
+      `NEWS_PORTAL_PROFILE must be "full_online_r2" for this preset; got ${
+        profile ? `"${profile}"` : "unset"
+      }.`
+    );
+  }
+
+  if (!isNewsMediaR2Enabled(env)) {
+    reasons.push("news_media_r2_disabled");
+    detail.push(
+      'NEWS_MEDIA_R2_ENABLED is not "true" — this preset requires the R2-only news media mode to be active (no local-storage alternative exists in this mode).'
+    );
+  } else {
+    const missing = findMissingNewsMediaR2Vars(env);
+    if (missing.length > 0) {
+      reasons.push("news_media_r2_config_incomplete");
+      detail.push(
+        `NEWS_MEDIA_R2_ENABLED=true but required var(s) missing: ${missing.join(", ")}.`
+      );
+    }
+
+    const violations = findNewsMediaR2SeparationViolations(env);
+    if (violations.length > 0) {
+      reasons.push("news_media_r2_shares_sync_storage_bucket_or_credentials");
+      detail.push(
+        `NEWS_MEDIA_R2_* must never share a bucket or credential with sync-storage's own R2_* vars (Issue #631 architecture doc §2): ${violations.join(", ")}.`
+      );
+    }
+  }
+
+  return { ready: reasons.length === 0, reasons, detail };
+}

--- a/src/modules/news-portal/module.ts
+++ b/src/modules/news-portal/module.ts
@@ -1,0 +1,12 @@
+import { defineModule } from "../_shared/module-contract";
+
+export const newsPortalModule = defineModule({
+  key: "news_portal",
+  name: "News Portal",
+  version: "0.1.0",
+  status: "active",
+  description:
+    "Editorial + media layer conceptually on top of blog_content/tenant_domain/visitor_analytics for a full-online, R2-only public news portal (epic `news_portal` #631-#642/#649). Issue #632 (this descriptor) adds ONLY the tenant module preset `news_portal_full_online_r2` (`module-management/domain/module-presets.ts`) and its activation readiness gate (`domain/news-portal-preset-readiness.ts`, `domain/news-media-r2-config.ts`, `application/apply-news-portal-preset.ts`) — no media object registry (#633), no upload endpoint (#634), no permissions/navigation/API of its own yet. Registered now (rather than deferred to a later issue) because the preset needs a real module key to enable/disable, matching `tenant_domain`'s own precedent (Issue #558 registered the descriptor ahead of its resolver/routes/admin UI). `permissions`/`navigation`/`api`/`settings`/`jobs`/`health` are deliberately left undeclared until the corresponding feature is real (same convention `visitor_analytics`, Issue #617, documented in its own module.ts test). `dependencies` deliberately does NOT list blog_content/tenant_domain/visitor_analytics despite the prose relationship above: this module has zero functional code importing/calling into any of them yet, and `blog_content`/`tenant_domain` themselves only depend on foundation modules (never on each other) for the exact same reason (see their own module.ts) — declaring a hard dependency here would make the reverse-dependency guard (`evaluateModuleDisable`'s MODULE_REVERSE_DEPENDENCY_ACTIVE) block disabling blog_content/tenant_domain/visitor_analytics for EVERY tenant (news_portal is enabled by default like every module), which broke existing integration tests when first tried (see git history/PR discussion) and is not something #632's own scope justifies. The preset's own `enabledModuleKeys` ordering (`module-management/domain/module-presets.ts`'s `planEnableOrder`) is what sequences enabling blog_content/tenant_domain/visitor_analytics before news_portal WITHIN one preset application — a permanent hard dependency is not needed for that.",
+  dependencies: ["tenant_admin", "identity_access"],
+  type: "domain"
+});

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -58,8 +58,8 @@ describe("soft delete helper", () => {
 });
 
 describe("module registry", () => {
-  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, email, module_management, blog_content, tenant_domain, and visitor_analytics are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498, #511-#513, #537, #558, #617", () => {
-    expect(listModules()).toHaveLength(13);
+  test("tenant_admin, profile_identity, identity_access, sync_storage, reporting, logging, workflow, form_drafts, email, module_management, blog_content, tenant_domain, visitor_analytics, and news_portal are registered after Issue 2.1-2.4, 12.1, 6.1-6.3, 9.1, 10.1, 11.1, #484, #493-#498, #511-#513, #537, #558, #617, #632", () => {
+    expect(listModules()).toHaveLength(14);
     expect(getModuleByKey("tenant_admin")).toMatchObject({
       key: "tenant_admin",
       status: "active"
@@ -129,6 +129,12 @@ describe("module registry", () => {
       status: "active",
       type: "system",
       dependencies: ["tenant_admin", "identity_access", "logging", "reporting"]
+    });
+    expect(getModuleByKey("news_portal")).toMatchObject({
+      key: "news_portal",
+      status: "active",
+      type: "domain",
+      dependencies: ["tenant_admin", "identity_access"]
     });
     expect(getModuleByKey("unknown_module")).toBeUndefined();
   });

--- a/tests/integration/module-presets.integration.test.ts
+++ b/tests/integration/module-presets.integration.test.ts
@@ -142,17 +142,21 @@ suite("tenant module preset application service", () => {
     for (const key of ["tenant_domain", "blog_content", "email", "reporting"]) {
       expect(changeByKey.has(key)).toBe(false);
     }
-    // logging/workflow/form_drafts/visitor_analytics aren't listed and
-    // nothing (that stays enabled) depends on them, so they're safely
-    // disabled to actually produce the profile. visitor_analytics itself
-    // depends on logging/reporting, but nothing depends on
+    // logging/workflow/form_drafts/visitor_analytics/news_portal aren't
+    // listed and nothing (that stays enabled) depends on them, so they're
+    // safely disabled to actually produce the profile. visitor_analytics
+    // itself depends on logging/reporting, but nothing depends on
     // visitor_analytics — a pure leaf — so it disables cleanly and, once
-    // it's gone, unblocks logging the same way.
+    // it's gone, unblocks logging the same way. news_portal (Issue #632)
+    // deliberately declares no hard dependency on blog_content/
+    // tenant_domain/visitor_analytics (see its own module.ts comment), so
+    // it is likewise a pure leaf here.
     for (const key of [
       "logging",
       "workflow",
       "form_drafts",
-      "visitor_analytics"
+      "visitor_analytics",
+      "news_portal"
     ]) {
       expect(changeByKey.get(key)?.outcome).toBe("applied");
       expect(changeByKey.get(key)?.action).toBe("disabled");
@@ -175,6 +179,7 @@ suite("tenant module preset application service", () => {
     expect(state.get("workflow")).toBe(false);
     expect(state.get("form_drafts")).toBe(false);
     expect(state.get("visitor_analytics")).toBe(false);
+    expect(state.get("news_portal")).toBe(false);
 
     const auditRows = await fetchAuditActions(owner.tenantId);
     const disabledResourceIds = auditRows
@@ -182,7 +187,13 @@ suite("tenant module preset application service", () => {
       .map((r) => r.resource_id)
       .sort();
     expect(disabledResourceIds).toEqual(
-      ["form_drafts", "logging", "workflow", "visitor_analytics"].sort()
+      [
+        "form_drafts",
+        "logging",
+        "workflow",
+        "visitor_analytics",
+        "news_portal"
+      ].sort()
     );
     // No audit event for modules that were already in the target state.
     expect(auditRows.some((r) => r.action === "tenant_module_enabled")).toBe(
@@ -268,7 +279,8 @@ suite("tenant module preset application service", () => {
       "tenant_domain",
       "workflow",
       "form_drafts",
-      "visitor_analytics"
+      "visitor_analytics",
+      "news_portal"
     ]) {
       expect(state.get(key)).toBe(false);
     }

--- a/tests/integration/news-portal-preset.integration.test.ts
+++ b/tests/integration/news-portal-preset.integration.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Integration tests for `applyNewsPortalFullOnlineR2Preset` (Issue #632,
+ * epic `news_portal`) against a real PostgreSQL: proves the readiness gate
+ * actually blocks activation (no module state change, rejection audited)
+ * when full-online R2-only config is missing, and that a fully-configured
+ * env lets the preset land through the existing, generic
+ * `applyModulePreset` (module enable/disable + its own audit events,
+ * covered already by `module-presets.integration.test.ts`) plus this
+ * wrapper's own confirmation audit event.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import { applyNewsPortalFullOnlineR2Preset } from "../../src/modules/news-portal/application/apply-news-portal-preset";
+import { applyModulePreset } from "../../src/modules/module-management/application/module-presets";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+const FULLY_CONFIGURED_ENV = {
+  NEWS_PORTAL_ENABLED: "true",
+  NEWS_PORTAL_PROFILE: "full_online_r2",
+  NEWS_MEDIA_R2_ENABLED: "true",
+  NEWS_MEDIA_R2_ACCOUNT_ID: "acct",
+  NEWS_MEDIA_R2_ACCESS_KEY_ID: "news-key",
+  NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "news-secret",
+  NEWS_MEDIA_R2_BUCKET: "news-media-bucket",
+  NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://media.example.test"
+} as NodeJS.ProcessEnv;
+
+type Bootstrap = { tenantId: string; token: string; tenantUserId: string };
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const loginIdentifier = `${tenantCode}-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  const admin = getAdminSql();
+  const tenantUserRows = (await admin`
+    SELECT tu.id FROM awcms_mini_tenant_users tu
+    JOIN awcms_mini_identities i ON i.id = tu.identity_id
+    WHERE tu.tenant_id = ${setup.body.data.tenantId} AND i.login_identifier = ${loginIdentifier}
+  `) as { id: string }[];
+
+  return {
+    tenantId: setup.body.data.tenantId,
+    token: login.body.data.token,
+    tenantUserId: tenantUserRows[0]!.id
+  };
+}
+
+async function fetchTenantModuleState(
+  tenantId: string
+): Promise<Map<string, boolean>> {
+  const admin = getAdminSql();
+  const rows = (await admin`
+    SELECT module_key, enabled FROM awcms_mini_tenant_modules
+    WHERE tenant_id = ${tenantId}
+  `) as { module_key: string; enabled: boolean }[];
+
+  return new Map(rows.map((row) => [row.module_key, row.enabled]));
+}
+
+async function fetchNewsPortalAuditRows(
+  tenantId: string
+): Promise<{ action: string; severity: string; attributes: unknown }[]> {
+  const admin = getAdminSql();
+  return (await admin`
+    SELECT action, severity, attributes
+    FROM awcms_mini_audit_events
+    WHERE tenant_id = ${tenantId}
+      AND module_key = 'news_portal'
+    ORDER BY created_at ASC
+  `) as { action: string; severity: string; attributes: unknown }[];
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("applyNewsPortalFullOnlineR2Preset", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("readiness gate blocks activation on an empty env: no module state changes, one rejection audit event", async () => {
+    const owner = await bootstrap();
+    const sql = getDatabaseClient();
+
+    const result = await withTenant(sql, owner.tenantId, (tx) =>
+      applyNewsPortalFullOnlineR2Preset(
+        tx,
+        owner.tenantId,
+        owner.tenantUserId,
+        {} as NodeJS.ProcessEnv
+      )
+    );
+
+    expect(result.outcome).toBe("rejected");
+    if (result.outcome !== "rejected") throw new Error("unreachable");
+    expect(result.code).toBe("NEWS_PORTAL_PRESET_NOT_READY");
+    expect(result.reasons).toContain("news_portal_disabled");
+
+    // news_portal itself was never enabled by this rejected attempt.
+    const state = await fetchTenantModuleState(owner.tenantId);
+    expect(state.get("news_portal")).toBeUndefined();
+
+    const auditRows = await fetchNewsPortalAuditRows(owner.tenantId);
+    expect(auditRows).toEqual([
+      {
+        action: "news_portal_preset_activation_rejected",
+        severity: "warning",
+        attributes: expect.objectContaining({
+          reasons: expect.arrayContaining(["news_portal_disabled"])
+        })
+      }
+    ]);
+  });
+
+  test("readiness gate blocks activation when NEWS_MEDIA_R2_BUCKET collides with sync-storage's R2_BUCKET", async () => {
+    const owner = await bootstrap();
+    const sql = getDatabaseClient();
+
+    const result = await withTenant(sql, owner.tenantId, (tx) =>
+      applyNewsPortalFullOnlineR2Preset(
+        tx,
+        owner.tenantId,
+        owner.tenantUserId,
+        {
+          ...FULLY_CONFIGURED_ENV,
+          R2_BUCKET: FULLY_CONFIGURED_ENV.NEWS_MEDIA_R2_BUCKET
+        } as NodeJS.ProcessEnv
+      )
+    );
+
+    expect(result.outcome).toBe("rejected");
+    if (result.outcome !== "rejected") throw new Error("unreachable");
+    expect(result.reasons).toContain(
+      "news_media_r2_shares_sync_storage_bucket_or_credentials"
+    );
+  });
+
+  test("fully-configured env lets the preset activate, enabling news_portal and writing a confirmation audit event", async () => {
+    const owner = await bootstrap();
+    const sql = getDatabaseClient();
+
+    // Start from "minimal" so news_portal is genuinely disabled first —
+    // proves this test observes a real state TRANSITION, not merely
+    // "already enabled by every module's fresh-tenant default".
+    await withTenant(sql, owner.tenantId, (tx) =>
+      applyModulePreset(tx, owner.tenantId, owner.tenantUserId, "minimal")
+    );
+    const stateBefore = await fetchTenantModuleState(owner.tenantId);
+    expect(stateBefore.get("news_portal")).toBe(false);
+
+    const result = await withTenant(sql, owner.tenantId, (tx) =>
+      applyNewsPortalFullOnlineR2Preset(
+        tx,
+        owner.tenantId,
+        owner.tenantUserId,
+        FULLY_CONFIGURED_ENV
+      )
+    );
+
+    expect(result.outcome).toBe("applied");
+    if (result.outcome !== "applied") throw new Error("unreachable");
+    expect(result.presetName).toBe("news_portal_full_online_r2");
+    expect(result.changes.find((c) => c.moduleKey === "news_portal")).toEqual({
+      moduleKey: "news_portal",
+      action: "enabled",
+      outcome: "applied"
+    });
+
+    const state = await fetchTenantModuleState(owner.tenantId);
+    expect(state.get("news_portal")).toBe(true);
+
+    const auditRows = await fetchNewsPortalAuditRows(owner.tenantId);
+    expect(auditRows).toEqual([
+      {
+        action: "news_portal_preset_activated",
+        severity: "info",
+        attributes: expect.objectContaining({ changes: expect.any(Number) })
+      }
+    ]);
+  });
+});

--- a/tests/modules/news-portal-module.test.ts
+++ b/tests/modules/news-portal-module.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { getModuleByKey, listModules } from "../../src/modules";
+import { newsPortalModule } from "../../src/modules/news-portal/module";
+
+describe("news_portal module descriptor (Issue #632)", () => {
+  test("listModules() includes news_portal", () => {
+    expect(listModules().some((m) => m.key === "news_portal")).toBe(true);
+    expect(getModuleByKey("news_portal")).toBe(newsPortalModule);
+  });
+
+  test("descriptor shape matches Issue #632's scope", () => {
+    expect(newsPortalModule.key).toBe("news_portal");
+    expect(newsPortalModule.status).toBe("active");
+    expect(newsPortalModule.type).toBe("domain");
+    // Deliberately NOT blog_content/tenant_domain/visitor_analytics — see
+    // module.ts's own comment: a hard dependency would block disabling
+    // those modules for every tenant (news_portal is enabled by default),
+    // which broke existing integration tests when first tried. The
+    // relationship is prose-only + enforced by preset-application
+    // ordering, not the module dependency graph.
+    expect(newsPortalModule.dependencies).toEqual([
+      "tenant_admin",
+      "identity_access"
+    ]);
+  });
+
+  test("the module never declares permissions, navigation, api, settings, jobs, or health before those capabilities are real (Issue #632 is preset-only)", () => {
+    // Consistent with visitor_analytics's own precedent (Issue #617): a
+    // descriptor should only claim a capability once it genuinely exists.
+    // #632 adds only a tenant module preset + its readiness gate — no
+    // media registry (#633), no upload endpoint (#634), no admin UI, no
+    // permission catalog of its own yet.
+    expect(newsPortalModule.permissions).toBeUndefined();
+    expect(newsPortalModule.navigation).toBeUndefined();
+    expect(newsPortalModule.api).toBeUndefined();
+    expect(newsPortalModule.settings).toBeUndefined();
+    expect(newsPortalModule.jobs).toBeUndefined();
+    expect(newsPortalModule.health).toBeUndefined();
+  });
+
+  test("descriptor never declares a secret, token, or provider credential", () => {
+    const serialized = JSON.stringify(newsPortalModule).toLowerCase();
+
+    for (const forbidden of [
+      "password",
+      "secret",
+      "credential",
+      "apikey",
+      "api_key"
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+});

--- a/tests/unit/module-presets.test.ts
+++ b/tests/unit/module-presets.test.ts
@@ -105,6 +105,25 @@ describe("MODULE_PRESETS / findModulePreset", () => {
   test("minimal preset's own enabledModuleKeys list is empty (core-only by construction)", () => {
     expect(findModulePreset("minimal")?.enabledModuleKeys).toEqual([]);
   });
+
+  test("news_portal_full_online_r2 (Issue #632) is a distinct preset from news_portal, listing blog_content/tenant_domain/visitor_analytics/module_management/identity_access/news_portal", () => {
+    const preset = findModulePreset("news_portal_full_online_r2");
+
+    expect(preset).not.toBeNull();
+    expect(preset?.enabledModuleKeys).toEqual([
+      "blog_content",
+      "tenant_domain",
+      "visitor_analytics",
+      "module_management",
+      "identity_access",
+      "news_portal"
+    ]);
+    // Genuinely a different preset from the pre-existing "news_portal" one
+    // (Issue #565) — not a rename/merge.
+    expect(findModulePreset("news_portal")?.enabledModuleKeys).not.toEqual(
+      preset?.enabledModuleKeys
+    );
+  });
 });
 
 describe("resolveProtectedModuleKeys", () => {

--- a/tests/unit/news-media-r2-config.test.ts
+++ b/tests/unit/news-media-r2-config.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  allowsSvgMimeType,
+  findMissingNewsMediaR2Vars,
+  findNewsMediaR2SeparationViolations,
+  isNewsMediaR2Enabled,
+  NEWS_MEDIA_R2_DEFAULTS,
+  NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED,
+  resolveNewsMediaR2Config
+} from "../../src/modules/news-portal/domain/news-media-r2-config";
+
+describe("resolveNewsMediaR2Config", () => {
+  test("defaults to disabled with empty credential fields when env is empty", () => {
+    const config = resolveNewsMediaR2Config({} as NodeJS.ProcessEnv);
+
+    expect(config.enabled).toBe(false);
+    expect(config.accountId).toBe("");
+    expect(config.accessKeyId).toBe("");
+    expect(config.secretAccessKey).toBe("");
+    expect(config.bucket).toBe("");
+    expect(config.publicBaseUrl).toBe("");
+    expect(config.presignedUploadTtlSeconds).toBe(
+      NEWS_MEDIA_R2_DEFAULTS.presignedUploadTtlSeconds
+    );
+    expect(config.maxUploadBytes).toBe(NEWS_MEDIA_R2_DEFAULTS.maxUploadBytes);
+    expect(config.allowedMimeTypes).toEqual(
+      NEWS_MEDIA_R2_DEFAULTS.allowedMimeTypes
+    );
+    expect(config.pendingTtlMinutes).toBe(
+      NEWS_MEDIA_R2_DEFAULTS.pendingTtlMinutes
+    );
+  });
+
+  test("parses a fully-configured enabled env", () => {
+    const config = resolveNewsMediaR2Config({
+      NEWS_MEDIA_R2_ENABLED: "true",
+      NEWS_MEDIA_R2_ACCOUNT_ID: "acct-news",
+      NEWS_MEDIA_R2_ACCESS_KEY_ID: "news-key",
+      NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "news-secret",
+      NEWS_MEDIA_R2_BUCKET: "news-media-bucket",
+      NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://media.example.test",
+      NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: "120",
+      NEWS_MEDIA_R2_MAX_UPLOAD_BYTES: "2048",
+      NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "image/jpeg, image/png",
+      NEWS_MEDIA_R2_PENDING_TTL_MINUTES: "15"
+    } as NodeJS.ProcessEnv);
+
+    expect(config).toEqual({
+      enabled: true,
+      accountId: "acct-news",
+      accessKeyId: "news-key",
+      secretAccessKey: "news-secret",
+      bucket: "news-media-bucket",
+      publicBaseUrl: "https://media.example.test",
+      presignedUploadTtlSeconds: 120,
+      maxUploadBytes: 2048,
+      allowedMimeTypes: ["image/jpeg", "image/png"],
+      pendingTtlMinutes: 15
+    });
+  });
+
+  test("falls back to defaults for malformed numeric values", () => {
+    const config = resolveNewsMediaR2Config({
+      NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: "not-a-number",
+      NEWS_MEDIA_R2_MAX_UPLOAD_BYTES: "-5",
+      NEWS_MEDIA_R2_PENDING_TTL_MINUTES: "0"
+    } as NodeJS.ProcessEnv);
+
+    expect(config.presignedUploadTtlSeconds).toBe(
+      NEWS_MEDIA_R2_DEFAULTS.presignedUploadTtlSeconds
+    );
+    expect(config.maxUploadBytes).toBe(NEWS_MEDIA_R2_DEFAULTS.maxUploadBytes);
+    expect(config.pendingTtlMinutes).toBe(
+      NEWS_MEDIA_R2_DEFAULTS.pendingTtlMinutes
+    );
+  });
+});
+
+describe("isNewsMediaR2Enabled", () => {
+  test("false by default", () => {
+    expect(isNewsMediaR2Enabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  test("true only for the literal string 'true'", () => {
+    expect(
+      isNewsMediaR2Enabled({
+        NEWS_MEDIA_R2_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+    expect(
+      isNewsMediaR2Enabled({
+        NEWS_MEDIA_R2_ENABLED: "TRUE"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+});
+
+describe("findMissingNewsMediaR2Vars", () => {
+  test("empty when disabled, regardless of what else is set", () => {
+    expect(findMissingNewsMediaR2Vars({} as NodeJS.ProcessEnv)).toEqual([]);
+  });
+
+  test("lists every required var missing when enabled with nothing else set", () => {
+    expect(
+      findMissingNewsMediaR2Vars({
+        NEWS_MEDIA_R2_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([...NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED]);
+  });
+
+  test("empty when enabled and fully configured", () => {
+    expect(
+      findMissingNewsMediaR2Vars({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_ACCOUNT_ID: "a",
+        NEWS_MEDIA_R2_ACCESS_KEY_ID: "b",
+        NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "c",
+        NEWS_MEDIA_R2_BUCKET: "d",
+        NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://media.example.test"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+});
+
+describe("findNewsMediaR2SeparationViolations — Keputusan kunci #1", () => {
+  test("no violation when neither sync-storage R2 var nor news-media R2 var is set", () => {
+    expect(
+      findNewsMediaR2SeparationViolations({} as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("no violation when only one side is set (nothing to collide with)", () => {
+    expect(
+      findNewsMediaR2SeparationViolations({
+        NEWS_MEDIA_R2_BUCKET: "news-bucket"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("no violation when both sides are set but genuinely different", () => {
+    expect(
+      findNewsMediaR2SeparationViolations({
+        R2_BUCKET: "sync-bucket",
+        R2_ACCESS_KEY_ID: "sync-key",
+        R2_SECRET_ACCESS_KEY: "sync-secret",
+        NEWS_MEDIA_R2_BUCKET: "news-bucket",
+        NEWS_MEDIA_R2_ACCESS_KEY_ID: "news-key",
+        NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "news-secret"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("flags a shared bucket", () => {
+    expect(
+      findNewsMediaR2SeparationViolations({
+        R2_BUCKET: "same-bucket",
+        NEWS_MEDIA_R2_BUCKET: "same-bucket"
+      } as NodeJS.ProcessEnv)
+    ).toEqual(["bucket_shared_with_sync_r2"]);
+  });
+
+  test("flags a shared access key id and secret access key independently", () => {
+    expect(
+      findNewsMediaR2SeparationViolations({
+        R2_ACCESS_KEY_ID: "same-key",
+        NEWS_MEDIA_R2_ACCESS_KEY_ID: "same-key",
+        R2_SECRET_ACCESS_KEY: "same-secret",
+        NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "same-secret"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([
+      "access_key_id_shared_with_sync_r2",
+      "secret_access_key_shared_with_sync_r2"
+    ]);
+  });
+});
+
+describe("allowsSvgMimeType", () => {
+  test("false for the default allow-list", () => {
+    expect(allowsSvgMimeType({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  test("true only when an operator explicitly overrides the allow-list to include it", () => {
+    expect(
+      allowsSvgMimeType({
+        NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "image/jpeg,image/svg+xml"
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+});

--- a/tests/unit/news-portal-no-local-fallback.test.ts
+++ b/tests/unit/news-portal-no-local-fallback.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Structural guard for Issue #632's acceptance criterion "Preset does not
+ * enable local filesystem uploads for news images." There is deliberately
+ * no `NEWS_MEDIA_LOCAL_FALLBACK_ENABLED`-style flag to check at runtime
+ * (see `news-portal-preset-readiness.ts`'s header comment) — this mode has
+ * structurally no local-fallback code path to disable. Since #632 itself
+ * adds no upload code at all (that is Issue #634), this test currently
+ * guards an empty set trivially; its real job is to keep failing loudly
+ * the moment any future PR under `src/modules/news-portal/` (in
+ * particular #634's upload endpoint) introduces a local-disk write for
+ * news media bytes — see architecture doc §3.3/§3.4 and Keputusan kunci #2
+ * in `.claude/skills/awcms-mini-news-portal/SKILL.md`.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const NEWS_PORTAL_SRC_DIR = path.join(
+  import.meta.dir,
+  "../../src/modules/news-portal"
+);
+
+const FORBIDDEN_PATTERNS = [
+  /Bun\.write\s*\(/,
+  /fs\.writeFile/,
+  /writeFileSync/,
+  /LOCAL_STORAGE_PATH/,
+  /FILE_STORAGE_DRIVER/,
+  /LOCAL_FILE_UPLOADS_ENABLED/,
+  /LOCAL_MEDIA_STORAGE_ENABLED/
+];
+
+function listTsFiles(dir: string): string[] {
+  const entries = readdirSync(dir);
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry);
+    const stat = statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      files.push(...listTsFiles(fullPath));
+    } else if (entry.endsWith(".ts")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+describe("news_portal module — no local filesystem fallback for news media", () => {
+  test("no source file under src/modules/news-portal writes bytes to local disk or references a local-upload flag", () => {
+    const files = listTsFiles(NEWS_PORTAL_SRC_DIR);
+    expect(files.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const content = readFileSync(file, "utf-8");
+
+      for (const pattern of FORBIDDEN_PATTERNS) {
+        if (pattern.test(content)) {
+          offenders.push(
+            `${path.relative(NEWS_PORTAL_SRC_DIR, file)} matches ${pattern}`
+          );
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/unit/news-portal-preset-readiness.test.ts
+++ b/tests/unit/news-portal-preset-readiness.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluateNewsPortalFullOnlineR2Readiness,
+  isKnownNewsPortalProfile,
+  NEWS_PORTAL_PROFILES
+} from "../../src/modules/news-portal/domain/news-portal-preset-readiness";
+
+const FULLY_CONFIGURED_ENV = {
+  NEWS_PORTAL_ENABLED: "true",
+  NEWS_PORTAL_PROFILE: "full_online_r2",
+  NEWS_MEDIA_R2_ENABLED: "true",
+  NEWS_MEDIA_R2_ACCOUNT_ID: "acct",
+  NEWS_MEDIA_R2_ACCESS_KEY_ID: "news-key",
+  NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "news-secret",
+  NEWS_MEDIA_R2_BUCKET: "news-media-bucket",
+  NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://media.example.test"
+} as NodeJS.ProcessEnv;
+
+describe("isKnownNewsPortalProfile", () => {
+  test("accepts the one known profile", () => {
+    expect(isKnownNewsPortalProfile("full_online_r2")).toBe(true);
+  });
+
+  test("rejects unknown/undefined values", () => {
+    expect(isKnownNewsPortalProfile("offline_lan")).toBe(false);
+    expect(isKnownNewsPortalProfile(undefined)).toBe(false);
+  });
+
+  test("NEWS_PORTAL_PROFILES currently has exactly one value", () => {
+    expect(NEWS_PORTAL_PROFILES).toEqual(["full_online_r2"]);
+  });
+});
+
+describe("evaluateNewsPortalFullOnlineR2Readiness", () => {
+  test("ready when every condition holds", () => {
+    const result =
+      evaluateNewsPortalFullOnlineR2Readiness(FULLY_CONFIGURED_ENV);
+
+    expect(result.ready).toBe(true);
+    expect(result.reasons).toEqual([]);
+  });
+
+  test("not ready by default (empty env) — opt-in only, never a default", () => {
+    const result = evaluateNewsPortalFullOnlineR2Readiness(
+      {} as NodeJS.ProcessEnv
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toContain("news_portal_disabled");
+    expect(result.reasons).toContain("profile_not_full_online_r2");
+    expect(result.reasons).toContain("news_media_r2_disabled");
+  });
+
+  test("fails when NEWS_PORTAL_ENABLED is true but profile is wrong", () => {
+    const result = evaluateNewsPortalFullOnlineR2Readiness({
+      ...FULLY_CONFIGURED_ENV,
+      NEWS_PORTAL_PROFILE: "something_else"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toEqual(["profile_not_full_online_r2"]);
+  });
+
+  test("fails when news media R2 is disabled even if everything else is configured", () => {
+    const result = evaluateNewsPortalFullOnlineR2Readiness({
+      ...FULLY_CONFIGURED_ENV,
+      NEWS_MEDIA_R2_ENABLED: "false"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toEqual(["news_media_r2_disabled"]);
+  });
+
+  test("fails when a required NEWS_MEDIA_R2_* var is missing", () => {
+    const { NEWS_MEDIA_R2_BUCKET, ...rest } = FULLY_CONFIGURED_ENV as Record<
+      string,
+      string
+    >;
+
+    const result = evaluateNewsPortalFullOnlineR2Readiness(
+      rest as NodeJS.ProcessEnv
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toEqual(["news_media_r2_config_incomplete"]);
+    expect(result.detail[0]).toContain("NEWS_MEDIA_R2_BUCKET");
+  });
+
+  test("fails when news-media R2 bucket collides with sync-storage's R2_BUCKET (Keputusan kunci #1)", () => {
+    const result = evaluateNewsPortalFullOnlineR2Readiness({
+      ...FULLY_CONFIGURED_ENV,
+      R2_BUCKET: FULLY_CONFIGURED_ENV.NEWS_MEDIA_R2_BUCKET
+    } as NodeJS.ProcessEnv);
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toEqual([
+      "news_media_r2_shares_sync_storage_bucket_or_credentials"
+    ]);
+  });
+
+  test("fails when news-media R2 access key collides with sync-storage's R2_ACCESS_KEY_ID", () => {
+    const result = evaluateNewsPortalFullOnlineR2Readiness({
+      ...FULLY_CONFIGURED_ENV,
+      R2_ACCESS_KEY_ID: FULLY_CONFIGURED_ENV.NEWS_MEDIA_R2_ACCESS_KEY_ID
+    } as NodeJS.ProcessEnv);
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toEqual([
+      "news_media_r2_shares_sync_storage_bucket_or_credentials"
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `news_portal_full_online_r2` module-management preset bundling `blog_content`/`tenant_domain`/`visitor_analytics` for a public news portal deployment, the `NEWS_MEDIA_R2_*` config gate, readiness checks, and audit logging on preset activation.

**Naming reconciliation (documented in the `awcms-mini-news-portal` skill for #633 onward):** Issue #632's illustrative env vars conflicted with #631's already-merged, security-audited architecture:
- R2 credentials use `NEWS_MEDIA_R2_*` (not `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`/`CLOUDFLARE_ACCOUNT_ID`, which would have shared credentials with `sync-storage`'s existing private object queue — exactly the risk #631 was designed to prevent).
- No new `DEPLOYMENT_PROFILE`/`BLOG_PUBLIC_ROUTE_MODE`/`BLOG_PUBLIC_BASE_PATH` env vars — equivalent mechanisms already exist (`tenant_domain`'s per-domain `route_mode` column, `PUBLIC_CANONICAL_BASE_PATH` from #556).
- No local-fallback runtime flag — this mode has no local-upload code path to disable in the first place; enforced by a structural test instead of a flag that would never be exercised.
- Credential/bucket separation from `sync-storage` is enforced (not just documented) in both `config:validate` and `security:readiness`.

## Test plan

- [x] `bun run check` — 1802 pass, 0 fail; lint, typecheck, docs check, build all green.
- [x] `bun run config:validate` — new checks pass/fail correctly on synthetic env.
- [x] `bun run security:readiness` — new checks pass on default config; 2 remaining critical findings are pre-existing/unrelated (documented false positives).
- [x] New tests: module descriptor, preset readiness gate (unit + integration), R2 config resolver, structural no-local-fallback guard.
- [x] Changeset added.

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)