### PR TITLE
feat(news-portal): add Cloudflare R2 image delivery readiness checks

### DIFF
--- a/.changeset/news-media-r2-readiness-checks-issue-635.md
+++ b/.changeset/news-media-r2-readiness-checks-issue-635.md
@@ -1,0 +1,25 @@
+---
+"awcms-mini": minor
+---
+
+Add Cloudflare R2 image delivery readiness checks for the news portal's
+R2-only media mode (Issue #635, epic `news_portal` #631-#642/#649).
+
+`bun run config:validate` now rejects a `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`
+allow-list containing any type outside the ones the MIME sniffer can
+actually recognize (JPEG/PNG/WebP/GIF/SVG — an unrecognized entry can
+never pass upload verification, so it is a misconfiguration, not just an
+unsafe default), and rejects a
+`NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` above 3600 seconds (a
+presigned PUT URL is reusable for its whole TTL, so an excessive expiry
+weakens that mitigation).
+
+`bun run security:readiness` adds two checks: a critical check that,
+when `APP_ENV=production`, rejects a `NEWS_MEDIA_R2_PUBLIC_BASE_URL`
+pointing at Cloudflare's default `*.r2.dev` domain or a loopback host
+(production must use a real custom domain — non-production is
+unaffected, by design); and a warning check that scans all tenants for
+`awcms_mini_news_media_objects` rows stuck in `pending_upload` past
+`NEWS_MEDIA_R2_PENDING_TTL_MINUTES`, surfacing that the automatic
+cleanup job this mode's architecture document describes has not been
+implemented yet.

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -861,6 +861,37 @@ menutup sisanya:
 Implementor issue yang akhirnya menambah salah satu dari dua hal di atas
 **wajib** memperbarui `r2-security-checklist.md` §7 dan bagian ini lagi.
 
+### PR #665 re-review — hostname bypass di check `checkNewsMediaR2PublicBaseUrlProductionSafe`
+
+Reviewer DAN security-auditor independen sama-sama menemukan
+`findNewsMediaR2PublicBaseUrlProductionUnsafeReason` (dan helper
+`isLoopbackHost`/`isR2DevHost`) bisa dilewati:
+
+1. **Trailing-dot FQDN** — `https://pub-abc123.r2.dev./x` punya
+   `hostname` literal `"pub-abc123.r2.dev."` (titik root DNS
+   dipertahankan `new URL(...).hostname`), tidak cocok regex
+   `/\.r2\.dev$/i` yang tidak menormalisasi titik akhir — padahal DNS
+   memperlakukan `abc.r2.dev.` PERSIS sama dengan `abc.r2.dev`. Sama
+   untuk `http://localhost.`.
+2. **IPv6/`0.0.0.0` loopback tidak tercakup** (reviewer) —
+   `new URL("http://[::1]/").hostname` mengembalikan `"[::1]"`, dan
+   `new URL("http://0.0.0.0/").hostname` mengembalikan `"0.0.0.0"` —
+   keduanya tidak cocok exact-string check yang tadinya cuma
+   `"localhost"`/`"127.0.0.1"`.
+
+**Fix**: `stripTrailingDot` (helper baru) menormalisasi titik akhir
+SEBELUM kedua check berjalan; `isLoopbackHost` diperluas mencakup
+`0.0.0.0`, `::1`, `[::1]` (case-insensitive). Encouragingly, obfuscation
+IP lain (oktal/desimal/hex — `0177.0.0.1`/`2130706433`/`0x7f000001`) DAN
+homograph Unicode pada dot (`．`/`。`) sudah otomatis dinetralkan oleh
+normalisasi `URL`/IDNA bawaan Bun SEBELUM regex/exact-match berjalan
+(diverifikasi kedua agent secara independen) — bukan sesuatu yang perlu
+ditangani manual di sini. Regression test untuk kedua bypass di atas
+ditambahkan ke `tests/unit/news-media-r2-config.test.ts`. Implementor
+lanjutan yang menyentuh fungsi ini lagi **wajib** mempertahankan
+`stripTrailingDot` dan keempat variant loopback ini — jangan
+menyederhanakan balik ke exact-string match polos.
+
 ### File yang dibuat/diubah (referensi cepat)
 
 - `src/modules/news-portal/domain/news-media-r2-config.ts`: tambah
@@ -877,7 +908,7 @@ Implementor issue yang akhirnya menambah salah satu dari dua hal di atas
   `runSecurityReadinessChecks`.
 - `.env.example`, `18_configuration_env_reference.md` §News portal,
   `full-online-r2-architecture.md` §4, `r2-security-checklist.md` §7 —
-  semua diperbarui untuk kelima check baru.
+  semua diperbarui untuk keempat check baru.
 - Test: `tests/unit/news-media-r2-config.test.ts` (tambah describe
   block untuk tiga helper baru), `tests/validate-env.test.ts` (tambah
   describe block untuk dua check config:validate baru),

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -40,7 +40,7 @@ status + pointer, bukan menduplikasi isinya.
 | #632  | Preset `news_portal_full_online_r2` (module descriptor/config gate)                                                          | **Selesai** — lihat §632 di bawah                    |
 | #633  | Tenant-scoped R2-only media object registry (schema + migration)                                                             | **Selesai** — lihat §633 di bawah                    |
 | #634  | Direct-to-R2 presigned upload flow (endpoint upload/confirm)                                                                 | **Selesai** — lihat §634 di bawah                    |
-| #635  | Config validation + readiness checks (`config:validate`/`security:readiness`/`production:preflight`) untuk R2 image delivery | Belum dikerjakan — lihat §635 di bawah               |
+| #635  | Config validation + readiness checks (`config:validate`/`security:readiness`/`production:preflight`) untuk R2 image delivery | **Selesai** — lihat §635 di bawah                    |
 | #636  | `blog_content` wajib referensi R2 media object untuk gambar berita saat mode aktif                                           | Belum dikerjakan — lihat §636 di bawah               |
 | #637  | Editorial homepage section composer `/news` dengan render R2-only                                                            | Belum dikerjakan — lihat §637 di bawah               |
 | #638  | Preset placement iklan news portal dengan validasi gambar R2-only                                                            | Belum dikerjakan — lihat §638 di bawah               |
@@ -747,7 +747,11 @@ merah/hijau.
 - Job pembersihan objek R2 `failed`/`orphaned`/`pending` kedaluwarsa —
   finalize hanya MENANDAI baris `failed` dan mengaudit, TIDAK
   menghapus objek R2 sungguhan (`r2-backup-lifecycle.md`'s lifecycle
-  job, kemungkinan besar #635, di luar cakupan issue ini).
+  job). **Update #635**: TERNYATA bukan scope #635 juga (judul issue itu
+  "readiness checks", bukan "cleanup job") — #635 hanya menambah
+  `checkNewsMediaR2NoStalePendingObjects` yang MELAPORKAN backlog
+  sebagai warning, tidak menghapus. Job penghapusan nyata masih belum
+  ada issue yang mengklaimnya — lihat §635 di bawah.
 - Endpoint `attach` nyata (permission `news_portal.media.attach` sudah
   di-declare, tapi belum ada route yang memanggilnya) — verifikasi
   `owner_resource_id` exist+tenant-match (temuan Medium security-auditor
@@ -757,15 +761,134 @@ merah/hijau.
   (dicatat di §633), tidak disentuh issue ini (tidak ada endpoint purge
   nyata yang dirilis di sini).
 
-## §635 — Readiness checks (belum dikerjakan)
+## §635 — R2 image delivery readiness checks (Selesai)
 
-Ringkasan scope: `config:validate`, `security:readiness`,
-`production:preflight` untuk R2 image delivery. Kontrak lengkap yang
-wajib dipenuhi: `r2-security-checklist.md` §7 (termasuk penegakan
-`NEWS_MEDIA_R2_BUCKET` ≠ `R2_BUCKET`, kredensial berbeda, SVG tidak di
-allow-list kecuali override eksplisit). Implementor **wajib**
-memperbarui `r2-security-checklist.md` §7 begitu check nyata ditulis
-(ganti "belum ada" jadi nama fungsi/test).
+### Rekonsiliasi — body issue #635 pakai nama var placeholder, BUKAN `NEWS_MEDIA_R2_*` nyata
+
+Body issue #635 menulis `R2_NEWS_IMAGE_*`, `NEWS_IMAGE_STORAGE_POLICY`,
+`FILE_STORAGE_DRIVER`, `LOCAL_FILE_UPLOADS_ENABLED`,
+`LOCAL_MEDIA_STORAGE_ENABLED` — TIDAK satu pun dari var ini ada di kode
+(sama pola rekonsiliasi #632/#633/#634 di atas). Var nyata tetap
+`NEWS_MEDIA_R2_*` (§4 architecture doc, ditegakkan sejak #632). Tidak
+ada `LOCAL_FILE_UPLOADS_ENABLED`/`LOCAL_MEDIA_STORAGE_ENABLED`/
+`FILE_STORAGE_DRIVER` karena mode ini secara struktural tidak punya
+jalur upload lokal untuk didisable (Keputusan kunci #2, `Tidak ada flag
+"local fallback" sungguhan` di §632 di atas — masih berlaku sama persis
+di sini, TIDAK diimplementasikan ulang sebagai flag baru).
+
+### Scope nyata yang dikerjakan — sebagian besar acceptance criteria issue SUDAH terpenuhi #632, sisanya di sini
+
+`r2-security-checklist.md` §7 (ditulis saat #631/#632) sudah menandai
+sebagian besar acceptance criteria issue #635 selesai lebih awal lewat
+#632 (`checkNewsPortalProfileConfig`, `checkNewsMediaR2Config`,
+`checkNewsMediaR2SeparationFromSyncR2`,
+`checkNewsPortalFullOnlineR2PresetReady`,
+`checkNewsMediaR2SvgNotAllowed`) DAN menandai eksplisit apa yang
+"masih terbuka untuk #635". Issue ini menambah EMPAT check baru yang
+menutup sisanya:
+
+- **`checkNewsMediaR2AllowedMimeTypesKnown`** (`config:validate`,
+  **fail**) — `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` wajib seluruhnya berada
+  di `NEWS_MEDIA_R2_KNOWN_MIME_TYPES` (domain
+  `news-media-r2-config.ts`: empat tipe raster yang bisa disniff
+  `news-media-mime-sniffer.ts` PLUS `image/svg+xml` — svg tetap "known"
+  karena punya jalur override yang sah lewat
+  `checkNewsMediaR2SvgNotAllowed`, bukan "unknown/unsafe"). Entri lain
+  (`text/html`, `application/octet-stream`, typo) tidak pernah bisa
+  lolos sniffing di `finalize` — ini murni misconfiguration, jadi
+  **fail** hard, bukan warning.
+- **`checkNewsMediaR2PresignedTtlUpperBound`** (`config:validate`,
+  **fail**) — `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` tidak boleh
+  melebihi `NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS` (konstanta
+  baru, 3600 detik/1 jam) — presigned PUT URL bisa dipakai ulang selama
+  TTL berlaku (architecture doc §8), jadi TTL berlebihan melemahkan
+  mitigasi itu. Angka 3600 dipilih sebagai batas atas yang longgar tapi
+  tetap bermakna — bukan dari acceptance criteria issue (yang tidak
+  memberi angka), didokumentasikan sebagai keputusan implementor.
+- **`checkNewsMediaR2PublicBaseUrlProductionSafe`** (`security:readiness`,
+  **critical**) — PERTAMA kalinya keluarga check ini (config:validate/
+  security:readiness untuk news-media R2) bercabang pada `APP_ENV`. Saat
+  `APP_ENV=production` DAN `NEWS_MEDIA_R2_ENABLED=true`: menolak host
+  `*.r2.dev` bawaan Cloudflare (regex `\.r2\.dev$` pada hostname, bukan
+  substring match — hindari false-positive terhadap domain kustom yang
+  kebetulan mengandung string itu di path) dan host loopback
+  (`localhost`/`127.0.0.1`). Non-production SELALU **pass** — issue
+  eksplisit minta "non-production/dev mode boleh didokumentasikan
+  terpisah tanpa melemahkan default production", jadi non-production
+  tidak pernah gagal di sini walau URL-nya `r2.dev`. Ini check
+  **critical** PERTAMA yang membaca `APP_ENV` di keluarga
+  `security-readiness.ts` — precedent untuk implementor lanjutan yang
+  butuh perilaku berbeda production vs non-production.
+- **`checkNewsMediaR2NoStalePendingObjects`** (`security:readiness`,
+  **warning**, ASYNC + butuh `DATABASE_URL`) — inilah yang
+  `r2-security-checklist.md` §7 versi lama tandai eksplisit "masih
+  terbuka untuk #635": check yang menyentuh TABEL REGISTRY itu sendiri,
+  bukan cuma shape env var. Scan lintas SEMUA tenant aktif untuk baris
+  `pending_upload` yang sudah lewat `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`
+  — pola IDENTIK `checkSsoBreakGlassReady` (Issue #593): query
+  `awcms_mini_tenants` dulu, lalu satu `sql.begin` per tenant dengan
+  `SET LOCAL app.current_tenant_id`, supaya check ini tetap benar lewat
+  RLS terlepas dari privilege `DATABASE_URL` yang dipakai
+  `security:readiness`. **Severity `warning`, bukan `critical`** —
+  backlog objek `pending_upload` basi adalah gap housekeeping (job
+  pembersihan §2 memang belum ada sama sekali di kode ini — lihat
+  paragraf di bawah), bukan bukti eksploitasi aktif.
+
+**PENTING — apa yang TIDAK dikerjakan issue ini (sengaja, per
+`r2-backup-lifecycle.md`)**:
+
+1. **Job pembersihan objek `pending_upload` basi yang NYATA** (§2 —
+   menghapus objek R2 + baris metadata). `checkNewsMediaR2NoStalePendingObjects`
+   di atas hanya MELAPORKAN backlog, TIDAK menghapus apa pun. Job nyata
+   masih murni scope operasional/lifecycle yang belum
+   diimplementasikan siapa pun sampai sekarang (§2 sendiri menulis
+   "kemungkinan bagian dari #633/#634" — ternyata tidak, dan #635 juga
+   bukan tempatnya karena judul issue ini adalah "readiness checks",
+   bukan "cleanup job").
+2. **Deteksi objek `confirmed` `orphaned`** (§4) — SENGAJA tidak
+   diimplementasikan di issue ini karena bergantung pada daftar
+   LENGKAP titik referensi (`blog_content` featured image, block
+   `gallery`/`video_news`, `ad.imageUrl`, SEO share image) yang baru ada
+   setelah #636-#640/#642/#649 selesai (§4 eksplisit: "daftar titik
+   referensi ini wajib diperbarui setiap kali issue lanjutan menambah
+   surface baru"). Mengimplementasikan deteksi orphan SEKARANG — sebelum
+   `blog_content` bahkan mewajibkan referensi R2 (#636) — akan salah
+   menandai SEMUA objek `confirmed`/`verified` sebagai orphan (belum ada
+   satu pun surface yang benar-benar mereferensikannya), persis
+   kesalahan "jangan bangun ke depan sebelum dependency siap" yang
+   epic ini berulang kali diperingatkan hindari.
+
+Implementor issue yang akhirnya menambah salah satu dari dua hal di atas
+**wajib** memperbarui `r2-security-checklist.md` §7 dan bagian ini lagi.
+
+### File yang dibuat/diubah (referensi cepat)
+
+- `src/modules/news-portal/domain/news-media-r2-config.ts`: tambah
+  `NEWS_MEDIA_R2_KNOWN_MIME_TYPES`,
+  `NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS`,
+  `findUnknownNewsMediaR2MimeTypes`, `isPresignedUploadTtlTooLong`,
+  `findNewsMediaR2PublicBaseUrlProductionUnsafeReason`.
+- `scripts/validate-env.ts`: `checkNewsMediaR2AllowedMimeTypesKnown`,
+  `checkNewsMediaR2PresignedTtlUpperBound`, wired into
+  `runEnvValidation`.
+- `scripts/security-readiness.ts`:
+  `checkNewsMediaR2PublicBaseUrlProductionSafe`,
+  `checkNewsMediaR2NoStalePendingObjects`, wired into
+  `runSecurityReadinessChecks`.
+- `.env.example`, `18_configuration_env_reference.md` §News portal,
+  `full-online-r2-architecture.md` §4, `r2-security-checklist.md` §7 —
+  semua diperbarui untuk kelima check baru.
+- Test: `tests/unit/news-media-r2-config.test.ts` (tambah describe
+  block untuk tiga helper baru), `tests/validate-env.test.ts` (tambah
+  describe block untuk dua check config:validate baru),
+  `tests/security-readiness.test.ts` (tambah describe block untuk
+  `checkNewsMediaR2PublicBaseUrlProductionSafe`; `checkNewsMediaR2NoStalePendingObjects`
+  SENGAJA tidak di-unit-test di sini — pola sama
+  `checkSsoBreakGlassReady`, lihat komentar header file test itu),
+  `tests/integration/security-readiness-news-media-r2.integration.test.ts`
+  (baru — DB nyata untuk `checkNewsMediaR2NoStalePendingObjects`, pola
+  sama `security-readiness-break-glass.integration.test.ts`).
+- Changeset: `.changeset/news-media-r2-readiness-checks-issue-635.md`.
 
 ## §636 — `blog_content` wajib referensi R2 media (belum dikerjakan)
 

--- a/.env.example
+++ b/.env.example
@@ -284,12 +284,25 @@ NEWS_MEDIA_R2_ENABLED=false
 # NEWS_MEDIA_R2_ACCESS_KEY_ID=
 # NEWS_MEDIA_R2_SECRET_ACCESS_KEY=
 # NEWS_MEDIA_R2_BUCKET=
+# Wajib custom domain (Cloudflare R2 "Custom Domains"), BUKAN URL *.r2.dev
+# bawaan, saat APP_ENV=production — `bun run security:readiness` menolak
+# (critical) *.r2.dev/localhost/127.0.0.1 di production (Issue #635,
+# architecture doc §11). Non-production boleh memakai r2.dev sementara.
 # NEWS_MEDIA_R2_PUBLIC_BASE_URL=
+# Presigned PUT URL bisa dipakai ulang selama TTL belum habis — jangan set
+# terlalu panjang (maksimum 3600 detik/1 jam, ditegakkan `config:validate`,
+# Issue #635 architecture doc §8).
 NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS=300
 NEWS_MEDIA_R2_MAX_UPLOAD_BYTES=10485760
 # image/svg+xml sengaja TIDAK termasuk default (risiko XSS) — lihat
-# architecture doc §9 sebelum menambahkannya.
+# architecture doc §9 sebelum menambahkannya. `config:validate` menolak
+# (fail) tipe apa pun di luar image/jpeg,image/png,image/webp,image/gif,
+# image/svg+xml — tipe lain tidak pernah bisa lolos MIME sniffing di
+# `finalize` (Issue #635).
 NEWS_MEDIA_R2_ALLOWED_MIME_TYPES=image/jpeg,image/png,image/webp,image/gif
+# Objek `pending_upload` yang lewat TTL ini dan belum dibersihkan otomatis
+# (job pembersihan belum ada di kode ini — r2-backup-lifecycle.md §2)
+# dilaporkan sebagai warning oleh `bun run security:readiness` (Issue #635).
 NEWS_MEDIA_R2_PENDING_TTL_MINUTES=60
 
 # Provider eksternal opsional (default off) — base tidak menetapkan provider

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -520,32 +520,41 @@ arsitektur lengkap (termasuk kenapa TIDAK ada var `DEPLOYMENT_PROFILE`/
 sudah ada sebagai konsep lain: `blog_content`'s per-tenant module setting
 `publicRouteMode` dan `PUBLIC_CANONICAL_BASE_PATH` di atas).
 
-| Var                                          | Wajib        | Default                                     | Sensitif | Fungsi                                                                                        |
-| -------------------------------------------- | ------------ | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `NEWS_PORTAL_ENABLED`                        | –            | `false`                                     | –        | Master switch preset `news_portal_full_online_r2` itu sendiri                                 |
-| `NEWS_PORTAL_PROFILE`                        | bila enabled | –                                           | –        | Wajib `full_online_r2` (satu-satunya nilai valid hari ini)                                    |
-| `NEWS_MEDIA_R2_ENABLED`                      | –            | `false`                                     | –        | Master switch mode R2-only news media                                                         |
-| `NEWS_MEDIA_R2_ACCOUNT_ID`                   | bila enabled | –                                           | –        | Boleh sama dengan `R2_ACCOUNT_ID` (satu akun Cloudflare) atau berbeda                         |
-| `NEWS_MEDIA_R2_ACCESS_KEY_ID`                | bila enabled | –                                           | Ya       | WAJIB berbeda dari `R2_ACCESS_KEY_ID` — ditegakkan `config:validate`/`security:readiness`     |
-| `NEWS_MEDIA_R2_SECRET_ACCESS_KEY`            | bila enabled | –                                           | Ya       | WAJIB berbeda dari `R2_SECRET_ACCESS_KEY` — ditegakkan `config:validate`/`security:readiness` |
-| `NEWS_MEDIA_R2_BUCKET`                       | bila enabled | –                                           | –        | WAJIB berbeda dari `R2_BUCKET` — ditegakkan `config:validate`/`security:readiness`            |
-| `NEWS_MEDIA_R2_PUBLIC_BASE_URL`              | bila enabled | –                                           | –        | Custom domain publik (HTTPS absolut), mis. `https://media.contoh-berita.id`                   |
-| `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` | –            | `300`                                       | –        | TTL presigned PUT upload (bukan TTL baca — baca selalu publik)                                |
-| `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`             | –            | `10485760` (10 MiB)                         | –        | Batas ukuran per file                                                                         |
-| `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`           | –            | `image/jpeg,image/png,image/webp,image/gif` | –        | Allow-list MIME — `image/svg+xml` sengaja tidak termasuk default (risiko XSS)                 |
-| `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`          | –            | `60`                                        | –        | Batas usia objek `pending` sebelum dibersihkan lifecycle job (Issue #633 lanjutan)            |
+| Var                                          | Wajib        | Default                                     | Sensitif | Fungsi                                                                                                                                                                                    |
+| -------------------------------------------- | ------------ | ------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEWS_PORTAL_ENABLED`                        | –            | `false`                                     | –        | Master switch preset `news_portal_full_online_r2` itu sendiri                                                                                                                             |
+| `NEWS_PORTAL_PROFILE`                        | bila enabled | –                                           | –        | Wajib `full_online_r2` (satu-satunya nilai valid hari ini)                                                                                                                                |
+| `NEWS_MEDIA_R2_ENABLED`                      | –            | `false`                                     | –        | Master switch mode R2-only news media                                                                                                                                                     |
+| `NEWS_MEDIA_R2_ACCOUNT_ID`                   | bila enabled | –                                           | –        | Boleh sama dengan `R2_ACCOUNT_ID` (satu akun Cloudflare) atau berbeda                                                                                                                     |
+| `NEWS_MEDIA_R2_ACCESS_KEY_ID`                | bila enabled | –                                           | Ya       | WAJIB berbeda dari `R2_ACCESS_KEY_ID` — ditegakkan `config:validate`/`security:readiness`                                                                                                 |
+| `NEWS_MEDIA_R2_SECRET_ACCESS_KEY`            | bila enabled | –                                           | Ya       | WAJIB berbeda dari `R2_SECRET_ACCESS_KEY` — ditegakkan `config:validate`/`security:readiness`                                                                                             |
+| `NEWS_MEDIA_R2_BUCKET`                       | bila enabled | –                                           | –        | WAJIB berbeda dari `R2_BUCKET` — ditegakkan `config:validate`/`security:readiness`                                                                                                        |
+| `NEWS_MEDIA_R2_PUBLIC_BASE_URL`              | bila enabled | –                                           | –        | Custom domain publik (HTTPS absolut), mis. `https://media.contoh-berita.id`. Saat `APP_ENV=production`, WAJIB custom domain nyata — bukan `*.r2.dev`/`localhost`/`127.0.0.1` (Issue #635) |
+| `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` | –            | `300`                                       | –        | TTL presigned PUT upload (bukan TTL baca — baca selalu publik). Maksimum `3600` detik (Issue #635)                                                                                        |
+| `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`             | –            | `10485760` (10 MiB)                         | –        | Batas ukuran per file                                                                                                                                                                     |
+| `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`           | –            | `image/jpeg,image/png,image/webp,image/gif` | –        | Allow-list MIME — `image/svg+xml` sengaja tidak termasuk default (risiko XSS). Tipe di luar kelima tipe yang dikenal sniffer ditolak `config:validate` (Issue #635)                       |
+| `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`          | –            | `60`                                        | –        | Batas usia objek `pending_upload` sebelum dibersihkan lifecycle job (belum ada — dilaporkan warning oleh `security:readiness` bila terlampaui, Issue #635)                                |
 
 `bun run config:validate` (`checkNewsPortalProfileConfig`,
-`checkNewsMediaR2Config`, `checkNewsMediaR2SeparationFromSyncR2`) menolak
+`checkNewsMediaR2Config`, `checkNewsMediaR2SeparationFromSyncR2`,
+`checkNewsMediaR2AllowedMimeTypesKnown`,
+`checkNewsMediaR2PresignedTtlUpperBound` — dua terakhir Issue #635) menolak
 boot bila `NEWS_PORTAL_PROFILE` bukan nilai yang dikenal, bila
-`NEWS_MEDIA_R2_ENABLED=true` tapi var wajib di atas hilang, ATAU bila
+`NEWS_MEDIA_R2_ENABLED=true` tapi var wajib di atas hilang, bila
 `NEWS_MEDIA_R2_BUCKET`/`_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` sama persis
 dengan `R2_BUCKET`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` milik
-sync-storage (Issue #631 architecture doc §2). `bun run security:readiness`
+sync-storage (Issue #631 architecture doc §2), bila allow-list MIME berisi
+tipe di luar yang dikenal sniffer, ATAU bila TTL presigned upload melebihi
+3600 detik. `bun run security:readiness`
 (`checkNewsPortalFullOnlineR2PresetReady`, critical;
-`checkNewsMediaR2SvgNotAllowed`, warning) menilai kombinasi penuh syarat
-aktivasi preset dan memperingatkan bila allow-list MIME di-override untuk
-mengizinkan `image/svg+xml`.
+`checkNewsMediaR2SvgNotAllowed`, warning;
+`checkNewsMediaR2PublicBaseUrlProductionSafe`, critical — Issue #635;
+`checkNewsMediaR2NoStalePendingObjects`, warning — Issue #635) menilai
+kombinasi penuh syarat aktivasi preset, memperingatkan bila allow-list MIME
+di-override untuk mengizinkan `image/svg+xml`, menolak (critical) URL
+publik `*.r2.dev`/loopback saat `APP_ENV=production`, dan memperingatkan
+bila ada objek `pending_upload` yang sudah lewat TTL di tabel registry
+(lintas semua tenant).
 
 Tidak ada var `FILE_STORAGE_DRIVER`/`LOCAL_FILE_UPLOADS_ENABLED`/
 `LOCAL_MEDIA_STORAGE_ENABLED` di sini — mode ini secara struktural tidak

--- a/docs/awcms-mini/news-portal/full-online-r2-architecture.md
+++ b/docs/awcms-mini/news-portal/full-online-r2-architecture.md
@@ -104,15 +104,20 @@ mengasumsikan akun yang sama.
 
 ## 4. Konvensi environment variable
 
-**Status: diimplementasikan oleh Issue #632.** Var di bawah sudah ada di
-`.env.example` dan `18_configuration_env_reference.md` §News portal,
-ditegakkan `scripts/validate-env.ts` (`checkNewsPortalProfileConfig`,
-`checkNewsMediaR2Config`, `checkNewsMediaR2SeparationFromSyncR2`) dan
+**Status: diimplementasikan oleh Issue #632, diperluas Issue #635.** Var
+di bawah sudah ada di `.env.example` dan
+`18_configuration_env_reference.md` §News portal, ditegakkan
+`scripts/validate-env.ts` (`checkNewsPortalProfileConfig`,
+`checkNewsMediaR2Config`, `checkNewsMediaR2SeparationFromSyncR2`,
+`checkNewsMediaR2AllowedMimeTypesKnown`,
+`checkNewsMediaR2PresignedTtlUpperBound` — dua terakhir Issue #635) dan
 `scripts/security-readiness.ts` (`checkNewsPortalFullOnlineR2PresetReady`,
-`checkNewsMediaR2SvgNotAllowed`), dan diresolusi oleh
-`src/modules/news-portal/domain/news-media-r2-config.ts`
+`checkNewsMediaR2SvgNotAllowed`,
+`checkNewsMediaR2PublicBaseUrlProductionSafe`,
+`checkNewsMediaR2NoStalePendingObjects` — dua terakhir Issue #635), dan
+diresolusi oleh `src/modules/news-portal/domain/news-media-r2-config.ts`
 (`resolveNewsMediaR2Config`). Nama di sini tetap **konvensi wajib**
-persis apa adanya untuk implementor lanjutan (#633/#634) — jangan
+persis apa adanya untuk implementor lanjutan (#633/#634/#635) — jangan
 menciptakan skema penamaan lain atau menimpakan arti baru ke `R2_*` yang
 sudah dipakai `sync-storage`.
 
@@ -126,13 +131,13 @@ Prefix **`NEWS_MEDIA_R2_`** — sengaja berbeda dari `R2_*` generik
 | `NEWS_MEDIA_R2_ACCESS_KEY_ID`                | bila enabled | –                                           | Token least-privilege terpisah dari `R2_ACCESS_KEY_ID` — **wajib** berbeda (§2, §13).                                                                                                                                                                                |
 | `NEWS_MEDIA_R2_SECRET_ACCESS_KEY`            | bila enabled | –                                           | Idem.                                                                                                                                                                                                                                                                |
 | `NEWS_MEDIA_R2_BUCKET`                       | bila enabled | –                                           | **Wajib** berbeda dari `R2_BUCKET` (§2) — divalidasi tidak sama saat `config:validate`/`security:readiness` (diimplementasikan #632, bukan #635 — #635 masih menambah check readiness lain di luar separation ini, mis. MIME sniffing/checksum runtime enforcement). |
-| `NEWS_MEDIA_R2_PUBLIC_BASE_URL`              | bila enabled | –                                           | Custom domain publik (§11), mis. `https://media.contoh-berita.id`. Harus HTTPS absolut.                                                                                                                                                                              |
-| `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` | –            | `300`                                       | TTL presigned PUT (§8). Bukan TTL baca — baca selalu publik lewat custom domain.                                                                                                                                                                                     |
+| `NEWS_MEDIA_R2_PUBLIC_BASE_URL`              | bila enabled | –                                           | Custom domain publik (§11), mis. `https://media.contoh-berita.id`. Harus HTTPS absolut. Saat `APP_ENV=production`, WAJIB custom domain nyata — bukan `*.r2.dev`/loopback (Issue #635, `checkNewsMediaR2PublicBaseUrlProductionSafe`).                                |
+| `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` | –            | `300`                                       | TTL presigned PUT (§8). Bukan TTL baca — baca selalu publik lewat custom domain. Maksimum `3600` detik (Issue #635, `NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS`).                                                                                               |
 | `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`             | –            | `10485760` (10 MiB)                         | Batas ukuran per file (§9).                                                                                                                                                                                                                                          |
-| `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`           | –            | `image/jpeg,image/png,image/webp,image/gif` | Allow-list MIME (§9) — **tidak termasuk** `image/svg+xml` (§9 alasan).                                                                                                                                                                                               |
-| `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`          | –            | `60`                                        | Batas usia objek `pending` sebelum dibersihkan lifecycle job (`r2-backup-lifecycle.md`).                                                                                                                                                                             |
+| `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES`           | –            | `image/jpeg,image/png,image/webp,image/gif` | Allow-list MIME (§9) — **tidak termasuk** `image/svg+xml` default (§9 alasan). Entri di luar `NEWS_MEDIA_R2_KNOWN_MIME_TYPES` (kelima tipe di atas) ditolak `config:validate` (Issue #635).                                                                          |
+| `NEWS_MEDIA_R2_PENDING_TTL_MINUTES`          | –            | `60`                                        | Batas usia objek `pending_upload` sebelum dibersihkan lifecycle job (`r2-backup-lifecycle.md` §2 — job itu sendiri belum ada; `checkNewsMediaR2NoStalePendingObjects`, Issue #635, hanya melaporkan warning bila TTL terlampaui).                                    |
 
-Implementor (#632/#633/#634) wajib memakai nama ini persis — jangan
+Implementor (#632/#633/#634/#635) wajib memakai nama ini persis — jangan
 memilih nama lain "yang mirip" tanpa memperbarui tabel ini.
 
 ## 5. Model data konseptual — media registry (Issue #633, **diimplementasikan**)

--- a/docs/awcms-mini/news-portal/r2-security-checklist.md
+++ b/docs/awcms-mini/news-portal/r2-security-checklist.md
@@ -196,7 +196,7 @@ detail lengkap) — ini bukan lagi gap, karena penegakannya terjadi
 sinkron di jalur request `finalize`, bukan lewat readiness-check
 terpisah.
 
-**Update #635 (selesai)**: kelima check baru di atas menutup seluruh
+**Update #635 (selesai)**: keempat check baru di atas menutup seluruh
 acceptance criteria issue #635 yang masih relevan setelah #632-#634 —
 lihat `.claude/skills/awcms-mini-news-portal/SKILL.md` §635 untuk
 rekonsiliasi lengkap (nama var body issue vs `NEWS_MEDIA_R2_*` nyata,

--- a/docs/awcms-mini/news-portal/r2-security-checklist.md
+++ b/docs/awcms-mini/news-portal/r2-security-checklist.md
@@ -143,6 +143,18 @@ menunggu #635):
     `_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` ≠ `R2_BUCKET`/`R2_ACCESS_KEY_ID`/
     `R2_SECRET_ACCESS_KEY` (§2 penegakan nyata, gagal boot bila sama —
     bukan hanya dokumentasi).
+- **`bun run config:validate`** (lanjutan, Issue #635):
+  - `checkNewsMediaR2AllowedMimeTypesKnown` — allow-list MIME wajib
+    seluruhnya berada di `NEWS_MEDIA_R2_KNOWN_MIME_TYPES` (empat tipe
+    raster yang bisa dikenali `news-media-mime-sniffer.ts` PLUS
+    `image/svg+xml`) — entri di luar itu (`text/html`,
+    `application/octet-stream`, typo, dst.) tidak pernah bisa lolos
+    sniffing di `finalize` sehingga adalah misconfiguration, ditolak
+    sebagai **fail**, bukan sekadar warning.
+  - `checkNewsMediaR2PresignedTtlUpperBound` — `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS`
+    tidak boleh melebihi `NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS`
+    (3600 detik/1 jam) — presigned PUT URL bisa dipakai ulang selama TTL
+    berlaku (§8), jadi TTL yang terlalu panjang melemahkan mitigasi itu.
 - **`bun run security:readiness`** (`scripts/security-readiness.ts`):
   - `checkNewsPortalFullOnlineR2PresetReady` (**critical**) — menilai
     kombinasi penuh syarat aktivasi preset (`NEWS_PORTAL_ENABLED`,
@@ -152,9 +164,25 @@ menunggu #635):
   - `checkNewsMediaR2SvgNotAllowed` (**warning**) — `image/svg+xml` tidak
     ada di `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` kecuali operator eksplisit
     override.
+  - `checkNewsMediaR2PublicBaseUrlProductionSafe` (**critical**, Issue
+    #635) — saat `APP_ENV=production`, `NEWS_MEDIA_R2_PUBLIC_BASE_URL`
+    wajib custom domain nyata — menolak host `*.r2.dev` bawaan Cloudflare
+    (§11: tidak stabil untuk produksi, tanpa kontrol cache/branding) dan
+    host loopback (`localhost`/`127.0.0.1`). Non-production selalu
+    **pass** (didokumentasikan terpisah, tidak pernah melemahkan default
+    production).
+  - `checkNewsMediaR2NoStalePendingObjects` (**warning**, Issue #635) —
+    scan lintas-tenant (pola sama `checkSsoBreakGlassReady`, satu
+    transaksi per tenant dengan `SET LOCAL app.current_tenant_id`) atas
+    `awcms_mini_news_media_objects` mencari baris `pending_upload` yang
+    sudah lewat `NEWS_MEDIA_R2_PENDING_TTL_MINUTES` — tanda job
+    pembersihan `r2-backup-lifecycle.md` §2 belum berjalan/belum ada.
+    Butuh `DATABASE_URL` nyata (fail bila tidak tersedia/tidak bisa
+    connect); lihat
+    `tests/integration/security-readiness-news-media-r2.integration.test.ts`.
 - **`bun run production:preflight`** — tidak butuh tahap baru (sudah
   menjalankan `config:validate` dan `security:readiness` sebagai bagian
-  urutannya, doc 18); kedua check di atas otomatis ikut terpanggil.
+  urutannya, doc 18); seluruh check di atas otomatis ikut terpanggil.
 
 **Update #634**: endpoint upload nyata sudah ada
 (`POST /api/v1/media/news-images/upload-sessions`,
@@ -168,13 +196,19 @@ detail lengkap) — ini bukan lagi gap, karena penegakannya terjadi
 sinkron di jalur request `finalize`, bukan lewat readiness-check
 terpisah.
 
-**Masih terbuka untuk #635** (di luar cakupan #632/#633/#634): tidak ada
-`config:validate`/`security:readiness`/`production:preflight` check yang
-menyentuh tabel media registry itu sendiri (objek `pending`/`failed`
-basi, orphaned object detection — `r2-backup-lifecycle.md` §2) — itu
-tetap murni operasional/lifecycle-job scope, belum ada implementasinya.
-Implementor #635 **wajib** memperbarui bagian ini lagi begitu check
-readiness baru yang relevan ditulis.
+**Update #635 (selesai)**: kelima check baru di atas menutup seluruh
+acceptance criteria issue #635 yang masih relevan setelah #632-#634 —
+lihat `.claude/skills/awcms-mini-news-portal/SKILL.md` §635 untuk
+rekonsiliasi lengkap (nama var body issue vs `NEWS_MEDIA_R2_*` nyata,
+dan kenapa "local storage enabled" tidak diimplementasikan sebagai flag
+runtime). **Belum diimplementasikan** (di luar cakupan #635, butuh
+`blog_content`/#637-#640/#642/#649 selesai lebih dulu per
+`r2-backup-lifecycle.md` §4): job pembersihan objek `pending_upload`
+basi yang nyata (§2 — `checkNewsMediaR2NoStalePendingObjects` di atas
+hanya MELAPORKAN, tidak MENGHAPUS) dan deteksi objek `confirmed`
+`orphaned` (§4, butuh daftar titik referensi lengkap dari surface yang
+belum ada). Implementor issue yang menambah job tersebut **wajib**
+memperbarui bagian ini lagi.
 
 ## 8. Monitoring & audit
 

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -49,7 +49,11 @@ import {
   checkTurnstileConfig
 } from "./validate-env";
 import { resolveVisitorAnalyticsConfig } from "../src/modules/visitor-analytics/domain/visitor-analytics-config";
-import { allowsSvgMimeType } from "../src/modules/news-portal/domain/news-media-r2-config";
+import {
+  allowsSvgMimeType,
+  findNewsMediaR2PublicBaseUrlProductionUnsafeReason,
+  resolveNewsMediaR2Config
+} from "../src/modules/news-portal/domain/news-media-r2-config";
 import { evaluateNewsPortalFullOnlineR2Readiness } from "../src/modules/news-portal/domain/news-portal-preset-readiness";
 
 export type CheckSeverity = "critical" | "warning" | "info";
@@ -1711,6 +1715,176 @@ export function checkNewsMediaR2SvgNotAllowed(
   };
 }
 
+/**
+ * Issue #635, architecture doc §11: production must use a real custom
+ * domain for `NEWS_MEDIA_R2_PUBLIC_BASE_URL`, never the `r2.dev` default
+ * (unstable for production, no caching/branding control) or a loopback
+ * host. Deliberately gated on `APP_ENV === "production"` — non-production
+ * deployments may legitimately point at a dev/staging bucket without a
+ * custom domain yet, and this check must never weaken the production
+ * default to accommodate that (Issue #635 acceptance criteria).
+ */
+export function checkNewsMediaR2PublicBaseUrlProductionSafe(
+  env: NodeJS.ProcessEnv = process.env
+): SecurityCheckResult {
+  const name = "News media R2 public base URL is production-safe";
+  const severity: CheckSeverity = "critical";
+
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence:
+        'NEWS_MEDIA_R2_ENABLED is not "true" — no public base URL in effect.'
+    };
+  }
+
+  if (env.APP_ENV !== "production") {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence: `APP_ENV is "${env.APP_ENV ?? "(unset)"}", not "production" — non-production deployments may use a non-custom-domain public base URL (documented separately, Issue #635).`
+    };
+  }
+
+  const publicBaseUrl = resolveNewsMediaR2Config(env).publicBaseUrl;
+  const reason =
+    findNewsMediaR2PublicBaseUrlProductionUnsafeReason(publicBaseUrl);
+
+  if (reason === null) {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence:
+        "NEWS_MEDIA_R2_PUBLIC_BASE_URL uses a custom domain, not the r2.dev default or a loopback host."
+    };
+  }
+
+  const reasonText: Record<NonNullable<typeof reason>, string> = {
+    r2_dev_default_domain:
+      "uses Cloudflare R2's default *.r2.dev domain — map a custom domain to the bucket instead (architecture doc §11: r2.dev is not stable for production and does not support caching/branding control).",
+    loopback_host:
+      "points at a loopback host (localhost/127.0.0.1) — not reachable by real visitors in production.",
+    unparseable_url: "is not a valid absolute URL."
+  };
+
+  return {
+    name,
+    severity,
+    status: "fail",
+    evidence: `APP_ENV=production but NEWS_MEDIA_R2_PUBLIC_BASE_URL ${reasonText[reason]}`
+  };
+}
+
+/**
+ * Issue #635 (tracked as "masih terbuka" in
+ * `docs/awcms-mini/news-portal/r2-security-checklist.md` §7 after #632-634
+ * landed): `awcms_mini_news_media_objects` rows stuck in `pending_upload`
+ * past `NEWS_MEDIA_R2_PENDING_TTL_MINUTES` mean the automatic cleanup
+ * `r2-backup-lifecycle.md` §2 requires has not run — one of the layered
+ * mitigations for "a valid `pending` object_key is already publicly
+ * reachable in R2 regardless of Postgres status" (architecture doc §8) is
+ * silently not in effect. `warning`, not `critical`: this is a housekeeping
+ * gap (no cleanup job exists in this codebase yet — §2's own text notes
+ * the job itself is a separate, not-yet-implemented piece of work), not
+ * proof of an active exposure by itself.
+ *
+ * Same RLS-respecting per-tenant scan pattern as `checkSsoBreakGlassReady`
+ * above — iterates `awcms_mini_tenants` and opens one short transaction per
+ * tenant with `SET LOCAL app.current_tenant_id`, so this works correctly
+ * regardless of whether `security:readiness` runs with a privileged or
+ * least-privilege `DATABASE_URL`.
+ */
+export async function checkNewsMediaR2NoStalePendingObjects(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<SecurityCheckResult> {
+  const name =
+    "No stale pending_upload news media objects past their TTL (Issue #635)";
+  const severity: CheckSeverity = "warning";
+
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence:
+        'NEWS_MEDIA_R2_ENABLED is not "true" — no news media object registry in use.'
+    };
+  }
+
+  const pendingTtlMinutes = resolveNewsMediaR2Config(env).pendingTtlMinutes;
+
+  try {
+    if (!process.env.DATABASE_URL) {
+      throw new Error("DATABASE_URL is not set.");
+    }
+
+    const sql = getDatabaseClient();
+    const tenants = (await sql<{ id: string }[]>`
+      SELECT id FROM awcms_mini_tenants WHERE status = 'active'
+    `) as { id: string }[];
+
+    let staleCount = 0;
+    const erroredTenants: string[] = [];
+
+    for (const tenant of tenants) {
+      const tenantId = assertUuid(tenant.id);
+
+      try {
+        await sql.begin(async (tx) => {
+          await tx.unsafe(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+          const rows = (await tx`
+            SELECT count(*)::int AS count
+            FROM awcms_mini_news_media_objects
+            WHERE status = 'pending_upload'
+              AND created_at < now() - (${pendingTtlMinutes} || ' minutes')::interval
+          `) as { count: number }[];
+
+          staleCount += rows[0]?.count ?? 0;
+        });
+      } catch (error) {
+        erroredTenants.push(`${tenantId} (${errorMessage(error)})`);
+      }
+    }
+
+    if (staleCount > 0 || erroredTenants.length > 0) {
+      const parts: string[] = [];
+
+      if (staleCount > 0) {
+        parts.push(
+          `${staleCount} object(s) across all tenants are still "pending_upload" past their ${pendingTtlMinutes}-minute TTL — the automatic cleanup job r2-backup-lifecycle.md §2 requires is not running (or not keeping up). These rows/objects should be reviewed and cleaned up manually until that job exists.`
+        );
+      }
+
+      if (erroredTenants.length > 0) {
+        parts.push(
+          `${erroredTenants.length} tenant(s) could not be checked: ${erroredTenants.join("; ")}.`
+        );
+      }
+
+      return { name, severity, status: "fail", evidence: parts.join(" ") };
+    }
+
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence: `No pending_upload news media objects older than ${pendingTtlMinutes} minutes across ${tenants.length} active tenant(s).`
+    };
+  } catch (error) {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `Could not scan for stale pending_upload news media objects: ${errorMessage(error)}.`
+    };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Out-of-scope items — printed as their own report section, never silently
 // dropped.
@@ -1786,6 +1960,8 @@ export async function runSecurityReadinessChecks(): Promise<
     checkVisitorAnalyticsHashSaltReady(),
     checkNewsPortalFullOnlineR2PresetReady(),
     checkNewsMediaR2SvgNotAllowed(),
+    checkNewsMediaR2PublicBaseUrlProductionSafe(),
+    await checkNewsMediaR2NoStalePendingObjects(),
     await checkErrorsDontLeakStackTraces(),
     await checkSecurityHeadersPresent(),
     checkLoginRateLimitImplemented()

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -193,7 +193,11 @@ import {
 } from "../src/modules/visitor-analytics/domain/visitor-analytics-config";
 import {
   findNewsMediaR2SeparationViolations,
-  NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED
+  findUnknownNewsMediaR2MimeTypes,
+  isPresignedUploadTtlTooLong,
+  NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS,
+  NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED,
+  resolveNewsMediaR2Config
 } from "../src/modules/news-portal/domain/news-media-r2-config";
 import {
   isKnownNewsPortalProfile,
@@ -993,6 +997,62 @@ export function checkNewsMediaR2SeparationFromSyncR2(
   };
 }
 
+/**
+ * Issue #635: an allow-list entry the MIME sniffer (`news-media-mime-sniffer.ts`)
+ * could never recognize is a misconfiguration — every real upload claiming
+ * it would fail-safe reject at `finalize` regardless, so this is a hard
+ * error, not just a warning.
+ */
+export function checkNewsMediaR2AllowedMimeTypesKnown(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult {
+  const name = "NEWS_MEDIA_R2_ALLOWED_MIME_TYPES (known types only)";
+  const unknown = findUnknownNewsMediaR2MimeTypes(env);
+
+  if (unknown.length === 0) {
+    return {
+      name,
+      status: "pass",
+      detail:
+        env.NEWS_MEDIA_R2_ENABLED === "true"
+          ? "NEWS_MEDIA_R2_ALLOWED_MIME_TYPES contains only known image MIME types."
+          : 'NEWS_MEDIA_R2_ENABLED is not "true" — no MIME allow-list in effect.'
+    };
+  }
+
+  return {
+    name,
+    status: "fail",
+    detail: `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES contains type(s) the MIME sniffer can never recognize, so uploads claiming them would always be rejected at finalize: ${unknown.join(", ")}.`
+  };
+}
+
+/** Issue #635: a presigned PUT URL is reusable for its whole TTL — an excessively long expiry undermines that mitigation (architecture doc §8). */
+export function checkNewsMediaR2PresignedTtlUpperBound(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult {
+  const name = "NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS (upper bound)";
+
+  if (isPresignedUploadTtlTooLong(env)) {
+    const ttl = resolveNewsMediaR2Config(env).presignedUploadTtlSeconds;
+
+    return {
+      name,
+      status: "fail",
+      detail: `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS=${ttl} exceeds the maximum of ${NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS}s (1 hour) — a presigned PUT URL is not single-use, so a long expiry weakens the "short-lived URL" mitigation (architecture doc §8).`
+    };
+  }
+
+  return {
+    name,
+    status: "pass",
+    detail:
+      env.NEWS_MEDIA_R2_ENABLED === "true"
+        ? `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS is within the ${NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS}s maximum.`
+        : 'NEWS_MEDIA_R2_ENABLED is not "true" — no presigned upload TTL in effect.'
+  };
+}
+
 export function runEnvValidation(
   env: NodeJS.ProcessEnv = process.env
 ): EnvCheckResult[] {
@@ -1011,7 +1071,9 @@ export function runEnvValidation(
     ...checkVisitorAnalyticsConfig(env),
     checkNewsPortalProfileConfig(env),
     ...checkNewsMediaR2Config(env),
-    checkNewsMediaR2SeparationFromSyncR2(env)
+    checkNewsMediaR2SeparationFromSyncR2(env),
+    checkNewsMediaR2AllowedMimeTypesKnown(env),
+    checkNewsMediaR2PresignedTtlUpperBound(env)
   ];
 }
 

--- a/src/modules/news-portal/domain/news-media-r2-config.ts
+++ b/src/modules/news-portal/domain/news-media-r2-config.ts
@@ -38,6 +38,39 @@ export const NEWS_MEDIA_R2_DEFAULT_ALLOWED_MIME_TYPES = [
 /** SVG is deliberately excluded by default — see architecture doc §9 (XSS via embedded `<script>`). */
 export const NEWS_MEDIA_R2_DISALLOWED_MIME_TYPE_DEFAULT = "image/svg+xml";
 
+/**
+ * Every MIME type this codebase actually knows how to reason about for
+ * `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` (Issue #635): the four raster types
+ * `news-media-mime-sniffer.ts` can sniff from magic bytes, PLUS
+ * `image/svg+xml` (excluded by default above, but a real, deliberate
+ * override path exists for it — `checkNewsMediaR2SvgNotAllowed`,
+ * `scripts/security-readiness.ts` — so it belongs in the "known" set, not
+ * the "unknown/unsafe" one). An operator listing anything OUTSIDE this set
+ * (`text/html`, `application/octet-stream`, a typo, ...) has misconfigured
+ * the allow-list: the sniffer can never accept such an upload (every real
+ * upload would fail-safe reject at `finalize`), so config:validate treats
+ * it as a hard error rather than a silent no-op, per Issue #635's
+ * acceptance criteria ("Allowed MIME types include unsafe/non-image
+ * types").
+ */
+export const NEWS_MEDIA_R2_KNOWN_MIME_TYPES = [
+  ...NEWS_MEDIA_R2_DEFAULT_ALLOWED_MIME_TYPES,
+  NEWS_MEDIA_R2_DISALLOWED_MIME_TYPE_DEFAULT
+] as const;
+
+/**
+ * Upper bound for `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` (Issue #635).
+ * Architecture doc §8 describes the default (300s/5min) as "short-lived —
+ * enough for one interactive upload, too short to be useful to a leaked
+ * URL long after being generated." A presigned PUT URL is not single-use
+ * (§8's own residual-risk note), so the whole TTL-based mitigation
+ * degrades the longer the window is — 1 hour is a generous ceiling that
+ * still keeps that property meaningful (an operator who needs longer has a
+ * different problem, e.g. a slow client upload path, not a config this
+ * check should silently accommodate).
+ */
+export const NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS = 3600;
+
 export const NEWS_MEDIA_R2_DEFAULTS = {
   enabled: false,
   presignedUploadTtlSeconds: 300,
@@ -214,4 +247,82 @@ export function allowsSvgMimeType(
   return resolveNewsMediaR2Config(env).allowedMimeTypes.includes(
     NEWS_MEDIA_R2_DISALLOWED_MIME_TYPE_DEFAULT
   );
+}
+
+/**
+ * Allow-list entries outside `NEWS_MEDIA_R2_KNOWN_MIME_TYPES` (Issue #635)
+ * — misconfigured/unsafe/non-image entries the MIME sniffer could never
+ * accept regardless. Empty when disabled or fully within the known set.
+ */
+export function findUnknownNewsMediaR2MimeTypes(
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") return [];
+
+  const known: readonly string[] = NEWS_MEDIA_R2_KNOWN_MIME_TYPES;
+
+  return resolveNewsMediaR2Config(env).allowedMimeTypes.filter(
+    (mimeType) => !known.includes(mimeType)
+  );
+}
+
+/**
+ * `true` when `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` exceeds
+ * `NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS` (Issue #635). `false`
+ * when disabled or unset (falls back to the safe default).
+ */
+export function isPresignedUploadTtlTooLong(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") return false;
+
+  return (
+    resolveNewsMediaR2Config(env).presignedUploadTtlSeconds >
+    NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS
+  );
+}
+
+/**
+ * Hostnames Cloudflare R2 assigns automatically for a bucket that has NO
+ * custom domain mapped — architecture doc §11: "bukan URL `r2.dev` bawaan
+ * (yang tidak stabil untuk produksi dan tidak mendukung caching/branding
+ * kustom)". Matches the exact `<bucket-hash>.r2.dev` pattern R2 issues,
+ * not merely "contains r2.dev" (avoids a false positive against a
+ * legitimate custom domain that happens to contain that substring
+ * elsewhere in its path).
+ */
+function isR2DevHost(hostname: string): boolean {
+  return /\.r2\.dev$/i.test(hostname);
+}
+
+/** Loopback hosts — never a legitimate production public media domain. */
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1";
+}
+
+export type NewsMediaR2PublicBaseUrlProductionUnsafeReason =
+  "r2_dev_default_domain" | "loopback_host" | "unparseable_url";
+
+/**
+ * `null` when the URL is safe for production use (or n/a — see callers);
+ * otherwise the specific reason it is NOT safe (Issue #635, architecture
+ * doc §11). Pure URL-hostname inspection — does not itself decide whether
+ * "production" applies; callers (`security-readiness.ts`) gate that on
+ * `APP_ENV === "production"`.
+ */
+export function findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+  publicBaseUrl: string
+): NewsMediaR2PublicBaseUrlProductionUnsafeReason | null {
+  let hostname: string;
+
+  try {
+    hostname = new URL(publicBaseUrl).hostname;
+  } catch {
+    return "unparseable_url";
+  }
+
+  if (isLoopbackHost(hostname)) return "loopback_host";
+  if (isR2DevHost(hostname)) return "r2_dev_default_domain";
+
+  return null;
 }

--- a/src/modules/news-portal/domain/news-media-r2-config.ts
+++ b/src/modules/news-portal/domain/news-media-r2-config.ts
@@ -283,6 +283,20 @@ export function isPresignedUploadTtlTooLong(
 }
 
 /**
+ * A trailing "." makes a hostname a fully-qualified DNS name that
+ * resolves IDENTICALLY to the same name without the dot (DNS root label —
+ * `abc.r2.dev.` and `abc.r2.dev` are the same host to any resolver/
+ * browser), but `new URL(...).hostname` preserves it literally, which
+ * would otherwise let a one-character trailing-dot variant silently slip
+ * past both the `.r2.dev` suffix check and the exact loopback-string
+ * checks below (reviewer + security-auditor finding, PR #665 re-review).
+ * Normalize it away before either check runs.
+ */
+function stripTrailingDot(hostname: string): string {
+  return hostname.endsWith(".") ? hostname.slice(0, -1) : hostname;
+}
+
+/**
  * Hostnames Cloudflare R2 assigns automatically for a bucket that has NO
  * custom domain mapped — architecture doc §11: "bukan URL `r2.dev` bawaan
  * (yang tidak stabil untuk produksi dan tidak mendukung caching/branding
@@ -292,12 +306,27 @@ export function isPresignedUploadTtlTooLong(
  * elsewhere in its path).
  */
 function isR2DevHost(hostname: string): boolean {
-  return /\.r2\.dev$/i.test(hostname);
+  return /\.r2\.dev$/i.test(stripTrailingDot(hostname));
 }
 
-/** Loopback hosts — never a legitimate production public media domain. */
+/**
+ * Loopback hosts — never a legitimate production public media domain.
+ * Covers IPv4 (`127.0.0.1`, unbracketed), IPv6 (`::1`, both bracketed
+ * `[::1]` — the form `new URL(...).hostname` actually returns for an IPv6
+ * host — and unbracketed), `0.0.0.0` (binds-to-all-interfaces, not a
+ * routable address either), and `localhost`, all case-insensitively
+ * (IPv6 literals are lowercased by `URL` already, but `localhost` is not).
+ */
 function isLoopbackHost(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1";
+  const normalized = stripTrailingDot(hostname).toLowerCase();
+
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "0.0.0.0" ||
+    normalized === "::1" ||
+    normalized === "[::1]"
+  );
 }
 
 export type NewsMediaR2PublicBaseUrlProductionUnsafeReason =

--- a/tests/integration/security-readiness-news-media-r2.integration.test.ts
+++ b/tests/integration/security-readiness-news-media-r2.integration.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Integration test for `checkNewsMediaR2NoStalePendingObjects` (Issue #635,
+ * epic `news_portal`).
+ *
+ * The check counts `awcms_mini_news_media_objects` rows stuck in
+ * `pending_upload` past `NEWS_MEDIA_R2_PENDING_TTL_MINUTES` ACROSS ALL
+ * TENANTS — that cross-tenant aggregation cannot be exercised by a unit
+ * test against a fake/mocked `Bun.SQL` without either bypassing RLS (which
+ * would stop testing the real per-tenant `SET LOCAL app.current_tenant_id`
+ * scan this check actually performs) or faking so much of `Bun.SQL` that
+ * the query itself is no longer under test. It needs a real Postgres round
+ * trip — same rationale `security-readiness-break-glass.integration.test.ts`
+ * documents for `checkSsoBreakGlassReady`.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  integrationEnabled,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { getDatabaseClient } from "../../src/lib/database/client";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import type { NewsMediaR2Config } from "../../src/modules/news-portal/domain/news-media-r2-config";
+import { createPendingNewsMediaObject } from "../../src/modules/news-portal/application/news-media-object-directory";
+import { checkNewsMediaR2NoStalePendingObjects } from "../../scripts/security-readiness";
+
+const TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const ACTOR_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+const CONFIG: NewsMediaR2Config = {
+  enabled: true,
+  accountId: "acct",
+  accessKeyId: "news-key",
+  secretAccessKey: "news-secret",
+  bucket: "news-media-bucket",
+  publicBaseUrl: "https://media.example.test",
+  presignedUploadTtlSeconds: 300,
+  maxUploadBytes: 10_485_760,
+  allowedMimeTypes: ["image/jpeg", "image/png", "image/webp", "image/gif"],
+  pendingTtlMinutes: 60
+};
+
+async function seedTenants(): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES
+      (${TENANT_A}, 'tenant-a', 'Tenant A', 'Tenant A Legal', 'active', 'en', 'light'),
+      (${TENANT_B}, 'tenant-b', 'Tenant B', 'Tenant B Legal', 'active', 'en', 'light')
+  `;
+}
+
+async function ageObject(objectId: string, minutesAgo: number): Promise<void> {
+  const admin = getAdminSql();
+  await admin`
+    UPDATE awcms_mini_news_media_objects
+    SET created_at = now() - (${minutesAgo} || ' minutes')::interval
+    WHERE id = ${objectId}
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("checkNewsMediaR2NoStalePendingObjects (Issue #635)", () => {
+  const previousEnv = { ...process.env };
+
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  afterAll(() => {
+    process.env = previousEnv;
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+    process.env.NEWS_MEDIA_R2_ENABLED = "true";
+    process.env.NEWS_MEDIA_R2_PENDING_TTL_MINUTES = "60";
+  });
+
+  test('passes when NEWS_MEDIA_R2_ENABLED is not "true" (no registry in use)', async () => {
+    process.env.NEWS_MEDIA_R2_ENABLED = "false";
+
+    const result = await checkNewsMediaR2NoStalePendingObjects();
+
+    expect(result.status).toBe("pass");
+    expect(result.severity).toBe("warning");
+  });
+
+  test("passes when no tenant has any pending_upload object at all", async () => {
+    const result = await checkNewsMediaR2NoStalePendingObjects();
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("passes when a pending_upload object exists but is still within the TTL", async () => {
+    const sql = getDatabaseClient();
+    await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/jpeg"
+      })
+    );
+
+    const result = await checkNewsMediaR2NoStalePendingObjects();
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when a pending_upload object is older than the TTL — the missing r2-backup-lifecycle.md §2 cleanup job has not run", async () => {
+    const sql = getDatabaseClient();
+    const created = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/jpeg"
+      })
+    );
+    await ageObject(created.id, 61);
+
+    const result = await checkNewsMediaR2NoStalePendingObjects();
+
+    expect(result.status).toBe("fail");
+    expect(result.severity).toBe("warning");
+    expect(result.evidence).toContain("1 object(s)");
+  });
+
+  test("aggregates stale objects across multiple tenants (cross-tenant scan, not just the first tenant)", async () => {
+    const sql = getDatabaseClient();
+    const createdA = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/jpeg"
+      })
+    );
+    const createdB = await withTenant(sql, TENANT_B, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_B, ACTOR_ID, CONFIG, {
+        mimeType: "image/png"
+      })
+    );
+    await ageObject(createdA.id, 61);
+    await ageObject(createdB.id, 90);
+
+    const result = await checkNewsMediaR2NoStalePendingObjects();
+
+    expect(result.status).toBe("fail");
+    expect(result.evidence).toContain("2 object(s)");
+  });
+
+  test("does not flag a stale object that already moved past pending_upload (e.g. verified)", async () => {
+    const sql = getDatabaseClient();
+    const created = await withTenant(sql, TENANT_A, (tx) =>
+      createPendingNewsMediaObject(tx, TENANT_A, ACTOR_ID, CONFIG, {
+        mimeType: "image/jpeg"
+      })
+    );
+    await ageObject(created.id, 120);
+
+    const admin = getAdminSql();
+    await admin`
+      UPDATE awcms_mini_news_media_objects
+      SET status = 'uploaded'
+      WHERE id = ${created.id}
+    `;
+
+    const result = await checkNewsMediaR2NoStalePendingObjects();
+
+    expect(result.status).toBe("pass");
+  });
+});

--- a/tests/security-readiness.test.ts
+++ b/tests/security-readiness.test.ts
@@ -6,6 +6,7 @@ import {
   checkGoogleOidcReady,
   checkLoginLockoutImplemented,
   checkLoginRateLimitImplemented,
+  checkNewsMediaR2PublicBaseUrlProductionSafe,
   checkOnlineAuthSecurityReady,
   checkSyncHmacSecretNotDefault,
   checkMfaReady,
@@ -20,15 +21,18 @@ import {
 
 // DB-dependent checks (`checkRlsEnabled`, `checkAuditLogTableReachable`,
 // `checkSoftDeletePermissionsSeededAndAudited`'s permission-row lookup,
-// `checkSsoBreakGlassReady` — Issue #593) are NOT unit-tested here — they
-// require a real PostgreSQL connection and can't be meaningfully faked
-// without either a real DB or a mock so heavy it would stop testing the
-// actual query. They are covered by live verification instead (`bun run
-// security:readiness` against a real migrated database, see
-// `docs/awcms-mini/production-readiness.md`) AND, for `checkSsoBreakGlassReady`
-// specifically, by `tests/integration/security-readiness-break-glass.integration.test.ts`
+// `checkSsoBreakGlassReady` — Issue #593, `checkNewsMediaR2NoStalePendingObjects`
+// — Issue #635) are NOT unit-tested here — they require a real PostgreSQL
+// connection and can't be meaningfully faked without either a real DB or a
+// mock so heavy it would stop testing the actual query. They are covered by
+// live verification instead (`bun run security:readiness` against a real
+// migrated database, see `docs/awcms-mini/production-readiness.md`) AND, for
+// `checkSsoBreakGlassReady` specifically, by
+// `tests/integration/security-readiness-break-glass.integration.test.ts`
 // (real Postgres, both the "eligible" pass case and the "deactivated after
-// save" fail case).
+// save" fail case); `checkNewsMediaR2NoStalePendingObjects` is covered the
+// same way by
+// `tests/integration/security-readiness-news-media-r2.integration.test.ts`.
 //
 // `checkSecurityHeadersPresent` (Issue #437) is likewise not unit-tested
 // here — it deliberately hits a *running* server to prove
@@ -499,5 +503,58 @@ describe("checkVisitorAnalyticsHashSaltReady", () => {
 
     expect(result.severity).toBe("warning");
     expect(result.status).toBe("pass");
+  });
+});
+
+describe("checkNewsMediaR2PublicBaseUrlProductionSafe (Issue #635)", () => {
+  test('passes when NEWS_MEDIA_R2_ENABLED is not "true"', () => {
+    const result = checkNewsMediaR2PublicBaseUrlProductionSafe({
+      APP_ENV: "production",
+      NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://pub-abc.r2.dev"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("pass");
+    expect(result.severity).toBe("critical");
+  });
+
+  test("passes for a non-production APP_ENV even with an r2.dev URL — documented separately, never weakens the production default", () => {
+    const result = checkNewsMediaR2PublicBaseUrlProductionSafe({
+      APP_ENV: "development",
+      NEWS_MEDIA_R2_ENABLED: "true",
+      NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://pub-abc.r2.dev"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("passes in production with a real custom domain", () => {
+    const result = checkNewsMediaR2PublicBaseUrlProductionSafe({
+      APP_ENV: "production",
+      NEWS_MEDIA_R2_ENABLED: "true",
+      NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://media.example.com"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails in production with Cloudflare's default *.r2.dev domain", () => {
+    const result = checkNewsMediaR2PublicBaseUrlProductionSafe({
+      APP_ENV: "production",
+      NEWS_MEDIA_R2_ENABLED: "true",
+      NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://pub-abc123.r2.dev"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("fail");
+    expect(result.evidence).toContain("r2.dev");
+  });
+
+  test("fails in production with a loopback host", () => {
+    const result = checkNewsMediaR2PublicBaseUrlProductionSafe({
+      APP_ENV: "production",
+      NEWS_MEDIA_R2_ENABLED: "true",
+      NEWS_MEDIA_R2_PUBLIC_BASE_URL: "http://localhost:3000"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("fail");
   });
 });

--- a/tests/unit/news-media-r2-config.test.ts
+++ b/tests/unit/news-media-r2-config.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, test } from "bun:test";
 import {
   allowsSvgMimeType,
   findMissingNewsMediaR2Vars,
+  findNewsMediaR2PublicBaseUrlProductionUnsafeReason,
   findNewsMediaR2SeparationViolations,
+  findUnknownNewsMediaR2MimeTypes,
   isNewsMediaR2Enabled,
+  isPresignedUploadTtlTooLong,
   NEWS_MEDIA_R2_DEFAULTS,
+  NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS,
   NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED,
   resolveNewsMediaR2Config
 } from "../../src/modules/news-portal/domain/news-media-r2-config";
@@ -186,5 +190,128 @@ describe("allowsSvgMimeType", () => {
         NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "image/jpeg,image/svg+xml"
       } as NodeJS.ProcessEnv)
     ).toBe(true);
+  });
+});
+
+describe("findUnknownNewsMediaR2MimeTypes (Issue #635)", () => {
+  test("empty when disabled, regardless of the allow-list value", () => {
+    expect(
+      findUnknownNewsMediaR2MimeTypes({
+        NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "text/html"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("empty for the default allow-list", () => {
+    expect(
+      findUnknownNewsMediaR2MimeTypes({
+        NEWS_MEDIA_R2_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("empty when the allow-list is deliberately overridden to include image/svg+xml (a known, if disallowed-by-default, type)", () => {
+    expect(
+      findUnknownNewsMediaR2MimeTypes({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "image/jpeg,image/svg+xml"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("flags entries the MIME sniffer could never recognize (misconfiguration, not just unsafe)", () => {
+    expect(
+      findUnknownNewsMediaR2MimeTypes({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_ALLOWED_MIME_TYPES:
+          "image/jpeg,text/html,application/octet-stream"
+      } as NodeJS.ProcessEnv)
+    ).toEqual(["text/html", "application/octet-stream"]);
+  });
+});
+
+describe("isPresignedUploadTtlTooLong (Issue #635)", () => {
+  test("false when disabled, regardless of the TTL value", () => {
+    expect(
+      isPresignedUploadTtlTooLong({
+        NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: "999999"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("false for the default TTL", () => {
+    expect(
+      isPresignedUploadTtlTooLong({
+        NEWS_MEDIA_R2_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("false exactly at the maximum", () => {
+    expect(
+      isPresignedUploadTtlTooLong({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: String(
+          NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS
+        )
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("true just above the maximum", () => {
+    expect(
+      isPresignedUploadTtlTooLong({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: String(
+          NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS + 1
+        )
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+});
+
+describe("findNewsMediaR2PublicBaseUrlProductionUnsafeReason (Issue #635)", () => {
+  test("null for a real custom domain", () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+        "https://media.example.com"
+      )
+    ).toBeNull();
+  });
+
+  test('"r2_dev_default_domain" for Cloudflare\'s default *.r2.dev host', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+        "https://pub-abc123.r2.dev"
+      )
+    ).toBe("r2_dev_default_domain");
+  });
+
+  test('does not false-positive on a custom domain that merely contains "r2.dev" as a substring elsewhere', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+        "https://media.example.com/r2.dev-archive"
+      )
+    ).toBeNull();
+  });
+
+  test('"loopback_host" for localhost', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+        "http://localhost:3000"
+      )
+    ).toBe("loopback_host");
+  });
+
+  test('"loopback_host" for 127.0.0.1', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason("http://127.0.0.1")
+    ).toBe("loopback_host");
+  });
+
+  test('"unparseable_url" for a malformed value', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason("not-a-url")
+    ).toBe("unparseable_url");
   });
 });

--- a/tests/unit/news-media-r2-config.test.ts
+++ b/tests/unit/news-media-r2-config.test.ts
@@ -309,6 +309,32 @@ describe("findNewsMediaR2PublicBaseUrlProductionUnsafeReason (Issue #635)", () =
     ).toBe("loopback_host");
   });
 
+  test('"loopback_host" for IPv6 ::1 (bracketed URL form)', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason("http://[::1]")
+    ).toBe("loopback_host");
+  });
+
+  test('"loopback_host" for 0.0.0.0', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason("http://0.0.0.0")
+    ).toBe("loopback_host");
+  });
+
+  test('"r2_dev_default_domain" for a trailing-dot FQDN variant of *.r2.dev (reviewer + security-auditor finding, PR #665 re-review — DNS treats "abc.r2.dev." identically to "abc.r2.dev", but a naive suffix regex would not)', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+        "https://pub-abc123.r2.dev./x"
+      )
+    ).toBe("r2_dev_default_domain");
+  });
+
+  test('"loopback_host" for a trailing-dot variant of localhost', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason("http://localhost.")
+    ).toBe("loopback_host");
+  });
+
   test('"unparseable_url" for a malformed value', () => {
     expect(
       findNewsMediaR2PublicBaseUrlProductionUnsafeReason("not-a-url")

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from "bun:test";
 import {
   checkEmailConfig,
   checkGoogleOidcConfig,
+  checkNewsMediaR2AllowedMimeTypesKnown,
+  checkNewsMediaR2PresignedTtlUpperBound,
   checkOnlineAuthSecurityConfig,
   checkPublicRoutingConfig,
   checkR2Config,
@@ -690,6 +692,62 @@ describe("checkVisitorAnalyticsConfig", () => {
     } as NodeJS.ProcessEnv);
 
     expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+});
+
+describe("checkNewsMediaR2AllowedMimeTypesKnown (Issue #635)", () => {
+  test("passes when disabled", () => {
+    const result = checkNewsMediaR2AllowedMimeTypesKnown({
+      NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "text/html"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("passes for the default allow-list", () => {
+    const result = checkNewsMediaR2AllowedMimeTypesKnown({
+      NEWS_MEDIA_R2_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when the allow-list contains a type the MIME sniffer could never recognize", () => {
+    const result = checkNewsMediaR2AllowedMimeTypesKnown({
+      NEWS_MEDIA_R2_ENABLED: "true",
+      NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "image/jpeg,application/octet-stream"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("application/octet-stream");
+  });
+});
+
+describe("checkNewsMediaR2PresignedTtlUpperBound (Issue #635)", () => {
+  test("passes when disabled", () => {
+    const result = checkNewsMediaR2PresignedTtlUpperBound({
+      NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: "999999"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("passes for the default TTL", () => {
+    const result = checkNewsMediaR2PresignedTtlUpperBound({
+      NEWS_MEDIA_R2_ENABLED: "true"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when the TTL exceeds the maximum", () => {
+    const result = checkNewsMediaR2PresignedTtlUpperBound({
+      NEWS_MEDIA_R2_ENABLED: "true",
+      NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: "7200"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("7200");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #635.

Most of #635's acceptance criteria were already satisfied by #632's `config:validate`/`security:readiness` implementation (tracked explicitly in `r2-security-checklist.md` §7). This PR adds the four checks that were genuinely still open — see the news-portal skill's new §635 section for the full reconciliation (issue body uses placeholder env var names that don't match this repo's actual `NEWS_MEDIA_R2_*` convention, same pattern as #632/#633/#634).

- `config:validate` rejects a `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` entry the MIME sniffer can never recognize (misconfiguration — such an upload always fail-safe rejects at finalize regardless).
- `config:validate` rejects `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` above 3600s — a presigned PUT URL is reusable for its whole TTL, so an excessive expiry weakens that mitigation.
- `security:readiness` (critical) rejects `NEWS_MEDIA_R2_PUBLIC_BASE_URL` pointing at Cloudflare's default `*.r2.dev` domain or a loopback host when `APP_ENV=production`, without weakening non-production defaults.
- `security:readiness` (warning) scans all tenants for `awcms_mini_news_media_objects` rows stuck in `pending_upload` past their TTL, surfacing that the automatic cleanup job this mode's architecture doc describes has not been implemented yet.

Deliberately **not** in scope (documented in the skill): the actual pending-object cleanup job, and orphaned confirmed-object detection — both depend on surfaces (#636-#640, #642, #649) that don't exist yet.

## Test plan

- [x] `bun run check` (lint, docs, api:spec:check, typecheck, unit tests, build) — green
- [x] New unit tests for all pure helpers + non-DB checks (`news-media-r2-config.test.ts`, `validate-env.test.ts`, `security-readiness.test.ts`)
- [x] New integration test (`security-readiness-news-media-r2.integration.test.ts`) for the DB-touching stale-pending-objects check, against real Postgres
- [x] Live-verified `bun run scripts/validate-env.ts` and `bun run scripts/security-readiness.ts` against a real database with deliberately-misconfigured env — all four new checks fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)