### PR TITLE
feat(news-portal): add editorial homepage section composer for /news

### DIFF
--- a/.changeset/news-portal-homepage-sections-issue-637.md
+++ b/.changeset/news-portal-homepage-sections-issue-637.md
@@ -1,0 +1,33 @@
+---
+"awcms-mini": minor
+---
+
+Add an editorial homepage section composer for the `/news` public route
+(Issue #637, epic `news_portal`).
+
+Tenants can now configure ordered, schedulable homepage sections via
+`POST/GET /api/v1/news-portal/homepage-sections` and
+`PATCH/DELETE .../{id}` (also a new admin UI page,
+`/admin/news-portal/homepage-sections`), of six types: `headline`,
+`latest_posts`, `featured_posts`, `editor_picks`, `category_grid`, and
+`gallery_block`. Every post/category/media reference in a section's
+`config` must already exist for the same tenant, and — for
+`gallery_block` — be a verified Cloudflare R2 media object (Issue
+#633's registry); a non-conforming reference is rejected with
+`422 HOMEPAGE_SECTION_REFERENCE_INVALID` before anything is written. A
+tenant with no configured sections sees the exact pre-#637 `/news` page
+— this is purely additive. At render time, every reference is
+re-resolved against live data (a curated post that's since been
+unpublished, or a category/media object that's since been removed,
+silently disappears rather than erroring), and any rendered image
+always comes from resolved, verified R2 media metadata via the
+existing shared whitelisted renderer — never a raw or arbitrary image
+URL.
+
+`video_block`, `ad_slot`, `custom_widget_block`, and `static_page_block`
+from the issue's suggested section list are deliberately not
+implemented yet — they depend on surfaces (#638's R2-only ad images,
+#639's video block) that don't exist, or are explicitly out of scope
+(arbitrary HTML widgets), or would require a new public page-detail
+route (`static_page_block`) that isn't otherwise needed. See the
+`awcms-mini-news-portal` skill's §637 section for the full reasoning.

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -42,7 +42,7 @@ status + pointer, bukan menduplikasi isinya.
 | #634  | Direct-to-R2 presigned upload flow (endpoint upload/confirm)                                                                 | **Selesai** — lihat §634 di bawah                    |
 | #635  | Config validation + readiness checks (`config:validate`/`security:readiness`/`production:preflight`) untuk R2 image delivery | **Selesai** — lihat §635 di bawah                    |
 | #636  | `blog_content` wajib referensi R2 media object untuk gambar berita saat mode aktif                                           | **Selesai** — lihat §636 di bawah                    |
-| #637  | Editorial homepage section composer `/news` dengan render R2-only                                                            | Belum dikerjakan — lihat §637 di bawah               |
+| #637  | Editorial homepage section composer `/news` dengan render R2-only                                                            | **Selesai** — lihat §637 di bawah                    |
 | #638  | Preset placement iklan news portal dengan validasi gambar R2-only                                                            | Belum dikerjakan — lihat §638 di bawah               |
 | #639  | Content block `video_news` dengan thumbnail R2 wajib                                                                         | Belum dikerjakan — lihat §639 di bawah               |
 | #640  | Content quality checklist publishing dengan syarat gambar R2                                                                 | Belum dikerjakan — lihat §640 di bawah               |
@@ -1178,21 +1178,149 @@ keempat route handler asli sudah mencakup semua jalur tulis yang ada.
   `AdminLayout.astro`'s pattern) — tapi tidak ada UI picker baru yang
   dibangun issue ini.
 
-## §637-#640, #642, #649 — konsumsi media registry (belum dikerjakan)
+## §637 — Editorial homepage section composer (Selesai)
+
+Implementasi lengkap: migration `044_awcms_mini_news_portal_homepage_sections_schema.sql`
+(tabel `awcms_mini_news_portal_homepage_sections`, RLS ENABLE+FORCE, sama
+idiom `awcms_mini_blog_ads`), domain `news-portal/domain/homepage-section-policy.ts`
+(whitelist enam `sectionType` + validator `config_json` per tipe, diskriminasi
+ketat), application `news-portal/application/homepage-section-directory.ts`
+(CRUD tenant-scoped), `homepage-section-reference-validation.ts` (existence/
+ownership check untuk setiap id/slug di `config`), `homepage-section-composer.ts`
+(orkestrasi render-time: resolve referensi live lalu panggil renderer),
+domain `homepage-section-rendering.ts` (renderer whitelist murni), endpoint
+admin `POST/GET /api/v1/news-portal/homepage-sections`,
+`PATCH/DELETE .../{id}`, admin UI `admin/news-portal/homepage-sections.astro`,
+dan wiring publik di `src/pages/news/index.ts` (halaman 1 saja).
+
+### Rekonsiliasi — enam `sectionType` diimplementasikan, EMPAT dari daftar "such as" issue TIDAK
+
+Body issue #637 menyarankan sepuluh tipe section
+(`headline, latest_posts, featured_posts, editor_picks, category_grid,
+video_block, gallery_block, ad_slot, static_page_block, custom_widget_block`)
+sebagai contoh ("such as"), BUKAN acceptance criteria wajib berbentuk daftar
+tertutup. Diimplementasikan: `headline`, `latest_posts`, `featured_posts`,
+`editor_picks`, `category_grid`, `gallery_block` — enam tipe yang SEMUANYA
+bisa dipenuhi acceptance criteria "setiap gambar yang dirender section wajib
+dari objek R2 media terverifikasi" memakai infrastruktur yang SUDAH ADA
+(post `featured_media_id`, sudah R2-gated sejak #636; registry media #633).
+EMPAT tipe berikut **sengaja tidak diimplementasikan issue ini**, didokumentasikan
+di migration 044's header comment:
+
+- **`video_block`** — butuh Issue #639 (content block `video_news` dengan
+  thumbnail R2 wajib) yang BELUM ada. Membangunnya sekarang berarti
+  "membangun ke depan sebelum dependency siap" — pola kesalahan yang epic
+  ini berulang kali diperingatkan hindari (lihat §635's catatan soal deteksi
+  orphan).
+- **`ad_slot`** — butuh Issue #638 (preset placement iklan R2-only) yang
+  BELUM ada. `awcms_mini_blog_ads`'s `image_url` HARI INI masih URL bebas
+  (lihat `blog-content` README §Ads) — merender iklan lewat homepage
+  composer sekarang akan MELANGGAR acceptance criteria issue ini sendiri
+  ("semua gambar section wajib R2 terverifikasi").
+- **`custom_widget_block`** — **eksplisit di luar cakupan** per body issue
+  sendiri ("Arbitrary HTML widgets" ada di §Out of scope).
+- **`static_page_block`** — dipertimbangkan lalu di-drop: TIDAK ADA route
+  publik yang me-render `awcms_mini_blog_pages` sama sekali di repo ini
+  hari ini (hanya `blog-page-directory.ts` sisi admin) — membangun rute
+  publik page-detail baru bukan efek samping issue homepage composer,
+  itu keputusan terpisah.
+
+Implementor #638/#639 yang akhirnya membangun dependency di atas **wajib**
+menambah `sectionType` baru ke whitelist (`homepage-section-policy.ts`,
+migration `CHECK` constraint-nya, OpenAPI enum) — bukan mengubah tipe yang
+sudah ada.
+
+### Reference validation — TANPA GERBANG mode R2-only, berbeda dari #636
+
+`homepage-section-reference-validation.ts` memvalidasi SETIAP referensi
+(`postId`/`postIds`/`categorySlugs`/`mediaObjectIds`) SETIAP KALI, TANPA
+gerbang `isNewsPortalFullOnlineR2ModeActiveForTenant` yang #636 pakai.
+Ini BUKAN kealpaan — tabel `awcms_mini_news_portal_homepage_sections`
+adalah tabel BARU dengan NOL baris pra-eksisting; tidak ada "bentuk lama"
+yang perlu dijaga kompatibel (beda dengan `featuredMediaId`/gallery
+`content_json` #636 yang sudah dipakai jutaan post sebelum R2-only mode
+ada). Implementor lanjutan JANGAN menambahkan gerbang mode di sini tanpa
+alasan baru — sengaja unconditional by design.
+
+### `sectionType` immutable setelah dibuat
+
+`validateUpdateHomepageSectionInput(body, currentSectionType)` menerima
+`currentSectionType` dari row yang SUDAH ADA (di-fetch pemanggil dulu) —
+`config` pada request update SELALU divalidasi terhadap tipe SAAT INI,
+BUKAN tipe baru yang mungkin diminta client. Request yang mencoba mengubah
+`sectionType` ditolak `400`. Alasan: mengizinkan ganti tipe berarti bentuk
+`config_json` lama (misal `postId` milik `headline`) jadi sampah tak
+tervalidasi untuk tipe baru (misal `gallery_block` yang butuh
+`mediaObjectIds`) — lebih sederhana & aman mewajibkan hapus+buat ulang
+daripada membangun migrasi bentuk config in-place.
+
+### Reorder — TIDAK ada endpoint bulk-reorder terpisah
+
+Repo ini TIDAK punya preseden endpoint "PATCH array of ids in order" atau
+"reorder" khusus di manapun (`grep -rn "reorder"` nihil hasil relevan
+sebelum issue ini) — konvensi yang ada (`widget-directory.ts`'s
+`updateWidget`) memperlakukan `sort_order` sebagai field yang di-PATCH
+satu-per-row seperti field lain. Issue ini mengikuti PERSIS pola itu:
+admin "reorder" dengan mem-PATCH `sortOrder` tiap section satu per satu
+lewat form edit yang sudah ada — TIDAK menambah endpoint baru untuk itu.
+
+### File yang dibuat/diubah (referensi cepat)
+
+- `sql/044_awcms_mini_news_portal_homepage_sections_schema.sql` (baru).
+- `src/modules/news-portal/domain/homepage-section-policy.ts`,
+  `domain/homepage-section-rendering.ts`,
+  `application/homepage-section-directory.ts`,
+  `application/homepage-section-reference-validation.ts`,
+  `application/homepage-section-composer.ts` (semua baru).
+- `src/modules/blog-content/application/public-blog-directory.ts`: tambah
+  `featuredMediaId` ke `PublicBlogPostSummary`/`toSummary` (sebelumnya
+  hanya di `PublicBlogPostDetail`, #636) + `fetchPublicBlogPostSummariesByIds`
+  baru (mempertahankan urutan permintaan pemanggil untuk konten kurasi,
+  BUKAN `published_at DESC`).
+- `src/pages/api/v1/news-portal/homepage-sections/index.ts` (create/list),
+  `.../[id].ts` (update/delete) — baru.
+- `src/pages/admin/news-portal/homepage-sections.astro` — baru, pola sama
+  `admin/blog/ads.astro` (JSON textarea untuk `config`, state
+  loading/empty/error/ready via `StateNotice`).
+- `src/pages/news/index.ts`: panggil `composeHomepageSectionsHtml` di atas
+  daftar post polos, HANYA `page === 1` — tenant tanpa section (mayoritas
+  hari ini) melihat halaman byte-identik dengan sebelum issue ini.
+- Diperbarui: `src/modules/news-portal/module.ts` (permissions
+  `homepage_sections.{read,configure}`, `navigation` baru dideklarasikan
+  — screen admin pertama modul ini, version 0.2.0→0.3.0),
+  `src/lib/i18n/error-messages.ts` (`HOMEPAGE_SECTION_REFERENCE_INVALID`/
+  `HOMEPAGE_SECTION_KEY_CONFLICT`), `i18n/en.po`/`i18n/id.po`.
+- `openapi/awcms-mini-public-api.openapi.yaml`: tag "News Portal Homepage
+  Sections" baru, tiga path, empat schema baru.
+- Test: `tests/unit/homepage-section-policy.test.ts`,
+  `tests/unit/homepage-section-rendering.test.ts`,
+  `tests/integration/news-portal-homepage-sections.integration.test.ts`
+  (baru — CRUD, reference validation per tipe, cross-tenant 404 (RLS,
+  bukan 403), ABAC 403 tanpa permission, render publik enabled/disabled/
+  degrade-saat-unpublish/gallery); diperbarui:
+  `tests/unit/news-media-permissions.test.ts`,
+  `tests/modules/news-portal-module.test.ts` (keduanya di-filter per
+  `activityCode` supaya jumlah permission `media` yang lama tidak
+  tercampur dengan `homepage_sections` yang baru),
+  `tests/foundation.test.ts` (migration list 044).
+- Changeset: `.changeset/news-portal-homepage-sections-issue-637.md`.
+
+## §638-#640, #642, #649 — konsumsi media registry lanjutan (belum dikerjakan)
 
 Ringkasan objective per issue (detail lengkap ada di body issue
 GitHub masing-masing, cek `gh issue view <n>` bila butuh acceptance
 criteria penuh):
 
-- **#637** — homepage section composer `/news` dengan render R2-only
-  (gambar section harus dari media registry, bukan URL bebas).
 - **#638** — preset placement iklan dengan validasi gambar R2-only
   (memperluas `awcms_mini_blog_ads`'s `image_url` yang saat ini bebas
-  URL http(s) — lihat `blog-content` README §Ads).
+  URL http(s) — lihat `blog-content` README §Ads). **Setelah ini selesai**,
+  `homepage-section-policy.ts`'s whitelist WAJIB diperluas dengan
+  `ad_slot` (lihat §637's "Rekonsiliasi" di atas).
 - **#639** — content block `video_news` baru dengan thumbnail R2 wajib
   (thumbnail, bukan video itu sendiri, yang wajib R2 — video hosting
   eksternal seperti YouTube/embed kemungkinan tetap di luar cakupan R2,
-  cek body issue untuk detail persis sebelum implementasi).
+  cek body issue untuk detail persis sebelum implementasi). **Setelah ini
+  selesai**, tambahkan `video_block` ke whitelist yang sama.
 - **#640** — content quality checklist publishing dengan syarat gambar
   R2 (mis. featured image wajib ada + confirmed sebelum status
   `published` diizinkan).

--- a/docs/awcms-mini/news-portal/full-online-r2-architecture.md
+++ b/docs/awcms-mini/news-portal/full-online-r2-architecture.md
@@ -667,7 +667,8 @@ auth-online-hardening di dokumen yang sama).
 | #634                  | §7 alur upload, §8 presigned URL, §9 validasi — **diimplementasikan** (lihat `.claude/skills/awcms-mini-news-portal/SKILL.md` §634) |
 | #635                  | §13 readiness (`config:validate`/`security:readiness`/`production:preflight`)                                                       |
 | #636                  | §5 "konten editorial wajib menunjuk media confirmed" diterapkan ke `blog_content`                                                   |
-| #637-#640, #642, #649 | Konsumsi media registry untuk fitur editorial spesifik (lihat skill untuk ringkasan per issue)                                      |
+| #637                  | Homepage section composer `/news` mengonsumsi §5 registry + post `featured_media_id` — **diimplementasikan** (lihat skill §637)     |
+| #638-#640, #642, #649 | Konsumsi media registry untuk fitur editorial spesifik lanjutan (lihat skill untuk ringkasan per issue)                             |
 
 ## 17. Referensi
 

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -227,6 +227,12 @@ msgstr "Password login is disabled for this account. Use single sign-on instead.
 msgid "error.news_media_reference_invalid"
 msgstr "One or more images are not verified R2 media objects. Upload the image first and select it from the media library."
 
+msgid "error.homepage_section_reference_invalid"
+msgstr "This section references content that does not exist, does not belong to this tenant, or is not verified yet."
+
+msgid "error.homepage_section_key_conflict"
+msgstr "That section key is already in use."
+
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"
 msgstr "No role"
@@ -1838,6 +1844,76 @@ msgstr "Delete this advertisement?"
 msgid "admin.blog.ads.delete_success"
 msgstr "Advertisement deleted."
 
+#. admin.news_portal.homepage_sections (Issue #637)
+msgid "admin.news_portal.access_denied_title"
+msgstr "Access denied"
+
+msgid "admin.news_portal.access_denied_body"
+msgstr "You do not have permission to view this page."
+
+msgid "admin.news_portal.homepage_sections.title"
+msgstr "Homepage Sections"
+
+msgid "admin.news_portal.homepage_sections.no_sections"
+msgstr "No homepage sections yet."
+
+msgid "admin.news_portal.homepage_sections.field_section_key"
+msgstr "Section key"
+
+msgid "admin.news_portal.homepage_sections.field_section_type"
+msgstr "Section type"
+
+msgid "admin.news_portal.homepage_sections.field_title"
+msgstr "Title"
+
+msgid "admin.news_portal.homepage_sections.field_config"
+msgstr "Config (JSON)"
+
+msgid "admin.news_portal.homepage_sections.config_hint"
+msgstr "Shape depends on section type — headline: {postId}; latest_posts: {limit?, categorySlug?}; featured_posts/editor_picks: {postIds: []}; category_grid: {categorySlugs: [], postsPerCategory?}; gallery_block: {mediaObjectIds: [], caption?}. Every id/slug must already exist for this tenant."
+
+msgid "admin.news_portal.homepage_sections.field_sort_order"
+msgstr "Sort order"
+
+msgid "admin.news_portal.homepage_sections.field_enabled"
+msgstr "Enabled"
+
+msgid "admin.news_portal.homepage_sections.field_starts_at"
+msgstr "Starts at"
+
+msgid "admin.news_portal.homepage_sections.field_ends_at"
+msgstr "Ends at"
+
+msgid "admin.news_portal.homepage_sections.invalid_config_json"
+msgstr "Config must be valid JSON."
+
+msgid "admin.news_portal.homepage_sections.save_button"
+msgstr "Save"
+
+msgid "admin.news_portal.homepage_sections.delete_button"
+msgstr "Delete section"
+
+msgid "admin.news_portal.homepage_sections.create_summary"
+msgstr "Add homepage section"
+
+msgid "admin.news_portal.homepage_sections.create_submit"
+msgstr "Create section"
+
+msgid "admin.news_portal.homepage_sections.create_success"
+msgstr "Homepage section created."
+
+msgid "admin.news_portal.homepage_sections.update_success"
+msgstr "Homepage section updated."
+
+msgid "admin.news_portal.homepage_sections.delete_reason_prompt"
+msgstr "Reason for deleting this homepage section:"
+
+msgid "admin.news_portal.homepage_sections.delete_confirm"
+msgstr "Delete this homepage section?"
+
+msgid "admin.news_portal.homepage_sections.delete_success"
+msgstr "Homepage section deleted."
+
 #. admin.tenant_domain (Issue #563)
 msgid "admin.tenant_domain.title"
 msgstr "Tenant Domains"
@@ -2232,6 +2308,10 @@ msgstr "Provide exactly one of client secret value or environment variable name.
 #. admin.layout.nav_visitor_analytics (Issue #617/#622, epic: visitor analytics #617-#624)
 msgid "admin.layout.nav_visitor_analytics"
 msgstr "Visitor Analytics"
+
+#. admin.layout.nav_news_portal_homepage_sections (Issue #637, epic: news_portal #631-#642/#649)
+msgid "admin.layout.nav_news_portal_homepage_sections"
+msgstr "Homepage Sections"
 
 #. admin.analytics (Issue #622, epic: visitor analytics #617-#624) — /admin/analytics dashboard
 msgid "admin.analytics.heading"

--- a/i18n/id.po
+++ b/i18n/id.po
@@ -227,6 +227,12 @@ msgstr "Login password dinonaktifkan untuk akun ini. Gunakan single sign-on."
 msgid "error.news_media_reference_invalid"
 msgstr "Satu atau lebih gambar bukan objek media R2 yang terverifikasi. Unggah gambar terlebih dahulu lalu pilih dari pustaka media."
 
+msgid "error.homepage_section_reference_invalid"
+msgstr "Section ini merujuk konten yang tidak ada, bukan milik tenant ini, atau belum terverifikasi."
+
+msgid "error.homepage_section_key_conflict"
+msgstr "Section key tersebut sudah dipakai."
+
 #. admin.layout (shared shell)
 msgid "admin.layout.no_role"
 msgstr "Tanpa role"
@@ -1838,6 +1844,76 @@ msgstr "Hapus iklan ini?"
 msgid "admin.blog.ads.delete_success"
 msgstr "Iklan berhasil dihapus."
 
+#. admin.news_portal.homepage_sections (Issue #637)
+msgid "admin.news_portal.access_denied_title"
+msgstr "Akses ditolak"
+
+msgid "admin.news_portal.access_denied_body"
+msgstr "Anda tidak memiliki izin untuk melihat halaman ini."
+
+msgid "admin.news_portal.homepage_sections.title"
+msgstr "Section Homepage"
+
+msgid "admin.news_portal.homepage_sections.no_sections"
+msgstr "Belum ada section homepage."
+
+msgid "admin.news_portal.homepage_sections.field_section_key"
+msgstr "Section key"
+
+msgid "admin.news_portal.homepage_sections.field_section_type"
+msgstr "Tipe section"
+
+msgid "admin.news_portal.homepage_sections.field_title"
+msgstr "Judul"
+
+msgid "admin.news_portal.homepage_sections.field_config"
+msgstr "Config (JSON)"
+
+msgid "admin.news_portal.homepage_sections.config_hint"
+msgstr "Bentuknya tergantung tipe section — headline: {postId}; latest_posts: {limit?, categorySlug?}; featured_posts/editor_picks: {postIds: []}; category_grid: {categorySlugs: [], postsPerCategory?}; gallery_block: {mediaObjectIds: [], caption?}. Semua id/slug harus sudah ada untuk tenant ini."
+
+msgid "admin.news_portal.homepage_sections.field_sort_order"
+msgstr "Urutan"
+
+msgid "admin.news_portal.homepage_sections.field_enabled"
+msgstr "Aktif"
+
+msgid "admin.news_portal.homepage_sections.field_starts_at"
+msgstr "Mulai pada"
+
+msgid "admin.news_portal.homepage_sections.field_ends_at"
+msgstr "Berakhir pada"
+
+msgid "admin.news_portal.homepage_sections.invalid_config_json"
+msgstr "Config harus berupa JSON yang valid."
+
+msgid "admin.news_portal.homepage_sections.save_button"
+msgstr "Simpan"
+
+msgid "admin.news_portal.homepage_sections.delete_button"
+msgstr "Hapus section"
+
+msgid "admin.news_portal.homepage_sections.create_summary"
+msgstr "Tambah section homepage"
+
+msgid "admin.news_portal.homepage_sections.create_submit"
+msgstr "Buat section"
+
+msgid "admin.news_portal.homepage_sections.create_success"
+msgstr "Section homepage berhasil dibuat."
+
+msgid "admin.news_portal.homepage_sections.update_success"
+msgstr "Section homepage berhasil diperbarui."
+
+msgid "admin.news_portal.homepage_sections.delete_reason_prompt"
+msgstr "Alasan menghapus section homepage ini:"
+
+msgid "admin.news_portal.homepage_sections.delete_confirm"
+msgstr "Hapus section homepage ini?"
+
+msgid "admin.news_portal.homepage_sections.delete_success"
+msgstr "Section homepage berhasil dihapus."
+
 #. admin.tenant_domain (Issue #563)
 msgid "admin.tenant_domain.title"
 msgstr "Domain Tenant"
@@ -2232,6 +2308,10 @@ msgstr "Isi tepat salah satu: nilai client secret atau nama environment variable
 #. admin.layout.nav_visitor_analytics (Issue #617/#622, epic: visitor analytics #617-#624)
 msgid "admin.layout.nav_visitor_analytics"
 msgstr "Analitik Pengunjung"
+
+#. admin.layout.nav_news_portal_homepage_sections (Issue #637, epic: news_portal #631-#642/#649)
+msgid "admin.layout.nav_news_portal_homepage_sections"
+msgstr "Section Homepage"
 
 #. admin.analytics (Issue #622, epic: visitor analytics #617-#624) — dashboard /admin/analytics
 msgid "admin.analytics.heading"

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -148,6 +148,18 @@ tags:
       security-auditor Critical finding on Issue #631), and cancel a
       still-`pending_upload` session. R2 credentials are never exposed to
       the browser; only a scoped, expiring presigned URL is returned.
+  - name: News Portal Homepage Sections
+    description: >-
+      Editorial homepage section composer for `/news` (epic `news_portal`
+      #631-#642/#649, Issue #637) — tenant-scoped, RLS-protected CRUD for
+      configurable homepage sections (headline, latest_posts,
+      featured_posts, editor_picks, category_grid, gallery_block).
+      `config` shape is validated per `sectionType` server-side; every
+      post/category/media reference in `config` must already exist for
+      the same tenant, and (for `gallery_block`) be a verified R2 media
+      object. `sectionType` is immutable after creation. Reordering is
+      just another patchable field (`sortOrder`) — there is no separate
+      bulk-reorder endpoint.
 paths:
   /api/v1/sync/push:
     post:
@@ -8047,6 +8059,213 @@ paths:
                 $ref: "#/components/schemas/ApiError"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/v1/news-portal/homepage-sections:
+    get:
+      tags:
+        - News Portal Homepage Sections
+      summary: List this tenant's homepage sections (admin view)
+      operationId: newsPortalHomepageSectionsList
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      responses:
+        "200":
+          description: Homepage sections.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        type: object
+                        required:
+                          - sections
+                        properties:
+                          sections:
+                            type: array
+                            items:
+                              $ref: "#/components/schemas/HomepageSectionItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    post:
+      tags:
+        - News Portal Homepage Sections
+      summary: Create a homepage section
+      operationId: newsPortalHomepageSectionsCreate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HomepageSectionCreateRequest"
+      responses:
+        "200":
+          description: Homepage section created.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/HomepageSectionItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: sectionKey is already in use for this tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: config references content that does not exist, does not belong to this tenant, or (for gallery_block) is not a verified R2 media object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/v1/news-portal/homepage-sections/{id}:
+    patch:
+      tags:
+        - News Portal Homepage Sections
+      summary: Update a homepage section (title/config/sortOrder/isEnabled/schedule) — sectionType is immutable
+      operationId: newsPortalHomepageSectionsUpdate
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HomepageSectionUpdateRequest"
+      responses:
+        "200":
+          description: Homepage section updated.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/HomepageSectionItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: config references content that does not exist, does not belong to this tenant, or (for gallery_block) is not a verified R2 media object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          $ref: "#/components/responses/InternalError"
+    delete:
+      tags:
+        - News Portal Homepage Sections
+      summary: Soft-delete a homepage section
+      operationId: newsPortalHomepageSectionsDelete
+      security:
+        - bearerAuth: []
+          tenantHeader: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+        - $ref: "#/components/parameters/RequestId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+      responses:
+        "200":
+          description: Homepage section deleted.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    required:
+                      - data
+                    properties:
+                      data:
+                        type: object
+                        required:
+                          - id
+                          - deleted
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                          deleted:
+                            type: boolean
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
 x-awcms-mini-soft-delete-pattern:
   delete:
     method: DELETE
@@ -13071,6 +13290,133 @@ components:
         updatedAt:
           type: string
           format: date-time
+    HomepageSectionConfig:
+      description: >-
+        Shape depends on sectionType — headline: {postId}; latest_posts:
+        {limit?, categorySlug?}; featured_posts/editor_picks: {postIds:
+        []}; category_grid: {categorySlugs: [], postsPerCategory?};
+        gallery_block: {mediaObjectIds: [], caption?}. Validated server-side
+        per sectionType (`homepage-section-policy.ts`); every id/slug must
+        already exist for the same tenant (`homepage-section-reference-
+        validation.ts`), and gallery_block's mediaObjectIds must each be a
+        verified R2 media object.
+      type: object
+      additionalProperties: true
+    HomepageSectionItem:
+      type: object
+      required:
+        - id
+        - tenantId
+        - sectionKey
+        - sectionType
+        - config
+        - sortOrder
+        - isEnabled
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        sectionKey:
+          type: string
+        sectionType:
+          type: string
+          enum:
+            [
+              headline,
+              latest_posts,
+              featured_posts,
+              editor_picks,
+              category_grid,
+              gallery_block
+            ]
+        title:
+          type: string
+          nullable: true
+        config:
+          $ref: "#/components/schemas/HomepageSectionConfig"
+        sortOrder:
+          type: integer
+        isEnabled:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    HomepageSectionCreateRequest:
+      type: object
+      required:
+        - sectionKey
+        - sectionType
+        - config
+      properties:
+        sectionKey:
+          type: string
+          pattern: "^[a-z0-9][a-z0-9_-]{0,63}$"
+        sectionType:
+          type: string
+          enum:
+            [
+              headline,
+              latest_posts,
+              featured_posts,
+              editor_picks,
+              category_grid,
+              gallery_block
+            ]
+        title:
+          type: string
+          nullable: true
+        config:
+          $ref: "#/components/schemas/HomepageSectionConfig"
+        sortOrder:
+          type: integer
+        isEnabled:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+    HomepageSectionUpdateRequest:
+      description: sectionType cannot be changed after creation — omit it, do not send the old or a new value.
+      type: object
+      properties:
+        title:
+          type: string
+          nullable: true
+        config:
+          $ref: "#/components/schemas/HomepageSectionConfig"
+        sortOrder:
+          type: integer
+        isEnabled:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
 security:
   - bearerAuth: []
     tenantHeader: []

--- a/sql/044_awcms_mini_news_portal_homepage_sections_schema.sql
+++ b/sql/044_awcms_mini_news_portal_homepage_sections_schema.sql
@@ -1,0 +1,66 @@
+-- Issue #637 (epic news_portal) — configurable editorial homepage section
+-- composer for the canonical `/news` route. Six section types, each backed
+-- entirely by EXISTING public-safe data (`blog_content` posts + the R2 media
+-- registry from Issue #633) — no new content-authoring surface, no raw HTML.
+-- `video_block`/`ad_slot`/`custom_widget_block` from the issue's suggested
+-- list are deliberately NOT included here: `video_block` needs Issue #639's
+-- (not yet built) R2 thumbnail-required video type; `ad_slot` needs Issue
+-- #638's (not yet built) R2-only ad image validation — `awcms_mini_blog_ads`
+-- today stores a free-form `image_url`, which would violate this issue's own
+-- "all images must come from a verified R2 media object" acceptance
+-- criterion; `custom_widget_block` is explicitly out of scope per the issue
+-- body ("Arbitrary HTML widgets"). A `static_page_block` referencing
+-- `awcms_mini_blog_pages` was also considered and dropped — there is no
+-- existing public page-detail route/visibility-tested query for pages
+-- anywhere in this repo yet (only admin-facing `blog-page-directory.ts`),
+-- and building one is its own decision, not a side effect of this issue.
+CREATE TABLE IF NOT EXISTS awcms_mini_news_portal_homepage_sections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_mini_tenants (id),
+  section_key text NOT NULL,
+  section_type text NOT NULL,
+  title text,
+  config_json jsonb NOT NULL DEFAULT '{}'::jsonb,
+  sort_order integer NOT NULL DEFAULT 0,
+  is_enabled boolean NOT NULL DEFAULT true,
+  starts_at timestamptz,
+  ends_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_mini_news_portal_homepage_sections_type_check
+    CHECK (section_type IN (
+      'headline', 'latest_posts', 'featured_posts', 'editor_picks',
+      'category_grid', 'gallery_block'
+    )),
+  CONSTRAINT awcms_mini_news_portal_homepage_sections_schedule_check
+    CHECK (starts_at IS NULL OR ends_at IS NULL OR ends_at > starts_at)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_news_portal_homepage_sections_tenant_key_dedup
+  ON awcms_mini_news_portal_homepage_sections (tenant_id, section_key)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_mini_news_portal_homepage_sections_tenant_order_idx
+  ON awcms_mini_news_portal_homepage_sections (tenant_id, sort_order)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE awcms_mini_news_portal_homepage_sections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_mini_news_portal_homepage_sections FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_mini_news_portal_homepage_sections_tenant_isolation
+  ON awcms_mini_news_portal_homepage_sections
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Permission catalog seed, same "configure" (create/update/reorder/delete)
+-- + "read" action pair `blog_content`'s ads/menus/widgets already use
+-- (`sql/030_awcms_mini_blog_content_presentation_permissions.sql`) — this
+-- table has no separate "reorder" action, per-section `sort_order` is just
+-- another field on the same `configure`-guarded update.
+INSERT INTO awcms_mini_permissions (module_key, activity_code, action, description)
+VALUES
+  ('news_portal', 'homepage_sections', 'read', 'Read editorial homepage section configuration'),
+  ('news_portal', 'homepage_sections', 'configure', 'Create, update, reorder, enable/disable, or delete editorial homepage sections')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/lib/i18n/error-messages.ts
+++ b/src/lib/i18n/error-messages.ts
@@ -82,7 +82,10 @@ export const ERROR_CODE_KEYS: Record<string, string> = {
   SSO_PROVIDER_LIMIT_EXCEEDED: "error.sso_provider_limit_exceeded",
   BREAK_GLASS_REQUIRED: "error.break_glass_required",
   PASSWORD_LOGIN_DISABLED: "error.password_login_disabled",
-  NEWS_MEDIA_REFERENCE_INVALID: "error.news_media_reference_invalid"
+  NEWS_MEDIA_REFERENCE_INVALID: "error.news_media_reference_invalid",
+  HOMEPAGE_SECTION_REFERENCE_INVALID:
+    "error.homepage_section_reference_invalid",
+  HOMEPAGE_SECTION_KEY_CONFLICT: "error.homepage_section_key_conflict"
 };
 
 /**

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -676,6 +676,8 @@ Doc issue #542 eksplisit: "Do not rebuild the base media library... Integrate wi
 
 **Update Issue #636** (epic `news_portal`, di luar epic #536): paragraf di atas tetap akurat untuk deployment non-R2-only (mayoritas hari ini). Ketika full-online R2-only mode aktif untuk tenant pemanggil, `featuredMediaId` dan item gallery `mediaType: "image"` WAJIB mereferensikan baris `verified`/`attached` di media registry `news_portal` (Issue #633) — item `mediaType: "video"` dan seluruh perilaku non-R2-only tidak berubah. Tetap **bukan** media library baru di `blog_content` — lihat `.claude/skills/awcms-mini-news-portal/SKILL.md` §636 untuk detail lengkap.
 
+**Update Issue #637** (epic `news_portal`): `public-blog-directory.ts`'s `PublicBlogPostSummary` (listing/archive/homepage-composer queries — sebelumnya hanya `PublicBlogPostDetail`, single-post-by-slug, punya `featuredMediaId`) sekarang juga menyertakan `featuredMediaId`, supaya `news_portal`'s homepage section composer bisa menampilkan gambar unggulan post di kartu ringkasan tanpa query terpisah. Tidak ada perubahan skema/validasi `blog_content` sendiri di sini — murni menambah satu kolom ke SELECT yang sudah ada.
+
 ## Settings API (Issue #543)
 
 `GET`/`PATCH /api/v1/blog/settings` (`src/pages/api/v1/blog/settings/index.ts`) — akhirnya mengaktifkan `awcms_mini_blog_settings` (migration 026, satu baris per tenant, `tenant_id` = PK) yang sejak Issue #537 sudah ada di schema tapi tidak punya route. Tidak ada `{id}` di path — sama seperti `PATCH /api/v1/blog/theme`, satu baris per tenant.

--- a/src/modules/blog-content/application/public-blog-directory.ts
+++ b/src/modules/blog-content/application/public-blog-directory.ts
@@ -93,6 +93,8 @@ export type PublicBlogPostSummary = {
   slug: string;
   excerpt: string | null;
   publishedAt: Date;
+  /** Issue #637 — added so homepage section cards can resolve it to a verified R2 media object, same reason #636 added it to `PublicBlogPostDetail`. Not selected by every query below (only where a caller actually renders an image). */
+  featuredMediaId: string | null;
 };
 
 type PublicBlogPostSummaryRow = {
@@ -101,6 +103,7 @@ type PublicBlogPostSummaryRow = {
   slug: string;
   excerpt: string | null;
   published_at: Date;
+  featured_media_id: string | null;
 };
 
 function toSummary(row: PublicBlogPostSummaryRow): PublicBlogPostSummary {
@@ -109,7 +112,8 @@ function toSummary(row: PublicBlogPostSummaryRow): PublicBlogPostSummary {
     title: row.title,
     slug: row.slug,
     excerpt: row.excerpt,
-    publishedAt: row.published_at
+    publishedAt: row.published_at,
+    featuredMediaId: row.featured_media_id
   };
 }
 
@@ -140,7 +144,7 @@ export async function listPublicBlogPosts(
   const offset = (page - 1) * pageSize;
 
   const rows = (await tx`
-    SELECT id, title, slug, excerpt, published_at
+    SELECT id, title, slug, excerpt, published_at, featured_media_id
     FROM awcms_mini_blog_posts
     WHERE tenant_id = ${tenantId}
       AND status = 'published' AND visibility = 'public'
@@ -210,7 +214,7 @@ export async function listPublicBlogPostsByTermId(
   const offset = (page - 1) * pageSize;
 
   const rows = (await tx`
-    SELECT p.id, p.title, p.slug, p.excerpt, p.published_at
+    SELECT p.id, p.title, p.slug, p.excerpt, p.published_at, p.featured_media_id
     FROM awcms_mini_blog_posts p
     JOIN awcms_mini_blog_post_terms pt
       ON pt.post_id = p.id AND pt.tenant_id = p.tenant_id
@@ -227,6 +231,42 @@ export async function listPublicBlogPostsByTermId(
     items: rows.slice(0, pageSize).map(toSummary),
     hasNextPage
   };
+}
+
+/**
+ * Fetches public/published summaries for a curated set of post ids (Issue
+ * #637 — `headline`/`featured_posts`/`editor_picks` homepage sections),
+ * preserving the CALLER's requested order (not `published_at DESC`) since
+ * curation order is editorially meaningful here, unlike the chronological
+ * listing functions above. A stale/unpublished/cross-tenant/soft-deleted
+ * id is silently dropped from the result rather than throwing — same
+ * "degrade, don't 500" convention `resolveVerifiedNewsMediaReferences`
+ * uses for media references.
+ */
+export async function fetchPublicBlogPostSummariesByIds(
+  tx: Bun.SQL,
+  tenantId: string,
+  postIds: readonly string[]
+): Promise<PublicBlogPostSummary[]> {
+  if (postIds.length === 0) {
+    return [];
+  }
+
+  const rows = (await tx`
+    SELECT id, title, slug, excerpt, published_at, featured_media_id
+    FROM awcms_mini_blog_posts
+    WHERE tenant_id = ${tenantId} AND id = ANY(${tx.array([...new Set(postIds)], "uuid")})
+      AND status = 'published' AND visibility = 'public'
+      AND deleted_at IS NULL AND published_at IS NOT NULL AND published_at <= now()
+  `) as PublicBlogPostSummaryRow[];
+
+  const byId = new Map(rows.map((row) => [row.id, toSummary(row)]));
+
+  return postIds
+    .map((id) => byId.get(id))
+    .filter(
+      (summary): summary is PublicBlogPostSummary => summary !== undefined
+    );
 }
 
 const FEED_ITEM_LIMIT = 50;

--- a/src/modules/news-portal/application/homepage-section-composer.ts
+++ b/src/modules/news-portal/application/homepage-section-composer.ts
@@ -1,0 +1,230 @@
+import {
+  fetchPublicBlogPostSummariesByIds,
+  fetchPublicTermBySlug,
+  listPublicBlogPosts,
+  listPublicBlogPostsByTermId,
+  type PublicBlogPostSummary
+} from "../../blog-content/application/public-blog-directory";
+import { resolveVerifiedNewsMediaReferences } from "../../blog-content/application/news-media-reference-gate";
+import {
+  renderCategoryGridSectionHtml,
+  renderGalleryBlockSectionHtml,
+  renderHomepageSectionsHtml,
+  renderPostCardListHtml,
+  type HomepageSectionCategoryGroup,
+  type HomepageSectionPostCard,
+  type RenderedHomepageSection
+} from "../domain/homepage-section-rendering";
+import {
+  listActiveHomepageSectionsForRendering,
+  type HomepageSectionView
+} from "./homepage-section-directory";
+import type {
+  CategoryGridSectionConfig,
+  CuratedPostsSectionConfig,
+  GalleryBlockSectionConfig,
+  HeadlineSectionConfig,
+  LatestPostsSectionConfig
+} from "../domain/homepage-section-policy";
+
+/**
+ * Orchestrates Issue #637's editorial homepage: fetches every active
+ * section for the tenant (`listActiveHomepageSectionsForRendering`), then
+ * for EACH section re-resolves its `config`'s references against current,
+ * live public/verified data — never trusting that a reference validated at
+ * save time is still valid now (a curated post could have been
+ * unpublished, a category deleted, a media object soft-deleted since).
+ * This is the only place in the module that turns a `HomepageSectionView`
+ * into rendered HTML; `/news/index.ts` calls only
+ * `composeHomepageSectionsHtml`, never the per-type renderers directly.
+ */
+const EMPTY_MESSAGE = "No content available yet.";
+
+function toPostCard(
+  post: PublicBlogPostSummary,
+  media: ReadonlyMap<string, { publicUrl: string; altText: string | null }>
+): HomepageSectionPostCard {
+  const resolved = post.featuredMediaId
+    ? (media.get(post.featuredMediaId) ?? null)
+    : null;
+
+  return {
+    title: post.title,
+    slug: post.slug,
+    excerpt: post.excerpt,
+    imageUrl: resolved?.publicUrl ?? null,
+    imageAlt: resolved?.altText ?? null
+  };
+}
+
+async function resolveMediaForPosts(
+  tx: Bun.SQL,
+  tenantId: string,
+  posts: readonly PublicBlogPostSummary[]
+) {
+  const mediaObjectIds = posts
+    .map((post) => post.featuredMediaId)
+    .filter((id): id is string => id !== null);
+
+  return resolveVerifiedNewsMediaReferences(tx, tenantId, mediaObjectIds);
+}
+
+async function renderPostCards(
+  tx: Bun.SQL,
+  tenantId: string,
+  basePath: string,
+  posts: readonly PublicBlogPostSummary[]
+): Promise<string> {
+  const media = await resolveMediaForPosts(tx, tenantId, posts);
+  return renderPostCardListHtml(
+    basePath,
+    posts.map((post) => toPostCard(post, media)),
+    EMPTY_MESSAGE
+  );
+}
+
+async function renderSectionBody(
+  tx: Bun.SQL,
+  tenantId: string,
+  basePath: string,
+  section: HomepageSectionView
+): Promise<string> {
+  switch (section.sectionType) {
+    case "headline": {
+      const config = section.config as HeadlineSectionConfig;
+      const posts = await fetchPublicBlogPostSummariesByIds(tx, tenantId, [
+        config.postId
+      ]);
+      return renderPostCards(tx, tenantId, basePath, posts);
+    }
+
+    case "latest_posts": {
+      const config = section.config as LatestPostsSectionConfig;
+      let posts: PublicBlogPostSummary[];
+
+      if (config.categorySlug) {
+        const term = await fetchPublicTermBySlug(
+          tx,
+          tenantId,
+          "category",
+          config.categorySlug
+        );
+        posts = term
+          ? (
+              await listPublicBlogPostsByTermId(tx, tenantId, term.id, {
+                pageSize: config.limit
+              })
+            ).items
+          : [];
+      } else {
+        posts = (
+          await listPublicBlogPosts(tx, tenantId, { pageSize: config.limit })
+        ).items;
+      }
+
+      return renderPostCards(tx, tenantId, basePath, posts);
+    }
+
+    case "featured_posts":
+    case "editor_picks": {
+      const config = section.config as CuratedPostsSectionConfig;
+      const posts = await fetchPublicBlogPostSummariesByIds(
+        tx,
+        tenantId,
+        config.postIds
+      );
+      return renderPostCards(tx, tenantId, basePath, posts);
+    }
+
+    case "category_grid": {
+      const config = section.config as CategoryGridSectionConfig;
+      const groups: HomepageSectionCategoryGroup[] = [];
+
+      for (const categorySlug of config.categorySlugs) {
+        const term = await fetchPublicTermBySlug(
+          tx,
+          tenantId,
+          "category",
+          categorySlug
+        );
+
+        if (!term) {
+          continue;
+        }
+
+        const posts = (
+          await listPublicBlogPostsByTermId(tx, tenantId, term.id, {
+            pageSize: config.postsPerCategory
+          })
+        ).items;
+        const media = await resolveMediaForPosts(tx, tenantId, posts);
+
+        groups.push({
+          categoryName: term.name,
+          categorySlug: term.slug,
+          posts: posts.map((post) => toPostCard(post, media))
+        });
+      }
+
+      return renderCategoryGridSectionHtml(basePath, groups, EMPTY_MESSAGE);
+    }
+
+    case "gallery_block": {
+      const config = section.config as GalleryBlockSectionConfig;
+      const media = await resolveVerifiedNewsMediaReferences(
+        tx,
+        tenantId,
+        config.mediaObjectIds
+      );
+      const resolvedUrls = new Map(
+        [...media].map(([id, entry]) => [id, entry.publicUrl])
+      );
+      return renderGalleryBlockSectionHtml(
+        config.mediaObjectIds,
+        config.caption,
+        resolvedUrls,
+        EMPTY_MESSAGE
+      );
+    }
+
+    default:
+      return "";
+  }
+}
+
+export type ComposedHomepageSections = {
+  hasSections: boolean;
+  html: string;
+};
+
+/** `hasSections: false` (no enabled/in-schedule-window rows for this tenant) is the signal `/news/index.ts` uses to fall back to the pre-#637 plain post list — this feature is additive, not a replacement, for tenants that never configure a homepage. */
+export async function composeHomepageSectionsHtml(
+  tx: Bun.SQL,
+  tenantId: string,
+  basePath: string,
+  now: Date = new Date()
+): Promise<ComposedHomepageSections> {
+  const sections = await listActiveHomepageSectionsForRendering(
+    tx,
+    tenantId,
+    now
+  );
+
+  if (sections.length === 0) {
+    return { hasSections: false, html: "" };
+  }
+
+  const rendered: RenderedHomepageSection[] = [];
+
+  for (const section of sections) {
+    const bodyHtml = await renderSectionBody(tx, tenantId, basePath, section);
+    rendered.push({
+      sectionKey: section.sectionKey,
+      sectionType: section.sectionType,
+      title: section.title,
+      bodyHtml
+    });
+  }
+
+  return { hasSections: true, html: renderHomepageSectionsHtml(rendered) };
+}

--- a/src/modules/news-portal/application/homepage-section-directory.ts
+++ b/src/modules/news-portal/application/homepage-section-directory.ts
@@ -1,0 +1,199 @@
+import type {
+  CreateHomepageSectionInput,
+  HomepageSectionType,
+  UpdateHomepageSectionInput
+} from "../domain/homepage-section-policy";
+
+/**
+ * Read/write query module for `awcms_mini_news_portal_homepage_sections`
+ * (Issue #637) — same "one directory, reads and writes" convention as
+ * `ads-directory.ts`/`blog-taxonomy-directory.ts`. The column list is
+ * repeated literally at each query site (not factored into a shared
+ * fragment) — same convention every other directory module in this repo
+ * uses (see `tenant-domain-directory.ts`'s own header comment), so every
+ * query stays a single self-contained tagged template.
+ */
+export type HomepageSectionView = {
+  id: string;
+  tenantId: string;
+  sectionKey: string;
+  sectionType: HomepageSectionType;
+  title: string | null;
+  config: Record<string, unknown>;
+  sortOrder: number;
+  isEnabled: boolean;
+  startsAt: Date | null;
+  endsAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+};
+
+type HomepageSectionRow = {
+  id: string;
+  tenant_id: string;
+  section_key: string;
+  section_type: HomepageSectionType;
+  title: string | null;
+  config_json: Record<string, unknown>;
+  sort_order: number;
+  is_enabled: boolean;
+  starts_at: Date | null;
+  ends_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+};
+
+function toView(row: HomepageSectionRow): HomepageSectionView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    sectionKey: row.section_key,
+    sectionType: row.section_type,
+    title: row.title,
+    config: row.config_json,
+    sortOrder: row.sort_order,
+    isEnabled: row.is_enabled,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason
+  };
+}
+
+export async function createHomepageSection(
+  tx: Bun.SQL,
+  tenantId: string,
+  input: CreateHomepageSectionInput
+): Promise<HomepageSectionView> {
+  const rows = (await tx`
+    INSERT INTO awcms_mini_news_portal_homepage_sections
+      (tenant_id, section_key, section_type, title, config_json, sort_order,
+       is_enabled, starts_at, ends_at)
+    VALUES (
+      ${tenantId}, ${input.sectionKey}, ${input.sectionType}, ${input.title},
+      ${input.config}, ${input.sortOrder}, ${input.isEnabled}, ${input.startsAt},
+      ${input.endsAt}
+    )
+    RETURNING id, tenant_id, section_key, section_type, title, config_json,
+      sort_order, is_enabled, starts_at, ends_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason
+  `) as HomepageSectionRow[];
+
+  return toView(rows[0]!);
+}
+
+export async function fetchHomepageSectionById(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<HomepageSectionView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, section_key, section_type, title, config_json,
+      sort_order, is_enabled, starts_at, ends_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason
+    FROM awcms_mini_news_portal_homepage_sections
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+  `) as HomepageSectionRow[];
+
+  const row = rows[0];
+  return row ? toView(row) : null;
+}
+
+/** Admin listing — every non-deleted section (enabled or not, in/out of schedule window), ordered for the reorder UI. */
+export async function listHomepageSections(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<HomepageSectionView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, section_key, section_type, title, config_json,
+      sort_order, is_enabled, starts_at, ends_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason
+    FROM awcms_mini_news_portal_homepage_sections
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+    ORDER BY sort_order ASC, created_at ASC
+    LIMIT 200
+  `) as HomepageSectionRow[];
+
+  return rows.map(toView);
+}
+
+export async function updateHomepageSection(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  input: UpdateHomepageSectionInput
+): Promise<HomepageSectionView | null> {
+  const rows = (await tx`
+    UPDATE awcms_mini_news_portal_homepage_sections
+    SET title = CASE WHEN ${input.title === undefined} THEN title ELSE ${input.title ?? null} END,
+        config_json = COALESCE(${input.config ?? null}, config_json),
+        sort_order = COALESCE(${input.sortOrder ?? null}, sort_order),
+        is_enabled = COALESCE(${input.isEnabled ?? null}, is_enabled),
+        starts_at = CASE WHEN ${input.startsAt === undefined} THEN starts_at ELSE ${input.startsAt ?? null} END,
+        ends_at = CASE WHEN ${input.endsAt === undefined} THEN ends_at ELSE ${input.endsAt ?? null} END,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, section_key, section_type, title, config_json,
+      sort_order, is_enabled, starts_at, ends_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason
+  `) as HomepageSectionRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export async function softDeleteHomepageSection(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_mini_news_portal_homepage_sections
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}
+
+/**
+ * Public-safe query for `/news` rendering — enabled, non-deleted, and
+ * within its schedule window (`starts_at`/`ends_at`, both optional bounds)
+ * as of `now`, ordered for display. Callers still MUST resolve/validate
+ * every reference in `config` (post ids, category slugs, media object ids)
+ * at render time via `homepage-section-rendering.ts` — a section existing
+ * and being "active" does not by itself mean everything it references is
+ * still public/verified (e.g. a curated post could have been unpublished
+ * since the section was configured).
+ */
+export async function listActiveHomepageSectionsForRendering(
+  tx: Bun.SQL,
+  tenantId: string,
+  now: Date = new Date()
+): Promise<HomepageSectionView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, section_key, section_type, title, config_json,
+      sort_order, is_enabled, starts_at, ends_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason
+    FROM awcms_mini_news_portal_homepage_sections
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL AND is_enabled = true
+      AND (starts_at IS NULL OR starts_at <= ${now})
+      AND (ends_at IS NULL OR ends_at > ${now})
+    ORDER BY sort_order ASC, created_at ASC
+    LIMIT 50
+  `) as HomepageSectionRow[];
+
+  return rows.map(toView);
+}

--- a/src/modules/news-portal/application/homepage-section-reference-validation.ts
+++ b/src/modules/news-portal/application/homepage-section-reference-validation.ts
@@ -1,0 +1,153 @@
+/**
+ * Application-layer existence/ownership checks for homepage section
+ * `config_json` references (Issue #637) — the domain validator
+ * (`homepage-section-policy.ts`) only checks shape (UUID format, array
+ * bounds); this checks that every referenced id/slug actually exists,
+ * belongs to the SAME tenant, and (for media) is a verified R2 object.
+ * Same "shape in the pure validator, existence in an application-layer gate
+ * called right before write" convention `news-media-reference-gate.ts`
+ * (Issue #636) and `countExistingTerms` (Issue #539) already established.
+ *
+ * Deliberately unconditional — unlike #636's gate (which only activates
+ * when full-online R2-only mode is active for the tenant, to stay backward
+ * compatible with pre-existing non-R2 content), homepage sections are a
+ * brand-new table with zero pre-existing rows: there is no legacy shape to
+ * stay compatible with, so every reference is validated every time,
+ * regardless of the tenant's R2-only mode status.
+ *
+ * A reference to another tenant's post/term/media object resolves to
+ * "not found" here (never "found but belongs to someone else") — the
+ * fetch functions this calls are themselves tenant-scoped, so a
+ * cross-tenant id is indistinguishable from a nonexistent one.
+ */
+import type { HomepageSectionType } from "../domain/homepage-section-policy";
+import { fetchBlogPostById } from "../../blog-content/application/blog-post-directory";
+import { fetchPublicTermBySlug } from "../../blog-content/application/public-blog-directory";
+import {
+  fetchNewsMediaObjectById,
+  isNewsMediaObjectSafeForPublicReference
+} from "./news-media-object-directory";
+
+export type HomepageSectionReferenceValidationError = {
+  field: string;
+  message: string;
+};
+
+export type HomepageSectionReferenceValidationResult =
+  | { valid: true }
+  | { valid: false; errors: HomepageSectionReferenceValidationError[] };
+
+async function validatePostId(
+  tx: Bun.SQL,
+  tenantId: string,
+  postId: string,
+  errors: HomepageSectionReferenceValidationError[]
+): Promise<void> {
+  const post = await fetchBlogPostById(tx, tenantId, postId);
+
+  if (!post) {
+    errors.push({
+      field: "config.postId",
+      message: `config.postId "${postId}" does not exist or does not belong to this tenant.`
+    });
+  }
+}
+
+async function validatePostIds(
+  tx: Bun.SQL,
+  tenantId: string,
+  postIds: readonly string[],
+  errors: HomepageSectionReferenceValidationError[]
+): Promise<void> {
+  for (const postId of new Set(postIds)) {
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+
+    if (!post) {
+      errors.push({
+        field: "config.postIds",
+        message: `config.postIds references "${postId}", which does not exist or does not belong to this tenant.`
+      });
+    }
+  }
+}
+
+async function validateCategorySlugs(
+  tx: Bun.SQL,
+  tenantId: string,
+  categorySlugs: readonly string[],
+  errors: HomepageSectionReferenceValidationError[]
+): Promise<void> {
+  for (const slug of new Set(categorySlugs)) {
+    const term = await fetchPublicTermBySlug(tx, tenantId, "category", slug);
+
+    if (!term) {
+      errors.push({
+        field: "config.categorySlugs",
+        message: `config.categorySlugs references "${slug}", which does not exist as a category for this tenant.`
+      });
+    }
+  }
+}
+
+async function validateMediaObjectIds(
+  tx: Bun.SQL,
+  tenantId: string,
+  mediaObjectIds: readonly string[],
+  errors: HomepageSectionReferenceValidationError[]
+): Promise<void> {
+  for (const mediaObjectId of new Set(mediaObjectIds)) {
+    const media = await fetchNewsMediaObjectById(tx, tenantId, mediaObjectId);
+
+    if (!media || !isNewsMediaObjectSafeForPublicReference(media.status)) {
+      errors.push({
+        field: "config.mediaObjectIds",
+        message: `config.mediaObjectIds references "${mediaObjectId}", which does not exist, does not belong to this tenant, or is not a verified R2 media object.`
+      });
+    }
+  }
+}
+
+/** Runs inside the caller's own tenant-scoped transaction (same `tx` the route handler already opened via `withTenant`). */
+export async function validateHomepageSectionReferences(
+  tx: Bun.SQL,
+  tenantId: string,
+  sectionType: HomepageSectionType,
+  config: Record<string, unknown>
+): Promise<HomepageSectionReferenceValidationResult> {
+  const errors: HomepageSectionReferenceValidationError[] = [];
+
+  switch (sectionType) {
+    case "headline":
+      await validatePostId(tx, tenantId, config.postId as string, errors);
+      break;
+    case "featured_posts":
+    case "editor_picks":
+      await validatePostIds(tx, tenantId, config.postIds as string[], errors);
+      break;
+    case "category_grid":
+      await validateCategorySlugs(
+        tx,
+        tenantId,
+        config.categorySlugs as string[],
+        errors
+      );
+      break;
+    case "gallery_block":
+      await validateMediaObjectIds(
+        tx,
+        tenantId,
+        config.mediaObjectIds as string[],
+        errors
+      );
+      break;
+    case "latest_posts": {
+      const categorySlug = config.categorySlug as string | null;
+      if (categorySlug) {
+        await validateCategorySlugs(tx, tenantId, [categorySlug], errors);
+      }
+      break;
+    }
+  }
+
+  return errors.length > 0 ? { valid: false, errors } : { valid: true };
+}

--- a/src/modules/news-portal/domain/homepage-section-policy.ts
+++ b/src/modules/news-portal/domain/homepage-section-policy.ts
@@ -1,0 +1,527 @@
+/**
+ * Editorial homepage section composer (Issue #637, epic `news_portal`).
+ * Six section types, each with its own strictly-whitelisted `config_json`
+ * shape — no field on any type ever accepts raw HTML or an arbitrary image
+ * URL, only UUIDs referencing already-public-safe/already-R2-verified data
+ * (`blog_content` posts via `postId`/`postIds`, the R2 media registry via
+ * `mediaObjectIds`). `sectionType` is immutable after creation (an update
+ * can change `config`/`title`/`sortOrder`/`isEnabled`/`startsAt`/`endsAt`,
+ * never `sectionType` itself) — the caller (`homepage-section-directory.ts`)
+ * passes the existing row's `sectionType` back into
+ * `validateUpdateHomepageSectionInput` so `config` is always validated
+ * against the one shape it must match, same "type gates which fields are
+ * meaningful" convention `ad-policy.ts`/`menu-policy.ts` already use.
+ *
+ * `video_block`/`ad_slot`/`custom_widget_block` deliberately NOT included —
+ * see migration `044_awcms_mini_news_portal_homepage_sections_schema.sql`'s
+ * header comment for why (blocked on #639/#638, and explicitly out of scope
+ * per the issue body, respectively). A `static_page_block` was considered
+ * and dropped for the same reason — no existing public page-detail
+ * visibility-tested query exists yet to reuse.
+ */
+export type HomepageSectionType =
+  | "headline"
+  | "latest_posts"
+  | "featured_posts"
+  | "editor_picks"
+  | "category_grid"
+  | "gallery_block";
+
+export const HOMEPAGE_SECTION_TYPES: readonly HomepageSectionType[] = [
+  "headline",
+  "latest_posts",
+  "featured_posts",
+  "editor_picks",
+  "category_grid",
+  "gallery_block"
+];
+
+export function isHomepageSectionType(
+  value: unknown
+): value is HomepageSectionType {
+  return (
+    typeof value === "string" &&
+    (HOMEPAGE_SECTION_TYPES as string[]).includes(value)
+  );
+}
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SECTION_KEY_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+const LATEST_POSTS_DEFAULT_LIMIT = 5;
+const LATEST_POSTS_MAX_LIMIT = 20;
+const CURATED_POSTS_MIN = 1;
+const CURATED_POSTS_MAX = 20;
+const CATEGORY_GRID_MIN_CATEGORIES = 1;
+const CATEGORY_GRID_MAX_CATEGORIES = 8;
+const CATEGORY_GRID_DEFAULT_POSTS_PER_CATEGORY = 3;
+const CATEGORY_GRID_MAX_POSTS_PER_CATEGORY = 6;
+const GALLERY_MIN_ITEMS = 1;
+const GALLERY_MAX_ITEMS = 20;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isUuid(value: unknown): value is string {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+function isUuidArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => isUuid(item));
+}
+
+export type HeadlineSectionConfig = { postId: string };
+export type LatestPostsSectionConfig = {
+  limit: number;
+  categorySlug: string | null;
+};
+export type CuratedPostsSectionConfig = { postIds: string[] };
+export type CategoryGridSectionConfig = {
+  categorySlugs: string[];
+  postsPerCategory: number;
+};
+export type GalleryBlockSectionConfig = {
+  mediaObjectIds: string[];
+  caption: string | null;
+};
+
+export type HomepageSectionConfigOf<T extends HomepageSectionType> =
+  T extends "headline"
+    ? HeadlineSectionConfig
+    : T extends "latest_posts"
+      ? LatestPostsSectionConfig
+      : T extends "featured_posts" | "editor_picks"
+        ? CuratedPostsSectionConfig
+        : T extends "category_grid"
+          ? CategoryGridSectionConfig
+          : T extends "gallery_block"
+            ? GalleryBlockSectionConfig
+            : never;
+
+function validateHeadlineConfig(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): HeadlineSectionConfig | null {
+  if (!isUuid(record.postId)) {
+    errors.push({
+      field: "config.postId",
+      message: "config.postId is required and must be a UUID."
+    });
+    return null;
+  }
+
+  return { postId: record.postId };
+}
+
+function validateLatestPostsConfig(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): LatestPostsSectionConfig | null {
+  let limit = LATEST_POSTS_DEFAULT_LIMIT;
+
+  if (record.limit !== undefined) {
+    if (
+      typeof record.limit !== "number" ||
+      !Number.isInteger(record.limit) ||
+      record.limit < 1 ||
+      record.limit > LATEST_POSTS_MAX_LIMIT
+    ) {
+      errors.push({
+        field: "config.limit",
+        message: `config.limit must be an integer between 1 and ${LATEST_POSTS_MAX_LIMIT}.`
+      });
+      return null;
+    }
+
+    limit = record.limit;
+  }
+
+  let categorySlug: string | null = null;
+
+  if (record.categorySlug !== undefined && record.categorySlug !== null) {
+    if (!isNonEmptyString(record.categorySlug)) {
+      errors.push({
+        field: "config.categorySlug",
+        message: "config.categorySlug must be a non-empty string when provided."
+      });
+      return null;
+    }
+
+    categorySlug = record.categorySlug.trim();
+  }
+
+  return { limit, categorySlug };
+}
+
+function validateCuratedPostsConfig(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): CuratedPostsSectionConfig | null {
+  if (
+    !isUuidArray(record.postIds) ||
+    record.postIds.length < CURATED_POSTS_MIN ||
+    record.postIds.length > CURATED_POSTS_MAX
+  ) {
+    errors.push({
+      field: "config.postIds",
+      message: `config.postIds is required and must be an array of ${CURATED_POSTS_MIN}-${CURATED_POSTS_MAX} UUIDs.`
+    });
+    return null;
+  }
+
+  return { postIds: record.postIds };
+}
+
+function validateCategoryGridConfig(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): CategoryGridSectionConfig | null {
+  if (
+    !Array.isArray(record.categorySlugs) ||
+    record.categorySlugs.length < CATEGORY_GRID_MIN_CATEGORIES ||
+    record.categorySlugs.length > CATEGORY_GRID_MAX_CATEGORIES ||
+    !record.categorySlugs.every((item) => isNonEmptyString(item))
+  ) {
+    errors.push({
+      field: "config.categorySlugs",
+      message: `config.categorySlugs is required and must be an array of ${CATEGORY_GRID_MIN_CATEGORIES}-${CATEGORY_GRID_MAX_CATEGORIES} non-empty strings.`
+    });
+    return null;
+  }
+
+  let postsPerCategory = CATEGORY_GRID_DEFAULT_POSTS_PER_CATEGORY;
+
+  if (record.postsPerCategory !== undefined) {
+    if (
+      typeof record.postsPerCategory !== "number" ||
+      !Number.isInteger(record.postsPerCategory) ||
+      record.postsPerCategory < 1 ||
+      record.postsPerCategory > CATEGORY_GRID_MAX_POSTS_PER_CATEGORY
+    ) {
+      errors.push({
+        field: "config.postsPerCategory",
+        message: `config.postsPerCategory must be an integer between 1 and ${CATEGORY_GRID_MAX_POSTS_PER_CATEGORY}.`
+      });
+      return null;
+    }
+
+    postsPerCategory = record.postsPerCategory;
+  }
+
+  return {
+    categorySlugs: record.categorySlugs.map((slug) => (slug as string).trim()),
+    postsPerCategory
+  };
+}
+
+function validateGalleryBlockConfig(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): GalleryBlockSectionConfig | null {
+  if (
+    !isUuidArray(record.mediaObjectIds) ||
+    record.mediaObjectIds.length < GALLERY_MIN_ITEMS ||
+    record.mediaObjectIds.length > GALLERY_MAX_ITEMS
+  ) {
+    errors.push({
+      field: "config.mediaObjectIds",
+      message: `config.mediaObjectIds is required and must be an array of ${GALLERY_MIN_ITEMS}-${GALLERY_MAX_ITEMS} UUIDs.`
+    });
+    return null;
+  }
+
+  let caption: string | null = null;
+
+  if (record.caption !== undefined && record.caption !== null) {
+    if (!isNonEmptyString(record.caption)) {
+      errors.push({
+        field: "config.caption",
+        message: "config.caption must be a non-empty string when provided."
+      });
+      return null;
+    }
+
+    caption = record.caption.trim();
+  }
+
+  return { mediaObjectIds: record.mediaObjectIds, caption };
+}
+
+/** Discriminated `config` validator — the ONLY place a `sectionType` is mapped to its allowed `config_json` shape. `rawConfig` must already be a plain object (checked by the caller). */
+export function validateHomepageSectionConfig(
+  sectionType: HomepageSectionType,
+  rawConfig: unknown,
+  errors: ValidationError[]
+): Record<string, unknown> | null {
+  const record = (
+    typeof rawConfig === "object" &&
+    rawConfig !== null &&
+    !Array.isArray(rawConfig)
+      ? rawConfig
+      : {}
+  ) as Record<string, unknown>;
+
+  switch (sectionType) {
+    case "headline":
+      return validateHeadlineConfig(record, errors);
+    case "latest_posts":
+      return validateLatestPostsConfig(record, errors);
+    case "featured_posts":
+    case "editor_picks":
+      return validateCuratedPostsConfig(record, errors);
+    case "category_grid":
+      return validateCategoryGridConfig(record, errors);
+    case "gallery_block":
+      return validateGalleryBlockConfig(record, errors);
+    default:
+      return null;
+  }
+}
+
+function parseOptionalDate(
+  value: unknown,
+  field: string,
+  errors: ValidationError[]
+): Date | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    errors.push({
+      field,
+      message: `${field} must be an ISO 8601 datetime string.`
+    });
+    return null;
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    errors.push({
+      field,
+      message: `${field} must be a valid ISO 8601 datetime.`
+    });
+    return null;
+  }
+
+  return parsed;
+}
+
+export type CreateHomepageSectionInput = {
+  sectionKey: string;
+  sectionType: HomepageSectionType;
+  title: string | null;
+  config: Record<string, unknown>;
+  sortOrder: number;
+  isEnabled: boolean;
+  startsAt: Date | null;
+  endsAt: Date | null;
+};
+
+export type CreateHomepageSectionValidationResult =
+  | { valid: true; value: CreateHomepageSectionInput }
+  | { valid: false; errors: ValidationError[] };
+
+export function validateCreateHomepageSectionInput(
+  body: unknown
+): CreateHomepageSectionValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  if (
+    !isNonEmptyString(record.sectionKey) ||
+    !SECTION_KEY_PATTERN.test(record.sectionKey.trim())
+  ) {
+    errors.push({
+      field: "sectionKey",
+      message:
+        "sectionKey is required and must match ^[a-z0-9][a-z0-9_-]{0,63}$."
+    });
+  }
+
+  if (!isHomepageSectionType(record.sectionType)) {
+    errors.push({
+      field: "sectionType",
+      message: `sectionType must be one of ${HOMEPAGE_SECTION_TYPES.join(", ")}.`
+    });
+  }
+
+  let title: string | null = null;
+
+  if (record.title !== undefined && record.title !== null) {
+    if (typeof record.title !== "string") {
+      errors.push({ field: "title", message: "title must be a string." });
+    } else {
+      title = record.title.trim() || null;
+    }
+  }
+
+  let sortOrder = 0;
+
+  if (record.sortOrder !== undefined) {
+    if (
+      typeof record.sortOrder !== "number" ||
+      !Number.isInteger(record.sortOrder)
+    ) {
+      errors.push({
+        field: "sortOrder",
+        message: "sortOrder must be an integer."
+      });
+    } else {
+      sortOrder = record.sortOrder;
+    }
+  }
+
+  const startsAt = parseOptionalDate(record.startsAt, "startsAt", errors);
+  const endsAt = parseOptionalDate(record.endsAt, "endsAt", errors);
+
+  if (startsAt && endsAt && endsAt <= startsAt) {
+    errors.push({ field: "endsAt", message: "endsAt must be after startsAt." });
+  }
+
+  let config: Record<string, unknown> | null = null;
+
+  if (isHomepageSectionType(record.sectionType)) {
+    config = validateHomepageSectionConfig(
+      record.sectionType,
+      record.config,
+      errors
+    );
+  }
+
+  if (
+    errors.length > 0 ||
+    !config ||
+    !isHomepageSectionType(record.sectionType)
+  ) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      sectionKey: record.sectionKey as string,
+      sectionType: record.sectionType,
+      title,
+      config,
+      sortOrder,
+      isEnabled: record.isEnabled !== false,
+      startsAt,
+      endsAt
+    }
+  };
+}
+
+export type UpdateHomepageSectionInput = {
+  title?: string | null;
+  config?: Record<string, unknown>;
+  sortOrder?: number;
+  isEnabled?: boolean;
+  startsAt?: Date | null;
+  endsAt?: Date | null;
+};
+
+export type UpdateHomepageSectionValidationResult =
+  | { valid: true; value: UpdateHomepageSectionInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** `currentSectionType` — the existing row's immutable type, supplied by the caller (`homepage-section-directory.ts`'s `updateHomepageSection`, which fetches the row first) — `config`, when present in the request, is validated against THIS type; a request cannot change `sectionType`. */
+export function validateUpdateHomepageSectionInput(
+  body: unknown,
+  currentSectionType: HomepageSectionType
+): UpdateHomepageSectionValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  const value: UpdateHomepageSectionInput = {};
+
+  if (
+    record.sectionType !== undefined &&
+    record.sectionType !== currentSectionType
+  ) {
+    errors.push({
+      field: "sectionType",
+      message: "sectionType cannot be changed after creation."
+    });
+  }
+
+  if (record.title !== undefined) {
+    if (record.title !== null && typeof record.title !== "string") {
+      errors.push({
+        field: "title",
+        message: "title must be a string or null."
+      });
+    } else {
+      value.title =
+        typeof record.title === "string" ? record.title.trim() || null : null;
+    }
+  }
+
+  if (record.sortOrder !== undefined) {
+    if (
+      typeof record.sortOrder !== "number" ||
+      !Number.isInteger(record.sortOrder)
+    ) {
+      errors.push({
+        field: "sortOrder",
+        message: "sortOrder must be an integer."
+      });
+    } else {
+      value.sortOrder = record.sortOrder;
+    }
+  }
+
+  if (record.isEnabled !== undefined) {
+    if (typeof record.isEnabled !== "boolean") {
+      errors.push({
+        field: "isEnabled",
+        message: "isEnabled must be a boolean."
+      });
+    } else {
+      value.isEnabled = record.isEnabled;
+    }
+  }
+
+  if (record.startsAt !== undefined) {
+    value.startsAt = parseOptionalDate(record.startsAt, "startsAt", errors);
+  }
+
+  if (record.endsAt !== undefined) {
+    value.endsAt = parseOptionalDate(record.endsAt, "endsAt", errors);
+  }
+
+  if (
+    value.startsAt !== undefined &&
+    value.endsAt !== undefined &&
+    value.startsAt &&
+    value.endsAt &&
+    value.endsAt <= value.startsAt
+  ) {
+    errors.push({ field: "endsAt", message: "endsAt must be after startsAt." });
+  }
+
+  if (record.config !== undefined) {
+    const config = validateHomepageSectionConfig(
+      currentSectionType,
+      record.config,
+      errors
+    );
+
+    if (config) {
+      value.config = config;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/news-portal/domain/homepage-section-rendering.ts
+++ b/src/modules/news-portal/domain/homepage-section-rendering.ts
@@ -1,0 +1,131 @@
+import { escapeHtml } from "../../../lib/html/escape";
+import {
+  renderContentJsonToHtml,
+  type ResolvedGalleryMediaUrls
+} from "../../blog-content/domain/content-block-rendering";
+
+/**
+ * Whitelist-based HTML renderer for editorial homepage sections (Issue
+ * #637). Every function here only ever emits text through `escapeHtml` (or
+ * delegates to `content-block-rendering.ts`'s already-whitelisted gallery
+ * renderer for `gallery_block`) — there is no raw-HTML field on any section
+ * `config`, so this renderer cannot emit a `<script>`/`<iframe>`/`<embed>`
+ * tag no matter what a section's `config_json` contains. Same "degrade,
+ * don't 500" convention as `content-block-rendering.ts`/
+ * `public-page-rendering.ts`: a section whose curated references have since
+ * become unpublished/unverified renders its configured empty state, never
+ * a broken link or a thrown error.
+ */
+export type HomepageSectionPostCard = {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  imageUrl: string | null;
+  imageAlt: string | null;
+};
+
+function renderPostCard(
+  basePath: string,
+  card: HomepageSectionPostCard
+): string {
+  const image = card.imageUrl
+    ? `<img src="${escapeHtml(card.imageUrl)}" alt="${escapeHtml(card.imageAlt ?? "")}" loading="lazy">`
+    : "";
+  const excerpt = card.excerpt ? `<p>${escapeHtml(card.excerpt)}</p>` : "";
+
+  return `<article class="homepage-section-post">
+  ${image}
+  <h3><a href="${escapeHtml(basePath)}/${escapeHtml(card.slug)}">${escapeHtml(card.title)}</a></h3>
+  ${excerpt}
+</article>`;
+}
+
+/** `headline`/`featured_posts`/`editor_picks`/`latest_posts` share this body renderer — a flat list of cards, empty state when the resolved list is empty (every curated id turned out unpublished/cross-tenant, or a chronological query genuinely had nothing to show). */
+export function renderPostCardListHtml(
+  basePath: string,
+  cards: readonly HomepageSectionPostCard[],
+  emptyMessage: string
+): string {
+  if (cards.length === 0) {
+    return `<p class="homepage-section-empty">${escapeHtml(emptyMessage)}</p>`;
+  }
+
+  return `<div class="homepage-section-posts">
+${cards.map((card) => renderPostCard(basePath, card)).join("\n")}
+</div>`;
+}
+
+export type HomepageSectionCategoryGroup = {
+  categoryName: string;
+  categorySlug: string;
+  posts: readonly HomepageSectionPostCard[];
+};
+
+/** `category_grid` — one card list per category, category name as a sub-heading; a category with zero currently-published posts still renders its (empty) group rather than being silently dropped, so admins can see their configured grid is wired up correctly. */
+export function renderCategoryGridSectionHtml(
+  basePath: string,
+  groups: readonly HomepageSectionCategoryGroup[],
+  emptyMessage: string
+): string {
+  return `<div class="homepage-section-category-grid">
+${groups
+  .map(
+    (group) => `<div class="homepage-section-category-group">
+  <h3>${escapeHtml(group.categoryName)}</h3>
+  ${renderPostCardListHtml(basePath, group.posts, emptyMessage)}
+</div>`
+  )
+  .join("\n")}
+</div>`;
+}
+
+/** `gallery_block` — reuses `content-block-rendering.ts`'s already-whitelisted gallery renderer verbatim (same code path a post's own gallery block uses) rather than emitting `<img>` tags independently here, so there is exactly one place in the codebase that decides how a gallery of `mediaObjectId`s becomes HTML. */
+export function renderGalleryBlockSectionHtml(
+  mediaObjectIds: readonly string[],
+  caption: string | null,
+  resolvedMediaUrls: ResolvedGalleryMediaUrls,
+  emptyMessage: string
+): string {
+  const html = renderContentJsonToHtml(
+    {
+      blocks: [
+        {
+          type: "gallery",
+          items: mediaObjectIds.map((mediaObjectId) => ({
+            mediaType: "image",
+            mediaObjectId,
+            caption: caption ?? undefined
+          }))
+        }
+      ]
+    },
+    resolvedMediaUrls
+  );
+
+  return (
+    html || `<p class="homepage-section-empty">${escapeHtml(emptyMessage)}</p>`
+  );
+}
+
+export type RenderedHomepageSection = {
+  sectionKey: string;
+  sectionType: string;
+  title: string | null;
+  bodyHtml: string;
+};
+
+function renderSectionShell(section: RenderedHomepageSection): string {
+  const heading = section.title ? `<h2>${escapeHtml(section.title)}</h2>` : "";
+
+  return `<section class="homepage-section homepage-section-${escapeHtml(section.sectionType)}" data-section-key="${escapeHtml(section.sectionKey)}">
+${heading}
+${section.bodyHtml}
+</section>`;
+}
+
+/** Composes every already-rendered section (in the caller-supplied order — `sort_order`) into the `/news` homepage body. */
+export function renderHomepageSectionsHtml(
+  sections: readonly RenderedHomepageSection[]
+): string {
+  return sections.map(renderSectionShell).join("\n");
+}

--- a/src/modules/news-portal/module.ts
+++ b/src/modules/news-portal/module.ts
@@ -4,17 +4,36 @@ import { NEWS_MEDIA_PERMISSION_ACTIVITY_CODE } from "./domain/news-media-permiss
 export const newsPortalModule = defineModule({
   key: "news_portal",
   name: "News Portal",
-  version: "0.2.0",
+  version: "0.3.0",
   status: "active",
   description:
-    "Editorial + media layer conceptually on top of blog_content/tenant_domain/visitor_analytics for a full-online, R2-only public news portal (epic `news_portal` #631-#642/#649). Issue #632 added ONLY the tenant module preset `news_portal_full_online_r2` (`module-management/domain/module-presets.ts`) and its activation readiness gate (`domain/news-portal-preset-readiness.ts`, `domain/news-media-r2-config.ts`, `application/apply-news-portal-preset.ts`). Issue #633 added the tenant-scoped R2-only media object registry (schema + domain/application helpers), permission constants only (not yet wired into this descriptor). Issue #634 (this update) adds the direct-to-R2 presigned upload flow — `POST /api/v1/media/news-images/upload-sessions` (create), `.../{id}/finalize` (real R2 `GET` + magic-byte MIME sniffing + server-side SHA-256 checksum, NOT `HEAD`-only — see `news-media-r2-verification.ts`), `.../{id}/cancel` — and is the first issue with a real HTTP surface, so `permissions`/`api` are now declared below (matching `NEWS_MEDIA_PERMISSIONS`, `news-media-permissions.ts`, exactly — see that file's own header for why #634 must reuse those constants rather than invent `media_objects.news_images.*` names from the issue's own body text). `navigation`/`settings`/`jobs`/`health` remain deliberately undeclared — no admin UI page, per-tenant setting, background job, or health check exists yet for this module specifically (same convention `visitor_analytics`, Issue #617, used before its own features landed). `dependencies` deliberately does NOT list blog_content/tenant_domain/visitor_analytics despite the prose relationship above: this module has zero functional code importing/calling into any of them yet, and `blog_content`/`tenant_domain` themselves only depend on foundation modules (never on each other) for the exact same reason (see their own module.ts) — declaring a hard dependency here would make the reverse-dependency guard (`evaluateModuleDisable`'s MODULE_REVERSE_DEPENDENCY_ACTIVE) block disabling blog_content/tenant_domain/visitor_analytics for EVERY tenant (news_portal is enabled by default like every module), which broke existing integration tests when first tried (see git history/PR discussion) and is not something #632's own scope justifies. The preset's own `enabledModuleKeys` ordering (`module-management/domain/module-presets.ts`'s `planEnableOrder`) is what sequences enabling blog_content/tenant_domain/visitor_analytics before news_portal WITHIN one preset application — a permanent hard dependency is not needed for that.",
+    "Editorial + media layer conceptually on top of blog_content/tenant_domain/visitor_analytics for a full-online, R2-only public news portal (epic `news_portal` #631-#642/#649). Issue #632 added ONLY the tenant module preset `news_portal_full_online_r2` (`module-management/domain/module-presets.ts`) and its activation readiness gate (`domain/news-portal-preset-readiness.ts`, `domain/news-media-r2-config.ts`, `application/apply-news-portal-preset.ts`). Issue #633 added the tenant-scoped R2-only media object registry (schema + domain/application helpers), permission constants only (not yet wired into this descriptor). Issue #634 adds the direct-to-R2 presigned upload flow — `POST /api/v1/media/news-images/upload-sessions` (create), `.../{id}/finalize` (real R2 `GET` + magic-byte MIME sniffing + server-side SHA-256 checksum, NOT `HEAD`-only — see `news-media-r2-verification.ts`), `.../{id}/cancel` — and is the first issue with a real HTTP surface, so `permissions`/`api` are now declared below (matching `NEWS_MEDIA_PERMISSIONS`, `news-media-permissions.ts`, exactly — see that file's own header for why #634 must reuse those constants rather than invent `media_objects.news_images.*` names from the issue's own body text). Issue #637 (this update) adds the editorial homepage section composer — `POST/GET /api/v1/news-portal/homepage-sections`, `PATCH/DELETE .../{id}` (`homepage_sections` activityCode, `read`/`configure` actions, same action pair `blog_content`'s ads/menus/widgets already use) plus a public composer (`homepage-section-composer.ts`) consumed by `/news/index.ts`, and its own admin UI page (`admin/news-portal/homepage-sections.astro`) — the first navigation-worthy admin screen this module ships, so `navigation` is now declared below too (one entry, same single-top-level-page-then-sub-navigation-inside-the-page convention `blog_content`'s single `/admin/blog` entry uses, even though this module only has one admin page so far). `settings`/`jobs`/`health` remain deliberately undeclared — no per-tenant setting, background job, or health check exists yet for this module specifically (same convention `visitor_analytics`, Issue #617, used before its own features landed). `dependencies` deliberately does NOT list blog_content/tenant_domain/visitor_analytics despite the prose relationship above: this module has zero functional code importing/calling into any of them yet, and `blog_content`/`tenant_domain` themselves only depend on foundation modules (never on each other) for the exact same reason (see their own module.ts) — declaring a hard dependency here would make the reverse-dependency guard (`evaluateModuleDisable`'s MODULE_REVERSE_DEPENDENCY_ACTIVE) block disabling blog_content/tenant_domain/visitor_analytics for EVERY tenant (news_portal is enabled by default like every module), which broke existing integration tests when first tried (see git history/PR discussion) and is not something #632's own scope justifies. The preset's own `enabledModuleKeys` ordering (`module-management/domain/module-presets.ts`'s `planEnableOrder`) is what sequences enabling blog_content/tenant_domain/visitor_analytics before news_portal WITHIN one preset application — a permanent hard dependency is not needed for that. Application code (`homepage-section-composer.ts`, `homepage-section-reference-validation.ts`) DOES import from `blog-content`'s application layer directly (posts/terms queries) — this is a normal cross-module TypeScript import, not the `dependencies` array above, which only governs enable/disable ordering/guards; Issue #636 already established the same cross-module import direction in reverse (`blog_content` importing from `news_portal`).",
   dependencies: ["tenant_admin", "identity_access"],
   type: "domain",
   api: {
     openApiPath: "openapi/awcms-mini-public-api.openapi.yaml",
     basePath: "/api/v1/media/news-images"
   },
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_news_portal_homepage_sections",
+      path: "/admin/news-portal/homepage-sections",
+      order: 80,
+      requiredPermission: "news_portal.homepage_sections.read"
+    }
+  ],
   permissions: [
+    {
+      activityCode: "homepage_sections",
+      action: "read",
+      description: "Read editorial homepage section configuration"
+    },
+    {
+      activityCode: "homepage_sections",
+      action: "configure",
+      description:
+        "Create, update, reorder, enable/disable, or delete editorial homepage sections"
+    },
     {
       activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
       action: "create",

--- a/src/pages/admin/news-portal/homepage-sections.astro
+++ b/src/pages/admin/news-portal/homepage-sections.astro
@@ -1,0 +1,559 @@
+---
+/**
+ * Editorial homepage section manager (Issue #637). `config` is a JSON
+ * textarea, same "structured JSON in a labeled textarea" convention
+ * `admin/blog/ads.astro`'s `placements` field and `admin/blog/menus.astro`'s
+ * menu items use — shape differs by `sectionType`
+ * (`homepage-section-policy.ts`'s `validateHomepageSectionConfig`), so a
+ * fixed per-type form isn't worth the complexity for a first admin screen.
+ * `sectionKey`/`sectionType` are immutable after creation (server rejects a
+ * `sectionType` change, see `validateUpdateHomepageSectionInput`) — shown
+ * as read-only text on the edit card, only chosen at creation.
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import StateNotice from "../../../components/ui/StateNotice.astro";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { listHomepageSections } from "../../../modules/news-portal/application/homepage-section-directory";
+import { HOMEPAGE_SECTION_TYPES } from "../../../modules/news-portal/domain/homepage-section-policy";
+import { createTranslator } from "../../../lib/i18n/translate";
+import { buildClientErrorMessages } from "../../../lib/i18n/error-messages";
+
+const context = Astro.locals.ssrContext;
+
+if (!context) {
+  throw new Error(
+    "admin/news-portal/homepage-sections.astro rendered without Astro.locals.ssrContext — src/middleware.ts should have redirected to /login before this page ever runs."
+  );
+}
+
+const t = await createTranslator(Astro.locals.locale);
+
+const CAN_READ = context.permissions.has(
+  permissionKey("news_portal", "homepage_sections", "read")
+);
+const CAN_CONFIGURE = context.permissions.has(
+  permissionKey("news_portal", "homepage_sections", "configure")
+);
+
+const clientStrings = {
+  createSuccess: t("admin.news_portal.homepage_sections.create_success"),
+  updateSuccess: t("admin.news_portal.homepage_sections.update_success"),
+  deleteSuccess: t("admin.news_portal.homepage_sections.delete_success"),
+  deleteReasonPrompt: t(
+    "admin.news_portal.homepage_sections.delete_reason_prompt"
+  ),
+  deleteConfirm: t("admin.news_portal.homepage_sections.delete_confirm"),
+  invalidConfigJson: t(
+    "admin.news_portal.homepage_sections.invalid_config_json"
+  ),
+  networkError: t("common.network_error"),
+  pleaseWait: t("common.please_wait"),
+  errorMessages: buildClientErrorMessages(t)
+};
+
+type SectionRow = Awaited<ReturnType<typeof listHomepageSections>>[number] & {
+  configJson: string;
+};
+
+let sections: SectionRow[] = [];
+let loadError = false;
+
+if (CAN_READ) {
+  try {
+    sections = await withTenant(
+      getDatabaseClient(),
+      context.tenantId,
+      async (tx) => {
+        const list = await listHomepageSections(tx, context.tenantId);
+        return list.map((section) => ({
+          ...section,
+          configJson: JSON.stringify(section.config, null, 2)
+        }));
+      }
+    );
+  } catch (error) {
+    console.error(
+      "admin/news-portal/homepage-sections.astro: failed to load sections",
+      error
+    );
+    loadError = true;
+  }
+}
+
+const EMPTY_CONFIG_JSON = "{}";
+
+function toDateTimeLocal(date: Date | null): string {
+  if (!date) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+---
+
+<AdminLayout title={t("admin.news_portal.homepage_sections.title")}>
+  {
+    !CAN_READ && (
+      <StateNotice
+        kind="denied"
+        title={t("admin.news_portal.access_denied_title")}
+        body={t("admin.news_portal.access_denied_body")}
+      />
+    )
+  }
+  {
+    CAN_READ && loadError && (
+      <StateNotice
+        kind="error"
+        title={t("common.error_title")}
+        body={t("common.error_body")}
+        retryLabel={t("common.retry")}
+        retryHref={Astro.url.pathname}
+      />
+    )
+  }
+  {
+    CAN_READ && !loadError && (
+      <div class="config-manager">
+        <div id="action-banner" class="action-banner" role="alert" hidden />
+        <script
+          type="application/json"
+          id="i18n-strings"
+          set:html={JSON.stringify(clientStrings)}
+        />
+
+        {sections.length === 0 ? (
+          <p class="empty-state">
+            {t("admin.news_portal.homepage_sections.no_sections")}
+          </p>
+        ) : (
+          sections.map((section) => (
+            <section class="section-card">
+              <h2>
+                {section.sectionKey}{" "}
+                <span class="section-type-badge">{section.sectionType}</span>
+              </h2>
+              {CAN_CONFIGURE && (
+                <form class="edit-config-form" data-id={section.id}>
+                  <label>
+                    {t("admin.news_portal.homepage_sections.field_title")}
+                    <input
+                      type="text"
+                      name="title"
+                      value={section.title ?? ""}
+                    />
+                  </label>
+                  <label>
+                    {t("admin.news_portal.homepage_sections.field_config")}
+                    <textarea name="config" rows="6" spellcheck="false">
+                      {section.configJson}
+                    </textarea>
+                    <span class="field-hint">
+                      {t("admin.news_portal.homepage_sections.config_hint")}
+                    </span>
+                  </label>
+                  <label>
+                    {t("admin.news_portal.homepage_sections.field_sort_order")}
+                    <input
+                      type="number"
+                      name="sortOrder"
+                      step="1"
+                      value={section.sortOrder}
+                    />
+                  </label>
+                  <label>
+                    {t("admin.news_portal.homepage_sections.field_starts_at")}
+                    <input
+                      type="datetime-local"
+                      name="startsAt"
+                      value={toDateTimeLocal(section.startsAt)}
+                    />
+                  </label>
+                  <label>
+                    {t("admin.news_portal.homepage_sections.field_ends_at")}
+                    <input
+                      type="datetime-local"
+                      name="endsAt"
+                      value={toDateTimeLocal(section.endsAt)}
+                    />
+                  </label>
+                  <label class="checkbox-label">
+                    <input
+                      type="checkbox"
+                      name="isEnabled"
+                      checked={section.isEnabled}
+                    />
+                    {t("admin.news_portal.homepage_sections.field_enabled")}
+                  </label>
+                  <button type="submit">
+                    {t("admin.news_portal.homepage_sections.save_button")}
+                  </button>
+                </form>
+              )}
+              {CAN_CONFIGURE && (
+                <button
+                  type="button"
+                  class="delete-config-button"
+                  data-id={section.id}
+                >
+                  {t("admin.news_portal.homepage_sections.delete_button")}
+                </button>
+              )}
+            </section>
+          ))
+        )}
+
+        {CAN_CONFIGURE && (
+          <details class="create-config">
+            <summary>
+              {t("admin.news_portal.homepage_sections.create_summary")}
+            </summary>
+            <form id="create-config-form" class="create-config-form">
+              <label>
+                {t("admin.news_portal.homepage_sections.field_section_key")}
+                <input type="text" name="sectionKey" required />
+              </label>
+              <label>
+                {t("admin.news_portal.homepage_sections.field_section_type")}
+                <select name="sectionType" required>
+                  {HOMEPAGE_SECTION_TYPES.map((type) => (
+                    <option value={type}>{type}</option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                {t("admin.news_portal.homepage_sections.field_title")}
+                <input type="text" name="title" />
+              </label>
+              <label>
+                {t("admin.news_portal.homepage_sections.field_config")}
+                <textarea name="config" rows="6" spellcheck="false">
+                  {EMPTY_CONFIG_JSON}
+                </textarea>
+                <span class="field-hint">
+                  {t("admin.news_portal.homepage_sections.config_hint")}
+                </span>
+              </label>
+              <label>
+                {t("admin.news_portal.homepage_sections.field_sort_order")}
+                <input type="number" name="sortOrder" step="1" value="0" />
+              </label>
+              <label>
+                {t("admin.news_portal.homepage_sections.field_starts_at")}
+                <input type="datetime-local" name="startsAt" />
+              </label>
+              <label>
+                {t("admin.news_portal.homepage_sections.field_ends_at")}
+                <input type="datetime-local" name="endsAt" />
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" name="isEnabled" checked />
+                {t("admin.news_portal.homepage_sections.field_enabled")}
+              </label>
+              <button type="submit">
+                {t("admin.news_portal.homepage_sections.create_submit")}
+              </button>
+            </form>
+          </details>
+        )}
+      </div>
+    )
+  }
+</AdminLayout>
+
+<style>
+  .config-manager {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-4);
+  }
+
+  .action-banner {
+    padding: var(--sp-2) var(--sp-3);
+    border-radius: var(--radius-sm);
+    font-size: var(--fs-sm);
+  }
+
+  .action-banner[data-variant="success"] {
+    background: color-mix(
+      in srgb,
+      var(--color-success) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-success);
+  }
+
+  .action-banner[data-variant="error"] {
+    background: color-mix(
+      in srgb,
+      var(--color-danger) 15%,
+      var(--color-surface)
+    );
+    border: 1px solid var(--color-danger);
+  }
+
+  .empty-state {
+    color: var(--color-text-muted);
+  }
+
+  .section-card {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .section-card h2 {
+    font-size: var(--fs-md);
+    margin: 0 0 var(--sp-2);
+  }
+
+  .section-type-badge {
+    font-size: var(--fs-xs);
+    font-weight: 400;
+    color: var(--color-text-muted);
+  }
+
+  .edit-config-form,
+  .create-config-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-2);
+    max-width: 560px;
+  }
+
+  .edit-config-form label,
+  .create-config-form label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    font-size: var(--fs-sm);
+  }
+
+  .checkbox-label {
+    flex-direction: row !important;
+    align-items: center;
+    gap: var(--sp-2) !important;
+  }
+
+  .edit-config-form input,
+  .edit-config-form textarea,
+  .edit-config-form select,
+  .create-config-form input,
+  .create-config-form select {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .edit-config-form textarea,
+  .create-config-form textarea {
+    font-family: var(--font-mono);
+    font-size: var(--fs-sm);
+  }
+
+  .field-hint {
+    color: var(--color-text-muted);
+    font-size: var(--fs-xs);
+  }
+
+  .edit-config-form button,
+  .create-config-form button {
+    align-self: flex-start;
+    background: var(--color-primary-strong);
+    color: var(--color-primary-contrast);
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-3);
+    min-height: 44px;
+    cursor: pointer;
+  }
+
+  .delete-config-button {
+    margin-top: var(--sp-2);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-danger-strong);
+    color: var(--color-danger-strong);
+    border-radius: var(--radius-sm);
+    padding: var(--sp-1) var(--sp-2);
+    min-height: 44px;
+    cursor: pointer;
+    font-size: var(--fs-xs);
+  }
+
+  .create-config {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-3);
+  }
+
+  .create-config summary {
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  input:focus-visible,
+  textarea:focus-visible,
+  select:focus-visible,
+  button:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+</style>
+
+<script>
+  import {
+    lockElement,
+    readClientStrings,
+    reloadAfterDelay,
+    showBanner,
+    submitJson
+  } from "../../../lib/ui/admin-form-client";
+
+  interface HomepageSectionManagerStrings {
+    createSuccess: string;
+    updateSuccess: string;
+    deleteSuccess: string;
+    deleteReasonPrompt: string;
+    deleteConfirm: string;
+    invalidConfigJson: string;
+    networkError: string;
+    pleaseWait: string;
+    errorMessages?: Record<string, string>;
+  }
+
+  const strings = readClientStrings<HomepageSectionManagerStrings>();
+
+  function submitButtonOf(form: HTMLFormElement): HTMLButtonElement | null {
+    return form.querySelector('button[type="submit"]');
+  }
+
+  function isoOrNull(value: FormDataEntryValue | null): string | null {
+    const raw = String(value ?? "").trim();
+    if (!raw) return null;
+    const date = new Date(raw);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+
+  document
+    .getElementById("create-config-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const form = event.target as HTMLFormElement;
+      const button = submitButtonOf(form);
+      if (button?.disabled) return;
+
+      const formData = new FormData(form);
+      let config: unknown;
+      try {
+        config = JSON.parse(String(formData.get("config") ?? "{}"));
+      } catch {
+        showBanner("action-banner", strings.invalidConfigJson, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const result = await submitJson(
+          "/api/v1/news-portal/homepage-sections",
+          "POST",
+          {
+            sectionKey: formData.get("sectionKey"),
+            sectionType: formData.get("sectionType"),
+            title: String(formData.get("title") ?? "").trim() || null,
+            config,
+            sortOrder: Number(formData.get("sortOrder") ?? 0),
+            isEnabled: formData.get("isEnabled") === "on",
+            startsAt: isoOrNull(formData.get("startsAt")),
+            endsAt: isoOrNull(formData.get("endsAt"))
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.createSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+
+  document.querySelectorAll(".edit-config-form").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const el = event.target as HTMLFormElement;
+      const button = submitButtonOf(el);
+      if (button?.disabled) return;
+
+      const formData = new FormData(el);
+      let config: unknown;
+      try {
+        config = JSON.parse(String(formData.get("config") ?? "{}"));
+      } catch {
+        showBanner("action-banner", strings.invalidConfigJson, "error");
+        return;
+      }
+
+      const unlock = button ? lockElement(button, strings.pleaseWait) : null;
+      try {
+        const id = el.dataset.id!;
+        const result = await submitJson(
+          `/api/v1/news-portal/homepage-sections/${id}`,
+          "PATCH",
+          {
+            title: String(formData.get("title") ?? "").trim() || null,
+            config,
+            sortOrder: Number(formData.get("sortOrder") ?? 0),
+            isEnabled: formData.get("isEnabled") === "on",
+            startsAt: isoOrNull(formData.get("startsAt")),
+            endsAt: isoOrNull(formData.get("endsAt"))
+          },
+          strings
+        );
+
+        showBanner(
+          "action-banner",
+          result.ok ? strings.updateSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock?.();
+      }
+    });
+  });
+
+  document.querySelectorAll(".delete-config-button").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const el = button as HTMLButtonElement;
+      if (el.disabled) return;
+
+      const reason = window.prompt(strings.deleteReasonPrompt);
+      if (!reason || reason.trim().length === 0) return;
+      if (!window.confirm(strings.deleteConfirm)) return;
+
+      const unlock = lockElement(el, strings.pleaseWait);
+      try {
+        const id = el.dataset.id!;
+        const result = await submitJson(
+          `/api/v1/news-portal/homepage-sections/${id}`,
+          "DELETE",
+          { reason },
+          strings
+        );
+        showBanner(
+          "action-banner",
+          result.ok ? strings.deleteSuccess : result.message,
+          result.ok ? "success" : "error"
+        );
+        if (result.ok) reloadAfterDelay();
+      } finally {
+        unlock();
+      }
+    });
+  });
+</script>

--- a/src/pages/api/v1/news-portal/homepage-sections/[id].ts
+++ b/src/pages/api/v1/news-portal/homepage-sections/[id].ts
@@ -1,0 +1,230 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchHomepageSectionById,
+  softDeleteHomepageSection,
+  updateHomepageSection
+} from "../../../../../modules/news-portal/application/homepage-section-directory";
+import { validateHomepageSectionReferences } from "../../../../../modules/news-portal/application/homepage-section-reference-validation";
+import { validateUpdateHomepageSectionInput } from "../../../../../modules/news-portal/domain/homepage-section-policy";
+import { validateDeleteReasonInput } from "../../../../../modules/blog-content/domain/content-validation";
+
+const CONFIGURE_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "homepage_sections",
+  action: "configure" as const
+};
+
+/** `PATCH /api/v1/news-portal/homepage-sections/{id}` (Issue #637) — partial update; `sortOrder` is how an admin reorders sections (no separate bulk-reorder endpoint, same "just another patchable field" convention `widget-directory.ts`'s `updateWidget` uses). `sectionType` is immutable — see `homepage-section-policy.ts`. */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Homepage section id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchHomepageSectionById(tx, tenantId, id);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Homepage section not found.");
+    }
+
+    const validation = validateUpdateHomepageSectionInput(
+      body,
+      existing.sectionType
+    );
+
+    if (!validation.valid) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "Homepage section update is invalid.",
+        {},
+        validation.errors
+      );
+    }
+
+    const input = validation.value;
+
+    if (input.config) {
+      const referenceValidation = await validateHomepageSectionReferences(
+        tx,
+        tenantId,
+        existing.sectionType,
+        input.config
+      );
+
+      if (!referenceValidation.valid) {
+        return fail(
+          422,
+          "HOMEPAGE_SECTION_REFERENCE_INVALID",
+          "Homepage section references invalid or inaccessible content.",
+          {},
+          referenceValidation.errors
+        );
+      }
+    }
+
+    const updated = await updateHomepageSection(tx, tenantId, id, input);
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Homepage section not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "news_portal",
+      action: "news_portal.homepage_section.updated",
+      resourceType: "news_portal_homepage_section",
+      resourceId: id,
+      severity: "info",
+      message: `Homepage section updated: ${updated.sectionKey}.`,
+      correlationId
+    });
+
+    log("info", "news-portal.homepage_section.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "news_portal",
+      sectionId: id
+    });
+
+    return ok(updated);
+  });
+};
+
+/** `DELETE /api/v1/news-portal/homepage-sections/{id}` (Issue #637) — soft-delete. `reason` required, same convention every other soft-deletable resource in this repo uses. */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Homepage section id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const validation = validateDeleteReasonInput(
+    await request.json().catch(() => null)
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "reason is required.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { reason } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchHomepageSectionById(tx, tenantId, id);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Homepage section not found.");
+    }
+
+    await softDeleteHomepageSection(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      id,
+      reason
+    );
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "news_portal",
+      action: "news_portal.homepage_section.deleted",
+      resourceType: "news_portal_homepage_section",
+      resourceId: id,
+      severity: "warning",
+      message: "Homepage section deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    log("info", "news-portal.homepage_section.deleted", {
+      correlationId,
+      tenantId,
+      moduleKey: "news_portal",
+      sectionId: id
+    });
+
+    return ok({ id, deleted: true });
+  });
+};

--- a/src/pages/api/v1/news-portal/homepage-sections/index.ts
+++ b/src/pages/api/v1/news-portal/homepage-sections/index.ts
@@ -1,0 +1,175 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  createHomepageSection,
+  listHomepageSections
+} from "../../../../../modules/news-portal/application/homepage-section-directory";
+import { validateHomepageSectionReferences } from "../../../../../modules/news-portal/application/homepage-section-reference-validation";
+import { validateCreateHomepageSectionInput } from "../../../../../modules/news-portal/domain/homepage-section-policy";
+
+const READ_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "homepage_sections",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "homepage_sections",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/news-portal/homepage-sections` (Issue #637) — list this tenant's non-deleted homepage sections (admin view: includes disabled/out-of-schedule rows). */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const sections = await listHomepageSections(tx, tenantId);
+
+    return ok({ sections });
+  });
+};
+
+/** `POST /api/v1/news-portal/homepage-sections` (Issue #637) — create a homepage section. `config` is validated for shape (domain layer) then for reference existence/tenant-ownership (`validateHomepageSectionReferences`) before the row is written — a request that fails either never creates a partially-written row. Not idempotent. */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+
+  const validation = validateCreateHomepageSectionInput(body);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Homepage section is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const referenceValidation = await validateHomepageSectionReferences(
+      tx,
+      tenantId,
+      input.sectionType,
+      input.config
+    );
+
+    if (!referenceValidation.valid) {
+      return fail(
+        422,
+        "HOMEPAGE_SECTION_REFERENCE_INVALID",
+        "Homepage section references invalid or inaccessible content.",
+        {},
+        referenceValidation.errors
+      );
+    }
+
+    let section;
+
+    try {
+      section = await createHomepageSection(tx, tenantId, input);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (
+        message.includes(
+          "awcms_mini_news_portal_homepage_sections_tenant_key_dedup"
+        )
+      ) {
+        return fail(
+          409,
+          "HOMEPAGE_SECTION_KEY_CONFLICT",
+          `sectionKey "${input.sectionKey}" is already in use.`
+        );
+      }
+
+      throw error;
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "news_portal",
+      action: "news_portal.homepage_section.created",
+      resourceType: "news_portal_homepage_section",
+      resourceId: section.id,
+      severity: "info",
+      message: `Homepage section created: ${section.sectionKey}.`,
+      correlationId
+    });
+
+    log("info", "news-portal.homepage_section.created", {
+      correlationId,
+      tenantId,
+      moduleKey: "news_portal",
+      sectionId: section.id
+    });
+
+    return ok(section);
+  });
+};

