### PR TITLE
feat(storage): add R2-only media object registry for news images

### DIFF
--- a/.changeset/news-media-object-registry-issue-633.md
+++ b/.changeset/news-media-object-registry-issue-633.md
@@ -1,0 +1,17 @@
+---
+"awcms-mini": minor
+---
+
+Add the R2-only news media object registry (Issue #633, epic
+`news_portal` #631-#642/#649) — `awcms_mini_news_media_objects`
+(migration `041`), tenant-scoped with `ENABLE`+`FORCE ROW LEVEL
+SECURITY`, metadata-only (no binary columns), `storage_driver`
+constrained to `cloudflare_r2`. Adds object-key generation/validation
+and trusted public-URL construction
+(`src/modules/news-portal/domain/news-media-object-key.ts`) plus
+create/verify/attach/detach/soft-delete/restore/purge application
+helpers with audit events
+(`src/modules/news-portal/application/news-media-object-directory.ts`).
+No upload endpoint yet (Issue #634) — permission key constants for it
+are prepared (`domain/news-media-permissions.ts`) but not yet wired
+into the module descriptor.

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -38,7 +38,7 @@ status + pointer, bukan menduplikasi isinya.
 | ----- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | #631  | Dokumentasi arsitektur full-online R2-only + SOP + security + IR + backup + user guide                                       | **Selesai** — lihat §Dokumen yang sudah ada di bawah |
 | #632  | Preset `news_portal_full_online_r2` (module descriptor/config gate)                                                          | **Selesai** — lihat §632 di bawah                    |
-| #633  | Tenant-scoped R2-only media object registry (schema + migration)                                                             | Belum dikerjakan — lihat §633 di bawah               |
+| #633  | Tenant-scoped R2-only media object registry (schema + migration)                                                             | **Selesai** — lihat §633 di bawah                    |
 | #634  | Direct-to-R2 presigned upload flow (endpoint upload/confirm)                                                                 | Belum dikerjakan — lihat §634 di bawah               |
 | #635  | Config validation + readiness checks (`config:validate`/`security:readiness`/`production:preflight`) untuk R2 image delivery | Belum dikerjakan — lihat §635 di bawah               |
 | #636  | `blog_content` wajib referensi R2 media object untuk gambar berita saat mode aktif                                           | Belum dikerjakan — lihat §636 di bawah               |
@@ -377,15 +377,111 @@ PR manapun (#634 khususnya) menambah jalur itu.
   `tests/integration/module-presets.integration.test.ts`,
   `tests/foundation.test.ts` (module count 13→14).
 
-## §633 — Media object registry (belum dikerjakan)
+## §633 — Media object registry (Selesai)
 
-Ringkasan scope: tabel tenant-scoped R2-only media registry dipakai
-`blog_content`, homepage section, galeri, ads, gambar SEO, thumbnail
-video. Implementor **wajib** mengikuti bentuk konseptual
-`full-online-r2-architecture.md` §5 (kolom, tidak ada binary),
-konvensi object key §6, dan migration lewat skill
-`awcms-mini-new-migration` (RLS `ENABLE`+`FORCE`, pola sama tabel
-tenant-scoped lain).
+Implementasi lengkap: migration
+`sql/041_awcms_mini_news_media_object_registry_schema.sql`, domain
+`src/modules/news-portal/domain/news-media-object-key.ts` (object key
+build/validate, trusted public URL) + `domain/news-media-permissions.ts`
+(permission constants for #634, not wired yet), application
+`application/news-media-object-directory.ts` (full CRUD + lifecycle).
+Two rekonsiliasi below **mengikat** issue #634+ lanjutan — jangan
+investigasi ulang.
+
+### Rekonsiliasi #1 — nama tabel `awcms_mini_news_media_objects`, BUKAN `awcms_mini_media_objects` dari body issue #633
+
+Body issue #633 menulis `awcms_mini_media_objects`. TIDAK diikuti — nama
+ini sudah dipilih lebih dulu oleh
+`full-online-r2-architecture.md` §5 ("rencana untuk Issue #633", ditulis
+saat Issue #631, sebelum #633 mulai) yang merupakan sumber kebenaran
+epic ini per header skill ini sendiri. Selain itu, nama generik
+`awcms_mini_media_objects` terbaca seolah "media library umum aplikasi"
+padahal tabel ini sengaja SEMPIT — hard-`CHECK`-constrained ke
+`storage_driver = 'cloudflare_r2'` dan hanya relevan saat preset
+full-online-R2-only (#632) aktif. Nama generik berisiko bentrok makna
+dengan sistem media benar-benar umum di masa depan (avatar, gambar
+produk, dll) yang mungkin ingin nama tanpa prefix itu untuk dirinya
+sendiri. Detail lengkap ada di migration 041's header comment.
+
+### Rekonsiliasi #2 — status enum 7-state, elaborasi dari sketsa 4-state §5 semula
+
+`full-online-r2-architecture.md` §5 (ditulis sebelum #633) mensketsa
+`pending|confirmed|orphaned|deleted`. Migration 041 memakai 7-state dari
+body issue #633 sendiri:
+`pending_upload|uploaded|verified|attached|orphaned|deleted|failed` —
+ini ELABORASI, bukan kontradiksi: `pending_upload` = `pending`;
+`uploaded`+`verified` memecah `confirmed` tunggal jadi "R2 PUT sukses"
+vs "MIME/checksum/dimensi sudah diverifikasi server" (cocok dengan alur
+dua-langkah Jalur A di §7 — #634 akan butuh kedua state ini untuk
+merepresentasikan celah antara HEAD sukses dan verifikasi konten
+penuh); `attached` baru (media benar-benar dirujuk resource pemilik,
+bukan sekadar verified-tapi-menganggur); `orphaned`/`deleted` tidak
+berubah; `failed` baru. **Soft delete (`deleted_at`) ortogonal terhadap
+`status`** (pola sama `awcms_mini_blog_posts`) — hapus/restore tidak
+pernah menulis ulang `status`.
+
+### `owner_resource_type`/`owner_resource_id` — polymorphic reference generik, TANPA FK ke `blog_content`
+
+Sengaja pasangan `(text, uuid)` longgar tanpa foreign key, meniru idiom
+yang SUDAH ADA di `awcms_mini_audit_events.resource_type`/`resource_id`
+(migration 011) dan `awcms_mini_workflow_instances.resource_type`/
+`resource_id` (migration 012) — BUKAN FK ke `awcms_mini_blog_posts` atau
+tabel spesifik lain. Ini memungkinkan satu registry melayani semua
+konsumen di objective (blog post/page, homepage section, gallery item,
+ad, video thumbnail, SEO image) tanpa FK per-konsumen, dan tanpa
+migration ini bergantung sama sekali pada skema `blog_content` — cocok
+dengan `news_portal`'s `module.ts` yang sengaja TIDAK punya hard
+dependency ke `blog_content` (lihat §"Kenapa modul baru... dependencies
+HANYA..." di atas). Kedua kolom `NULL` sampai baris mencapai
+`status='attached'` (ditegakkan `CHECK` di DB DAN oleh
+`attachNewsMediaObject` yang hanya menerima transisi dari
+`status='verified'`).
+
+### Object key & public URL — server-generated, divalidasi 3 lapis
+
+`buildNewsMediaObjectKey`/`isValidNewsMediaObjectKey`
+(`domain/news-media-object-key.ts`) menerapkan §6 persis:
+`news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}`, `{ext}` diturunkan
+dari `mime_type` tervalidasi (map eksplisit 4 tipe default, BUKAN
+`mime.split("/")[1]` generik — mime type di luar map melempar error
+loud, bukan menebak ekstensi). Divalidasi 3 lapis: (1) application layer
+saat generate, (2) `CHECK` constraint di Postgres sendiri
+(`awcms_mini_news_media_objects_object_key_format_check`,
+mereferensi kolom `tenant_id` baris yang sama — pertahanan bila ada
+INSERT langsung yang melewati helper), (3) unit test structural.
+`buildNewsMediaPublicUrl` membangun public URL HANYA dari
+`NEWS_MEDIA_R2_PUBLIC_BASE_URL` tepercaya (config #632) + object key
+server-generated — menolak base URL non-https/malformed
+(`UntrustedNewsMediaPublicBaseUrlError`), tidak pernah menerima input
+client.
+
+### Permission key untuk #634 — disiapkan sebagai konstanta, BELUM dideklarasikan di `module.ts`
+
+`domain/news-media-permissions.ts` mengekspor
+`NEWS_MEDIA_PERMISSIONS.{create,read,verify,attach,detach,delete,restore,purge}`
+(nilai `news_portal.media.<action>`) — dokumentasi/konstanta MURNI,
+belum disinkronkan ke `awcms_mini_permissions` (tidak ada baris DB, tidak
+ada perubahan `module.ts`'s `permissions` array). Alasan: `news_portal`
+sengaja meninggalkan `permissions` undeclared sampai endpoint nyata ada
+(pola sama `visitor_analytics`, lihat §"Kenapa modul baru..." di atas) —
+#633 hanya menambah domain/application helper, belum ada HTTP endpoint
+yang menegakkannya. **Wajib untuk #634**: pakai persis konstanta ini
+(jangan buat nama baru) saat mendeklarasikan `module.ts`'s `permissions`
+array dan memanggil `authorizeInTransaction` (skill
+`awcms-mini-abac-guard`).
+
+### File yang dibuat/diubah (referensi cepat)
+
+- `sql/041_awcms_mini_news_media_object_registry_schema.sql`.
+- `src/modules/news-portal/domain/news-media-object-key.ts`,
+  `domain/news-media-permissions.ts`,
+  `application/news-media-object-directory.ts`.
+- Test: `tests/unit/news-media-object-key.test.ts`,
+  `tests/unit/news-media-permissions.test.ts`,
+  `tests/integration/news-media-object-registry.integration.test.ts`;
+  diperbarui: `tests/foundation.test.ts` (migration list).
+- Docs: `full-online-r2-architecture.md` §5/§6/§16 (status diperbarui),
+  `04_erd_data_dictionary.md` (§News Portal baru ditambah).
 
 ## §634 — Direct-to-R2 presigned upload flow (belum dikerjakan)
 

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -422,20 +422,45 @@ pernah menulis ulang `status`.
 
 ### `owner_resource_type`/`owner_resource_id` — polymorphic reference generik, TANPA FK ke `blog_content`
 
-Sengaja pasangan `(text, uuid)` longgar tanpa foreign key, meniru idiom
-yang SUDAH ADA di `awcms_mini_audit_events.resource_type`/`resource_id`
-(migration 011) dan `awcms_mini_workflow_instances.resource_type`/
-`resource_id` (migration 012) — BUKAN FK ke `awcms_mini_blog_posts` atau
-tabel spesifik lain. Ini memungkinkan satu registry melayani semua
-konsumen di objective (blog post/page, homepage section, gallery item,
-ad, video thumbnail, SEO image) tanpa FK per-konsumen, dan tanpa
-migration ini bergantung sama sekali pada skema `blog_content` — cocok
-dengan `news_portal`'s `module.ts` yang sengaja TIDAK punya hard
-dependency ke `blog_content` (lihat §"Kenapa modul baru... dependencies
-HANYA..." di atas). Kedua kolom `NULL` sampai baris mencapai
-`status='attached'` (ditegakkan `CHECK` di DB DAN oleh
+Sengaja pasangan `(text, uuid)` longgar tanpa foreign key, mengikuti POLA
+yang sama (BUKAN tipe kolom identik — koreksi post-review PR #652) dengan
+idiom yang SUDAH ADA di `awcms_mini_audit_events.resource_type`/
+`resource_id` (migration 011, `resource_id text`) dan
+`awcms_mini_workflow_instances.resource_type`/`resource_id` (migration
+012, `resource_id text` juga) — BUKAN FK ke `awcms_mini_blog_posts` atau
+tabel spesifik lain. Tabel ini memakai `owner_resource_id uuid` (bukan
+`text`) plus `CHECK` enum untuk `owner_resource_type` — varian yang lebih
+ketat dari idiom yang sama, bukan replika persis. Ini memungkinkan satu
+registry melayani semua konsumen di objective (blog post/page, homepage
+section, gallery item, ad, video thumbnail, SEO image) tanpa FK
+per-konsumen, dan tanpa migration ini bergantung sama sekali pada skema
+`blog_content` — cocok dengan `news_portal`'s `module.ts` yang sengaja
+TIDAK punya hard dependency ke `blog_content` (lihat §"Kenapa modul
+baru... dependencies HANYA..." di atas). Kedua kolom `NULL` sampai baris
+mencapai `status='attached'` (ditegakkan `CHECK` di DB DAN oleh
 `attachNewsMediaObject` yang hanya menerima transisi dari
 `status='verified'`).
+
+**WAJIB untuk #634 (temuan security-auditor PR #652, Medium, laten —
+tidak ada endpoint yang bisa dieksploitasi hari ini, tapi mengikat
+sebelum #634 merilis endpoint attach/purge nyata):**
+
+1. `attachNewsMediaObject` **tidak pernah** memverifikasi `owner_resource_id`
+   benar-benar ada DAN milik tenant yang sama — karena tidak ada FK, fungsi
+   ini akan selalu sukses meng-attach ke UUID apa pun yang diberikan
+   pemanggil, termasuk UUID resource milik tenant lain atau yang tidak
+   pernah ada sama sekali. Sebelum endpoint attach di #634 dirilis, WAJIB
+   menambah query verifikasi (`SELECT 1 FROM <tabel pemilik> WHERE id = $1
+AND tenant_id = $2`) di dalam transaksi tenant-scoped yang sama SEBELUM
+   memanggil `attachNewsMediaObject`, plus test integrasi cross-tenant
+   attach yang eksplisit menegaskan penolakan.
+2. Tidak ada mekanisme retention/legal-hold pada `purgeNewsMediaObject`/
+   `restoreNewsMediaObject` sama sekali (gap sistemik, sama seperti
+   `blog-content`'s `purgeBlogPost` — bukan regresi baru PR ini). Karena
+   media R2 punya IR khusus (`r2-incident-response.md`) yang mengandalkan
+   retensi/audit forensik, #634 (atau issue retention terpisah) WAJIB
+   menentukan mekanisme yang memblokir purge pada objek yang masih dalam
+   periode retensi wajib sebelum endpoint purge nyata dirilis.
 
 ### Object key & public URL — server-generated, divalidasi 3 lapis
 

--- a/docs/awcms-mini/04_erd_data_dictionary.md
+++ b/docs/awcms-mini/04_erd_data_dictionary.md
@@ -264,6 +264,42 @@ Permission seed: 8 permission (`038_awcms_mini_visitor_analytics_permissions.sql
 
 Epic lengkap (#617-#624): middleware collector (#620), UA parser (#619), API + dashboard (#621/#622), enrichment geolokasi (#623), dan job rollup/retensi + readiness checks + dokumentasi kepatuhan (#624) semuanya selesai — lihat `docs/awcms-mini/visitor-analytics.md` untuk panduan operasional lengkap (mode offline/LAN vs online, retensi, pemetaan kepatuhan UU PDP/PP PSTE/ISO 27001-27002-27005-27701/OWASP ASVS/Logging Cheat Sheet).
 
+### News Portal — media object registry (Issue #633, epic `news_portal` #631-#642/#649, `sql/041`)
+
+R2-only, tenant-scoped media metadata registry for news images — lihat
+`docs/awcms-mini/news-portal/full-online-r2-architecture.md` §5/§6 dan
+`.claude/skills/awcms-mini-news-portal/SKILL.md` §633 untuk detail
+lengkap kolom/keputusan rekonsiliasi. Berbeda dari
+`awcms_mini_blog_content`'s `featuredMediaId`/`gallery` (URL bebas,
+tanpa tabel media): tabel ini adalah sumber kebenaran metadata gambar
+saat preset `news_portal_full_online_r2` (#632) aktif; binary tetap di
+Cloudflare R2, tidak pernah di Postgres.
+
+- **`awcms_mini_news_media_objects`** — satu baris per objek media.
+  `storage_driver` di-`CHECK` `= 'cloudflare_r2'` (satu-satunya driver
+  didukung untuk registry ini). `object_key` di-`CHECK` mengikuti format
+  `news-media/{tenant_id}/{yyyy}/{mm}/{uuid}.{ext}` (arsitektur doc §6)
+  — server-generated, `{ext}` diturunkan dari `mime_type` tervalidasi,
+  tidak pernah dari nama file client. `owner_resource_type`/
+  `owner_resource_id` adalah polymorphic reference generik tanpa FK
+  (pola sama `awcms_mini_audit_events.resource_type`/`resource_id`),
+  keduanya `NULL` kecuali `status='attached'` (`CHECK` menegakkan
+  konsistensi ini). `status` (`pending_upload → uploaded → verified →
+attached`, plus `orphaned`/`deleted`/`failed`) **ortogonal** terhadap
+  soft delete (`deleted_at`) — pola sama `awcms_mini_blog_posts`, hapus/
+  restore tidak menulis ulang `status`. `module_key` di-`CHECK`
+  `= 'news_portal'` untuk saat ini (lebar hanya bila modul lain benar-benar
+  reuse skema ini). Soft-deletable (`deleted_at`/`deleted_by`/
+  `delete_reason`/`restored_at`/`restored_by`); purge hanya dari baris
+  yang sudah soft-deleted. RLS `ENABLE`+`FORCE`.
+
+Permission key untuk endpoint upload/confirm mendatang (Issue #634)
+sudah disiapkan sebagai konstanta (`news_portal.media.{create,read,
+verify,attach,detach,delete,restore,purge}`,
+`domain/news-media-permissions.ts`) — **belum** dideklarasikan di
+`module.ts`'s `permissions` array (belum ada endpoint yang
+menegakkannya).
+
 ## Konten multi-bahasa (translatable content)
 
 Berbeda dari **string UI statis** (label/tombol/pesan error) yang memakai katalog `.po` gettext di sisi aplikasi (doc 14 §i18n), **data input pengguna** yang perlu tampil multi-bahasa disimpan **di database, satu nilai per bahasa aktif**. Base generik sudah punya satu contoh nyata (`awcms_mini_email_templates.subject_template`/`text_body_template`/`html_body_template`, `sql/021`, Issue #498 — lihat §Email di atas) — bukan lagi sekadar konvensi belum-terpakai; ini **standar** yang wajib diikuti aplikasi turunan (mis. modul domain seperti `blog_content`, epic #536) saat menambah field konten translatable baru.

--- a/docs/awcms-mini/news-portal/full-online-r2-architecture.md
+++ b/docs/awcms-mini/news-portal/full-online-r2-architecture.md
@@ -135,41 +135,76 @@ Prefix **`NEWS_MEDIA_R2_`** — sengaja berbeda dari `R2_*` generik
 Implementor (#632/#633/#634) wajib memakai nama ini persis — jangan
 memilih nama lain "yang mirip" tanpa memperbarui tabel ini.
 
-## 5. Model data konseptual — media registry (rencana untuk Issue #633)
+## 5. Model data konseptual — media registry (Issue #633, **diimplementasikan**)
 
-Bentuk metadata target (bukan DDL final — Issue #633 yang menulis
-migration sebenarnya, mengikuti skill `awcms-mini-new-migration`):
+**Status: diimplementasikan oleh Issue #633.** Skema final (migration
+`sql/041_awcms_mini_news_media_object_registry_schema.sql`) menggunakan
+tabel **`awcms_mini_news_media_objects`** — nama yang sudah dipilih di
+bawah ini SEBELUM issue #633 mulai dikerjakan, dan dipertahankan persis
+(bukan `awcms_mini_media_objects` yang sempat disebut di body issue
+#633 — lihat migration 041's header comment dan
+`.claude/skills/awcms-mini-news-portal/SKILL.md` §633 untuk alasan
+rekonsiliasi lengkap). Kolom final adalah **elaborasi** dari sketsa
+konseptual di bawah, bukan penggantian:
 
 ```text
 awcms_mini_news_media_objects (tenant-scoped, RLS ENABLE+FORCE)
-- id                 uuid PK
-- tenant_id          uuid FK -> awcms_mini_tenants
-- object_key         text UNIQUE (per tenant)   -- §6
-- original_filename  text                       -- hanya untuk tampilan, TIDAK pernah masuk object_key (§6)
-- mime_type          text                       -- hasil validasi server (§9), bukan input mentah client
-- byte_size          bigint
-- checksum_sha256    text
-- width_px/height_px integer, nullable           -- diisi bila server bisa membaca dimensi gambar
-- purpose            text  -- featured|gallery|ad|video_thumbnail|seo_share
-- status             text  -- pending|confirmed|orphaned|deleted (soft delete, doc 05)
-- alt_text           text, nullable              -- aksesibilitas (doc 14), wajib diisi sebelum publish (Issue #636/#640)
-- uploaded_by         uuid FK -> awcms_mini_identities
-- created_at, confirmed_at, deleted_at, deleted_by
+- id                        uuid PK
+- tenant_id                 uuid FK -> awcms_mini_tenants
+- module_key                text, CHECK = 'news_portal' (lebar bila modul lain reuse kelak)
+- owner_resource_type       text, nullable — polymorphic reference generik
+- owner_resource_id         uuid, nullable   (pola sama awcms_mini_audit_events, TANPA FK spesifik)
+- storage_driver            text, CHECK = 'cloudflare_r2'
+- bucket_name               text NOT NULL
+- object_key                text NOT NULL     -- §6, plus CHECK format tenant-prefixed di DB
+- original_filename         text, nullable    -- hanya untuk tampilan, TIDAK pernah masuk object_key (§6)
+- public_url                text NOT NULL     -- dibangun server dari NEWS_MEDIA_R2_PUBLIC_BASE_URL (#632), tidak pernah dari input client
+- mime_type                 text NOT NULL     -- hasil validasi server (§9), bukan input mentah client
+- size_bytes                bigint, nullable  -- terisi saat status='uploaded'
+- checksum_sha256           text, nullable
+- width/height              integer, nullable -- terisi saat status='verified'
+- alt_text, caption         text, nullable    -- aksesibilitas (doc 14), wajib diisi sebelum publish (Issue #636/#640)
+- status                    text — pending_upload|uploaded|verified|attached|orphaned|deleted|failed (elaborasi 7-state dari sketsa pending|confirmed|orphaned|deleted semula — lihat migration 041's header comment)
+- created_by_tenant_user_id uuid NOT NULL
+- created_at, updated_at, deleted_at, deleted_by, delete_reason, restored_at, restored_by
 ```
+
+Helper domain/application (`src/modules/news-portal/domain/news-media-object-key.ts`,
+`application/news-media-object-directory.ts`): `buildNewsMediaObjectKey`/
+`isValidNewsMediaObjectKey` (§6), `buildNewsMediaPublicUrl` (trusted base
+URL only), `createPendingNewsMediaObject`, `markNewsMediaObjectUploaded`/
+`Verified`/`Orphaned`/`Failed`, `attachNewsMediaObject`/`detachNewsMediaObject`,
+`softDeleteNewsMediaObject`/`restoreNewsMediaObject`/`purgeNewsMediaObject` —
+audit events (skill `awcms-mini-audit-log`) written for create/verify/
+attach/detach/delete/restore/purge. Permission key constants for the
+future upload endpoint (#634) are prepared, not yet wired into
+`module.ts`, in `domain/news-media-permissions.ts`.
 
 Catatan desain yang wajib dipertahankan:
 
 - **Tidak ada kolom binary apa pun** (§3.2) — pelanggaran ini adalah
   regresi kritis bila terjadi di issue mana pun.
-- **`status='pending'` bukan jaminan objek tidak bisa diakses publik** —
-  lihat §8 residual risk. Jangan berasumsi baris Postgres mengontrol
-  akses storage-level.
+- **`status='pending_upload'`/`'uploaded'` bukan jaminan objek tidak bisa
+  diakses publik** — lihat §8 residual risk. Jangan berasumsi baris
+  Postgres mengontrol akses storage-level.
+- Soft delete (`deleted_at`) **ortogonal** terhadap `status` (pola sama
+  `awcms_mini_blog_posts`) — hapus/restore tidak pernah menulis ulang
+  `status`.
 - Konten editorial (`blog_content`'s `featuredMediaId`, block `gallery`,
-  dsb.) **harus** menunjuk baris `status='confirmed'` di tabel ini
-  ketika mode R2-only aktif — inilah yang diterapkan Issue #636 (bukan
-  issue ini).
+  dsb.) **harus** menunjuk baris `status='attached'` (yang mensyaratkan
+  sebelumnya `verified`) di tabel ini ketika mode R2-only aktif — inilah
+  yang akan diterapkan Issue #636 (bukan issue ini); ditegakkan di level
+  write path oleh `attachNewsMediaObject` (hanya menerima dari
+  `status='verified'`), bukan hanya konvensi.
 
 ## 6. Konvensi object key
+
+**Status: diimplementasikan oleh Issue #633** —
+`src/modules/news-portal/domain/news-media-object-key.ts`
+(`buildNewsMediaObjectKey` generates it server-side;
+`isValidNewsMediaObjectKey` validates the tenant-prefixed shape; the
+same format is also enforced as a Postgres `CHECK` constraint on
+`awcms_mini_news_media_objects.object_key`, migration 041).
 
 Format wajib:
 
@@ -623,7 +658,7 @@ auth-online-hardening di dokumen yang sama).
 | Issue                 | Bagian dokumen ini yang diimplementasikan                                                      |
 | --------------------- | ---------------------------------------------------------------------------------------------- |
 | #632                  | §4 env var + preset `news_portal_full_online_r2`, §1 gating full-online                        |
-| #633                  | §5 media registry schema, §6 object key generator                                              |
+| #633                  | §5 media registry schema, §6 object key generator — **diimplementasikan**                      |
 | #634                  | §7 alur upload, §8 presigned URL, §9 validasi                                                  |
 | #635                  | §13 readiness (`config:validate`/`security:readiness`/`production:preflight`)                  |
 | #636                  | §5 "konten editorial wajib menunjuk media confirmed" diterapkan ke `blog_content`              |

--- a/sql/041_awcms_mini_news_media_object_registry_schema.sql
+++ b/sql/041_awcms_mini_news_media_object_registry_schema.sql
@@ -55,12 +55,18 @@
 -- ## `owner_resource_type`/`owner_resource_id` — generic polymorphic
 -- reference, no FK
 --
--- Deliberately a loose `(text, uuid)` pair with no foreign key, matching the
--- existing polymorphic-reference idiom already used by
+-- Deliberately a loose `(text, uuid)` pair with no foreign key, following
+-- the same PATTERN (not identical column types) as the existing
+-- polymorphic-reference idiom used by
 -- `awcms_mini_audit_events.resource_type`/`resource_id` (migration 011) and
 -- `awcms_mini_workflow_instances.resource_type`/`resource_id` (migration
--- 012) — NOT a hard FK to `awcms_mini_blog_posts` or any other specific
--- table. This lets one registry serve every consumer the objective lists
+-- 012, both `resource_id text`) — NOT a hard FK to `awcms_mini_blog_posts`
+-- or any other specific table. `owner_resource_id` here is `uuid` (every
+-- resource type this registry serves today already has a uuid primary
+-- key) and `owner_resource_type` is CHECK-constrained to a fixed enum
+-- (neither of which the two precedent tables do) — a stricter variant of
+-- the same loose-FK idiom, not a byte-for-byte match. This lets one
+-- registry serve every consumer the objective lists
 -- (blog post/page, homepage section, gallery item, ad, video thumbnail, SEO
 -- image) without a table-specific FK per consumer, and without this
 -- migration depending on `blog_content`'s schema at all (`news_portal`'s own
@@ -129,7 +135,7 @@ CREATE TABLE IF NOT EXISTS awcms_mini_news_media_objects (
   -- accepted. References this row's own `tenant_id` column, so the prefix
   -- is verified per-row, not just a fixed literal.
   CONSTRAINT awcms_mini_news_media_objects_object_key_format_check
-    CHECK (object_key ~ ('^news-media/' || tenant_id::text || '/[0-9]{4}/[0-9]{2}/[0-9a-fA-F-]{36}\.[a-z0-9]+$')),
+    CHECK (object_key ~ ('^news-media/' || tenant_id::text || '/[0-9]{4}/[0-9]{2}/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.[a-z0-9]+$')),
   CONSTRAINT awcms_mini_news_media_objects_status_check
     CHECK (status IN (
       'pending_upload', 'uploaded', 'verified', 'attached',

--- a/sql/041_awcms_mini_news_media_object_registry_schema.sql
+++ b/sql/041_awcms_mini_news_media_object_registry_schema.sql
@@ -1,0 +1,192 @@
+-- Issue #633 (epic `news_portal` #631-#642/#649) — tenant-scoped, R2-only
+-- media object metadata registry for news images (used by `blog_content`
+-- featured/gallery images, homepage sections, ads, SEO share images, and
+-- video thumbnails once #636-#640 wire them up). Metadata only — no binary
+-- column exists or will ever be added here (architecture doc §3.2/§5); the
+-- actual image bytes live in Cloudflare R2 (bucket configured via
+-- `NEWS_MEDIA_R2_*`, Issue #632, `news-portal/domain/news-media-r2-config.ts`
+-- — deliberately separate bucket/credentials from `sync-storage`'s own
+-- `R2_*`, "Keputusan kunci #1" in the epic skill).
+--
+-- ## Naming — a deliberate deviation from Issue #633's own body text
+--
+-- Issue #633's body suggests table name `awcms_mini_media_objects`. This
+-- migration uses `awcms_mini_news_media_objects` instead, matching the name
+-- ALREADY chosen by `docs/awcms-mini/news-portal/full-online-r2-architecture.md`
+-- §5 ("rencana untuk Issue #633" — written during Issue #631, before this
+-- issue started). Reasons this is treated as a real conflict, not just a
+-- cosmetic rename:
+--   1. The architecture doc is the epic's binding source of truth (per the
+--      epic skill's own header: "dokumen itu (bukan skill) adalah sumber
+--      kebenaran arsitektur") and it already named this table for this
+--      specific issue — the issue body's suggestion is a generic strawman,
+--      not a decision made with the doc in view.
+--   2. A generic `awcms_mini_media_objects` name reads as "the app's one
+--      general media library" — but this table is deliberately NOT that: it
+--      is hard-constrained to `storage_driver = 'cloudflare_r2'` and to the
+--      full-online, opt-in-only news portal preset (Issue #632). Naming it
+--      generically would misrepresent scope and collide semantically with
+--      any future *actually*-general media system for unrelated features
+--      (avatars, product images, etc.) that might reasonably want the
+--      unprefixed name for itself.
+-- Same reconciliation pattern Issue #632 already used three times for env
+-- var/preset naming (see `.claude/skills/awcms-mini-news-portal/SKILL.md`
+-- §632, Rekonsiliasi #1-#3) — documented here rather than silently deviating.
+--
+-- ## Status enum — elaboration of architecture doc §5's simpler model
+--
+-- Doc §5's conceptual model (written before this issue) sketches a 4-state
+-- `pending|confirmed|orphaned|deleted`. This migration instead uses the
+-- 7-state enum from Issue #633's own body
+-- (`pending_upload|uploaded|verified|attached|orphaned|deleted|failed`) —
+-- a strict elaboration, not a contradiction: `pending_upload` = doc's
+-- `pending`; `uploaded`+`verified` split doc's single `confirmed` into "R2
+-- PUT succeeded" vs "MIME/checksum/dimensions verified server-side"
+-- (matching the two-step Jalur A flow in doc §7 — Issue #634 will need both
+-- states to represent the gap between R2 HEAD success and full content
+-- verification); `attached` is new (media object is actually referenced by
+-- an owning resource, not just sitting verified-but-unused); `orphaned` and
+-- `deleted` are unchanged; `failed` is new (upload/verification failed,
+-- distinct from soft-deleted). Soft delete (`deleted_at`) is intentionally
+-- ORTHOGONAL to this `status` column (same as `awcms_mini_blog_posts`):
+-- deleting/restoring a row never rewrites `status`, it only toggles
+-- `deleted_at`/`deleted_by`/`delete_reason`/`restored_at`/`restored_by`.
+--
+-- ## `owner_resource_type`/`owner_resource_id` — generic polymorphic
+-- reference, no FK
+--
+-- Deliberately a loose `(text, uuid)` pair with no foreign key, matching the
+-- existing polymorphic-reference idiom already used by
+-- `awcms_mini_audit_events.resource_type`/`resource_id` (migration 011) and
+-- `awcms_mini_workflow_instances.resource_type`/`resource_id` (migration
+-- 012) — NOT a hard FK to `awcms_mini_blog_posts` or any other specific
+-- table. This lets one registry serve every consumer the objective lists
+-- (blog post/page, homepage section, gallery item, ad, video thumbnail, SEO
+-- image) without a table-specific FK per consumer, and without this
+-- migration depending on `blog_content`'s schema at all (`news_portal`'s own
+-- `module.ts` deliberately has no hard dependency on `blog_content` — see
+-- the epic skill's "Kenapa modul baru... dependencies HANYA..." section).
+-- Both columns are NULL until a row reaches `status='attached'` (enforced
+-- by the check constraint below) — a `pending_upload`/`uploaded`/`verified`
+-- object is valid, real media not yet bound to any specific resource.
+--
+-- ## RLS
+--
+-- `ENABLE`+`FORCE` + the standard `tenant_isolation` policy, same pattern as
+-- every tenant-scoped table since migration 013. No explicit `GRANT` needed
+-- for `awcms_mini_app` — migration 013's `ALTER DEFAULT PRIVILEGES` already
+-- covers it.
+--
+-- ## `module_key` — plain text, no FK, deliberately restricted to
+-- 'news_portal' for now
+--
+-- Same shape as `awcms_mini_audit_events.module_key` (plain `text NOT NULL`,
+-- no `REFERENCES awcms_mini_modules`) — NOT the FK pattern
+-- `module_management`'s own catalog tables use for their `module_key`
+-- columns (those describe module *state*; this describes which module owns
+-- a media registry row, a different concern). Restricted via `CHECK` to the
+-- single value `'news_portal'` because that is the only real caller today;
+-- widen the check (not a schema rename) if a second, unrelated module ever
+-- needs to reuse this exact registry shape.
+
+CREATE TABLE IF NOT EXISTS awcms_mini_news_media_objects (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  module_key text NOT NULL DEFAULT 'news_portal',
+  owner_resource_type text,
+  owner_resource_id uuid,
+  storage_driver text NOT NULL DEFAULT 'cloudflare_r2',
+  bucket_name text NOT NULL,
+  object_key text NOT NULL,
+  original_filename text,
+  public_url text NOT NULL,
+  mime_type text NOT NULL,
+  size_bytes bigint,
+  checksum_sha256 text,
+  width integer,
+  height integer,
+  alt_text text,
+  caption text,
+  status text NOT NULL DEFAULT 'pending_upload',
+  created_by_tenant_user_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  restored_at timestamptz,
+  restored_by uuid,
+  CONSTRAINT awcms_mini_news_media_objects_module_key_check
+    CHECK (module_key = 'news_portal'),
+  CONSTRAINT awcms_mini_news_media_objects_storage_driver_check
+    CHECK (storage_driver = 'cloudflare_r2'),
+  -- Schema-level defense in depth for doc §6's object key convention
+  -- (`news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}`) — the application
+  -- layer (`news-media-object-key.ts`) is the primary enforcement point
+  -- (it's what actually GENERATES the key), but a CHECK constraint means a
+  -- row that somehow bypassed that helper (a future direct INSERT, a bug in
+  -- a later issue) is rejected by Postgres itself rather than silently
+  -- accepted. References this row's own `tenant_id` column, so the prefix
+  -- is verified per-row, not just a fixed literal.
+  CONSTRAINT awcms_mini_news_media_objects_object_key_format_check
+    CHECK (object_key ~ ('^news-media/' || tenant_id::text || '/[0-9]{4}/[0-9]{2}/[0-9a-fA-F-]{36}\.[a-z0-9]+$')),
+  CONSTRAINT awcms_mini_news_media_objects_status_check
+    CHECK (status IN (
+      'pending_upload', 'uploaded', 'verified', 'attached',
+      'orphaned', 'deleted', 'failed'
+    )),
+  CONSTRAINT awcms_mini_news_media_objects_owner_resource_type_check
+    CHECK (owner_resource_type IS NULL OR owner_resource_type IN (
+      'blog_post', 'blog_page', 'homepage_section', 'gallery_item',
+      'ad', 'video_thumbnail', 'seo_image'
+    )),
+  -- Attach requires both owner columns; anything else must leave them NULL.
+  CONSTRAINT awcms_mini_news_media_objects_owner_consistency_check
+    CHECK (
+      (status = 'attached'
+        AND owner_resource_type IS NOT NULL AND owner_resource_id IS NOT NULL)
+      OR
+      (status <> 'attached'
+        AND owner_resource_type IS NULL AND owner_resource_id IS NULL)
+    ),
+  CONSTRAINT awcms_mini_news_media_objects_size_bytes_check
+    CHECK (size_bytes IS NULL OR size_bytes > 0),
+  CONSTRAINT awcms_mini_news_media_objects_width_check
+    CHECK (width IS NULL OR width > 0),
+  CONSTRAINT awcms_mini_news_media_objects_height_check
+    CHECK (height IS NULL OR height > 0)
+);
+
+-- Object key already embeds tenant_id + a random UUID (doc §6), so it can
+-- never collide across tenants in practice — the unique index is still
+-- scoped `(tenant_id, object_key)` rather than bare `object_key`, matching
+-- this repo's tenant-scoped-uniqueness convention everywhere else (e.g.
+-- `awcms_mini_blog_posts_slug_dedup`).
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_news_media_objects_tenant_key_dedup
+  ON awcms_mini_news_media_objects (tenant_id, object_key);
+
+CREATE INDEX IF NOT EXISTS idx_awcms_mini_news_media_objects_tenant
+  ON awcms_mini_news_media_objects (tenant_id);
+
+CREATE INDEX IF NOT EXISTS idx_awcms_mini_news_media_objects_tenant_created
+  ON awcms_mini_news_media_objects (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_awcms_mini_news_media_objects_active
+  ON awcms_mini_news_media_objects (tenant_id, created_at DESC)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_awcms_mini_news_media_objects_tenant_status
+  ON awcms_mini_news_media_objects (tenant_id, status)
+  WHERE deleted_at IS NULL;
+
+-- Owner lookup ("which media objects are attached to this blog post?").
+CREATE INDEX IF NOT EXISTS idx_awcms_mini_news_media_objects_owner
+  ON awcms_mini_news_media_objects (tenant_id, owner_resource_type, owner_resource_id)
+  WHERE deleted_at IS NULL AND owner_resource_type IS NOT NULL;
+
+ALTER TABLE awcms_mini_news_media_objects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_news_media_objects FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_news_media_objects_tenant_isolation
+  ON awcms_mini_news_media_objects
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/src/modules/news-portal/application/news-media-object-directory.ts
+++ b/src/modules/news-portal/application/news-media-object-directory.ts
@@ -1,0 +1,590 @@
+import { recordAuditEvent } from "../../logging/application/audit-log";
+import type { NewsMediaR2Config } from "../domain/news-media-r2-config";
+import {
+  buildNewsMediaObjectKey,
+  buildNewsMediaPublicUrl
+} from "../domain/news-media-object-key";
+
+/**
+ * Read/write directory for `awcms_mini_news_media_objects` (Issue #633,
+ * epic `news_portal`) — same "directory holds reads and writes for one
+ * resource" convention as `blog-content/application/blog-post-directory.ts`.
+ * Every function here takes an already tenant-scoped `Bun.SQL`/`Bun.TransactionSQL`
+ * (from `withTenant`, `lib/database/tenant-context.ts`) — none of them open
+ * their own transaction, matching the rest of this repo's directories.
+ *
+ * Out of scope here (Issue #634): actually talking to R2 (presign, HEAD/GET,
+ * streaming PUT) — every status transition below is a plain metadata
+ * UPDATE; the caller is responsible for having done the real R2 work first
+ * (ADR-0006: provider calls never happen inside a DB transaction).
+ *
+ * Audit events are written for exactly the actions the epic's acceptance
+ * criteria require: create, verify, attach, detach, delete, restore, purge
+ * (skill `awcms-mini-audit-log`). The intermediate `pending_upload -> uploaded`
+ * and any `-> orphaned`/`-> failed` transition are logged via the structured
+ * logger only (`src/lib/logging/logger.ts`) — see `markNewsMediaObjectUploaded`/
+ * `markNewsMediaObjectOrphaned`/`markNewsMediaObjectFailed` below for why
+ * these are treated as routine lifecycle bookkeeping, not high-risk actions.
+ */
+
+export type NewsMediaObjectStatus =
+  | "pending_upload"
+  | "uploaded"
+  | "verified"
+  | "attached"
+  | "orphaned"
+  | "deleted"
+  | "failed";
+
+export type NewsMediaOwnerResourceType =
+  | "blog_post"
+  | "blog_page"
+  | "homepage_section"
+  | "gallery_item"
+  | "ad"
+  | "video_thumbnail"
+  | "seo_image";
+
+export type NewsMediaObjectView = {
+  id: string;
+  tenantId: string;
+  moduleKey: string;
+  ownerResourceType: NewsMediaOwnerResourceType | null;
+  ownerResourceId: string | null;
+  storageDriver: string;
+  bucketName: string;
+  objectKey: string;
+  originalFilename: string | null;
+  publicUrl: string;
+  mimeType: string;
+  sizeBytes: number | null;
+  checksumSha256: string | null;
+  width: number | null;
+  height: number | null;
+  altText: string | null;
+  caption: string | null;
+  status: NewsMediaObjectStatus;
+  createdByTenantUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+  restoredAt: Date | null;
+  restoredBy: string | null;
+};
+
+type NewsMediaObjectRow = {
+  id: string;
+  tenant_id: string;
+  module_key: string;
+  owner_resource_type: NewsMediaOwnerResourceType | null;
+  owner_resource_id: string | null;
+  storage_driver: string;
+  bucket_name: string;
+  object_key: string;
+  original_filename: string | null;
+  public_url: string;
+  mime_type: string;
+  size_bytes: string | number | null;
+  checksum_sha256: string | null;
+  width: number | null;
+  height: number | null;
+  alt_text: string | null;
+  caption: string | null;
+  status: NewsMediaObjectStatus;
+  created_by_tenant_user_id: string;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+  restored_at: Date | null;
+  restored_by: string | null;
+};
+
+function toView(row: NewsMediaObjectRow): NewsMediaObjectView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    moduleKey: row.module_key,
+    ownerResourceType: row.owner_resource_type,
+    ownerResourceId: row.owner_resource_id,
+    storageDriver: row.storage_driver,
+    bucketName: row.bucket_name,
+    objectKey: row.object_key,
+    originalFilename: row.original_filename,
+    publicUrl: row.public_url,
+    mimeType: row.mime_type,
+    sizeBytes: row.size_bytes === null ? null : Number(row.size_bytes),
+    checksumSha256: row.checksum_sha256,
+    width: row.width,
+    height: row.height,
+    altText: row.alt_text,
+    caption: row.caption,
+    status: row.status,
+    createdByTenantUserId: row.created_by_tenant_user_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason,
+    restoredAt: row.restored_at,
+    restoredBy: row.restored_by
+  };
+}
+
+const AUDIT_MODULE_KEY = "news_portal";
+const AUDIT_RESOURCE_TYPE = "news_media_object";
+
+export type CreatePendingNewsMediaObjectInput = {
+  mimeType: string;
+  originalFilename?: string;
+  altText?: string;
+  caption?: string;
+};
+
+export class UnsupportedNewsMediaMimeTypeInputError extends Error {
+  constructor(mimeType: string, allowedMimeTypes: string[]) {
+    super(
+      `Mime type "${mimeType}" is not in the configured allow-list: ${allowedMimeTypes.join(", ")}.`
+    );
+    this.name = "UnsupportedNewsMediaMimeTypeInputError";
+  }
+}
+
+/**
+ * Creates a `status='pending_upload'` metadata row: generates the object
+ * key server-side (§6 convention) and the public URL from the trusted
+ * `config.publicBaseUrl` — NEVER from client input. `mimeType` is validated
+ * against `config.allowedMimeTypes` BEFORE the key is built (defense in
+ * depth — this is not the only place mime validation happens; #634's
+ * confirm step must still re-validate against actual bytes).
+ */
+export async function createPendingNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  config: NewsMediaR2Config,
+  input: CreatePendingNewsMediaObjectInput,
+  correlationId?: string
+): Promise<NewsMediaObjectView> {
+  const mimeType = input.mimeType.toLowerCase().trim();
+
+  if (!config.allowedMimeTypes.includes(mimeType)) {
+    throw new UnsupportedNewsMediaMimeTypeInputError(
+      mimeType,
+      config.allowedMimeTypes
+    );
+  }
+
+  const objectKey = buildNewsMediaObjectKey({ tenantId, mimeType });
+  const publicUrl = buildNewsMediaPublicUrl(config.publicBaseUrl, objectKey);
+
+  const rows = (await tx`
+    INSERT INTO awcms_mini_news_media_objects
+      (tenant_id, bucket_name, object_key, original_filename, public_url,
+       mime_type, alt_text, caption, created_by_tenant_user_id)
+    VALUES (
+      ${tenantId}, ${config.bucket}, ${objectKey}, ${input.originalFilename ?? null},
+      ${publicUrl}, ${mimeType}, ${input.altText ?? null}, ${input.caption ?? null},
+      ${actorTenantUserId}
+    )
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  const created = toView(rows[0]!);
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.created",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: created.id,
+    severity: "info",
+    message: `News media object created (pending upload): ${objectKey}.`,
+    attributes: { objectKey, mimeType },
+    correlationId
+  });
+
+  return created;
+}
+
+export async function fetchNewsMediaObjectById(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+    FROM awcms_mini_news_media_objects
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+  `) as NewsMediaObjectRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export type MarkNewsMediaObjectUploadedInput = {
+  sizeBytes: number;
+  checksumSha256: string;
+};
+
+/**
+ * `pending_upload -> uploaded` — the R2 PUT itself succeeded (proven by the
+ * caller's own HEAD/GET against R2, done OUTSIDE this transaction per
+ * ADR-0006 — this function only records the outcome). Deliberately NOT an
+ * audited action on its own: "uploaded" only means bytes exist at the
+ * object key, not that they were verified as safe/matching content
+ * (`markNewsMediaObjectVerified` is the audited "verify" action the epic's
+ * acceptance criteria actually requires).
+ */
+export async function markNewsMediaObjectUploaded(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  input: MarkNewsMediaObjectUploadedInput
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_mini_news_media_objects
+    SET status = 'uploaded', size_bytes = ${input.sizeBytes},
+        checksum_sha256 = ${input.checksumSha256}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'pending_upload' AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export type MarkNewsMediaObjectVerifiedInput = {
+  width?: number;
+  height?: number;
+};
+
+/**
+ * `uploaded -> verified` — server-side MIME sniffing/checksum verification
+ * (doc §9, #634's confirm step) passed. This is the "verify" audit action
+ * the epic's acceptance criteria requires.
+ */
+export async function markNewsMediaObjectVerified(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  input: MarkNewsMediaObjectVerifiedInput = {},
+  correlationId?: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_mini_news_media_objects
+    SET status = 'verified', width = ${input.width ?? null}, height = ${input.height ?? null},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'uploaded' AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  const updated = rows[0] ? toView(rows[0]) : null;
+  if (!updated) return null;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.verified",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "info",
+    message: `News media object verified: ${updated.objectKey}.`,
+    attributes: { objectKey: updated.objectKey },
+    correlationId
+  });
+
+  return updated;
+}
+
+export type AttachNewsMediaObjectInput = {
+  ownerResourceType: NewsMediaOwnerResourceType;
+  ownerResourceId: string;
+};
+
+/**
+ * `verified -> attached` — binds the media object to an owning resource.
+ * Deliberately requires `status = 'verified'` (never straight from
+ * `pending_upload`/`uploaded`) — this is what enforces "Keputusan kunci #4"
+ * (editorial content must only ever point at verified/confirmed media,
+ * never at an unverified upload) at the write path, not just by convention.
+ */
+export async function attachNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  input: AttachNewsMediaObjectInput,
+  correlationId?: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_mini_news_media_objects
+    SET status = 'attached', owner_resource_type = ${input.ownerResourceType},
+        owner_resource_id = ${input.ownerResourceId}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'verified' AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  const updated = rows[0] ? toView(rows[0]) : null;
+  if (!updated) return null;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.attached",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "info",
+    message: `News media object attached to ${input.ownerResourceType} ${input.ownerResourceId}.`,
+    attributes: {
+      objectKey: updated.objectKey,
+      ownerResourceType: input.ownerResourceType,
+      ownerResourceId: input.ownerResourceId
+    },
+    correlationId
+  });
+
+  return updated;
+}
+
+/**
+ * `attached -> verified` — reverses `attachNewsMediaObject`. Returns to
+ * `verified` (not `orphaned`): a detached-but-still-good media object
+ * remains immediately reusable for another `attach` call.
+ * `markNewsMediaObjectOrphaned` is the separate, deliberate "flag for
+ * cleanup" transition (doc `r2-backup-lifecycle.md` §2's orphan detection),
+ * not an automatic side effect of detach.
+ */
+export async function detachNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  correlationId?: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_mini_news_media_objects
+    SET status = 'verified', owner_resource_type = NULL, owner_resource_id = NULL,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'attached' AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  const updated = rows[0] ? toView(rows[0]) : null;
+  if (!updated) return null;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.detached",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "info",
+    message: `News media object detached: ${updated.objectKey}.`,
+    attributes: { objectKey: updated.objectKey },
+    correlationId
+  });
+
+  return updated;
+}
+
+/**
+ * `pending_upload|uploaded|verified -> orphaned` — flags a never-attached
+ * object as a cleanup candidate (doc `r2-backup-lifecycle.md` §2, e.g. a
+ * pending TTL job). Deliberately excluded from the required audit-event
+ * list (create/verify/attach/detach/delete/restore/purge) — this is routine
+ * lifecycle bookkeeping performed by an automated job, not itself a
+ * high-risk action; callers may still `log()` it structurally.
+ */
+export async function markNewsMediaObjectOrphaned(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_mini_news_media_objects
+    SET status = 'orphaned', updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status IN ('pending_upload', 'uploaded', 'verified') AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/**
+ * `pending_upload|uploaded -> failed` — upload or verification failed
+ * (checksum mismatch, R2 error, disallowed content sniffed, etc). Same
+ * "not in the required audit list" reasoning as `markNewsMediaObjectOrphaned`.
+ */
+export async function markNewsMediaObjectFailed(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_mini_news_media_objects
+    SET status = 'failed', updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status IN ('pending_upload', 'uploaded') AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/**
+ * Soft delete — orthogonal to `status` (same convention as
+ * `awcms_mini_blog_posts`): deleting never rewrites `status`, it only sets
+ * `deleted_at`/`deleted_by`/`delete_reason`. Works from any status.
+ */
+export async function softDeleteNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string,
+  correlationId?: string
+): Promise<boolean> {
+  const rows = (await tx`
+    UPDATE awcms_mini_news_media_objects
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING object_key
+  `) as { object_key: string }[];
+
+  if (rows.length === 0) return false;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.deleted",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "warning",
+    message: `News media object soft deleted: ${rows[0]!.object_key}.`,
+    attributes: { objectKey: rows[0]!.object_key, reason },
+    correlationId
+  });
+
+  return true;
+}
+
+export async function restoreNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  correlationId?: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_mini_news_media_objects
+    SET deleted_at = NULL, deleted_by = NULL, delete_reason = NULL,
+        restored_at = now(), restored_by = ${actorTenantUserId}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NOT NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  const restored = rows[0] ? toView(rows[0]) : null;
+  if (!restored) return null;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.restored",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "info",
+    message: `News media object restored: ${restored.objectKey}.`,
+    attributes: { objectKey: restored.objectKey },
+    correlationId
+  });
+
+  return restored;
+}
+
+/**
+ * Hard delete. Caller must have already verified the row is soft-deleted
+ * (this only guards it at the SQL level via `deleted_at IS NOT NULL` in the
+ * WHERE clause) — same "caller verifies eligibility first" convention as
+ * `blog-content/application/blog-post-directory.ts`'s `purgeBlogPost`.
+ */
+export async function purgeNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  correlationId?: string
+): Promise<boolean> {
+  const rows = (await tx`
+    DELETE FROM awcms_mini_news_media_objects
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NOT NULL
+    RETURNING object_key
+  `) as { object_key: string }[];
+
+  if (rows.length === 0) return false;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.purged",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "warning",
+    message: `News media object purged: ${rows[0]!.object_key}.`,
+    attributes: { objectKey: rows[0]!.object_key },
+    correlationId
+  });
+
+  return true;
+}

--- a/src/modules/news-portal/application/news-media-object-directory.ts
+++ b/src/modules/news-portal/application/news-media-object-directory.ts
@@ -215,20 +215,37 @@ export async function createPendingNewsMediaObject(
   return created;
 }
 
+export type FetchNewsMediaObjectOptions = {
+  includeDeleted?: boolean;
+};
+
 export async function fetchNewsMediaObjectById(
   tx: Bun.SQL,
   tenantId: string,
-  id: string
+  id: string,
+  options: FetchNewsMediaObjectOptions = {}
 ): Promise<NewsMediaObjectView | null> {
-  const rows = (await tx`
-    SELECT id, tenant_id, module_key, owner_resource_type, owner_resource_id,
-      storage_driver, bucket_name, object_key, original_filename, public_url,
-      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
-      status, created_by_tenant_user_id, created_at, updated_at,
-      deleted_at, deleted_by, delete_reason, restored_at, restored_by
-    FROM awcms_mini_news_media_objects
-    WHERE tenant_id = ${tenantId} AND id = ${id}
-  `) as NewsMediaObjectRow[];
+  const rows = (
+    options.includeDeleted
+      ? await tx`
+        SELECT id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+          storage_driver, bucket_name, object_key, original_filename, public_url,
+          mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+          status, created_by_tenant_user_id, created_at, updated_at,
+          deleted_at, deleted_by, delete_reason, restored_at, restored_by
+        FROM awcms_mini_news_media_objects
+        WHERE tenant_id = ${tenantId} AND id = ${id}
+      `
+      : await tx`
+        SELECT id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+          storage_driver, bucket_name, object_key, original_filename, public_url,
+          mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+          status, created_by_tenant_user_id, created_at, updated_at,
+          deleted_at, deleted_by, delete_reason, restored_at, restored_by
+        FROM awcms_mini_news_media_objects
+        WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+      `
+  ) as NewsMediaObjectRow[];
 
   return rows[0] ? toView(rows[0]) : null;
 }

--- a/src/modules/news-portal/domain/news-media-object-key.ts
+++ b/src/modules/news-portal/domain/news-media-object-key.ts
@@ -1,0 +1,157 @@
+/**
+ * Object key convention + trusted public URL construction for the R2-only
+ * news media registry (Issue #633, epic `news_portal`). Pure — no network/DB
+ * access, no `process.env` reads (callers pass in `NewsMediaR2Config` from
+ * `news-media-r2-config.ts`).
+ *
+ * Format, EXACTLY as `docs/awcms-mini/news-portal/full-online-r2-architecture.md`
+ * §6 mandates:
+ *
+ *   news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}
+ *
+ * - `tenantId` — the tenant UUID (never the human-readable `tenantCode`).
+ * - `{yyyy}/{mm}` — upload-date partition (server clock, not client input).
+ * - `{uuid}` — `crypto.randomUUID()` (Bun-native), the only component that
+ *   uniquely identifies the object. Never the client's original filename,
+ *   an article title, or any other client-supplied text — this is what
+ *   makes the key unguessable (mitigates the residual risk in doc §8: a
+ *   `pending_upload` row is not itself an access control) and prevents path
+ *   traversal / unsafe-character / information-leak issues a raw filename
+ *   would introduce.
+ * - `{ext}` — derived from the SERVER-VALIDATED mime type (doc §6/§9), never
+ *   from the client's original file extension. This is what closes the
+ *   "file.jpg that is actually HTML/PHP" spoofing gap.
+ *
+ * `original_filename` is stored as its own metadata column (never part of
+ * the key) purely for editor-facing display.
+ */
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Extension map for the mime types `news-media-r2-config.ts` allows by
+ * default. Deliberately explicit (no generic `mime.split("/")[1]` fallback)
+ * — if an operator ever widens `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` to a mime
+ * type not listed here, `deriveExtensionFromMimeType` must fail loudly
+ * (forcing this map to be extended deliberately) rather than silently
+ * deriving an unreviewed extension from the mime subtype string.
+ */
+const MIME_TYPE_TO_EXTENSION: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif"
+};
+
+/** `undefined` when `mimeType` has no known-safe extension mapping. */
+export function deriveExtensionFromMimeType(
+  mimeType: string
+): string | undefined {
+  return MIME_TYPE_TO_EXTENSION[mimeType.toLowerCase().trim()];
+}
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+export type BuildNewsMediaObjectKeyInput = {
+  tenantId: string;
+  mimeType: string;
+  /** Defaults to `crypto.randomUUID()` — override only from tests. */
+  uuid?: string;
+  /** Defaults to `new Date()` — override only from tests. */
+  now?: Date;
+};
+
+export class UnsupportedNewsMediaMimeTypeError extends Error {
+  constructor(mimeType: string) {
+    super(
+      `No object-key extension mapping for mime type "${mimeType}" — add it to MIME_TYPE_TO_EXTENSION in news-media-object-key.ts deliberately before allowing it.`
+    );
+    this.name = "UnsupportedNewsMediaMimeTypeError";
+  }
+}
+
+/**
+ * Builds a fresh, server-generated object key. Throws
+ * `UnsupportedNewsMediaMimeTypeError` for any mime type without a reviewed
+ * extension mapping — callers must validate `mimeType` against the
+ * configured allow-list (`NewsMediaR2Config.allowedMimeTypes`) BEFORE
+ * calling this, this is a second, structural line of defense, not the
+ * primary check.
+ */
+export function buildNewsMediaObjectKey(
+  input: BuildNewsMediaObjectKeyInput
+): string {
+  const ext = deriveExtensionFromMimeType(input.mimeType);
+  if (!ext) {
+    throw new UnsupportedNewsMediaMimeTypeError(input.mimeType);
+  }
+
+  const now = input.now ?? new Date();
+  const uuid = input.uuid ?? crypto.randomUUID();
+  const yyyy = now.getUTCFullYear().toString();
+  const mm = pad2(now.getUTCMonth() + 1);
+
+  return `news-media/${input.tenantId}/${yyyy}/${mm}/${uuid}.${ext}`;
+}
+
+/**
+ * Validates that `objectKey` matches the full §6 format AND belongs to
+ * `tenantId` — used both to sanity-check keys this module generated and to
+ * reject any object key supplied from outside (e.g. a confirm step payload
+ * in #634) that doesn't match the server-generated shape/prefix.
+ */
+export function isValidNewsMediaObjectKey(
+  tenantId: string,
+  objectKey: string
+): boolean {
+  const escapedTenantId = tenantId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `^news-media/${escapedTenantId}/\\d{4}/\\d{2}/[0-9a-f-]{36}\\.[a-z0-9]+$`,
+    "i"
+  );
+
+  if (!pattern.test(objectKey)) return false;
+
+  const uuidSegment = objectKey.split("/").pop()?.split(".")[0] ?? "";
+  return UUID_PATTERN.test(uuidSegment);
+}
+
+export class UntrustedNewsMediaPublicBaseUrlError extends Error {
+  constructor(publicBaseUrl: string) {
+    super(
+      `NEWS_MEDIA_R2_PUBLIC_BASE_URL must be an absolute https URL, got: "${publicBaseUrl}".`
+    );
+    this.name = "UntrustedNewsMediaPublicBaseUrlError";
+  }
+}
+
+/**
+ * Builds the public URL for a media object strictly from the trusted,
+ * server-side-configured `publicBaseUrl` (`NEWS_MEDIA_R2_PUBLIC_BASE_URL`,
+ * Issue #632's config resolver) and a server-generated `objectKey` — NEVER
+ * from any client-supplied URL/host. Rejects a malformed/non-https base URL
+ * rather than silently building an unsafe link (defense in depth; the base
+ * URL itself is also checked by `scripts/validate-env.ts`'s
+ * `isHttpsAbsoluteUrl` at config-validate time).
+ */
+export function buildNewsMediaPublicUrl(
+  publicBaseUrl: string,
+  objectKey: string
+): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(publicBaseUrl);
+  } catch {
+    throw new UntrustedNewsMediaPublicBaseUrlError(publicBaseUrl);
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new UntrustedNewsMediaPublicBaseUrlError(publicBaseUrl);
+  }
+
+  const trimmedBase = publicBaseUrl.replace(/\/+$/, "");
+  return `${trimmedBase}/${objectKey}`;
+}

--- a/src/modules/news-portal/domain/news-media-permissions.ts
+++ b/src/modules/news-portal/domain/news-media-permissions.ts
@@ -1,0 +1,50 @@
+/**
+ * Permission KEY CONSTANTS for the R2-only news media registry (Issue #633).
+ * These are documentation/constants ONLY — this file does not touch
+ * `module.ts`'s `permissions` array and does not insert any row into
+ * `awcms_mini_permissions`.
+ *
+ * Why not wired up yet: `news_portal`'s own `module.ts` deliberately leaves
+ * `permissions`/`navigation`/`api`/`settings`/`jobs`/`health` undeclared
+ * until the corresponding feature is real (same convention `visitor_analytics`
+ * used, Issue #617; see `module.ts`'s own descriptor comment). Issue #633
+ * adds domain/application helpers only — no HTTP endpoint exists yet to
+ * enforce these permissions, so declaring them in the module descriptor now
+ * would sync permission rows into `awcms_mini_permissions` with nothing
+ * that ever checks them, which is misleading (a permission that "exists"
+ * but is unreachable). Issue #634 (direct-to-R2 presigned upload flow) is
+ * expected to be the first issue that adds real endpoints — it MUST reuse
+ * these exact string constants (not invent new ones) when declaring
+ * `module.ts`'s `permissions` array and calling `authorizeInTransaction`
+ * (skill `awcms-mini-abac-guard`).
+ *
+ * `activityCode` follows this module's own resource shape (`media`, plural
+ * dropped to match e.g. `blog_content`'s `posts`/`pages` activity codes),
+ * `action` follows the same verb set already used elsewhere in this repo for
+ * a soft-deletable resource with an attach/detach lifecycle
+ * (`blog_content`'s `posts.create`/`.update`/`.delete`/`.restore`/`.purge`).
+ */
+export const NEWS_MEDIA_PERMISSION_ACTIVITY_CODE = "media";
+
+export const NEWS_MEDIA_PERMISSIONS = {
+  /** Create a pending media object metadata record. */
+  create: "news_portal.media.create",
+  /** Read media object metadata (list/detail). */
+  read: "news_portal.media.read",
+  /** Mark an uploaded object verified (MIME/checksum/dimension check passed). */
+  verify: "news_portal.media.verify",
+  /** Attach a verified media object to an owning blog/news resource. */
+  attach: "news_portal.media.attach",
+  /** Detach a media object from its current owning resource. */
+  detach: "news_portal.media.detach",
+  /** Soft delete media object metadata. */
+  delete: "news_portal.media.delete",
+  /** Restore a soft-deleted media object. */
+  restore: "news_portal.media.restore",
+  /** Hard purge an already soft-deleted media object. */
+  purge: "news_portal.media.purge"
+} as const;
+
+export type NewsMediaPermissionKey = keyof typeof NEWS_MEDIA_PERMISSIONS;
+export type NewsMediaPermissionValue =
+  (typeof NEWS_MEDIA_PERMISSIONS)[NewsMediaPermissionKey];

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -255,7 +255,8 @@ describe("database migration runner helpers", () => {
       "037_awcms_mini_tenant_oidc_sso_permissions.sql",
       "038_awcms_mini_visitor_analytics_permissions.sql",
       "039_awcms_mini_visitor_analytics_schema.sql",
-      "040_awcms_mini_visitor_analytics_session_lookup_index.sql"
+      "040_awcms_mini_visitor_analytics_session_lookup_index.sql",
+      "041_awcms_mini_news_media_object_registry_schema.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/news-media-object-registry.integration.test.ts
+++ b/tests/integration/news-media-object-registry.integration.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Integration tests for the R2-only news media object registry (Issue #633,
+ * epic `news_portal`) against a real PostgreSQL: schema/RLS/constraint
+ * enforcement (migration 041) plus the directory/application helpers
+ * (`news-media-object-directory.ts`) that create/verify/attach/detach/
+ * delete/restore/purge rows and their audit trail.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import type { NewsMediaR2Config } from "../../src/modules/news-portal/domain/news-media-r2-config";
+import {
+  attachNewsMediaObject,
+  createPendingNewsMediaObject,
+  detachNewsMediaObject,
+  fetchNewsMediaObjectById,
+  markNewsMediaObjectFailed,
+  markNewsMediaObjectOrphaned,
+  markNewsMediaObjectUploaded,
+  markNewsMediaObjectVerified,
+  purgeNewsMediaObject,
+  restoreNewsMediaObject,
+  softDeleteNewsMediaObject,
+  UnsupportedNewsMediaMimeTypeInputError
+} from "../../src/modules/news-portal/application/news-media-object-directory";
+
+const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const ACTOR_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+const CONFIG: NewsMediaR2Config = {
+  enabled: true,
+  accountId: "acct",
+  accessKeyId: "news-key",
+  secretAccessKey: "news-secret",
+  bucket: "news-media-bucket",
+  publicBaseUrl: "https://media.example.test",
+  presignedUploadTtlSeconds: 300,
+  maxUploadBytes: 10_485_760,
+  allowedMimeTypes: ["image/jpeg", "image/png", "image/webp", "image/gif"],
+  pendingTtlMinutes: 60
+};
+
+async function seedTenants(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES
+      (${TENANT_A}, 'tenant-a', 'Tenant A', 'Tenant A Legal', 'active', 'en', 'light'),
+      (${TENANT_B}, 'tenant-b', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+  `;
+}
+
+async function fetchAuditRows(
+  tenantId: string
+): Promise<{ action: string; severity: string }[]> {
+  const admin = getAdminSql();
+  return (await admin`
+    SELECT action, severity FROM awcms_mini_audit_events
+    WHERE tenant_id = ${tenantId} AND module_key = 'news_portal'
+    ORDER BY created_at ASC
+  `) as { action: string; severity: string }[];
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("news media object registry — schema, RLS, constraints", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+  });
+
+  test("tenant A cannot see tenant B's media objects (RLS isolation)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_news_media_objects
+        (tenant_id, bucket_name, object_key, public_url, mime_type, created_by_tenant_user_id)
+      VALUES
+        (${TENANT_A}, 'bucket',
+         'news-media/' || ${TENANT_A} || '/2026/03/11111111-1111-1111-1111-111111111111.jpg',
+         'https://media.example.test/a.jpg', 'image/jpeg', ${ACTOR_ID}),
+        (${TENANT_B}, 'bucket',
+         'news-media/' || ${TENANT_B} || '/2026/03/22222222-2222-2222-2222-222222222222.jpg',
+         'https://media.example.test/b.jpg', 'image/jpeg', ${ACTOR_ID})
+    `;
+
+    const sql = getDatabaseClient();
+    const rowsForA = await withTenant(
+      sql,
+      TENANT_A,
+      (tx) => tx`SELECT object_key FROM awcms_mini_news_media_objects`
+    );
+    expect(rowsForA).toHaveLength(1);
+    expect((rowsForA as { object_key: string }[])[0]?.object_key).toContain(
+      TENANT_A
+    );
+  });
+
+  test("querying without a tenant GUC set returns no rows (fail-closed)", async () => {
+    const admin = getAdminSql();
+    await admin`
+      INSERT INTO awcms_mini_news_media_objects
+        (tenant_id, bucket_name, object_key, public_url, mime_type, created_by_tenant_user_id)
+      VALUES (${TENANT_A}, 'bucket',
+         'news-media/' || ${TENANT_A} || '/2026/03/11111111-1111-1111-1111-111111111111.jpg',
+         'https://media.example.test/a.jpg', 'image/jpeg', ${ACTOR_ID})
+    `;
+
+    const sql = getDatabaseClient();
+    const rows =
+      await sql`SELECT object_key FROM awcms_mini_news_media_objects`;
+    expect(rows).toHaveLength(0);
+  });
+
+  test("rejects a non-cloudflare_r2 storage_driver", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_news_media_objects
+          (tenant_id, storage_driver, bucket_name, object_key, public_url, mime_type, created_by_tenant_user_id)
+        VALUES (${TENANT_A}, 'aws_s3', 'bucket',
+          'news-media/' || ${TENANT_A} || '/2026/03/11111111-1111-1111-1111-111111111111.jpg',
+          'https://media.example.test/a.jpg', 'image/jpeg', ${ACTOR_ID})
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+  });
+
+  test("rejects an object key that doesn't match the tenant-prefixed §6 format", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_news_media_objects
+          (tenant_id, bucket_name, object_key, public_url, mime_type, created_by_tenant_user_id)
+        VALUES (${TENANT_A}, 'bucket', '/uploads/photo.jpg',
+          'https://media.example.test/a.jpg', 'image/jpeg', ${ACTOR_ID})
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+  });
+
+  test("rejects a missing bucket_name", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_news_media_objects
+          (tenant_id, object_key, public_url, mime_type, created_by_tenant_user_id)
+        VALUES (${TENANT_A},
+          'news-media/' || ${TENANT_A} || '/2026/03/11111111-1111-1111-1111-111111111111.jpg',
+          'https://media.example.test/a.jpg', 'image/jpeg', ${ACTOR_ID})
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+  });
+
+  test("rejects an unknown status", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_news_media_objects
+          (tenant_id, bucket_name, object_key, public_url, mime_type, created_by_tenant_user_id, status)
+        VALUES (${TENANT_A}, 'bucket',
+          'news-media/' || ${TENANT_A} || '/2026/03/11111111-1111-1111-1111-111111111111.jpg',
+          'https://media.example.test/a.jpg', 'image/jpeg', ${ACTOR_ID}, 'bogus')
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+  });
+
+  test("rejects status='attached' without owner_resource_type/id", async () => {
+    const admin = getAdminSql();
+    let didThrow = false;
+    try {
+      await admin`
+        INSERT INTO awcms_mini_news_media_objects
+          (tenant_id, bucket_name, object_key, public_url, mime_type, created_by_tenant_user_id, status)
+        VALUES (${TENANT_A}, 'bucket',
+          'news-media/' || ${TENANT_A} || '/2026/03/11111111-1111-1111-1111-111111111111.jpg',
+          'https://media.example.test/a.jpg', 'image/jpeg', ${ACTOR_ID}, 'attached')
+      `;
+    } catch {
+      didThrow = true;
+    }
+    expect(didThrow).toBe(true);
+  });
+});
+
+suite("news media object directory — lifecycle + audit trail", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+  });
+
+  test("createPendingNewsMediaObject rejects a mime type outside the configured allow-list", async () => {
+    const sql = getDatabaseClient();
+
+    await expect(
+      withTenant(sql, TENANT_A, (tx) =>
+        createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+          mimeType: "image/svg+xml"
+        })
+      )
+    ).rejects.toBeInstanceOf(UnsupportedNewsMediaMimeTypeInputError);
+  });
+
+  test("full lifecycle: create -> uploaded -> verified -> attached -> detached -> deleted -> restored -> purged, with the required audit trail", async () => {
+    const sql = getDatabaseClient();
+
+    const created = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/jpeg",
+        originalFilename: "photo-lapangan.jpg",
+        altText: "A field photo"
+      })
+    );
+    expect(created.status).toBe("pending_upload");
+    expect(created.objectKey).toContain(`news-media/${TENANT_A}/`);
+    expect(created.objectKey).not.toContain("photo-lapangan");
+    expect(created.publicUrl).toBe(
+      `https://media.example.test/${created.objectKey}`
+    );
+    expect(created.bucketName).toBe(CONFIG.bucket);
+    expect(created.storageDriver).toBe("cloudflare_r2");
+
+    const uploaded = await withTenant(sql, TENANT_A, (tx) =>
+      markNewsMediaObjectUploaded(tx, TENANT_A, created.id, {
+        sizeBytes: 12_345,
+        checksumSha256: "a".repeat(64)
+      })
+    );
+    expect(uploaded?.status).toBe("uploaded");
+    expect(uploaded?.sizeBytes).toBe(12_345);
+
+    const verified = await withTenant(sql, TENANT_A, (tx) =>
+      markNewsMediaObjectVerified(tx, TENANT_A, ACTOR_ID, created.id, {
+        width: 800,
+        height: 600
+      })
+    );
+    expect(verified?.status).toBe("verified");
+    expect(verified?.width).toBe(800);
+
+    const attached = await withTenant(sql, TENANT_A, (tx) =>
+      attachNewsMediaObject(tx, TENANT_A, ACTOR_ID, created.id, {
+        ownerResourceType: "blog_post",
+        ownerResourceId: "dddddddd-dddd-dddd-dddd-dddddddddddd"
+      })
+    );
+    expect(attached?.status).toBe("attached");
+    expect(attached?.ownerResourceType).toBe("blog_post");
+
+    const detached = await withTenant(sql, TENANT_A, (tx) =>
+      detachNewsMediaObject(tx, TENANT_A, ACTOR_ID, created.id)
+    );
+    expect(detached?.status).toBe("verified");
+    expect(detached?.ownerResourceType).toBeNull();
+    expect(detached?.ownerResourceId).toBeNull();
+
+    const deletedOk = await withTenant(sql, TENANT_A, (tx) =>
+      softDeleteNewsMediaObject(
+        tx,
+        TENANT_A,
+        ACTOR_ID,
+        created.id,
+        "no longer needed"
+      )
+    );
+    expect(deletedOk).toBe(true);
+
+    const afterDelete = await withTenant(sql, TENANT_A, (tx) =>
+      fetchNewsMediaObjectById(tx, TENANT_A, created.id)
+    );
+    expect(afterDelete?.deletedAt).not.toBeNull();
+    // status is untouched by soft delete (orthogonal, same as blog_posts).
+    expect(afterDelete?.status).toBe("verified");
+
+    const restored = await withTenant(sql, TENANT_A, (tx) =>
+      restoreNewsMediaObject(tx, TENANT_A, ACTOR_ID, created.id)
+    );
+    expect(restored?.deletedAt).toBeNull();
+    expect(restored?.status).toBe("verified");
+
+    // Purge requires soft-deleted first.
+    const purgeBeforeDelete = await withTenant(sql, TENANT_A, (tx) =>
+      purgeNewsMediaObject(tx, TENANT_A, ACTOR_ID, created.id)
+    );
+    expect(purgeBeforeDelete).toBe(false);
+
+    await withTenant(sql, TENANT_A, (tx) =>
+      softDeleteNewsMediaObject(tx, TENANT_A, ACTOR_ID, created.id, "cleanup")
+    );
+    const purged = await withTenant(sql, TENANT_A, (tx) =>
+      purgeNewsMediaObject(tx, TENANT_A, ACTOR_ID, created.id)
+    );
+    expect(purged).toBe(true);
+
+    const gone = await withTenant(sql, TENANT_A, (tx) =>
+      fetchNewsMediaObjectById(tx, TENANT_A, created.id)
+    );
+    expect(gone).toBeNull();
+
+    const auditActions = (await fetchAuditRows(TENANT_A)).map((r) => r.action);
+    expect(auditActions).toEqual([
+      "news_media.object.created",
+      "news_media.object.verified",
+      "news_media.object.attached",
+      "news_media.object.detached",
+      "news_media.object.deleted",
+      "news_media.object.restored",
+      "news_media.object.deleted",
+      "news_media.object.purged"
+    ]);
+  });
+
+  test("attach requires status='verified' — rejects attaching straight from pending_upload", async () => {
+    const sql = getDatabaseClient();
+    const created = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/png"
+      })
+    );
+
+    const attached = await withTenant(sql, TENANT_A, (tx) =>
+      attachNewsMediaObject(tx, TENANT_A, ACTOR_ID, created.id, {
+        ownerResourceType: "blog_post",
+        ownerResourceId: "dddddddd-dddd-dddd-dddd-dddddddddddd"
+      })
+    );
+    expect(attached).toBeNull();
+
+    const auditActions = (await fetchAuditRows(TENANT_A)).map((r) => r.action);
+    expect(auditActions).toEqual(["news_media.object.created"]);
+  });
+
+  test("markNewsMediaObjectOrphaned and markNewsMediaObjectFailed transition without emitting an audit event", async () => {
+    const sql = getDatabaseClient();
+    const created = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/gif"
+      })
+    );
+
+    const orphaned = await withTenant(sql, TENANT_A, (tx) =>
+      markNewsMediaObjectOrphaned(tx, TENANT_A, created.id)
+    );
+    expect(orphaned?.status).toBe("orphaned");
+
+    const second = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/gif"
+      })
+    );
+    const failed = await withTenant(sql, TENANT_A, (tx) =>
+      markNewsMediaObjectFailed(tx, TENANT_A, second.id)
+    );
+    expect(failed?.status).toBe("failed");
+
+    const auditActions = (await fetchAuditRows(TENANT_A)).map((r) => r.action);
+    expect(auditActions).toEqual([
+      "news_media.object.created",
+      "news_media.object.created"
+    ]);
+  });
+
+  test("a tenant A media object is invisible to tenant B's directory calls (cross-tenant rejection)", async () => {
+    const sql = getDatabaseClient();
+    const created = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/jpeg"
+      })
+    );
+
+    const fromTenantB = await withTenant(sql, TENANT_B, (tx) =>
+      fetchNewsMediaObjectById(tx, TENANT_B, created.id)
+    );
+    expect(fromTenantB).toBeNull();
+
+    const verifiedFromTenantB = await withTenant(sql, TENANT_B, (tx) =>
+      markNewsMediaObjectVerified(tx, TENANT_B, ACTOR_ID, created.id)
+    );
+    expect(verifiedFromTenantB).toBeNull();
+  });
+});

