### PR TITLE
security(api): enforce global and endpoint-specific request body limits

### DIFF
--- a/.changeset/request-body-limits-issue-686.md
+++ b/.changeset/request-body-limits-issue-686.md
@@ -1,0 +1,13 @@
+---
+"awcms-mini": minor
+---
+
+Add application-level request body size limits across every `/api/v1` endpoint (Issue #686, epic #679, platform-hardening).
+
+Most handlers previously called `request.json()`/`request.text()` directly with no size cap of their own — a reverse-proxy `client_max_body_size` protects nothing for direct/local access (offline/LAN deployments often run with no proxy in front at all), and nothing at all protects against a chunked-transfer or `Content-Length`-lying body.
+
+New shared reader (`src/lib/security/request-body-limit.ts`) is now the only place any `/api/*` handler reads a request body — `readJsonBody`/`readTextBody`/`readFormBody` enforce a declared `Content-Length` check before any byte is read, and a running streamed-byte count that aborts the read the instant it's exceeded (catching a chunked or `Content-Length`-lying body the header check alone would miss). Two tiers: `default` (128 KiB, most endpoints) and `large` (5 MiB, content-heavy endpoints — blog post/page/template/theme, email template/announcement, news-portal homepage sections, sync push/pull). A hard ceiling (`BODY_SIZE_HARD_CEILING_BYTES`, 10 MiB) bounds every tier, enforced by a unit test invariant, not just documentation.
+
+All 71 call sites across 57 route files migrated. A new `checkContentLengthCeiling` backstop in `src/middleware.ts` additionally rejects any `/api/*` request with a declared `Content-Length` above the hard ceiling before it reaches a route handler at all — defense-in-depth for future endpoints, not a replacement for the per-handler tiered check (it can't catch a chunked/unlabeled body).
+
+Oversized requests return `413 PAYLOAD_TOO_LARGE` using the standard error envelope; malformed JSON continues to flow through as `null` into each endpoint's existing validator, unchanged from before, so `400 VALIDATION_ERROR` responses stay exactly as they were. `deploy/nginx/awcms-mini.conf.example` now sets `client_max_body_size 10m` to match the application's hard ceiling.

--- a/.claude/skills/awcms-mini-new-endpoint/SKILL.md
+++ b/.claude/skills/awcms-mini-new-endpoint/SKILL.md
@@ -23,6 +23,23 @@ flowchart LR
    **Rute publik tenant-scoped** (tanpa sesi/header — mis. halaman blog publik, RSS, sitemap) resolve tenant lewat segmen path `tenantCode` (`/<prefix>/{tenantCode}/...`), **bukan** subdomain — lihat ADR-0009 (`docs/adr/0009-public-tenant-scoped-routes.md`) untuk alasan lengkap (subdomain butuh wildcard DNS/TLS, bertentangan dengan topologi LAN-first default). Belum ada implementasi contoh di base ini — Issue #540 (epic #536, `blog_content`) adalah konsumen pertama.
 4. Cek akses dengan `awcms-mini-abac-guard` (default deny).
 5. Validasi semua input (UUID, enum, length, numeric range, unknown field).
+   Baca body lewat `readJsonBody`/`readTextBody`/`readFormBody`
+   (`src/lib/security/request-body-limit.ts`, Issue #686) —
+   **jangan pernah** panggil `request.json()`/`.text()`/`.formData()`
+   langsung, endpoint ini menegakkan batas ukuran body level aplikasi
+   (bukan hanya reverse-proxy). Pola drop-in:
+   ```ts
+   const bodyRead = await readJsonBody<XBody>(
+     request /* , "large" bila konten berat */
+   );
+   if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+   const validation = validateXInput(bodyRead.value); // sama seperti sebelumnya
+   ```
+   Tier `default` (128 KiB) untuk mayoritas endpoint; `large` (5 MiB)
+   hanya untuk endpoint konten-berat (HTML/rich content, batch sync).
+   Jangan menambah tier baru tanpa memperbarui plafon keras
+   `BODY_SIZE_HARD_CEILING_BYTES` DAN invariant test-nya
+   (`tests/unit/request-body-limit.test.ts`).
 6. Mutation high-risk → `awcms-mini-idempotency` (`Idempotency-Key`).
 7. Data sensitif keluar lewat mapper (`awcms-mini-sensitive-data`); jangan return row mentah.
 8. DELETE resource deletable berarti soft delete; restore/purge butuh ABAC, audit, OpenAPI, dan idempotency bila high-risk.
@@ -35,7 +52,7 @@ Sukses `{ success:true, data, meta }`; error `{ success:false, error:{ code, mes
 
 ## Error code standar
 
-`VALIDATION_ERROR`(400), `AUTH_REQUIRED`(401), `TOKEN_EXPIRED`(401), `ACCESS_DENIED`(403), `TENANT_REQUIRED`(400), `RESOURCE_NOT_FOUND`(404), `RESOURCE_DELETED`(410), `IDEMPOTENCY_REQUIRED`(400), `IDEMPOTENCY_CONFLICT`(409), `WORKFLOW_APPROVAL_REQUIRED`(409), `STOCK_NOT_AVAILABLE`(409), `SYNC_CONFLICT`(409), `DATABASE_BUSY`(503), `PROVIDER_ERROR`(502), `INTERNAL_ERROR`(500). Jangan expose stack trace.
+`VALIDATION_ERROR`(400), `AUTH_REQUIRED`(401), `TOKEN_EXPIRED`(401), `ACCESS_DENIED`(403), `TENANT_REQUIRED`(400), `RESOURCE_NOT_FOUND`(404), `RESOURCE_DELETED`(410), `IDEMPOTENCY_REQUIRED`(400), `IDEMPOTENCY_CONFLICT`(409), `WORKFLOW_APPROVAL_REQUIRED`(409), `STOCK_NOT_AVAILABLE`(409), `SYNC_CONFLICT`(409), `PAYLOAD_TOO_LARGE`(413), `DATABASE_BUSY`(503), `PROVIDER_ERROR`(502), `INTERNAL_ERROR`(500). Jangan expose stack trace.
 
 ## Header standar
 

--- a/deploy/nginx/awcms-mini.conf.example
+++ b/deploy/nginx/awcms-mini.conf.example
@@ -46,6 +46,17 @@ server {
     # Do not leak the nginx version in the Server response header.
     server_tokens off;
 
+    # Matches the app's own hard request-body ceiling
+    # (BODY_SIZE_HARD_CEILING_BYTES, src/lib/security/request-body-limit.ts,
+    # Issue #686, epic #679) — nginx's default (1m) is already close to this,
+    # but set it explicitly so proxy and app limits stay in sync rather than
+    # relying on nginx's default happening to line up. This is defense-in-
+    # depth only: the app enforces its own per-endpoint tiers (128 KiB
+    # default, 5 MiB for content-heavy endpoints) independently and does not
+    # trust this reverse-proxy layer to protect direct/local access (doc 18
+    # LAN-first deployments often run with no nginx in front at all).
+    client_max_body_size 10m;
+
     location / {
         proxy_pass http://127.0.0.1:4321;
         proxy_http_version 1.1;

--- a/docs/awcms-mini/05_openapi_asyncapi_detail.md
+++ b/docs/awcms-mini/05_openapi_asyncapi_detail.md
@@ -111,6 +111,7 @@ Default response list/detail tidak menampilkan soft-deleted record. Detail soft-
 | `WORKFLOW_APPROVAL_REQUIRED` |  409 | Perlu approval                                                   |
 | `STOCK_NOT_AVAILABLE`        |  409 | Stok tidak cukup                                                 |
 | `SYNC_CONFLICT`              |  409 | Konflik sync                                                     |
+| `PAYLOAD_TOO_LARGE`          |  413 | Body request melebihi batas ukuran (Issue #686)                  |
 | `DATABASE_BUSY`              |  503 | Pool/DB sibuk                                                    |
 | `PROVIDER_ERROR`             |  502 | Provider eksternal gagal                                         |
 | `INTERNAL_ERROR`             |  500 | Error internal                                                   |

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -295,6 +295,39 @@ online-only ini (lihat `deployment-profiles.md`).
   kebijakan disimpan" yang tidak bisa dideteksi `saveTenantAuthPolicy`'s
   validasi save-time saja.
 
+### Batas ukuran request body (Issue #686, epic #679, platform-hardening)
+
+Tidak ada env var — batas ini adalah konstanta kode
+(`src/lib/security/request-body-limit.ts`), sengaja tidak dibuat
+configurable agar tidak ada deployment yang bisa diam-diam melonggarkan
+plafon keras tanpa review kode. Setiap handler `/api/*` yang menerima
+body membaca lewat `readJsonBody`/`readTextBody`/`readFormBody`
+(pengganti `request.json()`/`.text()`/`.formData()` langsung) —
+menegakkan `Content-Length` yang dideklarasikan SEBELUM byte apa pun
+dibaca, dan penghitungan byte streaming untuk body chunked/tanpa
+`Content-Length` (declared length tidak pernah dipercaya sendirian).
+Tier: `default` (128 KiB, mayoritas endpoint CRUD/settings/auth),
+`large` (5 MiB, endpoint konten-berat: blog post/page/template/theme,
+email template/announcement, homepage section news-portal, sync
+push/pull). Plafon keras `BODY_SIZE_HARD_CEILING_BYTES` (10 MiB, sama
+urutan besaran dengan `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES` di atas) — tidak
+ada tier yang boleh melebihinya, ditegakkan tes unit, bukan hanya
+didokumentasikan. Body yang terlalu besar selalu `413
+PAYLOAD_TOO_LARGE`, dibedakan dari `400 VALIDATION_ERROR` (JSON tidak
+valid) — endpoint konten-media (`media/news-images/upload-sessions/*`)
+tidak terpengaruh karena byte gambar sesungguhnya lewat jalur presigned
+R2, tidak pernah lewat body handler Astro (Keputusan kunci #2, skill
+`awcms-mini-news-portal`). Backstop tambahan di
+`src/middleware.ts` menolak `Content-Length` yang dideklarasikan
+melebihi plafon keras SEBELUM request menyentuh handler mana pun — lapis
+kedua, bukan pengganti, pengecekan per-handler di atas (tidak bisa
+menangkap body chunked/tanpa `Content-Length`, hanya yang
+dideklarasikan). `deploy/nginx/awcms-mini.conf.example`'s
+`client_max_body_size 10m` diselaraskan dengan plafon keras yang sama
+— defense-in-depth di lapisan proxy, bukan satu-satunya perlindungan
+(doc 18 §Topologi deployment LAN-first: banyak deployment jalan tanpa
+nginx sama sekali).
+
 ### Sync & node
 
 | Var                            | Wajib     | Default          | Sensitif | Fungsi                |

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -306,10 +306,11 @@ body membaca lewat `readJsonBody`/`readTextBody`/`readFormBody`
 menegakkan `Content-Length` yang dideklarasikan SEBELUM byte apa pun
 dibaca, dan penghitungan byte streaming untuk body chunked/tanpa
 `Content-Length` (declared length tidak pernah dipercaya sendirian).
-Tier: `default` (128 KiB, mayoritas endpoint CRUD/settings/auth),
-`large` (5 MiB, endpoint konten-berat: blog post/page/template/theme,
-email template/announcement, homepage section news-portal, sync
-push/pull). Plafon keras `BODY_SIZE_HARD_CEILING_BYTES` (10 MiB, sama
+Tier: `default` (128 KiB, mayoritas endpoint CRUD/settings/auth — termasuk
+`sync/pull`, body-nya hanya `{ limit? }` kecil), `large` (5 MiB, endpoint
+konten-berat: blog post/page/template/theme, email template/announcement,
+homepage section news-portal, `sync/push`/`sync/objects` batch). Plafon
+keras `BODY_SIZE_HARD_CEILING_BYTES` (10 MiB, sama
 urutan besaran dengan `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES` di atas) — tidak
 ada tier yang boleh melebihinya, ditegakkan tes unit, bukan hanya
 didokumentasikan. Body yang terlalu besar selalu `413

--- a/docs/awcms-mini/20_threat_model_security_architecture.md
+++ b/docs/awcms-mini/20_threat_model_security_architecture.md
@@ -564,3 +564,67 @@ PRIVILEGES` yang sudah ada (migration 013) tetap otomatis memberi
   itu tidak menambah keamanan nyata, hanya menambah beban migrasi
   setiap tabel baru. Yang tidak tercakup convenience ini justru 9 tabel
   GLOBAL (non-RLS) — itulah yang dijaga `checkRuntimeRoleGlobalTableGrants`.
+
+## Standar tambahan dipicu epic platform-hardening (Issue #686, epic #679)
+
+Sebelum issue ini, mayoritas handler `/api/*` memanggil `request.json()`/
+`request.text()` langsung, tanpa batas ukuran level aplikasi — batas
+reverse-proxy (bila ada) tidak melindungi akses direct/local (deployment
+offline/LAN tanpa nginx sama sekali, doc 18 §Topologi deployment
+LAN-first), dan tidak ada batas sama sekali untuk body yang mengirim via
+chunked transfer encoding atau membohongi `Content-Length`-nya.
+
+`src/lib/security/request-body-limit.ts`'s `readJsonBody`/`readTextBody`/
+`readFormBody` sekarang menjadi SATU-SATUNYA jalur baca body di seluruh
+`/api/*` (71 titik panggil di 57 file dimigrasi, diverifikasi grep
+menunjukkan nol `request.json()`/`.text()`/`.formData()` langsung
+tersisa) — menegakkan `Content-Length` yang dideklarasikan SEBELUM byte
+apa pun dibaca (short-circuit murah untuk kasus jujur), DAN penghitungan
+byte streaming yang membatalkan baca begitu total terlampaui (menangkap
+body chunked/tanpa `Content-Length`, atau `Content-Length` yang
+berbohong lebih kecil dari byte sesungguhnya — declared length TIDAK
+PERNAH dipercaya sendirian). Dua tier (`default` 128 KiB, `large` 5 MiB)
+plus plafon keras `BODY_SIZE_HARD_CEILING_BYTES` (10 MiB) yang tidak
+boleh dilampaui tier mana pun — ditegakkan tes unit
+(`tests/unit/request-body-limit.test.ts`'s "tier configuration
+invariant"), bukan hanya didokumentasikan, sehingga tier baru yang salah
+ketik nilai besarnya gagal `bun test` sebelum sempat merge.
+
+Sengaja BUKAN diimplementasikan sebagai Astro middleware yang
+me-rewrite/mengganti `context.request` — memanggil `next(request)` di
+middleware Astro memicu `pipeline.tryRewrite` (re-routing sungguhan
+per-request, dimaksudkan untuk internal rewrite gaya i18n, bukan
+transformasi body transparan). Sebagai gantinya, setiap handler memanggil
+fungsi reader secara eksplisit — bentuk yang sama dengan pola pemeriksaan
+keamanan opt-in lain di codebase ini (`checkRateLimit`,
+`enforceTurnstileIfRequired`), dan memungkinkan setiap endpoint memilih
+tier ukurannya sendiri. `checkContentLengthCeiling`
+(`src/middleware.ts`) tetap ada sebagai backstop TERPISAH, murah,
+hanya-global: menolak `Content-Length` yang dideklarasikan melebihi
+plafon keras SEBELUM request menyentuh handler mana pun — defense-in-
+depth untuk endpoint masa depan yang lupa memanggil reader di atas,
+bukan pengganti pemeriksaan per-handler (tidak bisa menangkap body
+chunked/tanpa `Content-Length` sama sekali, karena itu perlu benar-benar
+mengonsumsi stream).
+
+`deploy/nginx/awcms-mini.conf.example`'s `client_max_body_size 10m`
+diselaraskan dengan plafon keras aplikasi yang sama — murni
+defense-in-depth di lapisan proxy opsional, bukan satu-satunya
+perlindungan (banyak deployment LAN-first jalan tanpa nginx sama
+sekali).
+
+### Batasan yang dicatat, bukan diabaikan (platform-hardening — request body limits)
+
+- **Middleware-level backstop tidak unit-testable** — `src/middleware.ts`
+  mengimpor `astro:middleware` (virtual module yang hanya tersedia di
+  dalam pipeline build/dev Astro sendiri), sama batasan yang sudah
+  didokumentasikan untuk `collectRequestAnalytics` (Issue #620). Coverage
+  untuk logika sesungguhnya datang dari `checkContentLengthCeiling`'s
+  tes unit langsung (fungsi murni, bukan wrapper middleware-nya) plus
+  verifikasi manual dev-server + curl.
+- **Endpoint upload/media tidak terpengaruh** — `media/news-images/
+upload-sessions/*` tetap di tier `default` (128 KiB) karena byte
+  gambar sesungguhnya tidak pernah lewat handler Astro sama sekali —
+  jalur presigned R2 (Keputusan kunci #2, skill `awcms-mini-news-portal`)
+  sudah lebih dulu memastikan itu; body JSON kecil (kunci objek,
+  checksum) di endpoint ini tidak butuh tier lebih besar.

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -12,8 +12,8 @@ info:
     that accepts a body enforces an application-level size cap, independent
     of any reverse-proxy limit — most endpoints allow up to 128 KiB;
     content-heavy endpoints (blog posts/pages/templates/theme, email
-    templates/announcements, news-portal homepage sections, sync
-    push/pull) allow up to 5 MiB. A body over the limit — whether declared
+    templates/announcements, news-portal homepage sections, sync push and
+    object-enqueue batches) allow up to 5 MiB. A body over the limit — whether declared
     via `Content-Length` or discovered while streaming a chunked/
     unlabeled body — is rejected with `413 Payload Too Large` and error
     code `PAYLOAD_TOO_LARGE`, using the same envelope as every other error
@@ -209,6 +209,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/SyncPushResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -256,6 +258,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/sync/status:
@@ -371,6 +375,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/SyncConflictResolveResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -422,6 +428,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/ObjectSyncEnqueueResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -536,6 +544,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiSuccess"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -706,6 +716,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/TenantSettingsResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -778,6 +790,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/SetupInitializeResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -838,6 +852,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/LoginResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1046,6 +1062,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/MfaEnrollVerifyResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           description: >-
             Validation error, or the code is invalid (`MFA_INVALID_CODE`).
@@ -1111,6 +1129,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/LoginResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1772,6 +1792,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/AuthProviderView"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1877,6 +1899,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/AuthProviderView"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -1951,6 +1975,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2038,6 +2064,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/TenantAuthPolicyView"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2093,6 +2121,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/ForgotPasswordResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "429":
@@ -2140,6 +2170,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/ResetPasswordResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           description: >-
             Validation error, or the token is invalid/expired/already used
@@ -2219,6 +2251,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/AccessEvaluateResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2257,6 +2291,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/AccessAssignmentResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2304,6 +2340,8 @@ paths:
                         properties:
                           unassigned:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2444,6 +2482,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/CreateUserResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2489,6 +2529,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiSuccess"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2562,6 +2604,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/CreateRoleResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2610,6 +2654,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiSuccess"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2659,6 +2705,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiSuccess"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2895,6 +2943,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/ProfileLifecycleResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3075,6 +3125,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/WorkflowTaskDecisionResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3178,6 +3230,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/FormDraftItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3265,6 +3319,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/FormDraftItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3332,6 +3388,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3465,6 +3523,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/EmailTemplateItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3558,6 +3618,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/EmailTemplateItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3622,6 +3684,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3727,6 +3791,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/EmailTemplatePreviewResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3772,6 +3838,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/AnnouncementCreateResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3827,6 +3895,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/AnnouncementPreviewResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -4005,6 +4075,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/SuppressionCreateResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -4515,6 +4587,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/TenantModuleMutationResponse"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -4633,6 +4707,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/ModuleSettingsView"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           description: >-
             Validation failed (see `error.code`: `VALIDATION_ERROR`,
@@ -4725,6 +4801,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/TenantDomainItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -4832,6 +4910,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/TenantDomainItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -4900,6 +4980,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -5163,6 +5245,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogPostItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -5268,6 +5352,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogPostItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -5356,6 +5442,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -5504,6 +5592,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogPostItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -5950,6 +6040,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogPageItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6055,6 +6147,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogPageItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6143,6 +6237,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6223,6 +6319,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogTermItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           description: >-
             Validation error, including a tag with a non-null parentId.
@@ -6280,6 +6378,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogTermItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           description: >-
             Validation error, including a tag with a non-null parentId.
@@ -6355,6 +6455,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6510,6 +6612,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogTemplateItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6569,6 +6673,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogTemplateItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6630,6 +6736,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6724,6 +6832,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogMenuItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6783,6 +6893,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogMenuItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6844,6 +6956,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6946,6 +7060,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogWidgetItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7004,6 +7120,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogWidgetItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7065,6 +7183,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7172,6 +7292,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogAdItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7240,6 +7362,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogAdItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7301,6 +7425,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7382,6 +7508,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogThemeSettings"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7455,6 +7583,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/BlogSettingsView"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7831,6 +7961,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/ModuleSettingsView"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7922,6 +8054,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/NewsMediaUploadSessionCreated"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -7986,6 +8120,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/NewsMediaObjectItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -8144,6 +8280,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/HomepageSectionItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -8202,6 +8340,8 @@ paths:
                     properties:
                       data:
                         $ref: "#/components/schemas/HomepageSectionItem"
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -8269,6 +8409,8 @@ paths:
                             format: uuid
                           deleted:
                             type: boolean
+        "413":
+          $ref: "#/components/responses/PayloadTooLarge"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -8419,6 +8561,16 @@ components:
             $ref: "#/components/schemas/ApiError"
     InternalError:
       description: Internal server error without stack trace.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ApiError"
+    PayloadTooLarge:
+      description: >-
+        Request body exceeds the endpoint's size limit (Issue #686, epic
+        #679) — either its declared `Content-Length` or, for a chunked/
+        unlabeled body, the actual streamed byte count. Error code
+        `PAYLOAD_TOO_LARGE`.
       content:
         application/json:
           schema:

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -6,6 +6,19 @@ info:
     Stable REST contract for the AWCMS-Mini modular monolith base (ADR-0008
     — contract version is independent of the package release version;
     bumped only when the contract shape itself changes).
+
+
+    **Request body size limits** (Issue #686, epic #679): every endpoint
+    that accepts a body enforces an application-level size cap, independent
+    of any reverse-proxy limit — most endpoints allow up to 128 KiB;
+    content-heavy endpoints (blog posts/pages/templates/theme, email
+    templates/announcements, news-portal homepage sections, sync
+    push/pull) allow up to 5 MiB. A body over the limit — whether declared
+    via `Content-Length` or discovered while streaming a chunked/
+    unlabeled body — is rejected with `413 Payload Too Large` and error
+    code `PAYLOAD_TOO_LARGE`, using the same envelope as every other error
+    response in this contract. No endpoint accepts a body larger than
+    10 MiB.
 servers:
   - url: http://localhost:4321
     description: Local development

--- a/src/lib/security/request-body-limit.ts
+++ b/src/lib/security/request-body-limit.ts
@@ -1,0 +1,251 @@
+/**
+ * Shared capped request-body reader (Issue #686, epic #679, platform-
+ * hardening). Most `/api/*` handlers previously called `request.json()`/
+ * `request.text()` directly with no application-level size cap — a
+ * reverse-proxy `client_max_body_size` protects nothing for direct/local
+ * access (offline/LAN deployments, doc 18), and does nothing for a request
+ * that lies about `Content-Length` or streams via chunked transfer
+ * encoding. This module is the ONE place body-size enforcement lives:
+ * every handler that reads a body should go through `readJsonBody`/
+ * `readTextBody` here instead of calling `request.json()`/`.text()`
+ * directly.
+ *
+ * Two layers of defense, both enforced by the same function:
+ * 1. `Content-Length` header, when present, is checked BEFORE any byte is
+ *    read — an honestly-oversized declared body is rejected with zero
+ *    stream consumption.
+ * 2. The body stream itself is read in chunks with a running byte count,
+ *    so a request that omits `Content-Length` (or lies — declares a small
+ *    value, then streams more) is still capped: the read aborts
+ *    (`reader.cancel()`) the instant the running total exceeds the limit,
+ *    before the oversized payload is ever fully buffered in memory.
+ *
+ * Deliberately NOT implemented as Astro middleware wrapping/rewriting
+ * `context.request` (a `next(request)` call in Astro middleware triggers
+ * `pipeline.tryRewrite` — real route re-matching overhead per request,
+ * intended for i18n-style internal rewrites, not a transparent per-request
+ * body transform) — a plain function each handler calls explicitly is the
+ * same shape as this codebase's other opt-in security checks
+ * (`checkRateLimit`, `enforceTurnstileIfRequired`), and lets each endpoint
+ * pick its own size tier.
+ *
+ * `checkContentLengthCeiling` (used by `src/middleware.ts`) is a SEPARATE,
+ * cheap, global-only backstop: it rejects any `/api/*` request whose
+ * declared `Content-Length` exceeds `BODY_SIZE_HARD_CEILING_BYTES` before
+ * the request even reaches a route handler — defense-in-depth for any
+ * future endpoint that forgets to call the reader below, not a
+ * replacement for it (it cannot catch a chunked/no-`Content-Length` body,
+ * only a declared one).
+ */
+import { fail } from "../../modules/_shared/api-response";
+
+export type BodySizeTier = "default" | "large";
+
+/**
+ * `default` (128 KiB) covers ordinary CRUD/settings/auth JSON bodies.
+ * `large` (5 MiB) covers content-heavy endpoints (blog post/page/template/
+ * theme HTML, email templates, news-portal homepage sections) and batched
+ * sync payloads (`sync/push`, `sync/pull`) — sized generously enough for
+ * legitimate use without approaching the hard ceiling. Media/upload
+ * endpoints (`media/news-images/upload-sessions/*`) stay on `default`:
+ * they only ever exchange small JSON (object keys, checksums) — the
+ * actual image bytes go straight to R2 via a presigned URL, never through
+ * an Astro handler (`docs/awcms-mini/news-portal/full-online-r2-architecture.md`
+ * §3.3/§3.4 "no local fallback, no temp file").
+ */
+export const BODY_SIZE_TIER_BYTES: Record<BodySizeTier, number> = {
+  default: 128 * 1024,
+  large: 5 * 1024 * 1024
+};
+
+/**
+ * No tier may exceed this without an explicit, reviewed change to this
+ * constant itself (acceptance criterion: "Endpoint overrides cannot
+ * exceed the documented hard ceiling without explicit review") — enforced
+ * by `tests/unit/request-body-limit.test.ts`, not just documented here.
+ * Matches `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`'s existing 10 MiB default
+ * (doc 18 §News portal) for a consistent order of magnitude across the
+ * codebase's two size-limit conventions.
+ */
+export const BODY_SIZE_HARD_CEILING_BYTES = 10 * 1024 * 1024;
+
+export type BodyReadResult<T> =
+  { tooLarge: false; value: T } | { tooLarge: true; limitBytes: number };
+
+function resolveLimitBytes(tier: BodySizeTier): number {
+  return BODY_SIZE_TIER_BYTES[tier];
+}
+
+function parseDeclaredLength(request: Request): number | null {
+  const header = request.headers.get("content-length");
+
+  if (header === null) {
+    return null;
+  }
+
+  const parsed = Number(header);
+
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+/**
+ * Reads the full body as text, capped at `limitBytes`. Never throws for a
+ * "too large" outcome (that's the `tooLarge: true` branch) — only a
+ * genuine stream error propagates as a rejected promise, same as
+ * `request.text()` would.
+ */
+async function readCappedText(
+  request: Request,
+  limitBytes: number
+): Promise<{ tooLarge: false; text: string } | { tooLarge: true }> {
+  const declaredLength = parseDeclaredLength(request);
+
+  if (declaredLength !== null && declaredLength > limitBytes) {
+    return { tooLarge: true };
+  }
+
+  const body = request.body;
+
+  if (!body) {
+    return { tooLarge: false, text: "" };
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+
+    if (done) {
+      break;
+    }
+
+    total += value.byteLength;
+
+    if (total > limitBytes) {
+      await reader.cancel().catch(() => {});
+      return { tooLarge: true };
+    }
+
+    chunks.push(value);
+  }
+
+  const combined = new Uint8Array(total);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return { tooLarge: false, text: new TextDecoder().decode(combined) };
+}
+
+/**
+ * Drop-in replacement for `await request.json().catch(() => null)`:
+ * `value` is `null` for an empty or malformed body (same as the old
+ * pattern — callers keep passing it straight into their existing
+ * validator, which already treats `null` as invalid input), and the
+ * `tooLarge: true` branch is the ONE new case callers must check first
+ * and map to a `413`, via `bodyTooLargeResponse` below.
+ */
+export async function readJsonBody<T = unknown>(
+  request: Request,
+  tier: BodySizeTier = "default"
+): Promise<BodyReadResult<T | null>> {
+  const limitBytes = resolveLimitBytes(tier);
+  const textResult = await readCappedText(request, limitBytes);
+
+  if (textResult.tooLarge) {
+    return { tooLarge: true, limitBytes };
+  }
+
+  if (textResult.text.length === 0) {
+    return { tooLarge: false, value: null };
+  }
+
+  try {
+    return { tooLarge: false, value: JSON.parse(textResult.text) as T };
+  } catch {
+    return { tooLarge: false, value: null };
+  }
+}
+
+/** Drop-in replacement for `await request.text()`, capped at `tier`'s limit. */
+export async function readTextBody(
+  request: Request,
+  tier: BodySizeTier = "default"
+): Promise<BodyReadResult<string>> {
+  const limitBytes = resolveLimitBytes(tier);
+  const textResult = await readCappedText(request, limitBytes);
+
+  if (textResult.tooLarge) {
+    return { tooLarge: true, limitBytes };
+  }
+
+  return { tooLarge: false, value: textResult.text };
+}
+
+/**
+ * Drop-in replacement for `await request.formData()`, capped at `tier`'s
+ * limit. No handler uses this yet (no endpoint accepts
+ * `multipart/form-data` or `application/x-www-form-urlencoded` today —
+ * confirmed by grep across `src/pages/api/`), but the issue's scope
+ * explicitly names form/multipart support as part of the shared reader;
+ * provided now so a future form-accepting endpoint doesn't have to
+ * reinvent this. Reuses the same capped-text read, then re-parses via a
+ * synthetic `Request` — `FormData` parsing itself has no separate
+ * size-relevant step once the bytes are already capped.
+ */
+export async function readFormBody(
+  request: Request,
+  tier: BodySizeTier = "default"
+): Promise<BodyReadResult<FormData | null>> {
+  const limitBytes = resolveLimitBytes(tier);
+  const textResult = await readCappedText(request, limitBytes);
+
+  if (textResult.tooLarge) {
+    return { tooLarge: true, limitBytes };
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+
+  try {
+    const synthetic = new Request(request.url, {
+      method: request.method,
+      headers: { "content-type": contentType },
+      body: textResult.text
+    });
+
+    return { tooLarge: false, value: await synthetic.formData() };
+  } catch {
+    return { tooLarge: false, value: null };
+  }
+}
+
+/** The standard `413` response for any `tooLarge: true` result above. */
+export function bodyTooLargeResponse(limitBytes: number): Response {
+  return fail(
+    413,
+    "PAYLOAD_TOO_LARGE",
+    `Request body exceeds the maximum allowed size of ${limitBytes} bytes.`
+  );
+}
+
+/**
+ * Cheap, global-only pre-check for `src/middleware.ts` — see this file's
+ * header for why this is a separate backstop, not the primary
+ * enforcement mechanism. Only ever compares against the HARD ceiling
+ * (never a per-endpoint tier — middleware has no route-specific
+ * knowledge), so it can only reject requests no tier would ever have
+ * accepted anyway; it never rejects a request a correctly-tiered handler
+ * would have allowed.
+ */
+export function checkContentLengthCeiling(request: Request): boolean {
+  const declaredLength = parseDeclaredLength(request);
+
+  return (
+    declaredLength === null || declaredLength <= BODY_SIZE_HARD_CEILING_BYTES
+  );
+}

--- a/src/lib/security/request-body-limit.ts
+++ b/src/lib/security/request-body-limit.ts
@@ -42,11 +42,12 @@ import { fail } from "../../modules/_shared/api-response";
 export type BodySizeTier = "default" | "large";
 
 /**
- * `default` (128 KiB) covers ordinary CRUD/settings/auth JSON bodies.
+ * `default` (128 KiB) covers ordinary CRUD/settings/auth JSON bodies —
+ * including `sync/pull`, whose body is only an optional `{ limit? }`.
  * `large` (5 MiB) covers content-heavy endpoints (blog post/page/template/
- * theme HTML, email templates, news-portal homepage sections) and batched
- * sync payloads (`sync/push`, `sync/pull`) — sized generously enough for
- * legitimate use without approaching the hard ceiling. Media/upload
+ * theme HTML, email templates, news-portal homepage sections) and the
+ * batched `sync/push`/`sync/objects` payloads — sized generously enough
+ * for legitimate use without approaching the hard ceiling. Media/upload
  * endpoints (`media/news-images/upload-sessions/*`) stay on `default`:
  * they only ever exchange small JSON (object keys, checksums) — the
  * actual image bytes go straight to R2 via a presigned URL, never through
@@ -224,12 +225,28 @@ export async function readFormBody(
   }
 }
 
-/** The standard `413` response for any `tooLarge: true` result above. */
+/**
+ * The standard `413` response for any `tooLarge: true` result above.
+ *
+ * Always sends `Connection: close` — security-auditor review of PR #704
+ * (Issue #686) found that on a real HTTP/1.1 keep-alive connection, an
+ * oversized request's body is abandoned mid-stream (never drained to its
+ * end), which desyncs the connection: Node's HTTP parser then reads the
+ * client's NEXT, unrelated, perfectly valid request as leftover garbage
+ * from the first one and returns it a spurious `400 Bad Request`. This
+ * only reproduces against a real socket (`tests/integration/...` uses an
+ * in-process harness that never touches HTTP framing, so it can't catch
+ * this) — `Connection: close` tells the client to open a fresh connection
+ * instead of reusing this now-desynced one, closing that gap.
+ */
 export function bodyTooLargeResponse(limitBytes: number): Response {
   return fail(
     413,
     "PAYLOAD_TOO_LARGE",
-    `Request body exceeds the maximum allowed size of ${limitBytes} bytes.`
+    `Request body exceeds the maximum allowed size of ${limitBytes} bytes.`,
+    {},
+    undefined,
+    { connection: "close" }
   );
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,11 @@ import {
   mergeCorrelationIdIntoApiPayload
 } from "./lib/logging/correlation-response";
 import { getDatabaseClient } from "./lib/database/client";
+import {
+  BODY_SIZE_HARD_CEILING_BYTES,
+  bodyTooLargeResponse,
+  checkContentLengthCeiling
+} from "./lib/security/request-body-limit";
 import { resolvePublicTenantFromRequest } from "./lib/tenant/public-host-tenant-resolver";
 import { log } from "./lib/logging/logger";
 import { resolveVisitorAnalyticsConfig } from "./modules/visitor-analytics/domain/visitor-analytics-config";
@@ -23,6 +28,7 @@ import {
 } from "./modules/visitor-analytics/application/collector";
 
 const PROTECTED_PREFIX = "/admin";
+const API_PREFIX = "/api/";
 const CORRELATION_ID_HEADER = "X-Correlation-ID";
 const VISITOR_KEY_COOKIE_NAME = "awcms_mini_visitor_key";
 /** 2 years — a conventional analytics cookie lifetime, same order of magnitude as `VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS`'s default. */
@@ -270,6 +276,27 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // `ssrContext` is available for `/admin/*` routes (doc 14
   // §Internationalization precedence: cookie -> tenant default -> `en`).
   context.locals.locale = resolveRequestLocale(context.cookies);
+
+  // Issue #686 (epic #679, platform-hardening) — global backstop, checked
+  // before `next()` even runs so an obviously-oversized declared body
+  // never reaches a route handler at all. This is defense-in-depth on top
+  // of (not a replacement for) each handler's own `readJsonBody`/
+  // `readTextBody` tiered check (`src/lib/security/request-body-limit.ts`)
+  // — it only catches a DECLARED `Content-Length` above the hard ceiling,
+  // never a chunked/absent-length body, since that requires actually
+  // consuming the stream.
+  if (
+    context.url.pathname.startsWith(API_PREFIX) &&
+    !checkContentLengthCeiling(context.request)
+  ) {
+    const response = await applyCorrelationIdToApiBody(
+      bodyTooLargeResponse(BODY_SIZE_HARD_CEILING_BYTES),
+      context.url.pathname,
+      context.locals.correlationId
+    );
+
+    return applyResponseHeaders(response, context.locals.correlationId);
+  }
 
   if (!context.url.pathname.startsWith(PROTECTED_PREFIX)) {
     const response = await applyCorrelationIdToApiBody(

--- a/src/pages/api/v1/access/assignments.ts
+++ b/src/pages/api/v1/access/assignments.ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
@@ -45,9 +49,13 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const parsed = readAssignmentBody(
-    (await request.json().catch(() => null)) as AssignmentBody | null
-  );
+  const bodyRead = await readJsonBody<AssignmentBody>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const parsed = readAssignmentBody(bodyRead.value);
 
   if (!parsed) {
     return fail(
@@ -128,9 +136,13 @@ export const DELETE: APIRoute = async ({ request, cookies }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const parsed = readAssignmentBody(
-    (await request.json().catch(() => null)) as AssignmentBody | null
-  );
+  const bodyRead = await readJsonBody<AssignmentBody>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const parsed = readAssignmentBody(bodyRead.value);
 
   if (!parsed) {
     return fail(

--- a/src/pages/api/v1/access/evaluate.ts
+++ b/src/pages/api/v1/access/evaluate.ts
@@ -3,6 +3,10 @@ import { fail, ok } from "../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
 import { extractBearerToken } from "../../../../modules/identity-access/application/session-lookup";
 import {
   fetchGrantedPermissionKeys,
@@ -29,7 +33,13 @@ export const POST: APIRoute = async ({ request }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = (await request.json().catch(() => null)) as EvaluateBody | null;
+  const bodyRead = await readJsonBody<EvaluateBody>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
 
   if (
     !body ||

--- a/src/pages/api/v1/analytics/settings.ts
+++ b/src/pages/api/v1/analytics/settings.ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
@@ -98,9 +102,13 @@ export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateModuleSettingsPatch(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateModuleSettingsPatch(bodyRead.value);
 
   if (!validation.valid) {
     return fail(400, validation.code, validation.message);

--- a/src/pages/api/v1/auth/login.ts
+++ b/src/pages/api/v1/auth/login.ts
@@ -16,6 +16,10 @@ import {
   checkRateLimit,
   resolveClientIp
 } from "../../../../lib/security/rate-limit";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
 import { enforceTurnstileIfRequired } from "../../../../lib/security/turnstile";
 import {
   isMfaRequired,
@@ -92,7 +96,13 @@ export const POST: APIRoute = async ({
     );
   }
 
-  const body = (await request.json().catch(() => null)) as LoginBody | null;
+  const bodyRead = await readJsonBody<LoginBody>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
 
   if (
     !body ||

--- a/src/pages/api/v1/auth/password/forgot.ts
+++ b/src/pages/api/v1/auth/password/forgot.ts
@@ -7,6 +7,10 @@ import {
   checkRateLimit,
   resolveClientIp
 } from "../../../../../lib/security/rate-limit";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { enforceTurnstileIfRequired } from "../../../../../lib/security/turnstile";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import { requestPasswordReset } from "../../../../../modules/identity-access/application/password-reset";
@@ -63,7 +67,13 @@ export const POST: APIRoute = async ({ request, clientAddress, locals }) => {
     );
   }
 
-  const rawBody = await request.json().catch(() => null);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const rawBody = bodyRead.value;
   const validation = validateForgotIdentifierInput(rawBody);
 
   if (!validation.valid) {

--- a/src/pages/api/v1/auth/password/reset.ts
+++ b/src/pages/api/v1/auth/password/reset.ts
@@ -7,6 +7,10 @@ import {
   checkRateLimit,
   resolveClientIp
 } from "../../../../../lib/security/rate-limit";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { enforceTurnstileIfRequired } from "../../../../../lib/security/turnstile";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import { completePasswordReset } from "../../../../../modules/identity-access/application/password-reset";
@@ -57,7 +61,13 @@ export const POST: APIRoute = async ({ request, clientAddress, locals }) => {
     );
   }
 
-  const rawBody = await request.json().catch(() => null);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const rawBody = bodyRead.value;
   const validation = validateCompleteResetInput(rawBody);
 
   if (!validation.valid) {

--- a/src/pages/api/v1/blog/ads/[id].ts
+++ b/src/pages/api/v1/blog/ads/[id].ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -47,11 +51,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = (await request.json().catch(() => null)) as Record<
-    string,
-    unknown
-  > | null;
+  const bodyRead = await readJsonBody<Record<string, unknown>>(request);
 
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const validation = validateUpdateAdInput(body);
 
   if (!validation.valid) {
@@ -156,9 +162,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateDeleteReasonInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/ads/index.ts
+++ b/src/pages/api/v1/blog/ads/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -79,11 +83,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = (await request.json().catch(() => null)) as Record<
-    string,
-    unknown
-  > | null;
+  const bodyRead = await readJsonBody<Record<string, unknown>>(request);
 
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const validation = validateCreateAdInput(body);
 
   if (!validation.valid) {

--- a/src/pages/api/v1/blog/menus/[id].ts
+++ b/src/pages/api/v1/blog/menus/[id].ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -46,10 +50,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = (await request.json().catch(() => null)) as Record<
-    string,
-    unknown
-  > | null;
+  const bodyRead = await readJsonBody<Record<string, unknown>>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const record = body ?? {};
 
   if (
@@ -152,9 +159,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateDeleteReasonInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/menus/index.ts
+++ b/src/pages/api/v1/blog/menus/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -84,10 +88,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = (await request.json().catch(() => null)) as Record<
-    string,
-    unknown
-  > | null;
+  const bodyRead = await readJsonBody<Record<string, unknown>>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const record = body ?? {};
 
   if (

--- a/src/pages/api/v1/blog/pages/[id].ts
+++ b/src/pages/api/v1/blog/pages/[id].ts
@@ -9,6 +9,10 @@ import {
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
   fetchGrantedPermissionKeys,
   resolveModuleEnabled,
   resolveTenantContext
@@ -112,10 +116,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateBlogPageInput(
-    await request.json().catch(() => null),
-    pageId
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateBlogPageInput(bodyRead.value, pageId);
 
   if (!validation.valid) {
     return fail(
@@ -313,9 +320,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateSoftDeleteBlogPageInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateSoftDeleteBlogPageInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/pages/index.ts
+++ b/src/pages/api/v1/blog/pages/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
   createBlogPage,
@@ -128,9 +132,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateBlogPageInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateBlogPageInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/posts/[id].ts
+++ b/src/pages/api/v1/blog/posts/[id].ts
@@ -9,6 +9,10 @@ import {
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
   fetchGrantedPermissionKeys,
   resolveModuleEnabled,
   resolveTenantContext
@@ -125,9 +129,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateBlogPostInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateBlogPostInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(
@@ -341,9 +349,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateSoftDeleteBlogPostInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateSoftDeleteBlogPostInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/posts/[id]/schedule.ts
+++ b/src/pages/api/v1/blog/posts/[id]/schedule.ts
@@ -12,6 +12,10 @@ import {
   resolveAuthInputs
 } from "../../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
 import {
@@ -61,9 +65,13 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
     );
   }
 
-  const validation = validateScheduleBlogPostInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateScheduleBlogPostInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/posts/index.ts
+++ b/src/pages/api/v1/blog/posts/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -114,9 +118,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateBlogPostInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateBlogPostInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/settings/index.ts
+++ b/src/pages/api/v1/blog/settings/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -75,9 +79,13 @@ export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateBlogSettingsInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateBlogSettingsInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/templates/[id].ts
+++ b/src/pages/api/v1/blog/templates/[id].ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -41,9 +45,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateTemplateInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateTemplateInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(
@@ -126,9 +134,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateDeleteReasonInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/templates/index.ts
+++ b/src/pages/api/v1/blog/templates/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -75,9 +79,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateTemplateInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateTemplateInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/terms/[id].ts
+++ b/src/pages/api/v1/blog/terms/[id].ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -50,9 +54,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateBlogTermInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateBlogTermInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(
@@ -195,9 +203,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateSoftDeleteBlogTermInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateSoftDeleteBlogTermInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/terms/index.ts
+++ b/src/pages/api/v1/blog/terms/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -88,9 +92,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateBlogTermInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateBlogTermInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/theme/index.ts
+++ b/src/pages/api/v1/blog/theme/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -75,9 +79,13 @@ export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateThemeSettingsInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateThemeSettingsInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/widgets/[id].ts
+++ b/src/pages/api/v1/blog/widgets/[id].ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -41,9 +45,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateWidgetInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateWidgetInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(
@@ -126,9 +134,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateDeleteReasonInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/blog/widgets/index.ts
+++ b/src/pages/api/v1/blog/widgets/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -88,9 +92,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateWidgetInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateWidgetInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/email/announcements/index.ts
+++ b/src/pages/api/v1/email/announcements/index.ts
@@ -12,6 +12,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
   computeRequestHash,
@@ -71,9 +75,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     );
   }
 
-  const validation = validateAnnouncementInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateAnnouncementInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/email/announcements/preview.ts
+++ b/src/pages/api/v1/email/announcements/preview.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { previewAnnouncement } from "../../../../../modules/email/application/announcement-directory";
 import { validateAnnouncementInput } from "../../../../../modules/email/domain/announcement-validation";
 
@@ -43,9 +47,13 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateAnnouncementInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateAnnouncementInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/email/suppressions/index.ts
+++ b/src/pages/api/v1/email/suppressions/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
   createSuppression,
@@ -82,9 +86,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateSuppressionInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateSuppressionInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/email/templates/[id].ts
+++ b/src/pages/api/v1/email/templates/[id].ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
   fetchActiveEmailTemplate,
@@ -95,9 +99,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateEmailTemplateInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateEmailTemplateInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(
@@ -178,7 +186,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = await request.json().catch(() => null);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const reasonRaw = (body as { reason?: unknown } | null)?.reason;
 
   if (typeof reasonRaw !== "string" || reasonRaw.trim().length === 0) {

--- a/src/pages/api/v1/email/templates/[id]/preview.ts
+++ b/src/pages/api/v1/email/templates/[id]/preview.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
 import { fetchActiveEmailTemplate } from "../../../../../../modules/email/application/email-template-directory";
 import { buildSyntheticSampleVariables } from "../../../../../../modules/email/domain/email-template-preview";
 import { renderEmailTemplate } from "../../../../../../modules/email/domain/email-template-render";
@@ -44,10 +48,16 @@ export const POST: APIRoute = async ({ request, params, cookies }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = (await request.json().catch(() => null)) as {
+  const bodyRead = await readJsonBody<{
     locale?: unknown;
     variables?: unknown;
-  } | null;
+  }>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
 
   const locale =
     typeof body?.locale === "string" && body.locale.trim().length > 0

--- a/src/pages/api/v1/email/templates/index.ts
+++ b/src/pages/api/v1/email/templates/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
   createEmailTemplate,
@@ -77,9 +81,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateEmailTemplateInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateEmailTemplateInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/form-drafts/[id].ts
+++ b/src/pages/api/v1/form-drafts/[id].ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
 import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
 import {
   deleteFormDraft,
@@ -101,9 +105,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateFormDraftInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateFormDraftInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(
@@ -178,7 +186,13 @@ export const DELETE: APIRoute = async ({ request, params, cookies }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = await request.json().catch(() => null);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const reasonRaw = (body as { reason?: unknown } | null)?.reason;
   const reason =
     typeof reasonRaw === "string" && reasonRaw.trim().length > 0

--- a/src/pages/api/v1/form-drafts/index.ts
+++ b/src/pages/api/v1/form-drafts/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
 import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
 import {
   createFormDraft,
@@ -103,9 +107,13 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateFormDraftInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateFormDraftInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/identity/sso/policy/index.ts
+++ b/src/pages/api/v1/identity/sso/policy/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
 import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
 import {
   getTenantAuthPolicy,
@@ -83,9 +87,13 @@ export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateTenantAuthPolicyInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateTenantAuthPolicyInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/identity/sso/providers/[id].ts
+++ b/src/pages/api/v1/identity/sso/providers/[id].ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
 import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
 import {
   fetchAuthProviderById,
@@ -95,9 +99,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateAuthProviderInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateAuthProviderInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(
@@ -186,9 +194,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = (await request.json().catch(() => null)) as {
-    reason?: unknown;
-  } | null;
+  const bodyRead = await readJsonBody<{ reason?: unknown }>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const reason = typeof body?.reason === "string" ? body.reason.trim() : "";
 
   if (reason.length === 0) {

--- a/src/pages/api/v1/identity/sso/providers/index.ts
+++ b/src/pages/api/v1/identity/sso/providers/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
 import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
 import {
   createAuthProvider,
@@ -83,9 +87,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateAuthProviderInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateAuthProviderInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/media/news-images/upload-sessions/[id]/finalize.ts
+++ b/src/pages/api/v1/media/news-images/upload-sessions/[id]/finalize.ts
@@ -4,6 +4,10 @@ import { fail } from "../../../../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../../../../lib/database/client";
 import { resolveAuthInputs } from "../../../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../../lib/security/request-body-limit";
 import { resolveNewsMediaR2Config } from "../../../../../../../modules/news-portal/domain/news-media-r2-config";
 import { validateFinalizeNewsMediaUploadSessionInput } from "../../../../../../../modules/news-portal/domain/news-media-upload-session-validation";
 import { finalizeNewsMediaUploadSession } from "../../../../../../../modules/news-portal/application/news-media-finalize-upload-session";
@@ -48,8 +52,15 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
     );
   }
 
-  const rawBody = await request.json().catch(() => null);
-  const validation = validateFinalizeNewsMediaUploadSessionInput(rawBody);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateFinalizeNewsMediaUploadSessionInput(
+    bodyRead.value
+  );
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/media/news-images/upload-sessions/index.ts
+++ b/src/pages/api/v1/media/news-images/upload-sessions/index.ts
@@ -9,6 +9,10 @@ import {
 } from "../../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
+import {
   resolveNewsMediaR2Config,
   findMissingNewsMediaR2Vars
 } from "../../../../../../modules/news-portal/domain/news-media-r2-config";
@@ -63,8 +67,14 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     );
   }
 
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
   const validation = validateCreateNewsMediaUploadSessionInput(
-    await request.json().catch(() => null),
+    bodyRead.value,
     config.allowedMimeTypes,
     config.maxUploadBytes
   );

--- a/src/pages/api/v1/news-portal/homepage-sections/[id].ts
+++ b/src/pages/api/v1/news-portal/homepage-sections/[id].ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -43,11 +47,16 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = (await request.json().catch(() => null)) as Record<
-    string,
-    unknown
-  > | null;
+  const bodyRead = await readJsonBody<Record<string, unknown>>(
+    request,
+    "large"
+  );
 
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const sql = getDatabaseClient();
   const tokenHash = hashSessionToken(token);
   const now = new Date();
@@ -160,9 +169,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateDeleteReasonInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/news-portal/homepage-sections/index.ts
+++ b/src/pages/api/v1/news-portal/homepage-sections/index.ts
@@ -8,6 +8,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
@@ -77,11 +81,16 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = (await request.json().catch(() => null)) as Record<
-    string,
-    unknown
-  > | null;
+  const bodyRead = await readJsonBody<Record<string, unknown>>(
+    request,
+    "large"
+  );
 
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const validation = validateCreateHomepageSectionInput(body);
 
   if (!validation.valid) {

--- a/src/pages/api/v1/profiles/[id].ts
+++ b/src/pages/api/v1/profiles/[id].ts
@@ -3,6 +3,10 @@ import { fail, ok } from "../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
 import { extractBearerToken } from "../../../../modules/identity-access/application/session-lookup";
 import {
   fetchGrantedPermissionKeys,
@@ -47,8 +51,13 @@ export const DELETE: APIRoute = async ({ request, params, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = await request.json().catch(() => null);
-  const validation = validateDeleteReasonRequestBody(body);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonRequestBody(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/roles/[id].ts
+++ b/src/pages/api/v1/roles/[id].ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
@@ -37,9 +41,13 @@ export const PATCH: APIRoute = async ({ request, cookies, params }) => {
     return fail(400, "VALIDATION_ERROR", "Role id is required.");
   }
 
-  const validation = validateUpdateRoleInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateRoleInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(
@@ -169,9 +177,13 @@ export const DELETE: APIRoute = async ({ request, cookies, params }) => {
     return fail(400, "VALIDATION_ERROR", "Role id is required.");
   }
 
-  const validation = validateDeleteReasonRequestBody(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonRequestBody(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/roles/index.ts
+++ b/src/pages/api/v1/roles/index.ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
@@ -69,9 +73,13 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateRoleInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateRoleInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/settings/index.ts
+++ b/src/pages/api/v1/settings/index.ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
@@ -73,9 +77,13 @@ export const PATCH: APIRoute = async ({ request, cookies }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateTenantSettingsInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateTenantSettingsInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/setup/initialize.ts
+++ b/src/pages/api/v1/setup/initialize.ts
@@ -2,6 +2,10 @@ import type { APIRoute } from "astro";
 import { fail, ok } from "../../../../modules/_shared/api-response";
 import { getSetupDatabaseClient } from "../../../../lib/database/client";
 import { resolveClientIp } from "../../../../lib/security/rate-limit";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
 import { enforceTurnstileIfRequired } from "../../../../lib/security/turnstile";
 import { validateSetupInitializeInput } from "../../../../modules/tenant-admin/domain/setup-validation";
 import { bootstrapPlatformTenant } from "../../../../modules/tenant-admin/application/platform-bootstrap";
@@ -20,7 +24,13 @@ import { bootstrapPlatformTenant } from "../../../../modules/tenant-admin/applic
  * header for the full role matrix.
  */
 export const POST: APIRoute = async ({ request, clientAddress }) => {
-  const body = await request.json().catch(() => null);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const validation = validateSetupInitializeInput(body);
 
   if (!validation.valid) {

--- a/src/pages/api/v1/sync/conflicts/[id]/resolve.ts
+++ b/src/pages/api/v1/sync/conflicts/[id]/resolve.ts
@@ -4,6 +4,10 @@ import { getDatabaseClient } from "../../../../../../lib/database/client";
 import { withTenant } from "../../../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../../../modules/identity-access/application/access-guard";
@@ -32,8 +36,13 @@ export const POST: APIRoute = async ({ request, cookies, params }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = await request.json().catch(() => null);
-  const validation = validateConflictResolutionRequestBody(body);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateConflictResolutionRequestBody(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/sync/nodes/[id].ts
+++ b/src/pages/api/v1/sync/nodes/[id].ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../../lib/database/client";
 import { withTenant } from "../../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
@@ -41,9 +45,13 @@ export const PATCH: APIRoute = async ({ request, cookies, params }) => {
     return fail(400, "VALIDATION_ERROR", "Node id is required.");
   }
 
-  const validation = validateUpdateSyncNodeInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateSyncNodeInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/sync/objects/index.ts
+++ b/src/pages/api/v1/sync/objects/index.ts
@@ -3,6 +3,10 @@ import { fail, ok } from "../../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../../lib/database/client";
 import { withTenant } from "../../../../../lib/database/tenant-context";
 import {
+  bodyTooLargeResponse,
+  readTextBody
+} from "../../../../../lib/security/request-body-limit";
+import {
   resolveOrRegisterSyncNode,
   verifySyncHeaders
 } from "../../../../../modules/sync-storage/application/sync-auth";
@@ -24,7 +28,13 @@ export const POST: APIRoute = async ({ request }) => {
     );
   }
 
-  const rawBody = await request.text();
+  const bodyRead = await readTextBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const rawBody = bodyRead.value;
   const authResult = verifySyncHeaders(
     request.headers.get("x-awcms-mini-timestamp"),
     request.headers.get("x-awcms-mini-signature"),
@@ -35,7 +45,20 @@ export const POST: APIRoute = async ({ request }) => {
     return fail(authResult.status, authResult.code, authResult.message);
   }
 
-  const parsedBody = rawBody.length > 0 ? JSON.parse(rawBody) : null;
+  let parsedBody: unknown = null;
+
+  if (rawBody.length > 0) {
+    try {
+      parsedBody = JSON.parse(rawBody);
+    } catch {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "Object sync enqueue body must be valid JSON."
+      );
+    }
+  }
+
   const validation = validateObjectSyncEnqueueRequestBody(parsedBody);
 
   if (!validation.valid) {

--- a/src/pages/api/v1/sync/objects/status.ts
+++ b/src/pages/api/v1/sync/objects/status.ts
@@ -3,6 +3,10 @@ import { fail, ok } from "../../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../../lib/database/client";
 import { withTenant } from "../../../../../lib/database/tenant-context";
 import {
+  bodyTooLargeResponse,
+  readTextBody
+} from "../../../../../lib/security/request-body-limit";
+import {
   resolveOrRegisterSyncNode,
   verifySyncHeaders
 } from "../../../../../modules/sync-storage/application/sync-auth";
@@ -25,7 +29,13 @@ export const GET: APIRoute = async ({ request }) => {
     );
   }
 
-  const rawBody = await request.text();
+  const bodyRead = await readTextBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const rawBody = bodyRead.value;
   const authResult = verifySyncHeaders(
     request.headers.get("x-awcms-mini-timestamp"),
     request.headers.get("x-awcms-mini-signature"),

--- a/src/pages/api/v1/sync/pull.ts
+++ b/src/pages/api/v1/sync/pull.ts
@@ -3,6 +3,10 @@ import { fail, ok } from "../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import {
+  bodyTooLargeResponse,
+  readTextBody
+} from "../../../../lib/security/request-body-limit";
+import {
   resolveOrRegisterSyncNode,
   verifySyncHeaders
 } from "../../../../modules/sync-storage/application/sync-auth";
@@ -26,7 +30,13 @@ export const POST: APIRoute = async ({ request }) => {
     );
   }
 
-  const rawBody = await request.text();
+  const bodyRead = await readTextBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const rawBody = bodyRead.value;
   const authResult = verifySyncHeaders(
     request.headers.get("x-awcms-mini-timestamp"),
     request.headers.get("x-awcms-mini-signature"),
@@ -37,7 +47,20 @@ export const POST: APIRoute = async ({ request }) => {
     return fail(authResult.status, authResult.code, authResult.message);
   }
 
-  const parsedBody = rawBody.length > 0 ? JSON.parse(rawBody) : {};
+  let parsedBody: { limit?: unknown } = {};
+
+  if (rawBody.length > 0) {
+    try {
+      parsedBody = JSON.parse(rawBody);
+    } catch {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "Sync pull body must be valid JSON."
+      );
+    }
+  }
+
   const requestedLimit = Number(parsedBody?.limit);
   const limit =
     Number.isInteger(requestedLimit) && requestedLimit > 0

--- a/src/pages/api/v1/sync/push.ts
+++ b/src/pages/api/v1/sync/push.ts
@@ -3,6 +3,10 @@ import { fail, ok } from "../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import {
+  bodyTooLargeResponse,
+  readTextBody
+} from "../../../../lib/security/request-body-limit";
+import {
   resolveOrRegisterSyncNode,
   verifySyncHeaders
 } from "../../../../modules/sync-storage/application/sync-auth";
@@ -25,7 +29,13 @@ export const POST: APIRoute = async ({ request }) => {
     );
   }
 
-  const rawBody = await request.text();
+  const bodyRead = await readTextBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const rawBody = bodyRead.value;
   const authResult = verifySyncHeaders(
     request.headers.get("x-awcms-mini-timestamp"),
     request.headers.get("x-awcms-mini-signature"),
@@ -36,7 +46,20 @@ export const POST: APIRoute = async ({ request }) => {
     return fail(authResult.status, authResult.code, authResult.message);
   }
 
-  const parsedBody = rawBody.length > 0 ? JSON.parse(rawBody) : null;
+  let parsedBody: unknown = null;
+
+  if (rawBody.length > 0) {
+    try {
+      parsedBody = JSON.parse(rawBody);
+    } catch {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "Sync push body must be valid JSON."
+      );
+    }
+  }
+
   const validation = validateSyncPushRequestBody(parsedBody);
 
   if (!validation.valid) {

--- a/src/pages/api/v1/sync/status.ts
+++ b/src/pages/api/v1/sync/status.ts
@@ -3,6 +3,10 @@ import { fail, ok } from "../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import {
+  bodyTooLargeResponse,
+  readTextBody
+} from "../../../../lib/security/request-body-limit";
+import {
   resolveOrRegisterSyncNode,
   verifySyncHeaders
 } from "../../../../modules/sync-storage/application/sync-auth";
@@ -23,7 +27,13 @@ export const GET: APIRoute = async ({ request }) => {
     );
   }
 
-  const rawBody = await request.text();
+  const bodyRead = await readTextBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const rawBody = bodyRead.value;
   const authResult = verifySyncHeaders(
     request.headers.get("x-awcms-mini-timestamp"),
     request.headers.get("x-awcms-mini-signature"),

--- a/src/pages/api/v1/tenant/domains/[id].ts
+++ b/src/pages/api/v1/tenant/domains/[id].ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../../lib/database/client";
 import { withTenant } from "../../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
@@ -103,9 +107,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateUpdateTenantDomainInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateTenantDomainInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(
@@ -186,7 +194,13 @@ export const DELETE: APIRoute = async ({
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = await request.json().catch(() => null);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const reasonRaw = (body as { reason?: unknown } | null)?.reason;
 
   if (typeof reasonRaw !== "string" || reasonRaw.trim().length === 0) {

--- a/src/pages/api/v1/tenant/domains/index.ts
+++ b/src/pages/api/v1/tenant/domains/index.ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../../lib/database/client";
 import { withTenant } from "../../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
@@ -103,9 +107,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateTenantDomainInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateTenantDomainInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/tenant/modules/[moduleKey]/disable.ts
+++ b/src/pages/api/v1/tenant/modules/[moduleKey]/disable.ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../../../lib/database/client";
 import { withTenant } from "../../../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../../../modules/identity-access/application/access-guard";
@@ -41,7 +45,13 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const body = await request.json().catch(() => null);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
   const reasonRaw = (body as { reason?: unknown } | null)?.reason;
 
   if (typeof reasonRaw !== "string" || reasonRaw.trim().length === 0) {

--- a/src/pages/api/v1/tenant/modules/[moduleKey]/settings.ts
+++ b/src/pages/api/v1/tenant/modules/[moduleKey]/settings.ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../../../lib/database/client";
 import { withTenant } from "../../../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../../../modules/identity-access/application/access-guard";
@@ -105,9 +109,13 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateModuleSettingsPatch(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateModuleSettingsPatch(bodyRead.value);
 
   if (!validation.valid) {
     return fail(400, validation.code, validation.message);

--- a/src/pages/api/v1/users/[id].ts
+++ b/src/pages/api/v1/users/[id].ts
@@ -5,6 +5,10 @@ import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
@@ -34,9 +38,13 @@ export const PATCH: APIRoute = async ({ request, cookies, params }) => {
     return fail(400, "VALIDATION_ERROR", "User id is required.");
   }
 
-  const validation = validateUpdateUserInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateUserInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/users/index.ts
+++ b/src/pages/api/v1/users/index.ts
@@ -6,6 +6,10 @@ import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
 import { hashPassword } from "../../../../lib/auth/password";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
@@ -70,9 +74,13 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const validation = validateCreateUserInput(
-    await request.json().catch(() => null)
-  );
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateUserInput(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/src/pages/api/v1/workflows/tasks/[id]/decisions.ts
+++ b/src/pages/api/v1/workflows/tasks/[id]/decisions.ts
@@ -7,6 +7,10 @@ import {
 import { getDatabaseClient } from "../../../../../../lib/database/client";
 import { withTenant } from "../../../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
 import { extractBearerToken } from "../../../../../../modules/identity-access/application/session-lookup";
 import {
   fetchGrantedPermissionKeys,
@@ -85,8 +89,13 @@ export const POST: APIRoute = async ({ request, params, locals }) => {
     );
   }
 
-  const body = await request.json().catch(() => null);
-  const validation = validateWorkflowDecisionRequestBody(body);
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateWorkflowDecisionRequestBody(bodyRead.value);
 
   if (!validation.valid) {
     return fail(

--- a/tests/integration/request-body-limit.integration.test.ts
+++ b/tests/integration/request-body-limit.integration.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Integration tests for the shared capped request-body reader (Issue #686,
+ * epic #679, platform-hardening) — proves real end-to-end wiring (route
+ * handler -> `readJsonBody` -> `413` response) at a `default`-tier and a
+ * `large`-tier endpoint, against the real Astro route handlers. The reader
+ * itself (JSON/text/form parsing, the streamed-byte-count path for a
+ * chunked/no-`Content-Length` body, the malformed-vs-oversized distinction)
+ * is already thoroughly unit-tested in
+ * `tests/unit/request-body-limit.test.ts` — this file only needs to prove
+ * that real handlers actually call it and actually return `413`, not
+ * re-prove the reader's own internals.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { PATCH as updateSettings } from "../../src/pages/api/v1/settings/index";
+import { PATCH as updateBlogTheme } from "../../src/pages/api/v1/blog/theme/index";
+import { BODY_SIZE_TIER_BYTES } from "../../src/lib/security/request-body-limit";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; token: string };
+
+async function bootstrap(): Promise<Bootstrap> {
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: "Acme",
+      tenantCode: "acme",
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: OWNER_LOGIN,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier: OWNER_LOGIN, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return { tenantId: setup.body.data.tenantId, token: login.body.data.token };
+}
+
+function authHeaders(b: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": b.tenantId,
+    authorization: `Bearer ${b.token}`
+  };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite(
+  "Request body size limits (Issue #686, epic #679) — real endpoints",
+  () => {
+    beforeAll(async () => {
+      await applyMigrations();
+      await provisionAppRole();
+    });
+
+    beforeEach(async () => {
+      await resetDatabase();
+    });
+
+    test("PATCH /api/v1/settings (default tier): a body declaring more than 128 KiB is rejected 413, never reaches the handler's own validation", async () => {
+      const b = await bootstrap();
+      const oversizedPayload = "a".repeat(BODY_SIZE_TIER_BYTES.default + 1);
+
+      const response = await invoke<{ error: { code: string } }>(
+        updateSettings,
+        {
+          method: "PATCH",
+          path: "/api/v1/settings",
+          headers: authHeaders(b),
+          body: { defaultLocale: oversizedPayload }
+        }
+      );
+
+      expect(response.status).toBe(413);
+      expect(response.body.error.code).toBe("PAYLOAD_TOO_LARGE");
+    });
+
+    test("PATCH /api/v1/settings (default tier): a boundary-size-safe valid body still reaches the handler and is validated normally", async () => {
+      const b = await bootstrap();
+
+      // Deliberately NOT close to the 128 KiB boundary here — asserting the
+      // exact boundary byte-for-byte is the unit suite's job
+      // (tests/unit/request-body-limit.test.ts); this only proves an
+      // ordinary small valid PATCH still reaches real validation and isn't
+      // accidentally caught by the new size check.
+      const response = await invoke<{ error: { code: string } }>(
+        updateSettings,
+        {
+          method: "PATCH",
+          path: "/api/v1/settings",
+          headers: authHeaders(b),
+          body: { defaultLocale: "not-a-real-locale-code" }
+        }
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    test("PATCH /api/v1/blog/theme (large tier): a body within the default tier but under the large tier is NOT rejected as too-large", async () => {
+      const b = await bootstrap();
+      // Bigger than the default tier (128 KiB) but well under the large tier
+      // (5 MiB) — proves this endpoint is actually wired to the "large" tier,
+      // not silently defaulting to "default".
+      const midSizedValue = "a".repeat(BODY_SIZE_TIER_BYTES.default + 1024);
+
+      const response = await invoke<{ error: { code: string } }>(
+        updateBlogTheme,
+        {
+          method: "PATCH",
+          path: "/api/v1/blog/theme",
+          headers: authHeaders(b),
+          body: { mode: midSizedValue }
+        }
+      );
+
+      expect(response.status).not.toBe(413);
+    });
+
+    test("PATCH /api/v1/blog/theme (large tier): a body declaring more than 5 MiB is still rejected 413", async () => {
+      const b = await bootstrap();
+      const oversizedPayload = "a".repeat(BODY_SIZE_TIER_BYTES.large + 1);
+
+      const response = await invoke<{ error: { code: string } }>(
+        updateBlogTheme,
+        {
+          method: "PATCH",
+          path: "/api/v1/blog/theme",
+          headers: authHeaders(b),
+          body: { mode: oversizedPayload }
+        }
+      );
+
+      expect(response.status).toBe(413);
+      expect(response.body.error.code).toBe("PAYLOAD_TOO_LARGE");
+    });
+  }
+);

--- a/tests/unit/request-body-limit.test.ts
+++ b/tests/unit/request-body-limit.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  BODY_SIZE_HARD_CEILING_BYTES,
+  BODY_SIZE_TIER_BYTES,
+  bodyTooLargeResponse,
+  checkContentLengthCeiling,
+  readFormBody,
+  readJsonBody,
+  readTextBody
+} from "../../src/lib/security/request-body-limit";
+
+function jsonRequest(body: string, overrideContentLength?: number): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+
+  if (overrideContentLength !== undefined) {
+    headers.set("content-length", String(overrideContentLength));
+  }
+
+  return new Request("https://example.test/api/v1/example", {
+    method: "POST",
+    headers,
+    body
+  });
+}
+
+/**
+ * No `Content-Length` at all (the runtime does not auto-compute one for a
+ * stream body) — exercises the byte-counting read path, not the
+ * declared-length short-circuit.
+ */
+function streamedRequest(totalBytes: number): Request {
+  const chunk = new Uint8Array(1024).fill(97); // 'a' repeated
+  let remaining = totalBytes;
+
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (remaining <= 0) {
+        controller.close();
+        return;
+      }
+
+      const size = Math.min(chunk.byteLength, remaining);
+      controller.enqueue(chunk.slice(0, size));
+      remaining -= size;
+    }
+  });
+
+  return new Request("https://example.test/api/v1/example", {
+    method: "POST",
+    headers: { "content-type": "text/plain" },
+    body: stream,
+    // @ts-expect-error -- required by the fetch spec for a streamed body,
+    // not yet in the DOM lib type for RequestInit in this TS target.
+    duplex: "half"
+  });
+}
+
+describe("readJsonBody", () => {
+  test("valid JSON well within the tier limit parses successfully", async () => {
+    const result = await readJsonBody(jsonRequest('{"a":1}'));
+
+    expect(result.tooLarge).toBe(false);
+    if (!result.tooLarge) {
+      expect(result.value).toEqual({ a: 1 });
+    }
+  });
+
+  test("empty body yields value: null (same as request.json().catch(() => null))", async () => {
+    const result = await readJsonBody(jsonRequest(""));
+
+    expect(result.tooLarge).toBe(false);
+    if (!result.tooLarge) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test("malformed JSON yields value: null, not tooLarge — a distinct 400 path from 413", async () => {
+    const result = await readJsonBody(jsonRequest("{not valid json"));
+
+    expect(result.tooLarge).toBe(false);
+    if (!result.tooLarge) {
+      expect(result.value).toBeNull();
+    }
+  });
+
+  test("declared Content-Length above the default tier is rejected without reading the body", async () => {
+    const oversizedDeclared = BODY_SIZE_TIER_BYTES.default + 1;
+    const result = await readJsonBody(
+      jsonRequest('{"a":1}', oversizedDeclared)
+    );
+
+    expect(result.tooLarge).toBe(true);
+    if (result.tooLarge) {
+      expect(result.limitBytes).toBe(BODY_SIZE_TIER_BYTES.default);
+    }
+  });
+
+  test("boundary size exactly at the tier limit succeeds", async () => {
+    // A JSON string value padded to land the whole body exactly at the limit.
+    const limit = BODY_SIZE_TIER_BYTES.default;
+    const padding = "a".repeat(limit - '{"a":""}'.length);
+    const body = `{"a":"${padding}"}`;
+    expect(new TextEncoder().encode(body).byteLength).toBe(limit);
+
+    const result = await readJsonBody(jsonRequest(body));
+    expect(result.tooLarge).toBe(false);
+  });
+
+  test("streamed body (no Content-Length) exceeding the tier limit is rejected mid-stream", async () => {
+    const result = await readJsonBody(
+      streamedRequest(BODY_SIZE_TIER_BYTES.default + 1)
+    );
+
+    expect(result.tooLarge).toBe(true);
+    if (result.tooLarge) {
+      expect(result.limitBytes).toBe(BODY_SIZE_TIER_BYTES.default);
+    }
+  });
+
+  test("streamed body within the tier limit succeeds", async () => {
+    const result = await readTextBody(
+      streamedRequest(BODY_SIZE_TIER_BYTES.default - 10)
+    );
+
+    expect(result.tooLarge).toBe(false);
+    if (!result.tooLarge) {
+      expect(result.value.length).toBe(BODY_SIZE_TIER_BYTES.default - 10);
+    }
+  });
+
+  test("a declared Content-Length that lies (too small) does not bypass the streamed-byte cap", async () => {
+    // Declares a tiny Content-Length but the stream itself carries more
+    // bytes than the tier allows — the running byte count must still catch
+    // it, since Content-Length is attacker-controlled and not trustworthy
+    // on its own.
+    const stream = streamedRequest(BODY_SIZE_TIER_BYTES.default + 1);
+    stream.headers.set("content-length", "10");
+
+    const result = await readJsonBody(stream);
+    expect(result.tooLarge).toBe(true);
+  });
+
+  test("the large tier accepts a body too big for the default tier", async () => {
+    const size = BODY_SIZE_TIER_BYTES.default + 1024;
+    const result = await readTextBody(streamedRequest(size), "large");
+
+    expect(result.tooLarge).toBe(false);
+  });
+});
+
+describe("readTextBody", () => {
+  test("returns the raw text unmodified when within the limit", async () => {
+    const result = await readTextBody(jsonRequest("raw-body-text"));
+
+    expect(result.tooLarge).toBe(false);
+    if (!result.tooLarge) {
+      expect(result.value).toBe("raw-body-text");
+    }
+  });
+});
+
+describe("readFormBody", () => {
+  test("parses application/x-www-form-urlencoded within the limit", async () => {
+    const request = new Request("https://example.test/api/v1/example", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "field=value"
+    });
+
+    const result = await readFormBody(request);
+
+    expect(result.tooLarge).toBe(false);
+    if (!result.tooLarge) {
+      expect(result.value?.get("field")).toBe("value");
+    }
+  });
+
+  test("declared Content-Length above the limit is rejected", async () => {
+    const request = new Request("https://example.test/api/v1/example", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "content-length": String(BODY_SIZE_TIER_BYTES.default + 1)
+      },
+      body: "field=value"
+    });
+
+    const result = await readFormBody(request);
+    expect(result.tooLarge).toBe(true);
+  });
+});
+
+describe("bodyTooLargeResponse", () => {
+  test("returns a 413 with the standard error envelope shape", async () => {
+    const response = bodyTooLargeResponse(BODY_SIZE_TIER_BYTES.default);
+
+    expect(response.status).toBe(413);
+    const body = (await response.json()) as {
+      success: boolean;
+      error: { code: string };
+    };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("PAYLOAD_TOO_LARGE");
+  });
+});
+
+describe("checkContentLengthCeiling (middleware backstop)", () => {
+  test("allows a request with no Content-Length header", () => {
+    const request = new Request("https://example.test/api/v1/example");
+    expect(checkContentLengthCeiling(request)).toBe(true);
+  });
+
+  test("allows a request declared at or below the hard ceiling", () => {
+    const request = new Request("https://example.test/api/v1/example", {
+      headers: { "content-length": String(BODY_SIZE_HARD_CEILING_BYTES) }
+    });
+    expect(checkContentLengthCeiling(request)).toBe(true);
+  });
+
+  test("rejects a request declared above the hard ceiling", () => {
+    const request = new Request("https://example.test/api/v1/example", {
+      headers: {
+        "content-length": String(BODY_SIZE_HARD_CEILING_BYTES + 1)
+      }
+    });
+    expect(checkContentLengthCeiling(request)).toBe(false);
+  });
+});
+
+describe("tier configuration invariant", () => {
+  test("no tier exceeds the documented hard ceiling", () => {
+    for (const bytes of Object.values(BODY_SIZE_TIER_BYTES)) {
+      expect(bytes).toBeLessThanOrEqual(BODY_SIZE_HARD_CEILING_BYTES);
+    }
+  });
+});

--- a/tests/unit/request-body-limit.test.ts
+++ b/tests/unit/request-body-limit.test.ts
@@ -203,6 +203,12 @@ describe("bodyTooLargeResponse", () => {
     expect(body.success).toBe(false);
     expect(body.error.code).toBe("PAYLOAD_TOO_LARGE");
   });
+
+  test("sends Connection: close so a keep-alive client doesn't reuse a connection with an undrained body (security-auditor finding, PR #704)", () => {
+    const response = bodyTooLargeResponse(BODY_SIZE_TIER_BYTES.default);
+
+    expect(response.headers.get("connection")).toBe("close");
+  });
 });
 
 describe("checkContentLengthCeiling (middleware backstop)", () => {


### PR DESCRIPTION
## Summary

- Adds a shared capped request-body reader (`src/lib/security/request-body-limit.ts`) — `readJsonBody`/`readTextBody`/`readFormBody` — that enforces a declared `Content-Length` check before any byte is read, plus a streamed-byte-count fallback that aborts the read the instant it's exceeded (catching a chunked-transfer or `Content-Length`-lying body the header check alone would miss).
- Two size tiers: `default` (128 KiB, most endpoints) and `large` (5 MiB, content-heavy endpoints — blog post/page/template/theme, email template/announcement, news-portal homepage sections, sync push/pull). A hard ceiling (`BODY_SIZE_HARD_CEILING_BYTES`, 10 MiB) bounds every tier, enforced by a unit test invariant.
- Migrates all 71 `request.json()`/`request.text()` call sites across 57 route files to the new reader — verified by grep, zero raw calls remain in `src/pages/api/`.
- Adds `checkContentLengthCeiling` as a middleware-level backstop (`src/middleware.ts`) that rejects any `/api/*` request with a declared `Content-Length` above the hard ceiling before it reaches a route handler at all — defense-in-depth on top of (not a replacement for) the per-handler tiered check.
- Oversized requests return `413 PAYLOAD_TOO_LARGE` using the standard error envelope. Malformed JSON continues to flow through as `null` into each endpoint's existing validator, unchanged from before — `400 VALIDATION_ERROR` responses are unaffected.
- Two pre-existing latent bugs fixed incidentally while migrating the sync endpoints: `sync/push.ts`, `sync/objects/index.ts`, and `sync/pull.ts` called `JSON.parse(rawBody)` without a try/catch, which would have 500'd on malformed JSON after a valid HMAC signature — now returns `400 VALIDATION_ERROR`.
- Updates `deploy/nginx/awcms-mini.conf.example` (`client_max_body_size 10m`, matching the app's hard ceiling), the OpenAPI spec description, `docs/awcms-mini/18_configuration_env_reference.md`, `docs/awcms-mini/20_threat_model_security_architecture.md`, and the `awcms-mini-new-endpoint` skill.

Closes #686.

## Test plan

- [x] `bun run check` (lint, check:docs, api:spec:check, modules:dag:check, typecheck, full test suite incl. integration against real Postgres, build) — 2061 tests pass, 0 fail
- [x] New unit suite `tests/unit/request-body-limit.test.ts` — valid/malformed/empty JSON, declared-oversized, streamed-oversized (no `Content-Length`), a lying `Content-Length` that understates the real stream size, tier boundary, form parsing, the 413 response shape, and the tier/hard-ceiling invariant
- [x] New integration suite `tests/integration/request-body-limit.integration.test.ts` — real route handlers (`PATCH /api/v1/settings` default tier, `PATCH /api/v1/blog/theme` large tier) against real Postgres, proving oversized → 413, boundary-safe → reaches real validation, and the two tiers are genuinely different
- [x] `grep -rn "request\.json()\|request\.text()\|request\.formData()" src/pages/api/` → zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)