### PR TITLE
fix(preflight): make production preflight non-destructive before quality gates

### DIFF
--- a/.changeset/preflight-non-destructive-issue-684.md
+++ b/.changeset/preflight-non-destructive-issue-684.md
@@ -1,0 +1,11 @@
+---
+"awcms-mini": minor
+---
+
+Make `bun run production:preflight` non-destructive by default (Issue #684, epic #679, platform-hardening).
+
+`db:migrate` previously ran as an early, unconditional stage — a later stage failing (spec check, tests, build) still left the target database migrated, even though the preflight's own final verdict was "GO-LIVE DIBLOKIR". `bun run production:preflight` is now entirely read-only: `config:validate`, `security:readiness`, a new `db:connectivity` check (confirms the database is reachable via a single `SELECT`, never a write), `api:spec:check`, `test`, `build`, `db:pool:health` (now blocks go-live if skipped when `APP_ENV=production`, rather than silently passing), and a new `migration:plan` dry-run stage that reports exactly which migrations are pending without applying them.
+
+Applying migrations is now a separate, explicit, gated action: `--apply-migrations --backup-verified --acknowledge-target=<APP_ENV value>`. All three flags are required together, the apply step only runs if every read-only stage passed, and `--acknowledge-target` must match `APP_ENV` exactly (a typo-catcher against accidentally targeting the wrong environment). `--json-output=<path>` optionally writes a structured `{ go, results, plan, applied }` result for deploy-evidence retention.
+
+New runbook (`docs/awcms-mini/production-preflight-runbook.md`) documents the full staging-rehearsal → backup-evidence → apply → rollback procedure.

--- a/.claude/skills/awcms-mini-production-preflight/SKILL.md
+++ b/.claude/skills/awcms-mini-production-preflight/SKILL.md
@@ -91,5 +91,5 @@ untuk urutan lengkap (dump → restore-test → catat evidence).
 
 Laporan production readiness: status tiap gate, temuan (severity), rollback plan, keputusan go/no-go. Critical control fail **memblokir** go-live.
 `--json-output=<path>` (opsional, Issue #684) menulis hasil terstruktur
-(`{ go, results, plan, applied }`) ke file — untuk arsip evidence deploy,
+(`{ go, failedStages, blockingSkips, results, plan, applied }`) ke file — untuk arsip evidence deploy,
 tidak mengubah output stdout default.

--- a/.claude/skills/awcms-mini-production-preflight/SKILL.md
+++ b/.claude/skills/awcms-mini-production-preflight/SKILL.md
@@ -11,20 +11,44 @@ Ikuti `docs/awcms-mini/07_sprint_testing_production_readiness.md` dan `docs/awcm
 
 ```bash
 bun install
-bun run config:validate
-bun run db:migrate
-bun run api:spec:check
-bun test
-bun run build
-bun run db:pool:health
-bun run security:readiness
 bun run production:preflight
 ```
 
-`bun run production:preflight` (Issue 12.2) runs `config:validate` as its
-first stage, before `db:migrate` — configuration must be valid before
-anything else attempts to connect to a database or run migrations (doc 18
-§Prinsip konfigurasi #5).
+Sejak Issue #684 (epic #679), `bun run production:preflight` (Issue 12.2)
+adalah SATU perintah **read-only** yang menjalankan urutan lengkap sendiri
+— `config:validate` → `security:readiness` → `db:connectivity` (BARU, satu
+`SELECT` memverifikasi koneksi + tabel ledger migrasi) → `api:spec:check`
+→ `test` → `build` → `db:pool:health` (skip bila server belum jalan,
+kecuali `APP_ENV=production` — di situ skip BLOKIR go-live) →
+`migration:plan` (BARU, dry-run: daftar migrasi pending TANPA
+menjalankannya). Tidak ada stage yang menulis ke database. Menjalankan
+command satu-satu secara manual (seperti daftar lama di atas) TIDAK lagi
+direkomendasikan — `bun run db:migrate` secara terpisah TIDAK termasuk
+dalam preflight ini sama sekali; lihat §Menerapkan migrasi di bawah.
+
+### Menerapkan migrasi (langkah terpisah, wajib eksplisit)
+
+`bun run production:preflight` sendiri **tidak pernah** menulis ke
+database — bug lama (Issue #684): `db:migrate` dulu berjalan sebagai
+stage awal tanpa syarat, jadi stage belakangan (spec check/test/build)
+yang gagal tetap meninggalkan database ter-migrasi walau verdict akhirnya
+"GO-LIVE DIBLOKIR". Sekarang menerapkan migrasi butuh flag eksplisit,
+HANYA berjalan bila verdict `GO-LIVE DIIZINKAN` (delapan stage read-only
+di atas semua lulus):
+
+```bash
+APP_ENV=production DATABASE_URL=<production-url> bun run production:preflight \
+  --apply-migrations --backup-verified --acknowledge-target=production
+```
+
+Ketiga flag WAJIB bersamaan (`scripts/production-preflight.ts`'s
+`authorizeApply`, diuji unit test): `--apply-migrations` (niat operator),
+`--backup-verified` (atestasi backup baru yang sudah dibuktikan bisa
+di-restore), `--acknowledge-target=<nilai>` yang harus SAMA PERSIS dengan
+`APP_ENV` (penangkap typo — menjalankan di shell/`.env` yang salah dengan
+`--acknowledge-target` salah menghasilkan penolakan keras, bukan mutasi
+diam-diam ke database yang salah). Prosedur lengkap (rehearsal staging,
+bukti backup, apply, rollback): `docs/awcms-mini/production-preflight-runbook.md`.
 
 ## Checklist go-live
 
@@ -58,7 +82,14 @@ Validasi restore: tenant/user/produk/stok/transaksi terbaca · login test · POS
 Sejak Issue 12.2, kedua command di atas sudah diimplementasikan sebagai
 skrip siap pakai: `deploy/backup/backup-postgres.sh` dan
 `deploy/backup/restore-postgres.sh` (lihat `deploy/backup/README.md`).
+Sejak Issue #684, `--backup-verified` di atas WAJIB berdasarkan bukti
+restore-test nyata dari skrip ini, bukan sekadar backup yang "ada" —
+lihat `docs/awcms-mini/production-preflight-runbook.md`'s §Backup evidence
+untuk urutan lengkap (dump → restore-test → catat evidence).
 
 ## Output
 
 Laporan production readiness: status tiap gate, temuan (severity), rollback plan, keputusan go/no-go. Critical control fail **memblokir** go-live.
+`--json-output=<path>` (opsional, Issue #684) menulis hasil terstruktur
+(`{ go, results, plan, applied }`) ke file — untuk arsip evidence deploy,
+tidak mengubah output stdout default.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ bun run changeset:tag            # tag rilis dari changeset
 bun run db:pool:health           # cek kesehatan pool DB
 bun run security:readiness       # cek security readiness
 bun run config:validate          # validasi env/config sebelum apapun jalan
-bun run production:preflight     # preflight sebelum go-live (config -> migrate -> spec -> test -> build -> pool -> security)
+bun run production:preflight     # preflight read-only sebelum go-live (config -> security -> connectivity -> spec -> test -> build -> pool -> migration:plan); apply migrasi terpisah & bergerbang (--apply-migrations --backup-verified --acknowledge-target=<APP_ENV>, Issue #684)
 bun run email:provider:health    # cek kesehatan provider email (Mailketing)
 bun run sync:objects:dispatch    # job terjadwal: dispatch antrian sync object R2
 bun run logs:audit:purge         # job terjadwal: purge audit log kedaluwarsa

--- a/docs/awcms-mini/07_sprint_testing_production_readiness.md
+++ b/docs/awcms-mini/07_sprint_testing_production_readiness.md
@@ -267,6 +267,14 @@ Piramida: banyak unit test di dasar, sedikit end-to-end di puncak; security & pe
 - POS transaction test.
 - Backup baru dibuat.
 
+Sejak Issue #684 (epic #679): `bun run production:preflight` sendiri
+**read-only** (config/security/connectivity/spec/test/build/pool-health/
+migration-plan — tidak ada stage yang menulis). Menerapkan migrasi adalah
+langkah terpisah dan eksplisit (`--apply-migrations --backup-verified
+--acknowledge-target=<APP_ENV>`), hanya berjalan bila verdict preflight
+`GO-LIVE DIIZINKAN`. Prosedur rehearsal staging → bukti backup → apply →
+rollback lengkap: `docs/awcms-mini/production-preflight-runbook.md`.
+
 ## Legacy migration checklist
 
 - Backup legacy tersedia.
@@ -284,9 +292,12 @@ Piramida: banyak unit test di dasar, sedikit end-to-end di puncak; security & pe
 ### Application
 
 - Build pass.
-- Migration pass.
+- Migration pass (`migration:plan` stage bersih, dan apply — langkah
+  terpisah, lihat §Migration checklist di atas — berhasil).
 - API spec valid.
-- Production preflight pass.
+- Production preflight pass (`bun run production:preflight`, read-only
+  sejak Issue #684; `APP_ENV=production` memblokir go-live bila
+  `db:pool:health` skip).
 - Setup wizard locked.
 - Role default tersedia.
 - ABAC default deny tested.

--- a/docs/awcms-mini/README.md
+++ b/docs/awcms-mini/README.md
@@ -124,6 +124,7 @@ Dokumen dikelompokkan mengikuti alur pengembangan agar mudah diimplementasi.
 |   – | `database-migrations.md`                          | Panduan runner migrasi PostgreSQL Bun-native                                                                                                  |
 |   – | `deployment-profiles.md`                          | Profil deployment (development/staging/production/offline-LAN) dan model dua-peran basis data                                                 |
 |   – | `deploy-coolify.md`                               | Panduan deploy Coolify: single-VPS, multi-aplikasi, opsi PostgreSQL, checklist keamanan (Issue #462)                                          |
+|   – | `production-preflight-runbook.md`                 | Rehearsal staging, bukti backup, apply migrasi bergerbang, dan rollback untuk `bun run production:preflight` (Issue #684, epic #679)          |
 |   – | `derived-application-guide.md`                    | Panduan membangun aplikasi turunan di atas base (9 langkah + 5 contoh ilustratif + checklist keamanan)                                        |
 |   – | `examples/minimal-domain-module.md`               | Contoh konkret satu modul domain minimal (Issue #463)                                                                                         |
 |   – | `examples/wizard-form-pattern.md`                 | Reusable multi-step wizard form pattern: komponen, helper, pola i18n (Issue #479)                                                             |

--- a/docs/awcms-mini/production-preflight-runbook.md
+++ b/docs/awcms-mini/production-preflight-runbook.md
@@ -1,0 +1,145 @@
+# Production Preflight — Rehearsal, Apply, and Rollback Runbook
+
+Issue #684 (epic #679, platform-hardening). Companion to
+`docs/awcms-mini/07_sprint_testing_production_readiness.md` and skill
+`awcms-mini-production-preflight` — this doc covers the operational
+procedure around `bun run production:preflight`, not the checklist itself.
+
+## Why this exists
+
+Before Issue #684, `bun run production:preflight` ran `bun run db:migrate`
+as an early, unconditional stage — a later stage failing (spec check,
+tests, build) still left the target database migrated, even though the
+script's own final verdict was "GO-LIVE DIBLOKIR". A preflight that
+mutates its target even when it blocks go-live is not safe to run
+repeatedly, which defeats the point of a preflight.
+
+`bun run production:preflight` is now **read-only by default**. It runs
+eight stages (`config:validate`, `security:readiness`, `db:connectivity`,
+`api:spec:check`, `test`, `build`, `db:pool:health`, `migration:plan`) and
+reports a go/no-go verdict — none of them write to the database. Applying
+pending migrations is a separate, explicit, gated action.
+
+## Stage 1 — Rehearsal (staging, always first)
+
+Never run `--apply-migrations` against production without first rehearsing
+the exact same migrations against a staging environment that is a recent
+copy of production.
+
+1. Restore a recent production backup into staging (see §Backup evidence
+   below — the same restore path proves both "the backup works" and gives
+   you a realistic staging database in one step).
+2. Run the read-only preflight against staging:
+   ```bash
+   APP_ENV=staging DATABASE_URL=<staging-url> bun run production:preflight
+   ```
+   Confirm `GO-LIVE DIIZINKAN` and read the `migration:plan` stage's output
+   — it lists exactly which migrations are pending, by name.
+3. Apply against staging:
+   ```bash
+   APP_ENV=staging DATABASE_URL=<staging-url> bun run production:preflight \
+     --apply-migrations --backup-verified --acknowledge-target=staging
+   ```
+4. Smoke-test staging (setup wizard already run / admin login / a
+   representative CRUD flow per module touched by the pending migrations).
+5. Only proceed to production once staging rehearsal is clean.
+
+## Stage 2 — Backup evidence (required before any `--apply-migrations`)
+
+`--backup-verified` is a flag, not an automated check — the operator is
+attesting to a specific evidence trail, not just remembering a backup
+exists somewhere. Before passing it:
+
+```bash
+DATABASE_URL=<production-url> \
+BACKUP_DIR=/var/backups/awcms-mini \
+./deploy/backup/backup-postgres.sh
+```
+
+Then **prove the dump restores** (a dump that was never test-restored is
+not verified evidence — this is the same principle
+`deploy/backup/README.md` and doc 07's restore SOP already establish):
+
+```bash
+DATABASE_URL=<production-url> \
+./deploy/backup/restore-postgres.sh /var/backups/awcms-mini/awcms_mini_<timestamp>.dump
+```
+
+(Defaults to restoring into the disposable `awcms_mini_restore_test`
+database — never the live one.) Record the dump filename, its `.sha256`
+checksum, and the restore-test timestamp somewhere durable (deploy
+ticket/runbook log) — this is the "evidence retention" the issue's scope
+asks for.
+
+## Stage 3 — Production preflight (read-only)
+
+```bash
+APP_ENV=production DATABASE_URL=<production-url> bun run production:preflight
+```
+
+Read the full report. In particular:
+
+- `db:pool:health` — if this shows `SKIP`, the verdict is **already**
+  `GO-LIVE DIBLOKIR` when `APP_ENV=production` (Issue #684's mandatory-skip
+  rule) — start the server (`bun run preview` after `bun run build`) so
+  this stage can actually run before proceeding.
+- `migration:plan` — the exact list of migrations that would apply. Diff
+  this against what you rehearsed in Stage 1; they must match exactly. A
+  mismatch (an extra pending migration you didn't rehearse) means stop and
+  rehearse it first, not apply blind.
+
+Optionally capture a machine-readable copy of the report for the deploy
+record:
+
+```bash
+APP_ENV=production DATABASE_URL=<production-url> bun run production:preflight \
+  --json-output=/var/log/awcms-mini/preflight-$(date +%Y%m%d_%H%M%S).json
+```
+
+## Stage 4 — Apply (production)
+
+Only after Stage 3 reports `GO-LIVE DIIZINKAN`:
+
+```bash
+APP_ENV=production DATABASE_URL=<production-url> bun run production:preflight \
+  --apply-migrations --backup-verified --acknowledge-target=production
+```
+
+All three flags are required together (`authorizeApply` in
+`scripts/production-preflight.ts` refuses otherwise, and refuses
+unconditionally if any of the eight read-only stages failed or was
+blocked — no flag combination overrides a failed quality gate).
+`--acknowledge-target` must match `APP_ENV` **exactly** — this is a
+deliberate typo-catcher: running this command in the wrong shell (wrong
+`.env` sourced, wrong `APP_ENV`) with the wrong `--acknowledge-target`
+value produces a hard refusal, not a silent mutation of the wrong
+database.
+
+## Rollback
+
+Migrations in this repo are forward-only (`sql/NNN_*.sql`, no paired
+`down` migration — see `awcms-mini-new-migration` skill). If an applied
+migration needs to be reversed:
+
+1. **Preferred**: restore the pre-apply backup captured in Stage 2 into a
+   fresh database, verify it, then cut traffic over
+   (`deploy/backup/restore-postgres.sh ... --target=<production-db>
+--yes`, after confirming the target name matches intentionally — this
+   is a genuinely destructive `pg_restore --clean --if-exists`, only ever
+   run against a database you mean to overwrite).
+2. **If the migration is additive and provably safe to leave in place**
+   (e.g. a new nullable column, a new table nothing references yet): leave
+   the schema change applied and instead revert the application code that
+   depends on it, via a normal deploy rollback (previous release
+   artifact/image). Only choose this path when you have verified the
+   migration made no destructive change (no dropped column, no data
+   rewrite) — when in doubt, restore instead.
+3. Record what happened (which path taken, why, evidence) in the same
+   place Stage 2's backup evidence was recorded.
+
+## Evidence retention
+
+Keep, per production apply: the backup dump + checksum (per
+`BACKUP_RETENTION_DAYS` in `deploy/backup/backup-postgres.sh`), the
+restore-test confirmation, the `--json-output` preflight report, and a
+one-line record of the rollback decision if the apply was ever reversed.

--- a/scripts/production-preflight.ts
+++ b/scripts/production-preflight.ts
@@ -62,13 +62,14 @@
  *     the wrong `--acknowledge-target` value gets a hard refusal instead
  *     of a silent mutation of the wrong database.
  *   - `--json-output=<path>` (optional, either mode) writes the full
- *     structured `{ go, results, plan, applied }` result to a file — the
+ *     structured `{ go, failedStages, blockingSkips, results, plan, applied }` result to a file — the
  *     "structured machine-readable result" the issue's scope asks for,
  *     without changing the default human-readable stdout output anyone
  *     already depends on.
  */
 import {
   discoverMigrationFiles,
+  redactDatabaseUrl,
   validateAppliedChecksums,
   type AppliedMigration,
   type MigrationFile
@@ -170,7 +171,8 @@ async function checkDatabaseConnectivity(): Promise<StageResult> {
       durationMs: performance.now() - start
     };
   } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
+    const rawMessage = error instanceof Error ? error.message : String(error);
+    const detail = redactDatabaseUrl(rawMessage, databaseUrl);
     console.log(`FAIL — ${detail}`);
     return {
       name: "db:connectivity",
@@ -261,7 +263,8 @@ async function planMigrations(): Promise<
       plan
     };
   } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
+    const rawMessage = error instanceof Error ? error.message : String(error);
+    const detail = redactDatabaseUrl(rawMessage, databaseUrl);
     console.log(`FAIL — ${detail}`);
     return {
       name: "migration:plan",

--- a/scripts/production-preflight.ts
+++ b/scripts/production-preflight.ts
@@ -2,35 +2,77 @@
  * production-preflight.ts — `bun run production:preflight`.
  *
  * Issue 10.3 (doc 07 §Production readiness checklist, skill
- * `awcms-mini-production-preflight`). Orchestrates the preflight command
- * list from the skill, in order, as child processes, and prints a final
- * aggregated go/no-go verdict:
+ * `awcms-mini-production-preflight`), reworked by Issue #684 (epic #679,
+ * platform-hardening) to be non-destructive by default.
  *
- *   bun run config:validate  (Issue 12.2 — runs first; config must be
- *                             valid before anything else attempts to
- *                             connect to a database or run migrations)
- *   bun run db:migrate
- *   bun run api:spec:check
- *   bun test
- *   bun run build
- *   bun run db:pool:health   (only if a server is actually reachable)
- *   bun run security:readiness
+ * PRIOR BEHAVIOR (the bug this issue fixes): `db:migrate` ran unconditionally
+ * as an early stage, before `api:spec:check`/`test`/`build`. A later stage
+ * failing therefore still left the target database mutated by a preflight
+ * run whose own final verdict was "GO-LIVE DIBLOKIR" — a "preflight" that
+ * mutates its target even when it blocks go-live is not actually safe to
+ * run repeatedly, which defeats the entire point of a preflight.
  *
- * `bun install` from the skill's command list is deliberately NOT run here
- * — it's an environment-setup step (fetching dependencies), not a readiness
- * check, and is outside this script's concern.
+ * NEW ORDER — every stage below is READ-ONLY (matches the issue's own
+ * required ordering: config/security, connectivity + read-only schema
+ * inspection, specs/contracts, tests/build, migration plan, then optional
+ * apply):
  *
- * `db:pool:health` requires a running HTTP server, which a CI/preflight run
- * may not have. Rather than block the entire preflight on that one stage,
- * this script first probes `GET /api/v1/health` (via
- * `scripts/lib/app-url.ts`'s `isServerReachable`) and, if nothing answers,
- * records that stage as "skipped" (not a failure) with a clear reason —
- * this is a deliberate design choice, not an oversight.
+ *   1. config:validate       — config must be valid before anything else
+ *                               attempts to connect to a database.
+ *   2. security:readiness
+ *   3. db:connectivity        (NEW) — confirms DATABASE_URL is reachable
+ *                               and the migration ledger table is
+ *                               queryable. Issues exactly one `SELECT`,
+ *                               never a write.
+ *   4. api:spec:check
+ *   5. test
+ *   6. build
+ *   7. db:pool:health          — needs a running server; skipped (not
+ *                               failed) if nothing answers, UNLESS
+ *                               `APP_ENV=production`, in which case a skip
+ *                               now blocks go-live (a production preflight
+ *                               that can't reach a running instance's pool
+ *                               metrics has not actually verified
+ *                               production readiness).
+ *   8. migration:plan          (NEW) — the actual pending-vs-applied diff,
+ *                               deliberately placed as the LAST read-only
+ *                               step, immediately before the decision to
+ *                               apply. Still zero writes: reuses
+ *                               `discoverMigrationFiles`/
+ *                               `validateAppliedChecksums` from
+ *                               `db-migrate.ts` (the same checksum-mismatch
+ *                               guard the real migration run uses) against
+ *                               a read-only `SELECT` of the ledger table.
  *
- * Every other stage runs regardless of earlier failures, so a single broken
- * stage doesn't hide problems in later ones — the final report lists every
- * stage that failed, not just the first.
+ * APPLYING MIGRATIONS is now a separate, explicit, gated step — never part
+ * of the stage list above:
+ *
+ *   - Only attempted if `go` (the verdict after all 8 stages) is `true`.
+ *     A failed quality gate — or, in `APP_ENV=production`, a skipped
+ *     `db:pool:health` — makes it structurally impossible to reach the
+ *     apply step, regardless of flags (`shouldApplyMigrations`'s caller,
+ *     `authorizeApply`, is the pure function this invariant lives in,
+ *     unit-tested directly).
+ *   - Requires `--apply-migrations` (the operator's intent to mutate).
+ *   - Requires `--backup-verified` (attests a recent, restorable backup
+ *     exists — see `docs/awcms-mini/production-preflight-runbook.md`).
+ *   - Requires `--acknowledge-target=<value>` where `<value>` matches
+ *     `APP_ENV` exactly — a deliberate typo-catcher: an operator who runs
+ *     this against the wrong environment (wrong shell, wrong `.env`) with
+ *     the wrong `--acknowledge-target` value gets a hard refusal instead
+ *     of a silent mutation of the wrong database.
+ *   - `--json-output=<path>` (optional, either mode) writes the full
+ *     structured `{ go, results, plan, applied }` result to a file — the
+ *     "structured machine-readable result" the issue's scope asks for,
+ *     without changing the default human-readable stdout output anyone
+ *     already depends on.
  */
+import {
+  discoverMigrationFiles,
+  validateAppliedChecksums,
+  type AppliedMigration,
+  type MigrationFile
+} from "./db-migrate";
 import { isServerReachable, resolveAppBaseUrl } from "./lib/app-url";
 
 export type StageStatus = "pass" | "fail" | "skipped";
@@ -47,16 +89,17 @@ type StageDefinition = {
   command: string[];
 };
 
-const STAGES: StageDefinition[] = [
-  { name: "config:validate", command: ["bun", "run", "config:validate"] },
-  { name: "db:migrate", command: ["bun", "run", "db:migrate"] },
+const REMAINING_CHILD_PROCESS_STAGES: StageDefinition[] = [
   { name: "api:spec:check", command: ["bun", "run", "api:spec:check"] },
   { name: "test", command: ["bun", "test"] },
   { name: "build", command: ["bun", "run", "build"] }
-  // db:pool:health and security:readiness are handled separately below —
-  // db:pool:health needs the reachability probe, security:readiness always
-  // runs last so its report reflects the state after build/migrate.
+  // db:connectivity, db:pool:health, and migration:plan are handled
+  // separately below — each needs custom logic (a direct read-only DB
+  // query, a reachability probe, or both), not a plain child-process spawn.
 ];
+
+/** Stages whose SKIP status blocks go-live specifically when APP_ENV=production. */
+const MANDATORY_IN_PRODUCTION = new Set(["db:pool:health"]);
 
 async function runStage(name: string, command: string[]): Promise<StageResult> {
   const start = performance.now();
@@ -77,10 +120,175 @@ async function runStage(name: string, command: string[]): Promise<StageResult> {
   };
 }
 
-export async function runProductionPreflight(): Promise<StageResult[]> {
+function getDatabaseUrlForReadOnlyCheck(): string | null {
+  const databaseUrl = process.env.DATABASE_URL;
+  return databaseUrl && databaseUrl.startsWith("postgres://")
+    ? databaseUrl
+    : null;
+}
+
+/**
+ * Read-only: a single `SELECT` confirming the database is reachable and
+ * the migration ledger table exists and is queryable. Never issues DDL/DML
+ * — `to_regclass` is a catalog lookup, not a table-creating call (unlike
+ * `db-migrate.ts`'s own `CREATE TABLE IF NOT EXISTS` bootstrap, which this
+ * deliberately does NOT run, since that would itself be a mutation).
+ */
+async function checkDatabaseConnectivity(): Promise<StageResult> {
+  const start = performance.now();
+  console.log(`\n=== production:preflight — db:connectivity ===`);
+
+  const databaseUrl = getDatabaseUrlForReadOnlyCheck();
+
+  if (!databaseUrl) {
+    const detail = "DATABASE_URL is not set or does not use postgres://";
+    console.log(`FAIL — ${detail}`);
+    return {
+      name: "db:connectivity",
+      status: "fail",
+      detail,
+      durationMs: performance.now() - start
+    };
+  }
+
+  let sql: Bun.SQL | undefined;
+
+  try {
+    sql = new Bun.SQL(databaseUrl, { max: 1 });
+    const rows =
+      await sql`SELECT to_regclass('public.awcms_mini_schema_migrations') AS reg`;
+    const ledgerExists = Boolean(rows[0]?.reg);
+    console.log(
+      `PASS — database reachable` +
+        (ledgerExists
+          ? "; migration ledger table found."
+          : "; migration ledger table not found yet (expected on a brand-new database).")
+    );
+    return {
+      name: "db:connectivity",
+      status: "pass",
+      durationMs: performance.now() - start
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.log(`FAIL — ${detail}`);
+    return {
+      name: "db:connectivity",
+      status: "fail",
+      detail,
+      durationMs: performance.now() - start
+    };
+  } finally {
+    await sql?.close({ timeout: 1 });
+  }
+}
+
+export type MigrationPlan = {
+  pending: string[];
+  appliedCount: number;
+};
+
+/** Pure diff — no I/O — so the "what would apply" logic is unit-testable without a database. */
+export function computeMigrationPlan(
+  migrations: MigrationFile[],
+  appliedRows: AppliedMigration[]
+): MigrationPlan {
+  validateAppliedChecksums(migrations, appliedRows);
+
+  const appliedNames = new Set(appliedRows.map((row) => row.migration_name));
+  const pending = migrations
+    .filter((migration) => !appliedNames.has(migration.name))
+    .map((migration) => migration.name);
+
+  return { pending, appliedCount: appliedNames.size };
+}
+
+/**
+ * Read-only dry-run: discovers local migration files and reads (never
+ * writes) the ledger table to report exactly what `bun run db:migrate`
+ * would apply — reuses `validateAppliedChecksums`, the same checksum-
+ * mismatch guard the real migration run uses, so a tampered/edited
+ * already-applied migration is caught here too, before any apply attempt.
+ */
+async function planMigrations(): Promise<
+  StageResult & { plan?: MigrationPlan }
+> {
+  const start = performance.now();
+  console.log(`\n=== production:preflight — migration:plan ===`);
+
+  const databaseUrl = getDatabaseUrlForReadOnlyCheck();
+
+  if (!databaseUrl) {
+    const detail = "DATABASE_URL is not set or does not use postgres://";
+    console.log(`FAIL — ${detail}`);
+    return {
+      name: "migration:plan",
+      status: "fail",
+      detail,
+      durationMs: performance.now() - start
+    };
+  }
+
+  let sql: Bun.SQL | undefined;
+
+  try {
+    const migrations = await discoverMigrationFiles();
+    sql = new Bun.SQL(databaseUrl, { max: 1 });
+
+    const tableCheck =
+      await sql`SELECT to_regclass('public.awcms_mini_schema_migrations') AS reg`;
+    const appliedRows = tableCheck[0]?.reg
+      ? ((await sql`
+          SELECT migration_name, checksum FROM awcms_mini_schema_migrations
+          ORDER BY migration_name ASC
+        `) as AppliedMigration[])
+      : [];
+
+    const plan = computeMigrationPlan(migrations, appliedRows);
+
+    console.log(
+      `migration:plan — ${plan.pending.length} pending, ${plan.appliedCount} already applied.`
+    );
+    if (plan.pending.length > 0) {
+      console.log(`  pending: ${plan.pending.join(", ")}`);
+    }
+
+    return {
+      name: "migration:plan",
+      status: "pass",
+      detail: `${plan.pending.length} pending`,
+      durationMs: performance.now() - start,
+      plan
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.log(`FAIL — ${detail}`);
+    return {
+      name: "migration:plan",
+      status: "fail",
+      detail,
+      durationMs: performance.now() - start
+    };
+  } finally {
+    await sql?.close({ timeout: 1 });
+  }
+}
+
+export async function runProductionPreflight(): Promise<{
+  results: StageResult[];
+  plan?: MigrationPlan;
+}> {
   const results: StageResult[] = [];
 
-  for (const stage of STAGES) {
+  results.push(
+    await runStage("config:validate", ["bun", "run", "config:validate"])
+  );
+  results.push(
+    await runStage("security:readiness", ["bun", "run", "security:readiness"])
+  );
+  results.push(await checkDatabaseConnectivity());
+
+  for (const stage of REMAINING_CHILD_PROCESS_STAGES) {
     results.push(await runStage(stage.name, stage.command));
   }
 
@@ -105,14 +313,55 @@ export async function runProductionPreflight(): Promise<StageResult[]> {
     });
   }
 
-  results.push(
-    await runStage("security:readiness", ["bun", "run", "security:readiness"])
-  );
+  const planResult = await planMigrations();
+  results.push({
+    name: planResult.name,
+    status: planResult.status,
+    detail: planResult.detail,
+    durationMs: planResult.durationMs
+  });
 
-  return results;
+  return { results, plan: planResult.plan };
 }
 
-function printVerdict(results: StageResult[]): boolean {
+export type Verdict = {
+  go: boolean;
+  failedStages: string[];
+  blockingSkips: string[];
+};
+
+/**
+ * Pure — no I/O — so the production-profile blocking-skip rule is directly
+ * unit-testable. `appEnv` is threaded in explicitly rather than read from
+ * `process.env` here, for the same testability reason.
+ */
+export function computeVerdict(
+  results: StageResult[],
+  appEnv: string | undefined
+): Verdict {
+  const failedStages = results
+    .filter((result) => result.status === "fail")
+    .map((result) => result.name);
+
+  const blockingSkips =
+    appEnv === "production"
+      ? results
+          .filter(
+            (result) =>
+              result.status === "skipped" &&
+              MANDATORY_IN_PRODUCTION.has(result.name)
+          )
+          .map((result) => result.name)
+      : [];
+
+  return {
+    go: failedStages.length === 0 && blockingSkips.length === 0,
+    failedStages,
+    blockingSkips
+  };
+}
+
+function printVerdict(verdict: Verdict, results: StageResult[]): void {
   console.log("\n=== production:preflight — summary ===");
 
   for (const result of results) {
@@ -126,27 +375,155 @@ function printVerdict(results: StageResult[]): boolean {
     console.log(`[${label}] ${result.name}${suffix}`);
   }
 
-  const failed = results.filter((result) => result.status === "fail");
-
   console.log("");
 
-  if (failed.length > 0) {
+  if (!verdict.go) {
     console.log("GO-LIVE DIBLOKIR");
-    console.log(
-      `Failed stage(s): ${failed.map((result) => result.name).join(", ")}.`
-    );
-    return false;
+    if (verdict.failedStages.length > 0) {
+      console.log(`Failed stage(s): ${verdict.failedStages.join(", ")}.`);
+    }
+    if (verdict.blockingSkips.length > 0) {
+      console.log(
+        `APP_ENV=production requires these stages to actually run, not skip: ${verdict.blockingSkips.join(", ")}.`
+      );
+    }
+    return;
   }
 
   console.log("GO-LIVE DIIZINKAN");
-  return true;
+}
+
+export type PreflightOptions = {
+  applyMigrations: boolean;
+  backupVerified: boolean;
+  acknowledgeTarget: string | null;
+  jsonOutputPath: string | null;
+};
+
+export function parseArgs(argv: string[]): PreflightOptions {
+  const acknowledgeFlag = argv.find((arg) =>
+    arg.startsWith("--acknowledge-target=")
+  );
+  const jsonOutputFlag = argv.find((arg) => arg.startsWith("--json-output="));
+
+  return {
+    applyMigrations: argv.includes("--apply-migrations"),
+    backupVerified: argv.includes("--backup-verified"),
+    acknowledgeTarget: acknowledgeFlag
+      ? acknowledgeFlag.split("=", 2)[1]!
+      : null,
+    jsonOutputPath: jsonOutputFlag ? jsonOutputFlag.split("=", 2)[1]! : null
+  };
+}
+
+/**
+ * Pure gate — the single place `--apply-migrations` is allowed to turn
+ * into an actual mutation. `go: false` (any failed stage, or a blocking
+ * production skip) short-circuits before backup/target checks even run —
+ * a failed quality gate is reason enough on its own, independent of what
+ * flags were passed (issue acceptance criterion: "Failed quality gates
+ * never apply migrations").
+ */
+export function authorizeApply(
+  go: boolean,
+  options: PreflightOptions,
+  appEnv: string | undefined
+): { ok: true } | { ok: false; reason: string } {
+  if (!go) {
+    return {
+      ok: false,
+      reason:
+        "Earlier stage(s) failed or were blocked — migrations were not applied."
+    };
+  }
+
+  if (!options.applyMigrations) {
+    return {
+      ok: false,
+      reason:
+        "Migrations were not applied (pass --apply-migrations to apply; see migration:plan above for what would run)."
+    };
+  }
+
+  if (!options.backupVerified) {
+    return {
+      ok: false,
+      reason:
+        "--apply-migrations requires --backup-verified (confirm a recent, restorable backup exists first — see docs/awcms-mini/production-preflight-runbook.md)."
+    };
+  }
+
+  if (!options.acknowledgeTarget) {
+    return {
+      ok: false,
+      reason:
+        "--apply-migrations requires --acknowledge-target=<APP_ENV value> to confirm the operator knows which environment is being mutated."
+    };
+  }
+
+  if (options.acknowledgeTarget !== appEnv) {
+    return {
+      ok: false,
+      reason: `--acknowledge-target="${options.acknowledgeTarget}" does not match APP_ENV="${appEnv ?? ""}". Refusing to apply migrations against a target you have not explicitly acknowledged.`
+    };
+  }
+
+  return { ok: true };
 }
 
 async function main() {
-  const results = await runProductionPreflight();
-  const go = printVerdict(results);
+  const options = parseArgs(process.argv.slice(2));
+  const { results, plan } = await runProductionPreflight();
+  const verdict = computeVerdict(results, process.env.APP_ENV);
 
-  if (!go) {
+  printVerdict(verdict, results);
+
+  const authorization = authorizeApply(
+    verdict.go,
+    options,
+    process.env.APP_ENV
+  );
+  let applyResult: StageResult | null = null;
+
+  if (authorization.ok) {
+    console.log(
+      `\n=== production:preflight — applying ${plan?.pending.length ?? 0} migration(s) ===`
+    );
+    applyResult = await runStage("db:migrate (apply)", [
+      "bun",
+      "run",
+      "db:migrate"
+    ]);
+    console.log(
+      applyResult.status === "pass"
+        ? "Migrations applied."
+        : `Migration apply FAILED — ${applyResult.detail}.`
+    );
+  } else {
+    console.log(`\n${authorization.reason}`);
+  }
+
+  if (options.jsonOutputPath) {
+    await Bun.write(
+      options.jsonOutputPath,
+      JSON.stringify(
+        {
+          go: verdict.go,
+          failedStages: verdict.failedStages,
+          blockingSkips: verdict.blockingSkips,
+          results,
+          plan,
+          applied: applyResult
+            ? { status: applyResult.status, detail: applyResult.detail }
+            : null
+        },
+        null,
+        2
+      )
+    );
+  }
+
+  if (!verdict.go || applyResult?.status === "fail") {
     process.exitCode = 1;
   }
 }

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -218,6 +218,51 @@ const REQUIRED_NON_EMPTY_VARS = [
   "AUTH_JWT_SECRET"
 ] as const;
 
+/**
+ * doc 18 §Referensi environment variable's own documented value set
+ * (`development`/`staging`/`production`) — previously only checked for
+ * non-emptiness (`checkRequiredVars`), never validated against this list.
+ * Security-auditor review of PR #705 (Issue #684, epic #679) flagged this
+ * as a foundation gap: `scripts/production-preflight.ts`'s new
+ * `APP_ENV=production` blocking-skip rule (a skipped `db:pool:health`
+ * blocks go-live) and its `--acknowledge-target=<APP_ENV value>` mutation
+ * gate both compare against `APP_ENV` verbatim — an unvalidated typo/
+ * casing variant (e.g. `Production`, `prod`) would silently opt an
+ * operator OUT of that production-only safety net without any error
+ * surfaced anywhere, since `--acknowledge-target` would still "match"
+ * whatever wrong value `APP_ENV` happened to hold.
+ */
+const KNOWN_APP_ENV_VALUES = ["development", "staging", "production"] as const;
+
+export function checkAppEnvValue(env: NodeJS.ProcessEnv): EnvCheckResult {
+  const name = "APP_ENV (known value)";
+  const raw = env.APP_ENV;
+
+  if (!isSet(raw)) {
+    return {
+      name,
+      status: "pass",
+      detail: "APP_ENV is not set — covered by the required-vars check above."
+    };
+  }
+
+  const value = (raw as string).trim();
+
+  if ((KNOWN_APP_ENV_VALUES as readonly string[]).includes(value)) {
+    return {
+      name,
+      status: "pass",
+      detail: `APP_ENV="${value}" is a known value.`
+    };
+  }
+
+  return {
+    name,
+    status: "fail",
+    detail: `APP_ENV="${value}" is not one of ${KNOWN_APP_ENV_VALUES.join("/")} — a typo or unexpected casing here would silently weaken production-only safety checks (e.g. scripts/production-preflight.ts's db:pool:health blocking-skip rule).`
+  };
+}
+
 const R2_REQUIRED_WHEN_ENABLED = [
   "R2_ACCOUNT_ID",
   "R2_ACCESS_KEY_ID",
@@ -1058,6 +1103,7 @@ export function runEnvValidation(
 ): EnvCheckResult[] {
   return [
     ...checkRequiredVars(env),
+    checkAppEnvValue(env),
     checkSyncConfig(env),
     ...checkR2Config(env),
     ...checkEmailConfig(env),

--- a/tests/unit/production-preflight.test.ts
+++ b/tests/unit/production-preflight.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  authorizeApply,
+  computeMigrationPlan,
+  computeVerdict,
+  parseArgs,
+  type PreflightOptions,
+  type StageResult
+} from "../../scripts/production-preflight";
+import type { AppliedMigration, MigrationFile } from "../../scripts/db-migrate";
+
+function migrationFile(
+  name: string,
+  checksum = `sha256:${name}`
+): MigrationFile {
+  return { name, path: `sql/${name}`, sql: "-- noop", checksum };
+}
+
+function stageResult(
+  name: string,
+  status: StageResult["status"],
+  detail?: string
+): StageResult {
+  return { name, status, detail, durationMs: 1 };
+}
+
+describe("parseArgs", () => {
+  test("defaults to no flags set", () => {
+    expect(parseArgs([])).toEqual({
+      applyMigrations: false,
+      backupVerified: false,
+      acknowledgeTarget: null,
+      jsonOutputPath: null
+    });
+  });
+
+  test("parses --apply-migrations and --backup-verified as booleans", () => {
+    const options = parseArgs(["--apply-migrations", "--backup-verified"]);
+    expect(options.applyMigrations).toBe(true);
+    expect(options.backupVerified).toBe(true);
+  });
+
+  test("parses --acknowledge-target=<value>", () => {
+    const options = parseArgs(["--acknowledge-target=production"]);
+    expect(options.acknowledgeTarget).toBe("production");
+  });
+
+  test("parses --json-output=<path>", () => {
+    const options = parseArgs(["--json-output=/tmp/result.json"]);
+    expect(options.jsonOutputPath).toBe("/tmp/result.json");
+  });
+
+  test("parses every flag together", () => {
+    const options = parseArgs([
+      "--apply-migrations",
+      "--backup-verified",
+      "--acknowledge-target=staging",
+      "--json-output=out.json"
+    ]);
+    expect(options).toEqual({
+      applyMigrations: true,
+      backupVerified: true,
+      acknowledgeTarget: "staging",
+      jsonOutputPath: "out.json"
+    });
+  });
+});
+
+describe("authorizeApply (mutation guard)", () => {
+  const fullyAuthorizedOptions: PreflightOptions = {
+    applyMigrations: true,
+    backupVerified: true,
+    acknowledgeTarget: "production",
+    jsonOutputPath: null
+  };
+
+  test("refuses to apply when an earlier stage failed, even with every flag set (acceptance criterion: failed quality gates never apply migrations)", () => {
+    const result = authorizeApply(
+      false /* go */,
+      fullyAuthorizedOptions,
+      "production"
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  test("refuses when --apply-migrations was not passed, even if everything else passed", () => {
+    const result = authorizeApply(
+      true,
+      { ...fullyAuthorizedOptions, applyMigrations: false },
+      "production"
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  test("refuses when --backup-verified is missing", () => {
+    const result = authorizeApply(
+      true,
+      { ...fullyAuthorizedOptions, backupVerified: false },
+      "production"
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("backup-verified");
+    }
+  });
+
+  test("refuses when --acknowledge-target is missing", () => {
+    const result = authorizeApply(
+      true,
+      { ...fullyAuthorizedOptions, acknowledgeTarget: null },
+      "production"
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("acknowledge-target");
+    }
+  });
+
+  test("refuses when --acknowledge-target does not match APP_ENV (typo-catcher)", () => {
+    const result = authorizeApply(
+      true,
+      { ...fullyAuthorizedOptions, acknowledgeTarget: "staging" },
+      "production"
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("staging");
+      expect(result.reason).toContain("production");
+    }
+  });
+
+  test("authorizes only when go=true AND all three flags are set AND acknowledge-target matches APP_ENV exactly", () => {
+    const result = authorizeApply(true, fullyAuthorizedOptions, "production");
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("computeVerdict", () => {
+  test("all-pass results in go=true", () => {
+    const verdict = computeVerdict(
+      [stageResult("config:validate", "pass"), stageResult("test", "pass")],
+      "staging"
+    );
+    expect(verdict.go).toBe(true);
+    expect(verdict.failedStages).toEqual([]);
+    expect(verdict.blockingSkips).toEqual([]);
+  });
+
+  test("any failed stage results in go=false and is listed", () => {
+    const verdict = computeVerdict(
+      [stageResult("test", "fail", "exit code 1")],
+      "staging"
+    );
+    expect(verdict.go).toBe(false);
+    expect(verdict.failedStages).toEqual(["test"]);
+  });
+
+  test("a skipped db:pool:health is non-blocking outside production", () => {
+    const verdict = computeVerdict(
+      [stageResult("db:pool:health", "skipped", "no server reachable")],
+      "staging"
+    );
+    expect(verdict.go).toBe(true);
+    expect(verdict.blockingSkips).toEqual([]);
+  });
+
+  test("a skipped db:pool:health BLOCKS go-live when APP_ENV=production", () => {
+    const verdict = computeVerdict(
+      [stageResult("db:pool:health", "skipped", "no server reachable")],
+      "production"
+    );
+    expect(verdict.go).toBe(false);
+    expect(verdict.blockingSkips).toEqual(["db:pool:health"]);
+  });
+
+  test("a skipped stage NOT in the mandatory-in-production set never blocks, even in production", () => {
+    const verdict = computeVerdict(
+      [stageResult("some-future-optional-stage", "skipped")],
+      "production"
+    );
+    expect(verdict.go).toBe(true);
+    expect(verdict.blockingSkips).toEqual([]);
+  });
+});
+
+describe("computeMigrationPlan", () => {
+  test("reports every local migration as pending when the ledger is empty", () => {
+    const plan = computeMigrationPlan(
+      [migrationFile("001_a.sql"), migrationFile("002_b.sql")],
+      []
+    );
+    expect(plan.pending).toEqual(["001_a.sql", "002_b.sql"]);
+    expect(plan.appliedCount).toBe(0);
+  });
+
+  test("excludes already-applied migrations from the pending list", () => {
+    const plan = computeMigrationPlan(
+      [migrationFile("001_a.sql"), migrationFile("002_b.sql")],
+      [{ migration_name: "001_a.sql", checksum: "sha256:001_a.sql" }]
+    );
+    expect(plan.pending).toEqual(["002_b.sql"]);
+    expect(plan.appliedCount).toBe(1);
+  });
+
+  test("reports zero pending when everything local is already applied", () => {
+    const plan = computeMigrationPlan(
+      [migrationFile("001_a.sql")],
+      [{ migration_name: "001_a.sql", checksum: "sha256:001_a.sql" }]
+    );
+    expect(plan.pending).toEqual([]);
+    expect(plan.appliedCount).toBe(1);
+  });
+
+  test("throws (never silently proceeds) when an applied migration's checksum no longer matches its local file — same guard the real apply uses", () => {
+    const appliedRows: AppliedMigration[] = [
+      { migration_name: "001_a.sql", checksum: "sha256:tampered" }
+    ];
+    expect(() =>
+      computeMigrationPlan([migrationFile("001_a.sql")], appliedRows)
+    ).toThrow("Checksum mismatch");
+  });
+});

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  checkAppEnvValue,
   checkEmailConfig,
   checkGoogleOidcConfig,
   checkNewsMediaR2AllowedMimeTypesKnown,
@@ -50,6 +51,33 @@ describe("checkRequiredVars", () => {
     const failed = results.find((result) => result.name === "APP_ENV");
 
     expect(failed?.status).toBe("fail");
+  });
+});
+
+describe("checkAppEnvValue (Issue #684 follow-up — security-auditor finding on PR #705)", () => {
+  test("passes for each documented value (doc 18)", () => {
+    for (const value of ["development", "staging", "production"]) {
+      const result = checkAppEnvValue({ ...VALID_ENV, APP_ENV: value });
+      expect(result.status).toBe("pass");
+    }
+  });
+
+  test("fails for a casing variant — a typo that would silently weaken production-only safety checks", () => {
+    const result = checkAppEnvValue({ ...VALID_ENV, APP_ENV: "Production" });
+    expect(result.status).toBe("fail");
+  });
+
+  test("fails for an unknown value", () => {
+    const result = checkAppEnvValue({ ...VALID_ENV, APP_ENV: "prod" });
+    expect(result.status).toBe("fail");
+  });
+
+  test("passes (defers to checkRequiredVars) when APP_ENV is unset, rather than double-reporting", () => {
+    const result = checkAppEnvValue({
+      ...VALID_ENV,
+      APP_ENV: undefined
+    } as NodeJS.ProcessEnv);
+    expect(result.status).toBe("pass");
   });
 });
 


### PR DESCRIPTION
## Summary

- `bun run production:preflight` previously ran `bun run db:migrate` as an early, unconditional stage — a later stage failing (spec check, tests, build) still left the target database mutated even though the final verdict was "GO-LIVE DIBLOKIR". Reworks the script to be **entirely read-only by default**.
- New stage order (all read-only): `config:validate` → `security:readiness` → `db:connectivity` (new — a single `SELECT` confirming the database is reachable and the migration ledger table is queryable) → `api:spec:check` → `test` → `build` → `db:pool:health` (needs a running server; skipped if unreachable, **unless** `APP_ENV=production`, in which case a skip now blocks go-live) → `migration:plan` (new — a dry-run diff of pending vs. applied migrations, reusing `db-migrate.ts`'s own checksum-mismatch guard, deliberately placed as the last read-only step before the decision to apply).
- Applying migrations is now a separate, explicit, gated action — never part of the stage list. Requires **all three** flags together: `--apply-migrations` (intent), `--backup-verified` (attests a tested backup exists), `--acknowledge-target=<value>` (must match `APP_ENV` exactly — a typo-catcher against mutating the wrong environment). The apply step is only reachable if every read-only stage passed (`authorizeApply`'s first check is `go`, before any flag is even inspected).
- `--json-output=<path>` optionally writes a structured `{ go, results, plan, applied }` result for deploy-evidence retention.
- New runbook `docs/awcms-mini/production-preflight-runbook.md` documents the full staging-rehearsal → backup-evidence → apply → rollback procedure, referencing the existing `deploy/backup/backup-postgres.sh`/`restore-postgres.sh` scripts.
- Updated the `awcms-mini-production-preflight` skill and doc 07 to match the new non-destructive default and gated-apply flow.

Closes #684.

## Test plan

- [x] `bun run check` — 2082 tests pass, 0 fail, build succeeds
- [x] New unit suite `tests/unit/production-preflight.test.ts` (20 tests) — `parseArgs`, `authorizeApply` (every refusal path: failed stage overrides all flags, missing `--apply-migrations`, missing `--backup-verified`, missing/mismatched `--acknowledge-target`, and the one path that authorizes), `computeVerdict` (pass-only, a failed stage, a non-blocking skip outside production, a **blocking** skip when `APP_ENV=production`, and a skip of a non-mandatory stage never blocking), `computeMigrationPlan` (empty ledger, partial ledger, fully-applied, and the checksum-mismatch guard)
- [x] Live-verified against the real dev database: `db:connectivity` and `migration:plan` report accurate real state (`0 pending, 45 already applied`); when `config:validate`/`security:readiness` fail (intentionally, in an incomplete ad-hoc shell), the script correctly reports `GO-LIVE DIBLOKIR` and refuses to apply migrations — **even with zero apply flags passed at all**, confirming the non-destructive default holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)