--- a/src/pages/news/index.ts
+++ b/src/pages/news/index.ts
@@ -17,6 +17,7 @@ import {
   renderPostSummaryListHtmlAtBasePath,
   renderPublicPageShell
 } from "../../modules/blog-content/domain/public-page-rendering";
+import { composeHomepageSectionsHtml } from "../../modules/news-portal/application/homepage-section-composer";
 
 /**
  * `GET /news` (Issue #560, epic #555) — public blog index, tenant-code-free
@@ -29,6 +30,15 @@ import {
  * disabled gate that function also enforces (an explicit Issue #560
  * acceptance criterion that does not exist yet for the legacy route — see
  * `src/modules/blog-content/README.md` §Rute publik `/news`).
+ *
+ * Issue #637 — the editorial homepage section composer renders ABOVE the
+ * plain chronological listing, page 1 only (sections are a curated
+ * "front page", pagination past page 1 is just the chronological archive
+ * — mixing the two there would be confusing). A tenant that has never
+ * configured any section (`composeHomepageSectionsHtml`'s
+ * `hasSections: false`, the overwhelming majority today) sees byte-for-byte
+ * the same page as before this issue — purely additive, never a
+ * replacement for the plain list.
  */
 export const GET: APIRoute = async ({ request, url }) => {
   try {
@@ -47,7 +57,13 @@ export const GET: APIRoute = async ({ request, url }) => {
         });
         const basePath = routeSettings.publicBasePath;
 
+        const composedSections =
+          page === 1
+            ? await composeHomepageSectionsHtml(tx, tenant.tenantId, basePath)
+            : { hasSections: false, html: "" };
+
         const bodyHtml = `<h1>${escapeHtml(tenant.tenantName)} ${escapeHtml(routeSettings.publicLabel)}</h1>
+${composedSections.hasSections ? composedSections.html : ""}
 <div class="posts">${renderPostSummaryListHtmlAtBasePath(basePath, posts.items, "No posts yet.")}</div>
 ${renderPaginationNavHtml(page, posts.hasNextPage, basePath)}`;
 

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -258,7 +258,8 @@ describe("database migration runner helpers", () => {
       "040_awcms_mini_visitor_analytics_session_lookup_index.sql",
       "041_awcms_mini_news_media_object_registry_schema.sql",
       "042_awcms_mini_news_media_permissions.sql",
-      "043_awcms_mini_news_portal_tenant_state_schema.sql"
+      "043_awcms_mini_news_portal_tenant_state_schema.sql",
+      "044_awcms_mini_news_portal_homepage_sections_schema.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/news-portal-homepage-sections.integration.test.ts
+++ b/tests/integration/news-portal-homepage-sections.integration.test.ts
@@ -738,4 +738,95 @@ suite("news_portal homepage sections (Issue #637)", () => {
     expect(response.text).toContain("media.example.test");
     expect(response.text).toContain("Gallery Caption");
   });
+
+  test("a section with a future startsAt or a past endsAt is hidden from /news (schedule window)", async () => {
+    const owner = await bootstrap();
+    const futurePost = await createAndPublishPost(owner, {
+      slug: "future-section-post"
+    });
+    const expiredPost = await createAndPublishPost(owner, {
+      slug: "expired-section-post"
+    });
+
+    await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-future",
+        sectionType: "headline",
+        config: { postId: futurePost.id },
+        startsAt: "2099-01-01T00:00:00.000Z"
+      }
+    });
+
+    await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-expired",
+        sectionType: "headline",
+        config: { postId: expiredPost.id },
+        endsAt: "2000-01-01T00:00:00.000Z"
+      }
+    });
+
+    const response = await invokeRaw(newsIndex, {
+      method: "GET",
+      path: "/news"
+    });
+    expect(response.status).toBe(200);
+    // Both posts remain reachable via the plain chronological list below the
+    // (empty, since neither section is in-window) composed section area —
+    // the schedule window only hides the SECTION wrapper, not the post
+    // itself. Absence of the section markup is what this test proves.
+    expect(response.text).not.toContain("homepage-section-headline");
+  });
+
+  test("sort_order controls the rendered order of multiple simultaneously-active sections on /news", async () => {
+    const owner = await bootstrap();
+    const firstPost = await createAndPublishPost(owner, {
+      slug: "first-section-post"
+    });
+    const secondPost = await createAndPublishPost(owner, {
+      slug: "second-section-post"
+    });
+
+    // Created out of visual order on purpose — sortOrder, not creation
+    // order, must determine render order.
+    await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-second",
+        sectionType: "headline",
+        config: { postId: secondPost.id },
+        sortOrder: 2
+      }
+    });
+    await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-first",
+        sectionType: "headline",
+        config: { postId: firstPost.id },
+        sortOrder: 1
+      }
+    });
+
+    const response = await invokeRaw(newsIndex, {
+      method: "GET",
+      path: "/news"
+    });
+    expect(response.status).toBe(200);
+    const firstIndex = response.text.indexOf("first-section-post");
+    const secondIndex = response.text.indexOf("second-section-post");
+    expect(firstIndex).toBeGreaterThan(-1);
+    expect(secondIndex).toBeGreaterThan(-1);
+    expect(firstIndex).toBeLessThan(secondIndex);
+  });
 });