--- a/tests/integration/news-media-object-registry.integration.test.ts
+++ b/tests/integration/news-media-object-registry.integration.test.ts
@@ -301,8 +301,17 @@ suite("news media object directory — lifecycle + audit trail", () => {
     );
     expect(deletedOk).toBe(true);
 
-    const afterDelete = await withTenant(sql, TENANT_A, (tx) =>
+    // Default read hides soft-deleted rows (fail-closed convention, same
+    // as blog-content's fetchBlogPostById).
+    const hiddenAfterDelete = await withTenant(sql, TENANT_A, (tx) =>
       fetchNewsMediaObjectById(tx, TENANT_A, created.id)
+    );
+    expect(hiddenAfterDelete).toBeNull();
+
+    const afterDelete = await withTenant(sql, TENANT_A, (tx) =>
+      fetchNewsMediaObjectById(tx, TENANT_A, created.id, {
+        includeDeleted: true
+      })
     );
     expect(afterDelete?.deletedAt).not.toBeNull();
     // status is untouched by soft delete (orthogonal, same as blog_posts).

--- a/tests/unit/news-media-object-key.test.ts
+++ b/tests/unit/news-media-object-key.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildNewsMediaObjectKey,
+  buildNewsMediaPublicUrl,
+  deriveExtensionFromMimeType,
+  isValidNewsMediaObjectKey,
+  UnsupportedNewsMediaMimeTypeError,
+  UntrustedNewsMediaPublicBaseUrlError
+} from "../../src/modules/news-portal/domain/news-media-object-key";
+
+const TENANT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const OTHER_TENANT_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const UUID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+describe("deriveExtensionFromMimeType", () => {
+  test("maps every default-allowed mime type per architecture doc §6", () => {
+    expect(deriveExtensionFromMimeType("image/jpeg")).toBe("jpg");
+    expect(deriveExtensionFromMimeType("image/png")).toBe("png");
+    expect(deriveExtensionFromMimeType("image/webp")).toBe("webp");
+    expect(deriveExtensionFromMimeType("image/gif")).toBe("gif");
+  });
+
+  test("is case-insensitive and trims whitespace", () => {
+    expect(deriveExtensionFromMimeType(" IMAGE/JPEG ")).toBe("jpg");
+  });
+
+  test("returns undefined for an unmapped mime type (e.g. svg, disallowed by default)", () => {
+    expect(deriveExtensionFromMimeType("image/svg+xml")).toBeUndefined();
+    expect(deriveExtensionFromMimeType("application/pdf")).toBeUndefined();
+  });
+});
+
+describe("buildNewsMediaObjectKey", () => {
+  test("builds the exact §6 format: news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}", () => {
+    const key = buildNewsMediaObjectKey({
+      tenantId: TENANT_ID,
+      mimeType: "image/png",
+      uuid: UUID,
+      now: new Date("2026-03-05T00:00:00Z")
+    });
+
+    expect(key).toBe(`news-media/${TENANT_ID}/2026/03/${UUID}.png`);
+  });
+
+  test("throws UnsupportedNewsMediaMimeTypeError for an unmapped mime type", () => {
+    expect(() =>
+      buildNewsMediaObjectKey({
+        tenantId: TENANT_ID,
+        mimeType: "image/svg+xml",
+        uuid: UUID
+      })
+    ).toThrow(UnsupportedNewsMediaMimeTypeError);
+  });
+
+  test("never includes an original filename, title, or other client text", () => {
+    const key = buildNewsMediaObjectKey({
+      tenantId: TENANT_ID,
+      mimeType: "image/jpeg",
+      uuid: UUID,
+      now: new Date("2026-01-01T00:00:00Z")
+    });
+
+    // The key is fully determined by tenantId/date/uuid/ext — nothing else
+    // could sneak in even if a caller tried (no such parameter exists).
+    expect(key).toBe(`news-media/${TENANT_ID}/2026/01/${UUID}.jpg`);
+  });
+});
+
+describe("isValidNewsMediaObjectKey", () => {
+  test("accepts a well-formed key for the given tenant", () => {
+    const key = `news-media/${TENANT_ID}/2026/03/${UUID}.jpg`;
+    expect(isValidNewsMediaObjectKey(TENANT_ID, key)).toBe(true);
+  });
+
+  test("rejects a key belonging to a different tenant", () => {
+    const key = `news-media/${OTHER_TENANT_ID}/2026/03/${UUID}.jpg`;
+    expect(isValidNewsMediaObjectKey(TENANT_ID, key)).toBe(false);
+  });
+
+  test("rejects a key with a local-filesystem-looking path", () => {
+    expect(isValidNewsMediaObjectKey(TENANT_ID, "/uploads/photo.jpg")).toBe(
+      false
+    );
+    expect(isValidNewsMediaObjectKey(TENANT_ID, "/public/photo.jpg")).toBe(
+      false
+    );
+  });
+
+  test("rejects a key using the original filename instead of a uuid", () => {
+    const key = `news-media/${TENANT_ID}/2026/03/photo-lapangan.jpg`;
+    expect(isValidNewsMediaObjectKey(TENANT_ID, key)).toBe(false);
+  });
+
+  test("rejects a key with a malformed date partition", () => {
+    const key = `news-media/${TENANT_ID}/26/3/${UUID}.jpg`;
+    expect(isValidNewsMediaObjectKey(TENANT_ID, key)).toBe(false);
+  });
+
+  test("rejects path traversal attempts", () => {
+    const key = `news-media/${TENANT_ID}/../../etc/passwd`;
+    expect(isValidNewsMediaObjectKey(TENANT_ID, key)).toBe(false);
+  });
+});
+
+describe("buildNewsMediaPublicUrl", () => {
+  test("builds a URL from the trusted base URL and server-generated object key", () => {
+    const key = `news-media/${TENANT_ID}/2026/03/${UUID}.jpg`;
+    expect(buildNewsMediaPublicUrl("https://media.example.test", key)).toBe(
+      `https://media.example.test/${key}`
+    );
+  });
+
+  test("trims a trailing slash on the base URL before joining", () => {
+    const key = `news-media/${TENANT_ID}/2026/03/${UUID}.jpg`;
+    expect(buildNewsMediaPublicUrl("https://media.example.test/", key)).toBe(
+      `https://media.example.test/${key}`
+    );
+  });
+
+  test("rejects a non-https base URL", () => {
+    expect(() =>
+      buildNewsMediaPublicUrl("http://media.example.test", "k")
+    ).toThrow(UntrustedNewsMediaPublicBaseUrlError);
+  });
+
+  test("rejects a malformed base URL", () => {
+    expect(() => buildNewsMediaPublicUrl("not-a-url", "k")).toThrow(
+      UntrustedNewsMediaPublicBaseUrlError
+    );
+  });
+});

--- a/tests/unit/news-media-permissions.test.ts
+++ b/tests/unit/news-media-permissions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { newsPortalModule } from "../../src/modules/news-portal/module";
+import {
+  NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+  NEWS_MEDIA_PERMISSIONS
+} from "../../src/modules/news-portal/domain/news-media-permissions";
+
+describe("NEWS_MEDIA_PERMISSIONS", () => {
+  test("declares one key per required media lifecycle action", () => {
+    expect(Object.keys(NEWS_MEDIA_PERMISSIONS).sort()).toEqual(
+      [
+        "attach",
+        "create",
+        "delete",
+        "detach",
+        "purge",
+        "read",
+        "restore",
+        "verify"
+      ].sort()
+    );
+  });
+
+  test("every permission key follows the news_portal.media.<action> shape", () => {
+    for (const value of Object.values(NEWS_MEDIA_PERMISSIONS)) {
+      expect(value).toMatch(
+        new RegExp(
+          `^news_portal\\.${NEWS_MEDIA_PERMISSION_ACTIVITY_CODE}\\.[a-z]+$`
+        )
+      );
+    }
+  });
+
+  test("module.ts does not declare these as real permissions yet (Issue #634 does, per this file's own header comment)", () => {
+    // `permissions` is deliberately left undeclared on `news_portal`'s module
+    // descriptor until a real endpoint exists to enforce them (see
+    // `module.ts`'s own description and this file's header comment) — this
+    // guards against silently wiring these constants into the descriptor
+    // without also adding the endpoint/ABAC check that should come with it.
+    expect(newsPortalModule.permissions).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `awcms_mini_news_media_objects`, a tenant-scoped, metadata-only registry for news image objects stored in Cloudflare R2. Schema + domain/application helpers only — no upload endpoint, no R2 network calls (that's Issue #634).

- Table: RLS `ENABLE`+`FORCE`, `storage_driver` hard-constrained to `'cloudflare_r2'`, `object_key`/`bucket_name` `NOT NULL`, DB-level `CHECK` enforcing the tenant/module-prefixed object key format from `full-online-r2-architecture.md` §6, `status` enum with an `attached` ⇒ non-null owner constraint.
- Domain helpers generate object keys and public URLs **server-side only** — never from client input.
- Application helpers cover the full `pending_upload → uploaded → verified → attached` lifecycle plus soft delete/restore/purge, each step audited.
- Table named `awcms_mini_news_media_objects` (not the issue body's generic `awcms_mini_media_objects`) to match the name already established in #631's architecture doc.
- `owner_resource_type`/`owner_resource_id` is a loose polymorphic reference (no FK) — consistent with `news_portal` having no hard dependency on `blog_content`.
- Permission key constants prepared for #634 (`news_portal.media.*`), not yet wired into the module descriptor (no endpoint exists yet).

## Test plan

- [x] `bun run check` — 1833 pass, 0 fail; lint, typecheck, docs check, build all green.
- [x] `bun run db:migrate` — applies cleanly.
- [x] New tests: RLS isolation + fail-closed without tenant GUC, invalid `storage_driver`/object key/missing bucket/invalid status rejection, attach-without-owner rejection, full lifecycle + audit trail, attach-requires-verified guard, cross-tenant rejection.
- [x] Changeset added.

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)