--- a/tests/integration/news-portal-homepage-sections.integration.test.ts
+++ b/tests/integration/news-portal-homepage-sections.integration.test.ts
@@ -1,0 +1,741 @@
+/**
+ * Integration tests for Issue #637 (epic `news_portal`): the editorial
+ * homepage section composer — tenant-scoped/RLS-protected CRUD
+ * (`/api/v1/news-portal/homepage-sections`), reference validation (every
+ * post/category/media id in `config` must exist for the SAME tenant, and
+ * for `gallery_block` be a verified R2 media object), and public rendering
+ * on `/news` (page 1 only, additive — a tenant with zero sections sees the
+ * exact pre-#637 page).
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  invokeRaw,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { getDatabaseClient } from "../../src/lib/database/client";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { POST as createPost } from "../../src/pages/api/v1/blog/posts/index";
+import { POST as publishPost } from "../../src/pages/api/v1/blog/posts/[id]/publish";
+import { POST as createTerm } from "../../src/pages/api/v1/blog/terms/index";
+import {
+  GET as listSections,
+  POST as createSection
+} from "../../src/pages/api/v1/news-portal/homepage-sections/index";
+import {
+  DELETE as deleteSection,
+  PATCH as updateSection
+} from "../../src/pages/api/v1/news-portal/homepage-sections/[id]";
+import { GET as newsIndex } from "../../src/pages/news/index";
+
+import { withTenant } from "../../src/lib/database/tenant-context";
+import {
+  createPendingNewsMediaObject,
+  markNewsMediaObjectUploaded,
+  markNewsMediaObjectVerified
+} from "../../src/modules/news-portal/application/news-media-object-directory";
+import type { NewsMediaR2Config } from "../../src/modules/news-portal/domain/news-media-r2-config";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+const MEDIA_CONFIG: NewsMediaR2Config = {
+  enabled: true,
+  accountId: "acct",
+  accessKeyId: "news-key",
+  secretAccessKey: "news-secret",
+  bucket: "news-media-bucket",
+  publicBaseUrl: "https://media.example.test",
+  presignedUploadTtlSeconds: 300,
+  maxUploadBytes: 10_485_760,
+  allowedMimeTypes: ["image/jpeg", "image/png", "image/webp", "image/gif"],
+  pendingTtlMinutes: 60
+};
+
+type Bootstrap = {
+  tenantId: string;
+  tenantCode: string;
+  token: string;
+  tenantUserId: string;
+};
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const loginIdentifier = `${tenantCode}-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  const admin = getAdminSql();
+  const tenantUserRows = (await admin`
+    SELECT tu.id FROM awcms_mini_tenant_users tu
+    JOIN awcms_mini_identities i ON i.id = tu.identity_id
+    WHERE tu.tenant_id = ${setup.body.data.tenantId} AND i.login_identifier = ${loginIdentifier}
+  `) as { id: string }[];
+
+  return {
+    tenantId: setup.body.data.tenantId,
+    tenantCode,
+    token: login.body.data.token,
+    tenantUserId: tenantUserRows[0]!.id
+  };
+}
+
+function authHeaders(b: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": b.tenantId,
+    authorization: `Bearer ${b.token}`
+  };
+}
+
+/** A second, fully-independent tenant — `/setup/initialize` is a one-time wizard (only the first call in the process succeeds), so a second tenant must be seeded via raw SQL + a real login, never the wizard again. */
+async function seedSecondTenant(tenantCode: string): Promise<Bootstrap> {
+  const tenantId = crypto.randomUUID();
+  const loginIdentifier = `${tenantCode}-${OWNER_LOGIN}`;
+  const password = "integration-test-tenant-b-password";
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_mini_tenants
+      (id, tenant_code, tenant_name, legal_name, status, default_locale, default_theme)
+    VALUES
+      (${tenantId}, ${tenantCode}, ${tenantCode}, ${tenantCode}, 'active', 'en', 'light')
+  `;
+
+  const passwordHash = await Bun.password.hash(password);
+  let tenantUserId = "";
+
+  await admin.begin(async (tx) => {
+    await tx.unsafe(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+    const profile = (await tx`
+      INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', 'Tenant B User') RETURNING id
+    `) as { id: string }[];
+    const identity = (await tx`
+      INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profile[0]!.id}, ${loginIdentifier}, ${passwordHash})
+      RETURNING id
+    `) as { id: string }[];
+    const tenantUser = (await tx`
+      INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+      VALUES (${tenantId}, ${identity[0]!.id}) RETURNING id
+    `) as { id: string }[];
+    const role = (await tx`
+      INSERT INTO awcms_mini_roles (tenant_id, role_code, role_name)
+      VALUES (${tenantId}, 'full_access', 'Full Access') RETURNING id
+    `) as { id: string }[];
+    const permissions = (await tx`
+      SELECT id FROM awcms_mini_permissions
+      WHERE (module_key = 'news_portal' AND activity_code = 'homepage_sections')
+         OR (module_key = 'blog_content' AND activity_code = 'posts' AND action IN ('create', 'publish'))
+    `) as { id: string }[];
+
+    for (const permission of permissions) {
+      await tx`
+        INSERT INTO awcms_mini_role_permissions (tenant_id, role_id, permission_id)
+        VALUES (${tenantId}, ${role[0]!.id}, ${permission.id})
+      `;
+    }
+
+    await tx`
+      INSERT INTO awcms_mini_access_assignments (tenant_id, tenant_user_id, role_id)
+      VALUES (${tenantId}, ${tenantUser[0]!.id}, ${role[0]!.id})
+    `;
+
+    tenantUserId = tenantUser[0]!.id;
+  });
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier, password },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId, tenantCode, token: login.body.data.token, tenantUserId };
+}
+
+async function createAndPublishPost(
+  owner: Bootstrap,
+  overrides: Record<string, unknown> = {}
+): Promise<{ id: string; slug: string }> {
+  const slug = (overrides.slug as string) ?? `post-${crypto.randomUUID()}`;
+  const created = await invoke<{ data: { id: string; slug: string } }>(
+    createPost,
+    {
+      method: "POST",
+      path: "/api/v1/blog/posts",
+      headers: authHeaders(owner),
+      body: {
+        title: "Test Post",
+        slug,
+        contentJson: { blocks: [{ type: "paragraph", text: "Hello world" }] },
+        contentText: "Hello world",
+        locale: "en",
+        ...overrides
+      }
+    }
+  );
+  expect(created.status).toBe(200);
+  const postId = created.body.data.id;
+
+  const published = await invoke(publishPost, {
+    method: "POST",
+    path: `/api/v1/blog/posts/${postId}/publish`,
+    headers: { ...authHeaders(owner), "idempotency-key": crypto.randomUUID() },
+    params: { id: postId }
+  });
+  expect(published.status).toBe(200);
+
+  return { id: postId, slug: created.body.data.slug };
+}
+
+async function createCategoryTerm(
+  owner: Bootstrap,
+  slug: string
+): Promise<{ id: string; slug: string }> {
+  const result = await invoke<{ data: { id: string; slug: string } }>(
+    createTerm,
+    {
+      method: "POST",
+      path: "/api/v1/blog/terms",
+      headers: authHeaders(owner),
+      body: {
+        taxonomyType: "category",
+        parentId: null,
+        name: slug,
+        slug,
+        description: null
+      }
+    }
+  );
+  expect(result.status).toBe(200);
+  return result.body.data;
+}
+
+async function seedVerifiedMediaObject(tenantId: string): Promise<string> {
+  const sql = getDatabaseClient();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const created = await createPendingNewsMediaObject(
+      tx,
+      tenantId,
+      crypto.randomUUID(),
+      MEDIA_CONFIG,
+      { mimeType: "image/jpeg" }
+    );
+    await markNewsMediaObjectUploaded(tx, tenantId, created.id, {
+      sizeBytes: 12_345,
+      checksumSha256: "a".repeat(64)
+    });
+    const verified = await markNewsMediaObjectVerified(
+      tx,
+      tenantId,
+      crypto.randomUUID(),
+      created.id,
+      {}
+    );
+    return verified!.id;
+  });
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("news_portal homepage sections (Issue #637)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("create a headline section referencing an existing post succeeds", async () => {
+    const owner = await bootstrap();
+    const post = await createAndPublishPost(owner);
+
+    const response = await invoke<{
+      data: { sectionKey: string; sectionType: string };
+    }>(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-headline",
+        sectionType: "headline",
+        config: { postId: post.id }
+      }
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data.sectionKey).toBe("front-page-headline");
+    expect(response.body.data.sectionType).toBe("headline");
+  });
+
+  test("rejects a headline section referencing a post that does not exist (422)", async () => {
+    const owner = await bootstrap();
+
+    const response = await invoke<{ error: { code: string } }>(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-headline",
+        sectionType: "headline",
+        config: { postId: "99999999-9999-9999-9999-999999999999" }
+      }
+    });
+
+    expect(response.status).toBe(422);
+    expect(response.body.error.code).toBe("HOMEPAGE_SECTION_REFERENCE_INVALID");
+  });
+
+  test("rejects a headline section referencing another tenant's post (cross-tenant reference is indistinguishable from nonexistent)", async () => {
+    const owner = await bootstrap("crossa");
+    const otherTenant = await seedSecondTenant("crossb");
+    const otherPost = await createAndPublishPost(otherTenant);
+
+    const response = await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-headline",
+        sectionType: "headline",
+        config: { postId: otherPost.id }
+      }
+    });
+
+    expect(response.status).toBe(422);
+  });
+
+  test("rejects duplicate sectionKey for the same tenant (409)", async () => {
+    const owner = await bootstrap();
+    const post = await createAndPublishPost(owner);
+    const body = {
+      sectionKey: "front-page-headline",
+      sectionType: "headline",
+      config: { postId: post.id }
+    };
+
+    const first = await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body
+    });
+    expect(first.status).toBe(200);
+
+    const second = await invoke<{ error: { code: string } }>(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body
+    });
+    expect(second.status).toBe(409);
+    expect(second.body.error.code).toBe("HOMEPAGE_SECTION_KEY_CONFLICT");
+  });
+
+  test("gallery_block accepts a verified same-tenant media object and rejects an unverified/cross-tenant one", async () => {
+    const owner = await bootstrap("gallerya");
+    const verifiedMediaId = await seedVerifiedMediaObject(owner.tenantId);
+
+    const accepted = await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-gallery",
+        sectionType: "gallery_block",
+        config: { mediaObjectIds: [verifiedMediaId] }
+      }
+    });
+    expect(accepted.status).toBe(200);
+
+    const otherTenant = await seedSecondTenant("galleryb");
+    const otherMediaId = await seedVerifiedMediaObject(otherTenant.tenantId);
+
+    const rejected = await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-gallery-2",
+        sectionType: "gallery_block",
+        config: { mediaObjectIds: [otherMediaId] }
+      }
+    });
+    expect(rejected.status).toBe(422);
+  });
+
+  test("category_grid rejects a categorySlug that does not exist for this tenant", async () => {
+    const owner = await bootstrap();
+
+    const response = await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-categories",
+        sectionType: "category_grid",
+        config: { categorySlugs: ["does-not-exist"] }
+      }
+    });
+    expect(response.status).toBe(422);
+  });
+
+  test("PATCH updates title/sortOrder/isEnabled and rejects changing sectionType", async () => {
+    const owner = await bootstrap();
+    const post = await createAndPublishPost(owner);
+    const created = await invoke<{ data: { id: string } }>(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-headline",
+        sectionType: "headline",
+        config: { postId: post.id }
+      }
+    });
+    const id = created.body.data.id;
+
+    const updated = await invoke<{
+      data: { title: string; sortOrder: number; isEnabled: boolean };
+    }>(updateSection, {
+      method: "PATCH",
+      path: `/api/v1/news-portal/homepage-sections/${id}`,
+      headers: authHeaders(owner),
+      params: { id },
+      body: { title: "Top Story", sortOrder: 5, isEnabled: false }
+    });
+    expect(updated.status).toBe(200);
+    expect(updated.body.data.title).toBe("Top Story");
+    expect(updated.body.data.sortOrder).toBe(5);
+    expect(updated.body.data.isEnabled).toBe(false);
+
+    const rejected = await invoke(updateSection, {
+      method: "PATCH",
+      path: `/api/v1/news-portal/homepage-sections/${id}`,
+      headers: authHeaders(owner),
+      params: { id },
+      body: { sectionType: "gallery_block" }
+    });
+    expect(rejected.status).toBe(400);
+  });
+
+  test("DELETE soft-deletes a section; it disappears from the list and 404s on further update", async () => {
+    const owner = await bootstrap();
+    const post = await createAndPublishPost(owner);
+    const created = await invoke<{ data: { id: string } }>(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-headline",
+        sectionType: "headline",
+        config: { postId: post.id }
+      }
+    });
+    const id = created.body.data.id;
+
+    const deleted = await invoke(deleteSection, {
+      method: "DELETE",
+      path: `/api/v1/news-portal/homepage-sections/${id}`,
+      headers: authHeaders(owner),
+      params: { id },
+      body: { reason: "no longer needed" }
+    });
+    expect(deleted.status).toBe(200);
+
+    const list = await invoke<{ data: { sections: { id: string }[] } }>(
+      listSections,
+      {
+        method: "GET",
+        path: "/api/v1/news-portal/homepage-sections",
+        headers: authHeaders(owner)
+      }
+    );
+    expect(list.body.data.sections.map((s) => s.id)).not.toContain(id);
+
+    const updateAfterDelete = await invoke(updateSection, {
+      method: "PATCH",
+      path: `/api/v1/news-portal/homepage-sections/${id}`,
+      headers: authHeaders(owner),
+      params: { id },
+      body: { title: "still here?" }
+    });
+    expect(updateAfterDelete.status).toBe(404);
+  });
+
+  test("cross-tenant isolation: tenant B cannot see or update tenant A's section (404, not 403 — RLS makes it invisible, not merely forbidden)", async () => {
+    const owner = await bootstrap("isoa");
+    const post = await createAndPublishPost(owner);
+    const created = await invoke<{ data: { id: string } }>(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-headline",
+        sectionType: "headline",
+        config: { postId: post.id }
+      }
+    });
+    const id = created.body.data.id;
+
+    const tenantB = await seedSecondTenant("isob");
+
+    const list = await invoke<{ data: { sections: { id: string }[] } }>(
+      listSections,
+      {
+        method: "GET",
+        path: "/api/v1/news-portal/homepage-sections",
+        headers: authHeaders(tenantB)
+      }
+    );
+    expect(list.body.data.sections.map((s) => s.id)).not.toContain(id);
+
+    const update = await invoke(updateSection, {
+      method: "PATCH",
+      path: `/api/v1/news-portal/homepage-sections/${id}`,
+      headers: authHeaders(tenantB),
+      params: { id },
+      body: { title: "hijacked" }
+    });
+    expect(update.status).toBe(404);
+  });
+
+  test("a tenant user without homepage_sections permissions is denied (403) on read and create", async () => {
+    const owner = await bootstrap();
+    const post = await createAndPublishPost(owner);
+    const admin = getAdminSql();
+    const passwordHash = await Bun.password.hash("no-permissions-password");
+    const noPermLogin = "no-perm@example.com";
+    let noPermTenantUserId = "";
+
+    await admin.begin(async (tx) => {
+      await tx.unsafe(`SET LOCAL app.current_tenant_id = '${owner.tenantId}'`);
+      const profile = (await tx`
+        INSERT INTO awcms_mini_profiles (tenant_id, profile_type, display_name)
+        VALUES (${owner.tenantId}, 'person', 'No Perm User') RETURNING id
+      `) as { id: string }[];
+      const identity = (await tx`
+        INSERT INTO awcms_mini_identities (tenant_id, profile_id, login_identifier, password_hash)
+        VALUES (${owner.tenantId}, ${profile[0]!.id}, ${noPermLogin}, ${passwordHash})
+        RETURNING id
+      `) as { id: string }[];
+      const tenantUser = (await tx`
+        INSERT INTO awcms_mini_tenant_users (tenant_id, identity_id)
+        VALUES (${owner.tenantId}, ${identity[0]!.id}) RETURNING id
+      `) as { id: string }[];
+      noPermTenantUserId = tenantUser[0]!.id;
+    });
+
+    const login = await invoke<{ data: { token: string } }>(authLogin, {
+      method: "POST",
+      path: "/api/v1/auth/login",
+      headers: {
+        "content-type": "application/json",
+        "x-awcms-mini-tenant-id": owner.tenantId
+      },
+      body: {
+        loginIdentifier: noPermLogin,
+        password: "no-permissions-password"
+      },
+      cookies: createCookieJar()
+    });
+    expect(login.status).toBe(200);
+
+    const noPermUser: Bootstrap = {
+      tenantId: owner.tenantId,
+      tenantCode: owner.tenantCode,
+      token: login.body.data.token,
+      tenantUserId: noPermTenantUserId
+    };
+
+    const list = await invoke(listSections, {
+      method: "GET",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(noPermUser)
+    });
+    expect(list.status).toBe(403);
+
+    const create = await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(noPermUser),
+      body: {
+        sectionKey: "front-page-headline",
+        sectionType: "headline",
+        config: { postId: post.id }
+      }
+    });
+    expect(create.status).toBe(403);
+  });
+
+  test("a tenant with zero homepage sections renders /news exactly as before Issue #637 (no homepage-section markup)", async () => {
+    const owner = await bootstrap();
+    await createAndPublishPost(owner, { slug: "plain-post" });
+
+    const index = await invokeRaw(newsIndex, { method: "GET", path: "/news" });
+    expect(index.status).toBe(200);
+    expect(index.text).toContain("plain-post");
+    expect(index.text).not.toContain("homepage-section");
+  });
+
+  test("an enabled headline section renders on /news; a disabled one does not", async () => {
+    const owner = await bootstrap();
+    const post = await createAndPublishPost(owner, { slug: "headline-post" });
+
+    await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-headline",
+        sectionType: "headline",
+        title: "Top Story",
+        config: { postId: post.id }
+      }
+    });
+
+    const enabled = await invokeRaw(newsIndex, {
+      method: "GET",
+      path: "/news"
+    });
+    expect(enabled.status).toBe(200);
+    expect(enabled.text).toContain("homepage-section-headline");
+    expect(enabled.text).toContain("Top Story");
+    expect(enabled.text).toContain("headline-post");
+
+    const sections = await invoke<{ data: { sections: { id: string }[] } }>(
+      listSections,
+      {
+        method: "GET",
+        path: "/api/v1/news-portal/homepage-sections",
+        headers: authHeaders(owner)
+      }
+    );
+    const sectionId = sections.body.data.sections[0]!.id;
+
+    await invoke(updateSection, {
+      method: "PATCH",
+      path: `/api/v1/news-portal/homepage-sections/${sectionId}`,
+      headers: authHeaders(owner),
+      params: { id: sectionId },
+      body: { isEnabled: false }
+    });
+
+    const disabled = await invokeRaw(newsIndex, {
+      method: "GET",
+      path: "/news"
+    });
+    expect(disabled.text).not.toContain("homepage-section-headline");
+  });
+
+  test("a curated post that becomes unpublished/removed after configuration silently disappears from the section (degrade, don't 500)", async () => {
+    const owner = await bootstrap();
+    const post = await createAndPublishPost(owner, { slug: "curated-post" });
+
+    await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-featured",
+        sectionType: "featured_posts",
+        config: { postIds: [post.id] }
+      }
+    });
+
+    const sql = getDatabaseClient();
+    await withTenant(
+      sql,
+      owner.tenantId,
+      (tx) =>
+        tx`UPDATE awcms_mini_blog_posts SET status = 'draft' WHERE id = ${post.id}`
+    );
+
+    const response = await invokeRaw(newsIndex, {
+      method: "GET",
+      path: "/news"
+    });
+    expect(response.status).toBe(200);
+    expect(response.text).not.toContain("curated-post");
+  });
+
+  test("gallery_block section renders the resolved image on /news via the shared whitelisted gallery renderer", async () => {
+    const owner = await bootstrap();
+    const mediaId = await seedVerifiedMediaObject(owner.tenantId);
+
+    await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-gallery",
+        sectionType: "gallery_block",
+        config: { mediaObjectIds: [mediaId], caption: "Gallery Caption" }
+      }
+    });
+
+    const response = await invokeRaw(newsIndex, {
+      method: "GET",
+      path: "/news"
+    });
+    expect(response.status).toBe(200);
+    expect(response.text).toContain("media.example.test");
+    expect(response.text).toContain("Gallery Caption");
+  });
+});

--- a/tests/modules/news-portal-module.test.ts
+++ b/tests/modules/news-portal-module.test.ts
@@ -26,12 +26,11 @@ describe("news_portal module descriptor (Issue #632, extended #634)", () => {
     ]);
   });
 
-  test("Issue #634 declares permissions + api now that a real HTTP surface exists, but still leaves navigation/settings/jobs/health undeclared", () => {
-    // navigation/settings/jobs/health still have no real feature backing
-    // them (no admin UI page, no per-tenant setting, no background job, no
-    // health check) — same "only claim a capability once it genuinely
-    // exists" convention visitor_analytics established (Issue #617).
-    expect(newsPortalModule.navigation).toBeUndefined();
+  test("Issue #634 declares permissions + api now that a real HTTP surface exists; Issue #637 adds navigation (one admin page) but still leaves settings/jobs/health undeclared", () => {
+    // settings/jobs/health still have no real feature backing them (no
+    // per-tenant setting, no background job, no health check) — same
+    // "only claim a capability once it genuinely exists" convention
+    // visitor_analytics established (Issue #617).
     expect(newsPortalModule.settings).toBeUndefined();
     expect(newsPortalModule.jobs).toBeUndefined();
     expect(newsPortalModule.health).toBeUndefined();
@@ -41,11 +40,22 @@ describe("news_portal module descriptor (Issue #632, extended #634)", () => {
       basePath: "/api/v1/media/news-images"
     });
 
+    expect(newsPortalModule.navigation).toEqual([
+      {
+        labelKey: "admin.layout.nav_news_portal_homepage_sections",
+        path: "/admin/news-portal/homepage-sections",
+        order: 80,
+        requiredPermission: "news_portal.homepage_sections.read"
+      }
+    ]);
+
     expect(newsPortalModule.permissions).toBeDefined();
   });
 
-  test("every declared permission's activityCode/action reproduces exactly one NEWS_MEDIA_PERMISSIONS constant from #633/#634 — no invented/duplicated/orphaned permission key", () => {
-    const permissions = newsPortalModule.permissions ?? [];
+  test("every declared `media` activityCode permission reproduces exactly one NEWS_MEDIA_PERMISSIONS constant from #633/#634 — no invented/duplicated/orphaned permission key", () => {
+    const permissions = (newsPortalModule.permissions ?? []).filter(
+      (p) => p.activityCode === "media"
+    );
     const expectedKeys = new Set(Object.values(NEWS_MEDIA_PERMISSIONS));
 
     expect(permissions.length).toBe(expectedKeys.size);
@@ -59,7 +69,21 @@ describe("news_portal module descriptor (Issue #632, extended #634)", () => {
     expect(declaredKeys.length).toBe(new Set(declaredKeys).size);
 
     for (const permission of permissions) {
-      expect(permission.activityCode).toBe("media");
+      expect(permission.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("Issue #637 declares exactly the homepage_sections read/configure permission pair", () => {
+    const permissions = (newsPortalModule.permissions ?? []).filter(
+      (p) => p.activityCode === "homepage_sections"
+    );
+
+    expect(permissions.map((p) => p.action).sort()).toEqual([
+      "configure",
+      "read"
+    ]);
+
+    for (const permission of permissions) {
       expect(permission.description.length).toBeGreaterThan(0);
     }
   });

--- a/tests/unit/homepage-section-policy.test.ts
+++ b/tests/unit/homepage-section-policy.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  HOMEPAGE_SECTION_TYPES,
+  isHomepageSectionType,
+  validateCreateHomepageSectionInput,
+  validateHomepageSectionConfig,
+  validateUpdateHomepageSectionInput
+} from "../../src/modules/news-portal/domain/homepage-section-policy";
+
+const VALID_ID = "11111111-1111-1111-1111-111111111111";
+const VALID_ID_2 = "22222222-2222-2222-2222-222222222222";
+
+describe("isHomepageSectionType (Issue #637)", () => {
+  test("accepts every declared type", () => {
+    for (const type of HOMEPAGE_SECTION_TYPES) {
+      expect(isHomepageSectionType(type)).toBe(true);
+    }
+  });
+
+  test("rejects unknown/deferred types (video_block, ad_slot, custom_widget_block, static_page_block)", () => {
+    for (const type of [
+      "video_block",
+      "ad_slot",
+      "custom_widget_block",
+      "static_page_block",
+      "not_a_type",
+      123,
+      null
+    ]) {
+      expect(isHomepageSectionType(type)).toBe(false);
+    }
+  });
+});
+
+describe("validateHomepageSectionConfig (Issue #637)", () => {
+  test("headline requires a UUID postId", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig("headline", { postId: VALID_ID }, errors)
+    ).toEqual({ postId: VALID_ID });
+    expect(errors).toEqual([]);
+
+    const badErrors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "headline",
+        { postId: "not-a-uuid" },
+        badErrors
+      )
+    ).toBeNull();
+    expect(badErrors.length).toBeGreaterThan(0);
+  });
+
+  test("latest_posts defaults limit and allows optional categorySlug", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(validateHomepageSectionConfig("latest_posts", {}, errors)).toEqual({
+      limit: 5,
+      categorySlug: null
+    });
+    expect(errors).toEqual([]);
+
+    const errors2: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "latest_posts",
+        { limit: 10, categorySlug: "world" },
+        errors2
+      )
+    ).toEqual({ limit: 10, categorySlug: "world" });
+  });
+
+  test("latest_posts rejects limit out of bounds", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig("latest_posts", { limit: 0 }, errors)
+    ).toBeNull();
+    expect(errors.length).toBeGreaterThan(0);
+
+    const errors2: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig("latest_posts", { limit: 21 }, errors2)
+    ).toBeNull();
+    expect(errors2.length).toBeGreaterThan(0);
+  });
+
+  test("featured_posts/editor_picks require a non-empty postIds array of UUIDs", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "featured_posts",
+        { postIds: [VALID_ID, VALID_ID_2] },
+        errors
+      )
+    ).toEqual({ postIds: [VALID_ID, VALID_ID_2] });
+
+    const errors2: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig("editor_picks", { postIds: [] }, errors2)
+    ).toBeNull();
+    expect(errors2.length).toBeGreaterThan(0);
+
+    const errors3: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "featured_posts",
+        { postIds: ["not-a-uuid"] },
+        errors3
+      )
+    ).toBeNull();
+    expect(errors3.length).toBeGreaterThan(0);
+  });
+
+  test("category_grid requires categorySlugs and defaults postsPerCategory", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "category_grid",
+        { categorySlugs: ["world", "sports"] },
+        errors
+      )
+    ).toEqual({ categorySlugs: ["world", "sports"], postsPerCategory: 3 });
+
+    const errors2: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "category_grid",
+        { categorySlugs: [] },
+        errors2
+      )
+    ).toBeNull();
+    expect(errors2.length).toBeGreaterThan(0);
+
+    const errors3: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "category_grid",
+        { categorySlugs: ["a"], postsPerCategory: 7 },
+        errors3
+      )
+    ).toBeNull();
+    expect(errors3.length).toBeGreaterThan(0);
+  });
+
+  test("gallery_block requires a non-empty mediaObjectIds array and allows optional caption", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "gallery_block",
+        { mediaObjectIds: [VALID_ID], caption: "Gallery" },
+        errors
+      )
+    ).toEqual({ mediaObjectIds: [VALID_ID], caption: "Gallery" });
+
+    const errors2: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "gallery_block",
+        { mediaObjectIds: [] },
+        errors2
+      )
+    ).toBeNull();
+    expect(errors2.length).toBeGreaterThan(0);
+  });
+});
+
+describe("validateCreateHomepageSectionInput (Issue #637)", () => {
+  test("accepts a well-formed headline section with defaults", () => {
+    const result = validateCreateHomepageSectionInput({
+      sectionKey: "front-page-headline",
+      sectionType: "headline",
+      config: { postId: VALID_ID }
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.sectionKey).toBe("front-page-headline");
+      expect(result.value.sortOrder).toBe(0);
+      expect(result.value.isEnabled).toBe(true);
+      expect(result.value.startsAt).toBeNull();
+      expect(result.value.endsAt).toBeNull();
+    }
+  });
+
+  test("rejects a sectionKey that doesn't match the slug pattern", () => {
+    const result = validateCreateHomepageSectionInput({
+      sectionKey: "Not A Valid Key!",
+      sectionType: "headline",
+      config: { postId: VALID_ID }
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an unknown sectionType", () => {
+    const result = validateCreateHomepageSectionInput({
+      sectionKey: "front-page",
+      sectionType: "video_block",
+      config: {}
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects endsAt before startsAt", () => {
+    const result = validateCreateHomepageSectionInput({
+      sectionKey: "front-page",
+      sectionType: "latest_posts",
+      config: {},
+      startsAt: "2026-02-01T00:00:00.000Z",
+      endsAt: "2026-01-01T00:00:00.000Z"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects config that doesn't match the declared sectionType's shape", () => {
+    const result = validateCreateHomepageSectionInput({
+      sectionKey: "front-page",
+      sectionType: "gallery_block",
+      config: { postId: VALID_ID }
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("validateUpdateHomepageSectionInput (Issue #637)", () => {
+  test("allows a partial update touching only isEnabled", () => {
+    const result = validateUpdateHomepageSectionInput(
+      { isEnabled: false },
+      "headline"
+    );
+    expect(result).toEqual({ valid: true, value: { isEnabled: false } });
+  });
+
+  test("validates config against the CURRENT sectionType, not a client-supplied one", () => {
+    const result = validateUpdateHomepageSectionInput(
+      { config: { mediaObjectIds: [VALID_ID] } },
+      "gallery_block"
+    );
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.config).toEqual({
+        mediaObjectIds: [VALID_ID],
+        caption: null
+      });
+    }
+  });
+
+  test("rejects an attempt to change sectionType", () => {
+    const result = validateUpdateHomepageSectionInput(
+      { sectionType: "gallery_block" },
+      "headline"
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects config that doesn't match the current sectionType's shape", () => {
+    const result = validateUpdateHomepageSectionInput(
+      { config: { postId: VALID_ID } },
+      "gallery_block"
+    );
+    expect(result.valid).toBe(false);
+  });
+});

--- a/tests/unit/homepage-section-rendering.test.ts
+++ b/tests/unit/homepage-section-rendering.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  renderCategoryGridSectionHtml,
+  renderGalleryBlockSectionHtml,
+  renderHomepageSectionsHtml,
+  renderPostCardListHtml
+} from "../../src/modules/news-portal/domain/homepage-section-rendering";
+
+describe("renderPostCardListHtml (Issue #637)", () => {
+  test("renders an empty state message when there are no cards", () => {
+    const html = renderPostCardListHtml("/news", [], "Nothing here.");
+    expect(html).toContain("Nothing here.");
+    expect(html).not.toContain("<img");
+  });
+
+  test("renders a card with an image when imageUrl is present, escaping all fields", () => {
+    const html = renderPostCardListHtml(
+      "/news",
+      [
+        {
+          title: "<script>alert(1)</script>",
+          slug: "hello",
+          excerpt: "An excerpt",
+          imageUrl: "https://media.example.com/a.jpg",
+          imageAlt: "An alt"
+        }
+      ],
+      "empty"
+    );
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain('<img src="https://media.example.com/a.jpg"');
+    expect(html).toContain('alt="An alt"');
+    expect(html).toContain('href="/news/hello"');
+    expect(html).toContain("An excerpt");
+  });
+
+  test("renders a card with no <img> tag at all when imageUrl is null", () => {
+    const html = renderPostCardListHtml(
+      "/news",
+      [
+        {
+          title: "No image",
+          slug: "no-image",
+          excerpt: null,
+          imageUrl: null,
+          imageAlt: null
+        }
+      ],
+      "empty"
+    );
+    expect(html).not.toContain("<img");
+    expect(html).toContain("No image");
+  });
+});
+
+describe("renderCategoryGridSectionHtml (Issue #637)", () => {
+  test("renders one group per category with its own post list", () => {
+    const html = renderCategoryGridSectionHtml(
+      "/news",
+      [
+        {
+          categoryName: "World",
+          categorySlug: "world",
+          posts: [
+            {
+              title: "Post A",
+              slug: "post-a",
+              excerpt: null,
+              imageUrl: null,
+              imageAlt: null
+            }
+          ]
+        },
+        { categoryName: "Sports", categorySlug: "sports", posts: [] }
+      ],
+      "No posts."
+    );
+    expect(html).toContain("World");
+    expect(html).toContain("Post A");
+    expect(html).toContain("Sports");
+    expect(html).toContain("No posts.");
+  });
+});
+
+describe("renderGalleryBlockSectionHtml (Issue #637)", () => {
+  const MEDIA_ID = "11111111-1111-1111-1111-111111111111";
+
+  test("renders resolved gallery images via the shared content-block gallery renderer", () => {
+    const media = new Map([[MEDIA_ID, "https://media.example.com/a.jpg"]]);
+    const html = renderGalleryBlockSectionHtml(
+      [MEDIA_ID],
+      "Caption",
+      media,
+      "empty"
+    );
+    expect(html).toContain("https://media.example.com/a.jpg");
+    expect(html).toContain("Caption");
+  });
+
+  test("renders the empty state when no media resolves (unverified/cross-tenant/deleted since configured)", () => {
+    const html = renderGalleryBlockSectionHtml(
+      [MEDIA_ID],
+      null,
+      new Map(),
+      "No images."
+    );
+    expect(html).toContain("No images.");
+    expect(html).not.toContain("<img");
+  });
+});
+
+describe("renderHomepageSectionsHtml (Issue #637)", () => {
+  test("wraps each rendered section in its own <section> with sectionKey/type attributes and optional heading", () => {
+    const html = renderHomepageSectionsHtml([
+      {
+        sectionKey: "front-page",
+        sectionType: "headline",
+        title: "Top Story",
+        bodyHtml: "<p>body</p>"
+      },
+      {
+        sectionKey: "no-title",
+        sectionType: "latest_posts",
+        title: null,
+        bodyHtml: "<p>other</p>"
+      }
+    ]);
+    expect(html).toContain('data-section-key="front-page"');
+    expect(html).toContain("homepage-section-headline");
+    expect(html).toContain("<h2>Top Story</h2>");
+    expect(html).toContain('data-section-key="no-title"');
+    expect(html).not.toContain("<h2></h2>");
+  });
+});

--- a/tests/unit/news-media-permissions.test.ts
+++ b/tests/unit/news-media-permissions.test.ts
@@ -38,9 +38,17 @@ describe("NEWS_MEDIA_PERMISSIONS", () => {
     // a real endpoint existed to enforce them. Issue #634 added the
     // presigned-upload-session endpoints (create/finalize/cancel) — see
     // `tests/modules/news-portal-module.test.ts` for the exhaustive
-    // key-by-key match against these exact constants.
+    // key-by-key match against these exact constants. Issue #637 later
+    // added TWO more permissions under a DIFFERENT activityCode
+    // (`homepage_sections`) — filtered out here since this test is
+    // specifically about the `media` activityCode's own permission count,
+    // not the module's total permission count.
     expect(newsPortalModule.permissions).toBeDefined();
-    expect(newsPortalModule.permissions?.length).toBe(
+    const mediaPermissions = newsPortalModule.permissions?.filter(
+      (permission) =>
+        permission.activityCode === NEWS_MEDIA_PERMISSION_ACTIVITY_CODE
+    );
+    expect(mediaPermissions?.length).toBe(
       Object.keys(NEWS_MEDIA_PERMISSIONS).length
     );
   });


### PR DESCRIPTION
## Summary
- Adds a tenant-scoped, RLS-protected editorial homepage section composer for the public `/news` route (Issue #637, epic `news_portal`): `POST/GET /api/v1/news-portal/homepage-sections`, `PATCH/DELETE .../{id}`, plus an admin UI page.
- Six section types (`headline`, `latest_posts`, `featured_posts`, `editor_picks`, `category_grid`, `gallery_block`) with a strict per-type `config_json` whitelist validator. `video_block`, `ad_slot`, `custom_widget_block`, `static_page_block` are deliberately deferred — see migration 044's header comment and the skill's §637 section for why.
- Every post/category/media reference in `config` is validated to exist for the same tenant (unconditionally — this is a brand-new table, no legacy shape to preserve), and `gallery_block` media must be a verified R2 object (Issue #633's registry) — rejected with `422 HOMEPAGE_SECTION_REFERENCE_INVALID`.
- At render time, every reference is re-resolved against live data — an unpublished/removed reference silently disappears (degrade, don't 500) — and images always come from the existing whitelisted renderer (reused from `content-block-rendering.ts`), never a raw URL.
- A tenant with zero configured sections sees the exact pre-#637 `/news` page (additive only, page 1 only).

## Test plan
- [x] `bun run check` (lint, check:docs, api:spec:check, typecheck, full test suite incl. integration against real Postgres, build) — all green
- [x] New unit tests: `homepage-section-policy.test.ts`, `homepage-section-rendering.test.ts`
- [x] New integration test: `news-portal-homepage-sections.integration.test.ts` — CRUD, reference validation per section type, cross-tenant isolation (404 via RLS, not 403), ABAC 403 without permission, public rendering (enabled/disabled, degrade-on-unpublish, gallery)
- [x] Updated existing tests for new permission/navigation entries (`news-media-permissions.test.ts`, `news-portal-module.test.ts`, `foundation.test.ts`)
- [x] Manually reasoned through admin UI states (loading/empty/error/ready) via `StateNotice` pattern, consistent with `admin/blog/ads.astro`

Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)