### PR TITLE
feat(news-portal): add public social share buttons for news articles

### DIFF
--- a/.changeset/news-portal-social-share-buttons-issue-642.md
+++ b/.changeset/news-portal-social-share-buttons-issue-642.md
@@ -1,0 +1,21 @@
+---
+"awcms-mini": minor
+---
+
+Add public social share buttons and expanded Open Graph/Twitter Card
+metadata for published news articles (Issue #642, epic `news_portal`
+#631-#642/#649): native Web Share API, copy-link, WhatsApp, Telegram,
+Facebook, LinkedIn, X, and email on `/news/{slug}` and
+`/blog/{tenantCode}/{slug}` — every link built from the server-resolved
+canonical URL only (never the request's raw querystring/tracking
+parameters), `rel="noopener noreferrer"` on all external links, no
+third-party script loaded (native share/copy-link is a small same-origin
+static file, `public/js/news-share.js`). Instagram has no supported
+web-share URL, so it is never a fake button — only a short note pointing
+to native share/copy-link. Adds `og:title`/`og:description`/`og:url`/
+`og:site_name` and `twitter:title`/`twitter:description`/`twitter:card`
+to the public page shell (derived from the same title/description/
+canonical URL fields already rendered — `og:image`/`twitter:image` remain
+gated on a verified R2 media object per Issue #636). New per-platform
+`NEWS_SHARE_*_ENABLED` config flags (all default `true`) let operators
+disable the widget or a specific platform.

--- a/.claude/skills/awcms-mini-news-portal/SKILL.md
+++ b/.claude/skills/awcms-mini-news-portal/SKILL.md
@@ -47,7 +47,7 @@ status + pointer, bukan menduplikasi isinya.
 | #639  | Content block `video_news` dengan thumbnail R2 wajib                                                                         | Belum dikerjakan — lihat §639 di bawah               |
 | #640  | Content quality checklist publishing dengan syarat gambar R2                                                                 | Belum dikerjakan — lihat §640 di bawah               |
 | #641  | Automatic internal tag linking untuk konten post/news                                                                        | Belum dikerjakan — lihat §641 di bawah               |
-| #642  | Public social share buttons di halaman artikel `/news`                                                                       | Belum dikerjakan — lihat §642 di bawah               |
+| #642  | Public social share buttons di halaman artikel `/news`                                                                       | **Selesai** — lihat §642 di bawah                    |
 | #649  | SEO + social preview metadata lengkap di halaman artikel `/news`                                                             | Belum dikerjakan — lihat §649 di bawah               |
 
 Urutan dependency yang disarankan (dari objective masing-masing issue):
@@ -1433,7 +1433,7 @@ daftar file lengkap kalau butuh contoh call-site persis.
   detail, 3 news_portal homepage-sections/`/news` index) — wiring adapter
   di composition root.
 
-## §638-#640, #642, #649 — konsumsi media registry lanjutan (belum dikerjakan)
+## §638-#640, #649 — konsumsi media registry lanjutan (belum dikerjakan)
 
 Ringkasan objective per issue (detail lengkap ada di body issue
 GitHub masing-masing, cek `gh issue view <n>` bila butuh acceptance
@@ -1452,13 +1452,159 @@ criteria penuh):
 - **#640** — content quality checklist publishing dengan syarat gambar
   R2 (mis. featured image wajib ada + confirmed sebelum status
   `published` diizinkan).
-- **#642** — social share buttons publik di `/news` dengan canonical
-  URL aman + Open Graph/Twitter Card + privacy-conscious.
 - **#649** — SEO + social preview metadata lengkap (title/excerpt/
-  canonical/gambar R2 terverifikasi) untuk crawler share.
+  canonical/gambar R2 terverifikasi) untuk crawler share. §642 di bawah
+  sudah menambah irisan minimal `og:title`/`og:description`/`og:url`/
+  `og:site_name` + `twitter:title`/`twitter:description`/`twitter:card`
+  (selalu `summary`, naik ke `summary_large_image` saat ada gambar R2) —
+  #649 kemungkinan menambah structured data (JSON-LD)/polish lebih lanjut,
+  bukan membangun ulang dasar OG/Twitter yang sudah ada.
 
-Semua issue ini **wajib** mengonsumsi media registry (#633) dan validasi
-`confirmed`-only (#636) — bukan re-derive validasi URL/MIME sendiri.
+Kedua issue di atas (#638/#639/#640) **wajib** mengonsumsi media registry
+(#633) dan validasi `confirmed`-only (#636) — bukan re-derive validasi
+URL/MIME sendiri.
+
+## §642 — Public social share buttons (Selesai)
+
+Implementasi lengkap: domain baru
+`src/modules/news-portal/domain/news-share-config.ts` (resolver env
+`NEWS_SHARE_*`, pure),
+`src/modules/blog-content/domain/social-share-links.ts` (link builder
+allowlisted per platform + renderer HTML widget), script client statis
+`public/js/news-share.js` (native share + copy-link, progressive
+enhancement), dan perluasan
+`src/modules/blog-content/domain/public-page-rendering.ts` (og:title/
+og:description/og:url/og:site_name + twitter:title/twitter:description/
+twitter:card selalu ada). **Tidak ada migration baru** — murni
+UI/rendering/config, tidak ada data baru yang dipersist (highest migration
+tetap `047` di saat issue ini dikerjakan; awasi nomor yang benar-benar
+terbaru di `sql/` sebelum issue lanjutan menambah migration, karena issue
+lain di epic yang sama bisa jalan paralel).
+
+### Kenapa config resolver di `news-portal`, tapi link-builder+renderer di `blog-content`
+
+`NEWS_SHARE_*` env var **dimiliki** modul `news-portal` (konvensi
+CONFIG_REGISTRY: prefix `NEWS_` = `ownerModule: "news-portal"`, sama
+seperti `NEWS_PORTAL_ENABLED`/`NEWS_MEDIA_R2_*`) — jadi resolver env
+(`resolveNewsShareConfig`) hidup di sana. Tapi fungsi murni yang membangun
+URL share per platform + merender widget HTML
+(`buildSocialShareLinks`/`renderSocialShareButtonsHtml`) hidup di
+`blog-content` karena beroperasi pada konsep `blog_content` murni
+(title/excerpt/canonical URL post) dan dipanggil dari route yang sama
+(`/news/[slug].ts`, `/blog/[tenantCode]/[slug].ts`) yang sudah merender
+`seo-rendering.ts`/`public-page-rendering.ts` — TIDAK ada dependency
+fungsional ke media registry R2 sama sekali untuk fitur ini (beda dari
+#636). `SocialShareRenderConfig` (di `blog-content`) sengaja punya field
+yang sama persis dengan `NewsShareConfig` (di `news-portal`) TANPA
+cross-module import — struktural TypeScript cukup, route (composition
+root) yang memanggil keduanya langsung, sama pola "route mengimpor dari
+dua modul sekaligus" yang sudah ada (`[slug].ts` sudah mengimpor
+`newsMediaPortAdapter` dari `news-portal/application/` langsung sebelum
+issue ini).
+
+### Instagram — TIDAK ada tombol/URL, hanya catatan teks
+
+Tidak ada URL web-share Instagram yang didukung untuk sharing dari URL
+eksternal sembarang (beda dari WhatsApp/Telegram/Facebook/LinkedIn/X yang
+semuanya punya endpoint share-intent resmi) — jadi `STATIC_SHARE_LINK_BUILDERS`
+di `social-share-links.ts` TIDAK PERNAH punya entry Instagram.
+`NEWS_SHARE_INSTAGRAM_NATIVE_ONLY` (default `true`) hanya menggerbang
+sebuah catatan teks statis di dekat tombol native-share, menjelaskan
+Instagram dibagikan lewat native share (`navigator.share`, saat OS
+menampilkannya sebagai target) atau copy-link — tidak pernah membangun
+tombol/URL baru untuk itu. Test `social-share-links.test.ts`'s "never
+emits a fake Instagram share link/button" menegakkan ini secara eksplisit
+(grep `instagram.com`/`news-share__link--instagram` tidak pernah ada di
+output manapun).
+
+### Canonical URL, bukan querystring — dijamin struktural, bukan filter
+
+Setiap link/atribut `data-share-url` dibangun HANYA dari `canonicalUrl`
+yang sudah di-resolve `resolveCanonicalUrl` (server-side, dari
+`url.origin` + slug post) — tidak pernah dari `request.url`/`Astro.url`
+mentah. Karena `canonicalUrl` server-generated tidak pernah membawa
+querystring/tracking parameter/session id sama sekali, syarat issue "do
+not leak admin preview URLs, draft URLs, session IDs, or private query
+parameters" terpenuhi secara struktural (nilai itu memang tidak pernah
+ada di sana), bukan oleh sebuah filter yang bisa lupa memfilter sesuatu.
+Test integrasi membuktikan ini dengan memanggil route dengan
+`?utm_source=newsletter&session_id=abc123` di URL request dan menegaskan
+tidak satupun string itu muncul di respons.
+
+### Script client — file statis same-origin, BUKAN inline (CSP)
+
+`native_web_share`/`copy_link` butuh JS (Web Share API, Clipboard API) —
+semua platform lain adalah `<a href>` statis tanpa JS sama sekali.
+`public/js/news-share.js` dimuat via `<script src="/js/news-share.js"
+defer>` (same-origin, `public/` Astro default) — **bukan** `<script>`
+inline. Ini sengaja menghindari seluruh kerumitan CSP hash/nonce yang
+`astro.config.mjs`/`theme-init-script.ts` sudah dokumentasikan
+(Astro's `security.csp` hanya meng-hash script yang **ia proses**
+sendiri — script yang dirender lewat `.ts` API route seperti
+`/news/[slug].ts` bukan `.astro` component, jadi TIDAK pernah lewat
+pipeline hashing Astro sama sekali; sebuah `<script>` inline di sini
+berisiko diblokir CSP browser nyata tanpa test headless-Chrome yang bisa
+mendeteksinya lewat `curl`). `script-src 'self'` (default Astro) sudah
+cukup untuk file statis same-origin — nol entri hash baru diperlukan.
+Tombol native-share dirender `hidden` di server, hanya di-unhide oleh
+script ini setelah deteksi fitur nyata (`window.isSecureContext &&
+navigator.share`) — issue: "native share uses `navigator.share` only
+after user activation and only in secure context." Tidak ada dependency
+eksternal, tidak ada `fetch`/`import` ke origin manapun selain halaman itu
+sendiri — `tests/unit/news-share-client-script.test.ts` menegaskan tidak
+ada string `http(s)://` eksternal apa pun di file ini.
+
+### Konfigurasi — semua flag default `true`, deviasi sengaja dari kebiasaan repo
+
+Setiap flag `NEWS_SHARE_*` default `true` (lihat header comment
+`news-share-config.ts` untuk alasan lengkap) — berbeda dari kebiasaan
+"opt-in, default off" var lain di repo ini (`NEWS_PORTAL_ENABLED`,
+`VISITOR_ANALYTICS_ENABLED`, dst.) karena fitur ini tidak mengumpulkan
+data/memuat script eksternal/butuh kredensial apa pun untuk diaktifkan.
+Tidak ada flag terpisah untuk copy-link (selalu ada begitu
+`NEWS_SHARE_BUTTONS_ENABLED=true`) — body issue #642 tidak
+menyarankannya, dan copy-link adalah fallback universal yang seharusnya
+selalu tersedia.
+
+### Meta tag OG/Twitter — perluasan `renderPublicPageShell`, bukan fungsi baru
+
+`og:title`/`og:description`/`og:url` + `twitter:title`/
+`twitter:description` diturunkan dari field `title`/`description`/
+`canonicalUrl` yang SUDAH ada di `PublicPageShellOptions` (satu sumber
+kebenaran per field — tidak ada kolom kedua yang bisa drift).
+`twitter:card` sekarang SELALU dirender (`summary` tanpa gambar,
+`summary_large_image` dengan `og:image` — beda dari sebelum issue ini,
+yang meng-omit `twitter:card` sama sekali tanpa gambar). `og:image`/
+`twitter:image`/`og:image:alt` TIDAK berubah — tetap gerbang R2-only
+Issue #636 (`resolveOgImageUrl`, hanya media `verified`/`attached`).
+`og:site_name` baru, opsional, dari `PublicTenantResolution.tenantName` —
+diteruskan kedua route (`/news/[slug].ts`, `/blog/[tenantCode]/[slug].ts`)
+tanpa lookup tambahan (tenant sudah di-resolve untuk gerbang tenant/module
+yang sudah ada).
+
+### File yang dibuat/diubah (referensi cepat)
+
+- `src/modules/news-portal/domain/news-share-config.ts` (baru).
+- `src/modules/blog-content/domain/social-share-links.ts` (baru).
+- `public/js/news-share.js` (baru).
+- `src/modules/blog-content/domain/public-page-rendering.ts`: `PublicPageShellOptions`
+  gains `siteName`; `renderOpenGraphMetaTags` baru (og:title/description/
+  url/site_name + twitter:title/description/card selalu ada).
+- `src/pages/news/[slug].ts`, `src/pages/blog/[tenantCode]/[slug].ts`:
+  panggil `resolveNewsShareConfig()` + `renderSocialShareButtonsHtml`,
+  teruskan `siteName: tenant.tenantName` ke shell.
+- `src/lib/config/registry.ts`: sembilan entri `NEWS_SHARE_*` baru
+  (`ownerModule: "news-portal"`, `profiles: ALL_PROFILES`, semua
+  default `"true"`).
+- `.env.example`, `18_configuration_env_reference.md` §News portal —
+  public social share buttons (tabel + fenced block ringkas).
+- Test: `tests/unit/news-share-config.test.ts`,
+  `tests/unit/social-share-links.test.ts`,
+  `tests/unit/news-share-client-script.test.ts`,
+  `tests/integration/news-portal-share-buttons.integration.test.ts`;
+  diperbarui: `tests/blog-content-public-rendering.test.ts` (og:title/
+  description/url/site_name/twitter:card selalu ada).
+- Changeset: `.changeset/news-portal-social-share-buttons-issue-642.md`.
 
 ## §641 — Automatic internal tag linking (belum dikerjakan)
 

--- a/.env.example
+++ b/.env.example
@@ -376,6 +376,27 @@ NEWS_MEDIA_R2_PENDING_TTL_MINUTES=60
 # ditegakkan `config:validate`.
 NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS=30
 
+# News portal — public social share buttons (opsional, Issue #642, epic
+# `news_portal`). Setiap flag default `true` (berbeda dari kebiasaan
+# "default off" var lain di file ini) karena fitur ini tidak mengumpulkan
+# data apa pun dan tidak memuat script pihak ketiga apa pun — lihat header
+# comment `src/modules/news-portal/domain/news-share-config.ts` untuk
+# alasan lengkap. Tidak ada flag terpisah untuk copy-link (selalu tersedia
+# begitu NEWS_SHARE_BUTTONS_ENABLED=true) atau Instagram (tidak ada URL
+# web-share Instagram yang didukung — lihat
+# NEWS_SHARE_INSTAGRAM_NATIVE_ONLY di bawah).
+NEWS_SHARE_BUTTONS_ENABLED=true
+NEWS_SHARE_NATIVE_ENABLED=true
+NEWS_SHARE_WHATSAPP_ENABLED=true
+NEWS_SHARE_TELEGRAM_ENABLED=true
+NEWS_SHARE_FACEBOOK_ENABLED=true
+NEWS_SHARE_LINKEDIN_ENABLED=true
+NEWS_SHARE_X_ENABLED=true
+NEWS_SHARE_EMAIL_ENABLED=true
+# Tidak menggerbang sebuah tombol Instagram (tidak ada) — hanya catatan teks
+# yang menjelaskan Instagram dibagikan lewat native share/copy-link.
+NEWS_SHARE_INSTAGRAM_NATIVE_ONLY=true
+
 # Provider eksternal opsional (default off) — base tidak menetapkan provider
 # tertentu; aplikasi turunan menambah flag provider-nya sendiri di sini
 # (lihat contoh domain retail/POS di doc 18 §Provider CRM/AI analyst).

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -712,6 +712,44 @@ lokal untuk media berita yang perlu dimatikan — lihat
 `tests/unit/news-portal-no-local-fallback.test.ts` dan architecture doc
 §3.3-3.4).
 
+### News portal — public social share buttons (opsional, Issue #642, epic `news_portal` #631-#642/#649)
+
+Widget share publik (`src/modules/blog-content/domain/social-share-links.ts`,
+`public/js/news-share.js`) di halaman detail artikel `/news/{slug}` dan
+`/blog/{tenantCode}/{slug}` — `native_web_share`, `copy_link`, WhatsApp,
+Telegram, Facebook, LinkedIn, X, email. Setiap flag di bawah default
+`true` — **deviasi sengaja** dari kebiasaan "default off" var lain di
+dokumen ini (lihat header comment
+`src/modules/news-portal/domain/news-share-config.ts`): fitur ini tidak
+mengumpulkan data apa pun dan tidak memuat script pihak ketiga apa pun,
+tidak seperti `NEWS_PORTAL_ENABLED`/`VISITOR_ANALYTICS_ENABLED`/dst. yang
+menyalakan integrasi eksternal/pengumpulan data baru.
+
+| Var                                | Wajib | Default | Sensitif | Fungsi                                                                                                                                 |
+| ---------------------------------- | ----- | ------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEWS_SHARE_BUTTONS_ENABLED`       | –     | `true`  | –        | Master switch seluruh widget share (termasuk copy-link, yang tidak punya flag sendiri)                                                 |
+| `NEWS_SHARE_NATIVE_ENABLED`        | –     | `true`  | –        | Tombol Web Share API — tetap `hidden` sampai `public/js/news-share.js` mendeteksi `navigator.share` tersedia di secure context         |
+| `NEWS_SHARE_WHATSAPP_ENABLED`      | –     | `true`  | –        | Link share WhatsApp (`wa.me`)                                                                                                          |
+| `NEWS_SHARE_TELEGRAM_ENABLED`      | –     | `true`  | –        | Link share Telegram (`t.me/share`)                                                                                                     |
+| `NEWS_SHARE_FACEBOOK_ENABLED`      | –     | `true`  | –        | Link Facebook Share Dialog                                                                                                             |
+| `NEWS_SHARE_LINKEDIN_ENABLED`      | –     | `true`  | –        | Link LinkedIn share-offsite                                                                                                            |
+| `NEWS_SHARE_X_ENABLED`             | –     | `true`  | –        | Link X/Twitter intent/tweet                                                                                                            |
+| `NEWS_SHARE_EMAIL_ENABLED`         | –     | `true`  | –        | Link `mailto:`                                                                                                                         |
+| `NEWS_SHARE_INSTAGRAM_NATIVE_ONLY` | –     | `true`  | –        | TIDAK menggerbang tombol Instagram (tidak ada URL web-share Instagram yang didukung) — hanya catatan teks di dekat tombol native share |
+
+Setiap link platform dibangun oleh fungsi murni allowlisted
+(`buildSocialShareLinks`, satu builder tetap per platform) dari canonical URL
+yang SUDAH di-resolve server (`resolveCanonicalUrl`) — tidak pernah dari
+querystring/tracking URL request asli — dengan setiap nilai
+`encodeURIComponent`-ed. Semua link eksternal memakai
+`rel="noopener noreferrer"`. `native_web_share`/`copy_link` diimplementasi
+oleh satu file script statis same-origin (`public/js/news-share.js`,
+`<script src>` — bukan inline, jadi tidak menambah entri hash CSP apa pun
+di `astro.config.mjs`); tidak ada script pihak ketiga yang dimuat. Widget
+hanya dirender untuk post yang sudah lolos gerbang publik/published yang
+sama (`fetchPublicBlogPostBySlug`) — draft/private/scheduled/soft-deleted
+tetap 404 sebelum widget ini pernah dipertimbangkan.
+
 ### Provider CRM (opsional) — contoh domain retail/POS
 
 | Var                    | Wajib      | Default | Sensitif | Fungsi             |
@@ -829,6 +867,11 @@ VISITOR_ANALYTICS_GEO_ENABLED=false
 # `news_portal`). Tidak di-set sama sekali = preset tidak aktif.
 NEWS_PORTAL_ENABLED=false
 NEWS_MEDIA_R2_ENABLED=false
+
+# News portal — public social share buttons (opsional — Issue #642, epic
+# `news_portal`). Default true, lihat §"News portal — public social share
+# buttons" di bawah untuk alasan lengkap.
+NEWS_SHARE_BUTTONS_ENABLED=true
 
 # Provider opsional (default off) — contoh domain retail/POS
 STARSENDER_ENABLED=false

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -101,15 +101,15 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 
 ## Tests
 
-208 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
+212 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
 
 | Directory     | Test files |
 | ------------- | ---------- |
 | `(root)`      | 46         |
 | `e2e`         | 9          |
-| `integration` | 70         |
+| `integration` | 71         |
 | `modules`     | 3          |
-| `unit`        | 80         |
+| `unit`        | 83         |
 
 ## Routes / Operations (summary)
 

--- a/public/js/news-share.js
+++ b/public/js/news-share.js
@@ -1,0 +1,146 @@
+/**
+ * Public news article share widget progressive enhancement (Issue #642,
+ * epic `news_portal`). Loaded same-origin via `<script src="/js/news-share.js"
+ * defer>` by `src/modules/blog-content/domain/social-share-links.ts`'s
+ * `renderSocialShareButtonsHtml` — never inlined, so this file adds no
+ * Content-Security-Policy hash/nonce bookkeeping (plain `'self'` script-src
+ * already allows it, see `astro.config.mjs`).
+ *
+ * Deliberately vanilla, dependency-free, and does not fetch/import anything
+ * from a third-party origin — the whole point of this file is to satisfy
+ * the issue's "no third-party tracking JavaScript is loaded by default"
+ * requirement while still implementing the two share actions that
+ * structurally require client-side JS (native OS share sheet, clipboard
+ * copy). Every other share platform (WhatsApp/Telegram/Facebook/LinkedIn/
+ * X/email) is a plain server-rendered `<a href>` and needs no JS at all.
+ */
+(function () {
+  "use strict";
+
+  function showStatus(widget, message) {
+    var status = widget.querySelector(".js-news-share-status");
+
+    if (!status) {
+      return;
+    }
+
+    status.textContent = message;
+    status.hidden = false;
+  }
+
+  function findWidget(button) {
+    return button.closest(".news-share");
+  }
+
+  /**
+   * Native share button: stays `hidden` (server-rendered default) unless
+   * `navigator.share` really exists in a secure context — issue: "Native
+   * share uses `navigator.share` only after user activation and only in
+   * secure context." The button is only ever revealed here (feature
+   * detection); the actual `navigator.share(...)` call happens strictly
+   * inside the `click` handler below, i.e. only as the direct result of a
+   * real user activation, never on page load/automatically.
+   */
+  function enhanceNativeShareButtons() {
+    if (!window.isSecureContext || typeof navigator.share !== "function") {
+      return;
+    }
+
+    var buttons = document.querySelectorAll(".js-news-share-native");
+
+    buttons.forEach(function (button) {
+      button.hidden = false;
+
+      button.addEventListener("click", function () {
+        var shareData = {
+          url: button.getAttribute("data-share-url") || "",
+          title: button.getAttribute("data-share-title") || "",
+          text: button.getAttribute("data-share-text") || ""
+        };
+
+        navigator.share(shareData).catch(function (error) {
+          // AbortError = the visitor closed the native share sheet without
+          // picking a target — not a real failure, no status message.
+          if (error && error.name === "AbortError") {
+            return;
+          }
+
+          var widget = findWidget(button);
+
+          if (widget) {
+            showStatus(widget, "Unable to share right now.");
+          }
+        });
+      });
+    });
+  }
+
+  function fallbackCopyToClipboard(url) {
+    var textarea = document.createElement("textarea");
+    textarea.value = url;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    var succeeded = false;
+
+    try {
+      succeeded = document.execCommand("copy");
+    } catch (error) {
+      succeeded = false;
+    }
+
+    document.body.removeChild(textarea);
+    return succeeded;
+  }
+
+  function enhanceCopyLinkButtons() {
+    var buttons = document.querySelectorAll(".js-news-share-copy");
+
+    buttons.forEach(function (button) {
+      button.addEventListener("click", function () {
+        var url = button.getAttribute("data-share-url") || "";
+        var widget = findWidget(button);
+
+        if (
+          window.isSecureContext &&
+          navigator.clipboard &&
+          typeof navigator.clipboard.writeText === "function"
+        ) {
+          navigator.clipboard
+            .writeText(url)
+            .then(function () {
+              if (widget) {
+                showStatus(widget, "Link copied.");
+              }
+            })
+            .catch(function () {
+              var succeeded = fallbackCopyToClipboard(url);
+
+              if (widget) {
+                showStatus(
+                  widget,
+                  succeeded ? "Link copied." : "Could not copy the link."
+                );
+              }
+            });
+          return;
+        }
+
+        var succeeded = fallbackCopyToClipboard(url);
+
+        if (widget) {
+          showStatus(
+            widget,
+            succeeded ? "Link copied." : "Could not copy the link."
+          );
+        }
+      });
+    });
+  }
+
+  enhanceNativeShareButtons();
+  enhanceCopyLinkButtons();
+})();

--- a/src/lib/config/registry.ts
+++ b/src/lib/config/registry.ts
@@ -1363,6 +1363,103 @@ export const CONFIG_REGISTRY: readonly ConfigVarEntry[] = [
     default: "30",
     description:
       "Grace period (days) before bun run news-media:reconcile (Issue #690) physically deletes a grace-period-expired orphaned media object's R2 object + soft-deletes its metadata row. Minimum 30 days (r2-backup-lifecycle.md §3), enforced by config:validate."
+  },
+
+  // ---------------------------------------------------------------------
+  // News portal — public social share buttons (Issue #642)
+  // ---------------------------------------------------------------------
+  {
+    name: "NEWS_SHARE_BUTTONS_ENABLED",
+    type: "boolean",
+    required: "optional",
+    ownerModule: "news-portal",
+    sensitivity: "non-secret",
+    profiles: ALL_PROFILES,
+    default: "true",
+    description:
+      "Master switch for the public share widget (native share/copy-link/WhatsApp/Telegram/Facebook/LinkedIn/X/email) on /news and /blog/{tenantCode} article pages — src/modules/blog-content/domain/social-share-links.ts."
+  },
+  {
+    name: "NEWS_SHARE_NATIVE_ENABLED",
+    type: "boolean",
+    required: "optional",
+    ownerModule: "news-portal",
+    sensitivity: "non-secret",
+    profiles: ALL_PROFILES,
+    default: "true",
+    description:
+      "Renders the native Web Share API button (navigator.share, revealed by public/js/news-share.js only in a secure context when supported)."
+  },
+  {
+    name: "NEWS_SHARE_WHATSAPP_ENABLED",
+    type: "boolean",
+    required: "optional",
+    ownerModule: "news-portal",
+    sensitivity: "non-secret",
+    profiles: ALL_PROFILES,
+    default: "true",
+    description: "Renders the WhatsApp (wa.me) share link."
+  },
+  {
+    name: "NEWS_SHARE_TELEGRAM_ENABLED",
+    type: "boolean",
+    required: "optional",
+    ownerModule: "news-portal",
+    sensitivity: "non-secret",
+    profiles: ALL_PROFILES,
+    default: "true",
+    description: "Renders the Telegram (t.me/share) share link."
+  },
+  {
+    name: "NEWS_SHARE_FACEBOOK_ENABLED",
+    type: "boolean",
+    required: "optional",
+    ownerModule: "news-portal",
+    sensitivity: "non-secret",
+    profiles: ALL_PROFILES,
+    default: "true",
+    description: "Renders the Facebook Share Dialog link."
+  },
+  {
+    name: "NEWS_SHARE_LINKEDIN_ENABLED",
+    type: "boolean",
+    required: "optional",
+    ownerModule: "news-portal",
+    sensitivity: "non-secret",
+    profiles: ALL_PROFILES,
+    default: "true",
+    description: "Renders the LinkedIn share-offsite link."
+  },
+  {
+    name: "NEWS_SHARE_X_ENABLED",
+    type: "boolean",
+    required: "optional",
+    ownerModule: "news-portal",
+    sensitivity: "non-secret",
+    profiles: ALL_PROFILES,
+    default: "true",
+    description: "Renders the X/Twitter intent/tweet share link."
+  },
+  {
+    name: "NEWS_SHARE_EMAIL_ENABLED",
+    type: "boolean",
+    required: "optional",
+    ownerModule: "news-portal",
+    sensitivity: "non-secret",
+    profiles: ALL_PROFILES,
+    default: "true",
+    description: "Renders the mailto: email share link."
+  },
+  {
+    name: "NEWS_SHARE_INSTAGRAM_NATIVE_ONLY",
+    type: "boolean",
+    required: "optional",
+    ownerModule: "news-portal",
+    sensitivity: "non-secret",
+    profiles: ALL_PROFILES,
+    default: "true",
+    description:
+      "There is no supported Instagram web-share intent URL, so this never renders a dedicated Instagram button — it only toggles a short text note clarifying that Instagram sharing goes through native share (when NEWS_SHARE_NATIVE_ENABLED=true) or copy-link, never a fake Instagram URL."
   }
 ];
 

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -362,6 +362,45 @@ statuses, unlisted-reachable-by-direct-link, canonical URL under `/news`,
 feed/sitemap links under `/news`, module-disabled 404, `tenant_code_legacy`
 404, cross-tenant isolation).
 
+### Public social share buttons + expanded OG/Twitter metadata — Issue #642 (epic `news_portal`)
+
+Both post detail routes (`/news/{slug}`, `/blog/{tenantCode}/{slug}`) now
+render a public share widget (native Web Share API, copy-link, WhatsApp,
+Telegram, Facebook, LinkedIn, X, email) and expanded Open Graph/Twitter
+Card metadata. New pure modules:
+`domain/social-share-links.ts` (`buildSocialShareLinks` — six-platform
+fixed allowlist, every URL `encodeURIComponent`-encoded;
+`renderSocialShareButtonsHtml` — full widget markup) and
+`src/modules/news-portal/domain/news-share-config.ts`
+(`resolveNewsShareConfig` — per-platform `NEWS_SHARE_*_ENABLED` env
+flags, all defaulting `true`; see that file's header comment for why this
+deviates from this repo's usual "opt-in, default off" feature-flag
+convention). See `.claude/skills/awcms-mini-news-portal/SKILL.md` §642 for
+the full design rationale (Instagram has no supported web-share URL so
+never gets a dedicated button; the canonical URL — never the request's
+raw querystring — is the only URL ever shared; the native-share/copy-link
+client script is a same-origin static file, `public/js/news-share.js`,
+never inline, so it adds zero Content-Security-Policy surface).
+
+`public-page-rendering.ts`'s `renderPublicPageShell` now also emits
+`og:title`/`og:description`/`og:url`/`og:site_name` (derived from the same
+`title`/`description`/`canonicalUrl` fields it already renders as
+`<title>`/`<meta name="description">`/`<link rel="canonical">` — one
+source of truth, `siteName` new and optional from
+`PublicTenantResolution.tenantName`) and `twitter:title`/
+`twitter:description`/`twitter:card` (now always present — `summary`
+without an image, `summary_large_image` with one). `og:image`/
+`twitter:image`/`og:image:alt` are unchanged from Issue #636 (still gated
+on a verified R2 media object).
+
+Test: `tests/unit/social-share-links.test.ts`, `tests/unit/news-share-config.test.ts`,
+`tests/unit/news-share-client-script.test.ts`,
+`tests/integration/news-portal-share-buttons.integration.test.ts` (real
+`/news/{slug}`/`/blog/{tenantCode}/{slug}` routes — default-enabled
+widget, master-switch/per-platform disable, draft never renders it,
+canonical URL used even when the request URL carries tracking
+querystring parameters).
+
 ## `/news` (default) vs `/blog/{tenantCode}` (legacy) — Issue #561
 
 Two public route families exist side by side, and neither is going away.

--- a/src/modules/blog-content/domain/public-page-rendering.ts
+++ b/src/modules/blog-content/domain/public-page-rendering.ts
@@ -32,22 +32,61 @@ export type PublicPageShellOptions = {
   ogImageUrl?: string | null;
   /** Alt text for the `og:image`, from the same verified media object (`altText`) — omitted if there is no image or no alt text set. */
   ogImageAlt?: string | null;
+  /**
+   * Issue #642 — tenant-specific site name (`PublicTenantResolution.tenantName`)
+   * rendered as `og:site_name`. Omitted (no tag) when not provided — every
+   * existing caller predates this option and stays behavior-identical.
+   */
+  siteName?: string | null;
 };
+
+/**
+ * `og:title`/`og:description`/`og:url` + `twitter:title`/`twitter:description`/
+ * `twitter:card` (Issue #642 — "Open Graph/Twitter Card metadata" for public
+ * social share previews). Derived from the SAME `title`/`description`/
+ * `canonicalUrl` this shell already renders as `<title>`/
+ * `<meta name="description">`/`<link rel="canonical">` — one source of
+ * truth per field, never a second copy that could drift. `og:url` is
+ * omitted (like the canonical link) when `canonicalUrl` is `null` (no safe
+ * URL to point crawlers at). `twitter:card` is always emitted — unlike
+ * `og:image`/`twitter:image` (still gated on a verified R2 image existing,
+ * per Issue #636's R2-only policy), a text-only `summary` card is always
+ * safe to advertise; it upgrades to `summary_large_image` once an image is
+ * present.
+ */
+function renderOpenGraphMetaTags(options: PublicPageShellOptions): string {
+  const tags = [
+    `<meta property="og:title" content="${escapeHtml(options.title)}" />`,
+    `<meta property="og:description" content="${escapeHtml(options.description)}" />`,
+    options.canonicalUrl
+      ? `<meta property="og:url" content="${escapeHtml(options.canonicalUrl)}" />`
+      : "",
+    options.siteName
+      ? `<meta property="og:site_name" content="${escapeHtml(options.siteName)}" />`
+      : "",
+    `<meta name="twitter:card" content="${options.ogImageUrl ? "summary_large_image" : "summary"}" />`,
+    `<meta name="twitter:title" content="${escapeHtml(options.title)}" />`,
+    `<meta name="twitter:description" content="${escapeHtml(options.description)}" />`,
+    options.ogImageUrl
+      ? `<meta property="og:image" content="${escapeHtml(options.ogImageUrl)}" />`
+      : "",
+    options.ogImageUrl
+      ? `<meta name="twitter:image" content="${escapeHtml(options.ogImageUrl)}" />`
+      : "",
+    options.ogImageUrl && options.ogImageAlt
+      ? `<meta property="og:image:alt" content="${escapeHtml(options.ogImageAlt)}" />`
+      : ""
+  ];
+
+  return tags.filter((tag) => tag.length > 0).join("\n");
+}
 
 export function renderPublicPageShell(options: PublicPageShellOptions): string {
   const canonicalTag = options.canonicalUrl
     ? `<link rel="canonical" href="${escapeHtml(options.canonicalUrl)}" />`
     : "";
 
-  const ogTags = options.ogImageUrl
-    ? `<meta property="og:image" content="${escapeHtml(options.ogImageUrl)}" />
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:image" content="${escapeHtml(options.ogImageUrl)}" />${
-        options.ogImageAlt
-          ? `\n<meta property="og:image:alt" content="${escapeHtml(options.ogImageAlt)}" />`
-          : ""
-      }`
-    : "";
+  const ogTags = renderOpenGraphMetaTags(options);
 
   return `<!doctype html>
 <html lang="${escapeHtml(options.locale)}">

--- a/src/modules/blog-content/domain/social-share-links.ts
+++ b/src/modules/blog-content/domain/social-share-links.ts
@@ -1,0 +1,223 @@
+import { escapeHtml } from "../../../lib/html/escape";
+import { isAbsoluteHttpUrl } from "./seo-validation";
+
+/**
+ * Public social share buttons (Issue #642, epic `news_portal`). Pure — no
+ * I/O, no `process.env` reads (the caller passes in an already-resolved
+ * config, e.g. `news-portal/domain/news-share-config.ts`'s
+ * `resolveNewsShareConfig()`, structurally compatible with
+ * `SocialShareRenderConfig` below by field name — no cross-module import
+ * needed, same "composition root wires modules together, domain layers stay
+ * decoupled" convention Issue #681 established for this epic).
+ *
+ * ## Canonical URL only — never the request's raw querystring
+ *
+ * Every function here takes an already-resolved `canonicalUrl` (the same
+ * value `seo-rendering.ts`'s `resolveCanonicalUrl` produces and
+ * `renderPublicPageShell` already emits as `<link rel="canonical">`), never
+ * `Astro`/`request.url` directly. That value is server-constructed from
+ * `url.origin` + the post's own slug (`/news/[slug].ts`,
+ * `/blog/[tenantCode]/[slug].ts`) — it can never carry a tracking
+ * querystring, an admin preview flag, a session id, or any other private
+ * query parameter a visitor's actual browser URL might contain, satisfying
+ * the issue's "do not leak admin preview URLs, draft URLs, session IDs, or
+ * private query parameters" requirement structurally rather than by
+ * filtering.
+ *
+ * ## Instagram — no fake web-share URL
+ *
+ * There is no supported Instagram "share to feed/story from an arbitrary
+ * external URL" web intent (unlike WhatsApp/Telegram/Facebook/LinkedIn/X,
+ * which all have documented `https://` share-intent endpoints). Instagram
+ * sharing is therefore NEVER a static `<a href>` in `STATIC_SHARE_LINK_BUILDERS`
+ * below — it is reachable only through the native `navigator.share` share
+ * sheet (when the visitor's OS/browser lists Instagram as an installed
+ * share target) or the copy-link fallback, both already rendered for other
+ * reasons. `renderSocialShareButtonsHtml`'s `instagramNativeOnly` flag only
+ * controls a short static text note clarifying this, never a dedicated
+ * button of its own — see that function's doc comment.
+ */
+
+export type SocialShareArticle = {
+  /** Already-resolved, already-validated canonical URL — see module doc comment. */
+  canonicalUrl: string;
+  title: string;
+  /** Falls back to `title` when null/empty for platforms that share a text snippet (WhatsApp/X/email body). */
+  excerpt: string | null;
+};
+
+/** Structurally compatible with `news-portal/domain/news-share-config.ts`'s `NewsShareConfig` — see module doc comment for why this isn't imported from there directly. */
+export type SocialShareRenderConfig = {
+  buttonsEnabled: boolean;
+  native: boolean;
+  whatsapp: boolean;
+  telegram: boolean;
+  facebook: boolean;
+  linkedin: boolean;
+  x: boolean;
+  email: boolean;
+  instagramNativeOnly: boolean;
+};
+
+export type SocialSharePlatform =
+  "whatsapp" | "telegram" | "facebook" | "linkedin" | "x_twitter" | "email";
+
+export type SocialShareLink = {
+  platform: SocialSharePlatform;
+  label: string;
+  href: string;
+};
+
+function shareText(article: SocialShareArticle): string {
+  return article.excerpt && article.excerpt.trim().length > 0
+    ? article.excerpt
+    : article.title;
+}
+
+/**
+ * Every entry's `buildHref` receives the already-validated `canonicalUrl` +
+ * article fields and returns a fully `encodeURIComponent`-escaped share
+ * intent URL. This array IS the platform allowlist (issue: "keep all share
+ * URLs encoded and allowlisted by platform") — no caller can request a
+ * platform outside this fixed set, and no raw/unencoded value is ever
+ * concatenated into a URL.
+ */
+const STATIC_SHARE_LINK_BUILDERS: ReadonlyArray<{
+  platform: SocialSharePlatform;
+  label: string;
+  isEnabled: (config: SocialShareRenderConfig) => boolean;
+  buildHref: (article: SocialShareArticle) => string;
+}> = [
+  {
+    platform: "whatsapp",
+    label: "WhatsApp",
+    isEnabled: (config) => config.whatsapp,
+    buildHref: (article) =>
+      `https://wa.me/?text=${encodeURIComponent(`${article.title} ${article.canonicalUrl}`)}`
+  },
+  {
+    platform: "telegram",
+    label: "Telegram",
+    isEnabled: (config) => config.telegram,
+    buildHref: (article) =>
+      `https://t.me/share/url?url=${encodeURIComponent(article.canonicalUrl)}&text=${encodeURIComponent(article.title)}`
+  },
+  {
+    platform: "facebook",
+    label: "Facebook",
+    isEnabled: (config) => config.facebook,
+    buildHref: (article) =>
+      `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(article.canonicalUrl)}`
+  },
+  {
+    platform: "linkedin",
+    label: "LinkedIn",
+    isEnabled: (config) => config.linkedin,
+    buildHref: (article) =>
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(article.canonicalUrl)}`
+  },
+  {
+    platform: "x_twitter",
+    label: "X",
+    isEnabled: (config) => config.x,
+    buildHref: (article) =>
+      `https://twitter.com/intent/tweet?url=${encodeURIComponent(article.canonicalUrl)}&text=${encodeURIComponent(article.title)}`
+  },
+  {
+    platform: "email",
+    label: "Email",
+    isEnabled: (config) => config.email,
+    buildHref: (article) =>
+      `mailto:?subject=${encodeURIComponent(article.title)}&body=${encodeURIComponent(`${shareText(article)}\n\n${article.canonicalUrl}`)}`
+  }
+];
+
+/**
+ * Builds the enabled static-link platforms only (native share + copy link
+ * are not part of this list — they need client-side JS, rendered separately
+ * by `renderSocialShareButtonsHtml`). Returns `[]` when the canonical URL
+ * isn't a safe absolute http(s) URL — same "degrade, don't render an unsafe
+ * link" convention `resolveOgImageUrl`/`resolveCanonicalUrl` use.
+ */
+export function buildSocialShareLinks(
+  article: SocialShareArticle,
+  config: SocialShareRenderConfig
+): SocialShareLink[] {
+  if (!isAbsoluteHttpUrl(article.canonicalUrl)) {
+    return [];
+  }
+
+  return STATIC_SHARE_LINK_BUILDERS.filter((entry) =>
+    entry.isEnabled(config)
+  ).map((entry) => ({
+    platform: entry.platform,
+    label: entry.label,
+    href: entry.buildHref(article)
+  }));
+}
+
+function renderInstagramNote(config: SocialShareRenderConfig): string {
+  if (!config.instagramNativeOnly) {
+    return "";
+  }
+
+  const message = config.native
+    ? "Instagram: use the Share button above, or Copy link."
+    : "Instagram: use Copy link to share this article.";
+
+  return `<p class="news-share__note">${escapeHtml(message)}</p>`;
+}
+
+/**
+ * Full public share widget for one article — the ONLY function route files
+ * (`/news/[slug].ts`, `/blog/[tenantCode]/[slug].ts`) need to call. Returns
+ * `""` (renders nothing) when `config.buttonsEnabled` is `false` or the
+ * canonical URL isn't safe — callers can splice the result straight into
+ * `bodyHtml` unconditionally.
+ *
+ * Native share and copy-link are rendered as `hidden`/plain `<button>`
+ * elements with `data-share-*` attributes read by `scriptSrc`
+ * (`public/js/news-share.js`, loaded same-origin via `<script src>` — never
+ * inline, so this widget adds zero new Content-Security-Policy surface: no
+ * hash/nonce bookkeeping, just an ordinary `'self'` same-origin script).
+ * That script progressively enhances: the native-share button starts
+ * `hidden` and is only revealed when `navigator.share` actually exists in a
+ * secure context (issue: "native share uses `navigator.share` only after
+ * user activation and only in secure context") — with JS disabled or
+ * unsupported, it silently stays hidden rather than rendering a dead
+ * button.
+ */
+export function renderSocialShareButtonsHtml(
+  article: SocialShareArticle,
+  config: SocialShareRenderConfig,
+  scriptSrc: string
+): string {
+  if (!config.buttonsEnabled || !isAbsoluteHttpUrl(article.canonicalUrl)) {
+    return "";
+  }
+
+  const staticLinks = buildSocialShareLinks(article, config);
+  const staticLinkItems = staticLinks
+    .map(
+      (link) =>
+        `<li><a class="news-share__link news-share__link--${escapeHtml(link.platform)}" href="${escapeHtml(link.href)}" target="_blank" rel="noopener noreferrer" aria-label="Share on ${escapeHtml(link.label)}">${escapeHtml(link.label)}</a></li>`
+    )
+    .join("\n");
+
+  const nativeItem = config.native
+    ? `<li><button type="button" class="news-share__native js-news-share-native" hidden data-share-url="${escapeHtml(article.canonicalUrl)}" data-share-title="${escapeHtml(article.title)}" data-share-text="${escapeHtml(shareText(article))}" aria-label="Share this article">Share</button></li>`
+    : "";
+
+  const copyItem = `<li><button type="button" class="news-share__copy js-news-share-copy" data-share-url="${escapeHtml(article.canonicalUrl)}" aria-label="Copy article link">Copy link</button></li>`;
+
+  return `<nav class="news-share" aria-label="Share this article">
+<ul class="news-share__list">
+${nativeItem}
+${copyItem}
+${staticLinkItems}
+</ul>
+<p class="news-share__status js-news-share-status" role="status" aria-live="polite" hidden></p>
+${renderInstagramNote(config)}
+<script src="${escapeHtml(scriptSrc)}" defer></script>
+</nav>`;
+}

--- a/src/modules/news-portal/domain/news-share-config.ts
+++ b/src/modules/news-portal/domain/news-share-config.ts
@@ -1,0 +1,89 @@
+/**
+ * `NEWS_SHARE_*` configuration gate (Issue #642, epic `news_portal`
+ * #631-#642/#649 — "public social share buttons for news articles"). Pure —
+ * no `process.env` reads except the default parameter value, same split as
+ * `news-media-r2-config.ts` and `src/lib/auth/mfa-config.ts`
+ * (`env: NodeJS.ProcessEnv = process.env`).
+ *
+ * ## Scope — UI/rendering config only, no new persisted data
+ *
+ * Every var here is a simple boolean feature flag gating whether a given
+ * share platform's button/link is rendered on a public `/news`/
+ * `/blog/{tenantCode}` article page — there is no per-tenant override table
+ * (unlike, say, `blog_content`'s `publicRouteMode` module setting). This
+ * matches the issue body's own "Suggested settings" list, which is
+ * env-var-shaped (`NEWS_SHARE_BUTTONS_ENABLED=true`, ALL_CAPS `=true/false`)
+ * — the same convention every other global feature flag in this repo uses
+ * (`NEWS_PORTAL_ENABLED`, `VISITOR_ANALYTICS_ENABLED`, `R2_ENABLED`), not a
+ * tenant-scoped DB setting. Deliberately does NOT invent a
+ * `NEWS_SHARE_COPY_LINK_ENABLED` var — the issue's own suggested list has no
+ * such entry; copy-link is the universal fallback whenever the master
+ * switch (`NEWS_SHARE_BUTTONS_ENABLED`) is on, gated by nothing else.
+ *
+ * ## Default `true`, not `false` — a deliberate deviation from this
+ * repo's usual "opt-in, default off" convention for new feature flags
+ *
+ * Every other recently-added master switch in this codebase
+ * (`NEWS_PORTAL_ENABLED`, `NEWS_MEDIA_R2_ENABLED`, `VISITOR_ANALYTICS_ENABLED`,
+ * `AUTH_MFA_ENABLED`, ...) defaults `false` because enabling it turns on
+ * either a new data-collection surface (visitor analytics), a new
+ * credential-bearing external integration (R2), or a new auth code path
+ * that needs operator-supplied secrets first (MFA/SSO). Share buttons have
+ * none of those properties: no data is collected, no third-party script is
+ * loaded, no secret needs provisioning — every link is a same-origin
+ * `<a href>`/`<button>` built entirely from data the page already renders
+ * publicly (title/excerpt/canonical URL). Defaulting to `true` matches the
+ * issue's own "Suggested settings" block verbatim and the ordinary
+ * expectation that a public news site ships with working share buttons out
+ * of the box; operators who need to disable a specific platform (regulatory,
+ * editorial policy) still can, per-flag.
+ *
+ * `NEWS_SHARE_INSTAGRAM_NATIVE_ONLY` does not gate a dedicated "Instagram"
+ * button at all (there is no supported Instagram web-share intent URL — see
+ * the architecture note in `social-share-links.ts`) — it only toggles a
+ * short, non-interactive accessibility note next to the native-share button
+ * clarifying that Instagram sharing goes through the OS share sheet (native
+ * share) or copy-link, never a fake Instagram URL.
+ */
+
+export type NewsShareConfig = {
+  buttonsEnabled: boolean;
+  native: boolean;
+  whatsapp: boolean;
+  telegram: boolean;
+  facebook: boolean;
+  linkedin: boolean;
+  x: boolean;
+  email: boolean;
+  instagramNativeOnly: boolean;
+};
+
+function readBooleanFlag(
+  value: string | undefined,
+  defaultValue: boolean
+): boolean {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  return value === "true";
+}
+
+export function resolveNewsShareConfig(
+  env: NodeJS.ProcessEnv = process.env
+): NewsShareConfig {
+  return {
+    buttonsEnabled: readBooleanFlag(env.NEWS_SHARE_BUTTONS_ENABLED, true),
+    native: readBooleanFlag(env.NEWS_SHARE_NATIVE_ENABLED, true),
+    whatsapp: readBooleanFlag(env.NEWS_SHARE_WHATSAPP_ENABLED, true),
+    telegram: readBooleanFlag(env.NEWS_SHARE_TELEGRAM_ENABLED, true),
+    facebook: readBooleanFlag(env.NEWS_SHARE_FACEBOOK_ENABLED, true),
+    linkedin: readBooleanFlag(env.NEWS_SHARE_LINKEDIN_ENABLED, true),
+    x: readBooleanFlag(env.NEWS_SHARE_X_ENABLED, true),
+    email: readBooleanFlag(env.NEWS_SHARE_EMAIL_ENABLED, true),
+    instagramNativeOnly: readBooleanFlag(
+      env.NEWS_SHARE_INSTAGRAM_NATIVE_ONLY,
+      true
+    )
+  };
+}

--- a/src/pages/blog/[tenantCode]/[slug].ts
+++ b/src/pages/blog/[tenantCode]/[slug].ts
@@ -12,6 +12,7 @@ import { log } from "../../../lib/logging/logger";
 import { fetchPublicBlogPostBySlug } from "../../../modules/blog-content/application/public-blog-directory";
 import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
 import { newsMediaPortAdapter } from "../../../modules/news-portal/application/news-media-port-adapter";
+import { resolveNewsShareConfig } from "../../../modules/news-portal/domain/news-share-config";
 import {
   collectRenderableGalleryMediaObjectIds,
   renderContentJsonToHtml
@@ -23,6 +24,9 @@ import {
   resolveSeoTitle
 } from "../../../modules/blog-content/domain/seo-rendering";
 import { renderPublicPageShell } from "../../../modules/blog-content/domain/public-page-rendering";
+import { renderSocialShareButtonsHtml } from "../../../modules/blog-content/domain/social-share-links";
+
+const NEWS_SHARE_CLIENT_SCRIPT_SRC = "/js/news-share.js";
 
 /**
  * `GET /blog/{tenantCode}/{slug}` (Issue #540) — public post detail.
@@ -92,11 +96,23 @@ export const GET: APIRoute = async ({ params, url }) => {
         resolvedGalleryUrls
       );
 
+      // Issue #642 — see `/news/[slug].ts`'s identical comment: share
+      // buttons only for this already-gated public/published post, built
+      // from the resolved canonical URL only.
+      const shareButtonsHtml = canonicalUrl
+        ? renderSocialShareButtonsHtml(
+            { canonicalUrl, title: seoTitle, excerpt: metaDescription },
+            resolveNewsShareConfig(),
+            NEWS_SHARE_CLIENT_SCRIPT_SRC
+          )
+        : "";
+
       const bodyHtml = `<article>
   <h1>${escapeHtml(post.title)}</h1>
   <p><time datetime="${post.publishedAt.toISOString()}">${escapeHtml(post.publishedAt.toDateString())}</time></p>
   ${contentHtml}
 </article>
+${shareButtonsHtml}
 <p><a href="/blog/${escapeHtml(tenantCode)}">Back to blog</a></p>`;
 
       const html = renderPublicPageShell({
@@ -106,7 +122,8 @@ export const GET: APIRoute = async ({ params, url }) => {
         bodyHtml,
         locale: post.locale,
         ogImageUrl: resolveOgImageUrl(featuredMedia?.publicUrl ?? null),
-        ogImageAlt: featuredMedia?.altText ?? null
+        ogImageAlt: featuredMedia?.altText ?? null,
+        siteName: tenant.tenantName
       });
 
       return new Response(html, {

--- a/src/pages/news/[slug].ts
+++ b/src/pages/news/[slug].ts
@@ -10,6 +10,7 @@ import { log } from "../../lib/logging/logger";
 import { fetchPublicBlogPostBySlug } from "../../modules/blog-content/application/public-blog-directory";
 import { withNewsTenant } from "../../modules/blog-content/application/public-news-tenant-resolution";
 import { newsMediaPortAdapter } from "../../modules/news-portal/application/news-media-port-adapter";
+import { resolveNewsShareConfig } from "../../modules/news-portal/domain/news-share-config";
 import {
   collectRenderableGalleryMediaObjectIds,
   renderContentJsonToHtml
@@ -21,6 +22,9 @@ import {
   resolveSeoTitle
 } from "../../modules/blog-content/domain/seo-rendering";
 import { renderPublicPageShell } from "../../modules/blog-content/domain/public-page-rendering";
+import { renderSocialShareButtonsHtml } from "../../modules/blog-content/domain/social-share-links";
+
+const NEWS_SHARE_CLIENT_SCRIPT_SRC = "/js/news-share.js";
 
 /**
  * `GET /news/{slug}` (Issue #560) — public post detail, tenant-code-free
@@ -85,11 +89,27 @@ export const GET: APIRoute = async ({ params, request, url }) => {
           resolvedGalleryUrls
         );
 
+        // Issue #642 — public share buttons, rendered only for this
+        // already-gated public/published post (withNewsTenant + a non-null
+        // fetchPublicBlogPostBySlug result above already exclude draft/
+        // private/scheduled/soft-deleted content, matching the acceptance
+        // criterion "buttons render only on public/published pages").
+        // `canonicalUrl` (never the request's raw querystring) is the only
+        // URL ever handed to the share widget.
+        const shareButtonsHtml = canonicalUrl
+          ? renderSocialShareButtonsHtml(
+              { canonicalUrl, title: seoTitle, excerpt: metaDescription },
+              resolveNewsShareConfig(),
+              NEWS_SHARE_CLIENT_SCRIPT_SRC
+            )
+          : "";
+
         const bodyHtml = `<article>
   <h1>${escapeHtml(post.title)}</h1>
   <p><time datetime="${post.publishedAt.toISOString()}">${escapeHtml(post.publishedAt.toDateString())}</time></p>
   ${contentHtml}
 </article>
+${shareButtonsHtml}
 <p><a href="${escapeHtml(basePath)}">Back to ${escapeHtml(routeSettings.publicLabel)}</a></p>`;
 
         const html = renderPublicPageShell({
@@ -99,7 +119,8 @@ export const GET: APIRoute = async ({ params, request, url }) => {
           bodyHtml,
           locale: post.locale,
           ogImageUrl: resolveOgImageUrl(featuredMedia?.publicUrl ?? null),
-          ogImageAlt: featuredMedia?.altText ?? null
+          ogImageAlt: featuredMedia?.altText ?? null,
+          siteName: tenant.tenantName
         });
 
         return new Response(html, {

--- a/tests/blog-content-public-rendering.test.ts
+++ b/tests/blog-content-public-rendering.test.ts
@@ -458,6 +458,76 @@ describe("renderPublicPageShell", () => {
     expect(html).toContain('<meta property="og:image"');
     expect(html).not.toContain("og:image:alt");
   });
+
+  test("Issue #642: emits escaped og:title/og:description/twitter:title/twitter:description derived from title/description", () => {
+    const html = renderPublicPageShell({
+      title: "<b>Title</b>",
+      description: "<i>desc</i>",
+      canonicalUrl: "https://example.com/post",
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(html).toContain(
+      '<meta property="og:title" content="&lt;b&gt;Title&lt;/b&gt;" />'
+    );
+    expect(html).toContain(
+      '<meta property="og:description" content="&lt;i&gt;desc&lt;/i&gt;" />'
+    );
+    expect(html).toContain(
+      '<meta name="twitter:title" content="&lt;b&gt;Title&lt;/b&gt;" />'
+    );
+    expect(html).toContain(
+      '<meta name="twitter:description" content="&lt;i&gt;desc&lt;/i&gt;" />'
+    );
+    expect(html).toContain(
+      '<meta property="og:url" content="https://example.com/post" />'
+    );
+  });
+
+  test("Issue #642: omits og:url when canonicalUrl is null", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(html).not.toContain("og:url");
+  });
+
+  test("Issue #642: emits twitter:card=summary (not summary_large_image) when there is no og:image", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(html).toContain('<meta name="twitter:card" content="summary" />');
+  });
+
+  test("Issue #642: emits og:site_name only when siteName is provided", () => {
+    const withSiteName = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en",
+      siteName: "Acme <News>"
+    });
+    expect(withSiteName).toContain(
+      '<meta property="og:site_name" content="Acme &lt;News&gt;" />'
+    );
+
+    const withoutSiteName = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(withoutSiteName).not.toContain("og:site_name");
+  });
 });
 
 describe("resolveOgImageUrl (Issue #636)", () => {

--- a/tests/integration/news-portal-share-buttons.integration.test.ts
+++ b/tests/integration/news-portal-share-buttons.integration.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Integration tests for Issue #642 (epic `news_portal`): public social
+ * share buttons + Open Graph/Twitter Card metadata on the real
+ * `/news/{slug}` and `/blog/{tenantCode}/{slug}` detail routes. Unlike
+ * Issue #636 (`blog-content-news-media-r2-references.integration.test.ts`),
+ * this feature does NOT depend on the full-online R2-only preset at all —
+ * share buttons work for any published post regardless of
+ * `NEWS_PORTAL_ENABLED`/`NEWS_MEDIA_R2_ENABLED`, so these tests never call
+ * `applyNewsPortalFullOnlineR2Preset`.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  integrationEnabled,
+  invoke,
+  invokeRaw,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { POST as createPost } from "../../src/pages/api/v1/blog/posts/index";
+import { POST as publishPost } from "../../src/pages/api/v1/blog/posts/[id]/publish";
+import { GET as newsDetail } from "../../src/pages/news/[slug]";
+import { GET as legacyBlogDetail } from "../../src/pages/blog/[tenantCode]/[slug]";
+
+const OWNER_LOGIN = "owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+
+type Bootstrap = { tenantId: string; tenantCode: string; token: string };
+
+async function bootstrap(
+  tenantCode = "acme",
+  tenantName = "Acme"
+): Promise<Bootstrap> {
+  const loginIdentifier = `${tenantCode}-${OWNER_LOGIN}`;
+  const setup = await invoke<{ data: { tenantId: string } }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "HQ",
+      ownerLoginIdentifier: loginIdentifier,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": setup.body.data.tenantId
+    },
+    body: { loginIdentifier, password: OWNER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+
+  return {
+    tenantId: setup.body.data.tenantId,
+    tenantCode,
+    token: login.body.data.token
+  };
+}
+
+function authHeaders(b: Bootstrap): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-mini-tenant-id": b.tenantId,
+    authorization: `Bearer ${b.token}`
+  };
+}
+
+async function createPostAs(
+  owner: Bootstrap,
+  overrides: Record<string, unknown> = {}
+): Promise<{ id: string; slug: string }> {
+  const slug = (overrides.slug as string) ?? `post-${crypto.randomUUID()}`;
+  const created = await invoke<{ data: { id: string; slug: string } }>(
+    createPost,
+    {
+      method: "POST",
+      path: "/api/v1/blog/posts",
+      headers: authHeaders(owner),
+      body: {
+        title: "Share Me & Read <b>this</b>",
+        slug,
+        excerpt: "A short excerpt.",
+        contentJson: { blocks: [{ type: "paragraph", text: "Hello world" }] },
+        contentText: "Hello world",
+        ...overrides
+      }
+    }
+  );
+  expect(created.status).toBe(200);
+  return { id: created.body.data.id, slug: created.body.data.slug };
+}
+
+async function publish(owner: Bootstrap, postId: string): Promise<void> {
+  const published = await invoke(publishPost, {
+    method: "POST",
+    path: `/api/v1/blog/posts/${postId}/publish`,
+    headers: { ...authHeaders(owner), "idempotency-key": crypto.randomUUID() },
+    params: { id: postId }
+  });
+  expect(published.status).toBe(200);
+}
+
+/** Same env-override-then-restore helper `blog-content-public-news.integration.test.ts` uses. */
+async function withEnvOverride<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous: Record<string, string | undefined> = {};
+
+  for (const key of Object.keys(overrides)) {
+    previous[key] = process.env[key];
+    const value = overrides[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const key of Object.keys(overrides)) {
+      const value = previous[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("public social share buttons (Issue #642)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  afterEach(() => {
+    for (const key of [
+      "NEWS_SHARE_BUTTONS_ENABLED",
+      "NEWS_SHARE_NATIVE_ENABLED",
+      "NEWS_SHARE_WHATSAPP_ENABLED",
+      "NEWS_SHARE_INSTAGRAM_NATIVE_ONLY"
+    ]) {
+      delete process.env[key];
+    }
+  });
+
+  test("/news/{slug} renders the full share widget + Open Graph/Twitter Card tags for a published post by default", async () => {
+    const owner = await bootstrap();
+    const { id, slug } = await createPostAs(owner);
+    await publish(owner, id);
+
+    const response = await invokeRaw(newsDetail, {
+      method: "GET",
+      path: `/news/${slug}`,
+      params: { slug }
+    });
+
+    expect(response.status).toBe(200);
+    const canonicalUrl = `http://integration.test/news/${slug}`;
+
+    // Open Graph / Twitter Card metadata (issue acceptance criteria).
+    expect(response.text).toContain(
+      `<meta property="og:url" content="${canonicalUrl}" />`
+    );
+    expect(response.text).toContain('<meta property="og:title"');
+    expect(response.text).toContain('<meta property="og:description"');
+    expect(response.text).toContain('<meta name="twitter:title"');
+    expect(response.text).toContain('<meta name="twitter:description"');
+    expect(response.text).toContain(
+      `<meta property="og:site_name" content="Acme" />`
+    );
+
+    // Share widget: static platform links present, canonical URL used.
+    expect(response.text).toContain("news-share__link--whatsapp");
+    expect(response.text).toContain("news-share__link--telegram");
+    expect(response.text).toContain("news-share__link--facebook");
+    expect(response.text).toContain("news-share__link--linkedin");
+    expect(response.text).toContain("news-share__link--x_twitter");
+    expect(response.text).toContain("news-share__link--email");
+    expect(response.text).toContain(
+      `data-share-url="${canonicalUrl}"` // native + copy-link buttons
+    );
+    expect(response.text).toContain('src="/js/news-share.js"');
+    // No third-party script.
+    expect(response.text).not.toMatch(/<script[^>]*src="https?:\/\//);
+  });
+
+  test("NEWS_SHARE_BUTTONS_ENABLED=false disables the entire widget (og tags stay present)", async () => {
+    const owner = await bootstrap();
+    const { id, slug } = await createPostAs(owner);
+    await publish(owner, id);
+
+    await withEnvOverride({ NEWS_SHARE_BUTTONS_ENABLED: "false" }, async () => {
+      const response = await invokeRaw(newsDetail, {
+        method: "GET",
+        path: `/news/${slug}`,
+        params: { slug }
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.text).not.toContain("news-share");
+      expect(response.text).not.toContain("news-share.js");
+      // SEO metadata is independent of the share-widget flag.
+      expect(response.text).toContain('<meta property="og:title"');
+    });
+  });
+
+  test("NEWS_SHARE_WHATSAPP_ENABLED=false disables only the WhatsApp link", async () => {
+    const owner = await bootstrap();
+    const { id, slug } = await createPostAs(owner);
+    await publish(owner, id);
+
+    await withEnvOverride(
+      { NEWS_SHARE_WHATSAPP_ENABLED: "false" },
+      async () => {
+        const response = await invokeRaw(newsDetail, {
+          method: "GET",
+          path: `/news/${slug}`,
+          params: { slug }
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.text).not.toContain("news-share__link--whatsapp");
+        expect(response.text).toContain("news-share__link--telegram");
+      }
+    );
+  });
+
+  test("draft (never-published) post never renders the share widget — 404, same as any other public route gate", async () => {
+    const owner = await bootstrap();
+    const { slug } = await createPostAs(owner);
+
+    const response = await invokeRaw(newsDetail, {
+      method: "GET",
+      path: `/news/${slug}`,
+      params: { slug }
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.text).not.toContain("news-share");
+  });
+
+  test("share links use the server-resolved canonical URL, never the request's raw querystring/tracking parameters", async () => {
+    const owner = await bootstrap();
+    const { id, slug } = await createPostAs(owner);
+    await publish(owner, id);
+
+    const response = await invokeRaw(newsDetail, {
+      method: "GET",
+      path: `/news/${slug}?utm_source=newsletter&session_id=abc123`,
+      params: { slug }
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.text).not.toContain("utm_source");
+    expect(response.text).not.toContain("session_id");
+    expect(response.text).toContain(
+      `data-share-url="http://integration.test/news/${slug}"`
+    );
+  });
+
+  test("legacy /blog/{tenantCode}/{slug} route renders the same share widget", async () => {
+    const owner = await bootstrap();
+    const { id, slug } = await createPostAs(owner);
+    await publish(owner, id);
+
+    const response = await invokeRaw(legacyBlogDetail, {
+      method: "GET",
+      path: `/blog/${owner.tenantCode}/${slug}`,
+      params: { tenantCode: owner.tenantCode, slug }
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain("news-share__link--whatsapp");
+    expect(response.text).toContain(
+      `<meta property="og:site_name" content="Acme" />`
+    );
+  });
+});

--- a/tests/unit/news-share-client-script.test.ts
+++ b/tests/unit/news-share-client-script.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Structural checks on the static client script (Issue #642) that the
+ * public share widget references via same-origin `<script src>` — same
+ * "assert the exact bytes, don't re-derive/execute them" convention
+ * `tests/theme-init-script.test.ts` uses for the one other hand-authored
+ * client script in this repo. This file cannot exercise real
+ * `navigator.share`/`navigator.clipboard` browser behavior (no DOM/browser
+ * runtime in `bun test`) — that belongs to a Playwright e2e smoke test
+ * (`awcms-mini-browser-test` skill) if/when one is added; this test instead
+ * guards the two properties a security review most cares about: no
+ * third-party network origin is ever referenced, and the two
+ * security-sensitive browser APIs (`navigator.share`, secure-context/
+ * `isSecureContext` gating, `navigator.clipboard`) are actually present in
+ * the shipped file.
+ */
+
+const SCRIPT_PATH = `${import.meta.dir}/../../public/js/news-share.js`;
+
+describe("public/js/news-share.js (Issue #642)", () => {
+  test("references navigator.share gated by window.isSecureContext", async () => {
+    const source = await Bun.file(SCRIPT_PATH).text();
+
+    expect(source).toContain("navigator.share");
+    expect(source).toContain("window.isSecureContext");
+  });
+
+  test("references navigator.clipboard.writeText with a non-clipboard-API fallback", async () => {
+    const source = await Bun.file(SCRIPT_PATH).text();
+
+    expect(source).toContain("navigator.clipboard");
+    expect(source).toContain("writeText");
+    expect(source).toContain("execCommand");
+  });
+
+  test("never references any third-party/external network origin", async () => {
+    const source = await Bun.file(SCRIPT_PATH).text();
+    const externalUrlMatches = source.match(/https?:\/\/[^\s"'`)]+/g) ?? [];
+
+    expect(externalUrlMatches).toEqual([]);
+  });
+
+  test("does not use eval/Function constructor/document.write", async () => {
+    const source = await Bun.file(SCRIPT_PATH).text();
+
+    expect(source).not.toContain("eval(");
+    expect(source).not.toContain("new Function(");
+    expect(source).not.toContain("document.write");
+  });
+
+  test("the native-share click handler ignores a user-cancel AbortError without showing an error message", async () => {
+    const source = await Bun.file(SCRIPT_PATH).text();
+
+    expect(source).toContain("AbortError");
+  });
+});

--- a/tests/unit/news-share-config.test.ts
+++ b/tests/unit/news-share-config.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveNewsShareConfig } from "../../src/modules/news-portal/domain/news-share-config";
+
+describe("resolveNewsShareConfig (Issue #642)", () => {
+  test("defaults every flag to true when no NEWS_SHARE_* var is set", () => {
+    const config = resolveNewsShareConfig({});
+
+    expect(config).toEqual({
+      buttonsEnabled: true,
+      native: true,
+      whatsapp: true,
+      telegram: true,
+      facebook: true,
+      linkedin: true,
+      x: true,
+      email: true,
+      instagramNativeOnly: true
+    });
+  });
+
+  test("each flag can be independently disabled via its own env var", () => {
+    const config = resolveNewsShareConfig({
+      NEWS_SHARE_WHATSAPP_ENABLED: "false",
+      NEWS_SHARE_X_ENABLED: "false"
+    });
+
+    expect(config.whatsapp).toBe(false);
+    expect(config.x).toBe(false);
+    // Untouched flags stay at their true default.
+    expect(config.telegram).toBe(true);
+    expect(config.facebook).toBe(true);
+    expect(config.linkedin).toBe(true);
+    expect(config.email).toBe(true);
+    expect(config.native).toBe(true);
+    expect(config.buttonsEnabled).toBe(true);
+  });
+
+  test("master switch NEWS_SHARE_BUTTONS_ENABLED=false disables the whole widget", () => {
+    const config = resolveNewsShareConfig({
+      NEWS_SHARE_BUTTONS_ENABLED: "false"
+    });
+
+    expect(config.buttonsEnabled).toBe(false);
+  });
+
+  test('only the exact string "true" enables a flag — any other value is treated as false', () => {
+    const config = resolveNewsShareConfig({
+      NEWS_SHARE_NATIVE_ENABLED: "TRUE",
+      NEWS_SHARE_EMAIL_ENABLED: "1"
+    });
+
+    expect(config.native).toBe(false);
+    expect(config.email).toBe(false);
+  });
+
+  test("NEWS_SHARE_INSTAGRAM_NATIVE_ONLY can be independently disabled", () => {
+    const config = resolveNewsShareConfig({
+      NEWS_SHARE_INSTAGRAM_NATIVE_ONLY: "false"
+    });
+
+    expect(config.instagramNativeOnly).toBe(false);
+  });
+});

--- a/tests/unit/social-share-links.test.ts
+++ b/tests/unit/social-share-links.test.ts
@@ -233,11 +233,11 @@ describe("renderSocialShareButtonsHtml (Issue #642)", () => {
       ALL_ENABLED,
       "/js/news-share.js"
     );
-    const scriptTags = [...html.matchAll(/<script\b[^>]*>/g)];
+    const scriptTags = [...html.matchAll(/<script\b[^>]*>/gi)];
 
     expect(scriptTags.length).toBe(1);
     expect(scriptTags[0]![0]).toContain('src="/js/news-share.js"');
-    expect(html).not.toMatch(/<script[^>]*src="https?:\/\//);
+    expect(html).not.toMatch(/<script[^>]*src="https?:\/\//i);
   });
 
   test("uses the canonical URL, never a raw querystring-bearing URL, in data-share-url/href", () => {

--- a/tests/unit/social-share-links.test.ts
+++ b/tests/unit/social-share-links.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildSocialShareLinks,
+  renderSocialShareButtonsHtml,
+  type SocialShareRenderConfig
+} from "../../src/modules/blog-content/domain/social-share-links";
+
+const ARTICLE = {
+  canonicalUrl: "https://news.example.test/articles/hello-world",
+  title: "Hello & World",
+  excerpt: "An excerpt with <b>markup</b>."
+};
+
+const ALL_ENABLED: SocialShareRenderConfig = {
+  buttonsEnabled: true,
+  native: true,
+  whatsapp: true,
+  telegram: true,
+  facebook: true,
+  linkedin: true,
+  x: true,
+  email: true,
+  instagramNativeOnly: true
+};
+
+describe("buildSocialShareLinks (Issue #642)", () => {
+  test("builds every enabled platform's URL-encoded share link", () => {
+    const links = buildSocialShareLinks(ARTICLE, ALL_ENABLED);
+    const byPlatform = new Map(links.map((link) => [link.platform, link.href]));
+
+    expect(byPlatform.get("whatsapp")).toBe(
+      `https://wa.me/?text=${encodeURIComponent("Hello & World https://news.example.test/articles/hello-world")}`
+    );
+    expect(byPlatform.get("telegram")).toBe(
+      `https://t.me/share/url?url=${encodeURIComponent(ARTICLE.canonicalUrl)}&text=${encodeURIComponent(ARTICLE.title)}`
+    );
+    expect(byPlatform.get("facebook")).toBe(
+      `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(ARTICLE.canonicalUrl)}`
+    );
+    expect(byPlatform.get("linkedin")).toBe(
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(ARTICLE.canonicalUrl)}`
+    );
+    expect(byPlatform.get("x_twitter")).toBe(
+      `https://twitter.com/intent/tweet?url=${encodeURIComponent(ARTICLE.canonicalUrl)}&text=${encodeURIComponent(ARTICLE.title)}`
+    );
+    expect(byPlatform.get("email")).toContain("mailto:?subject=");
+  });
+
+  test("never emits raw/unencoded title or URL characters (e.g. '&', ' ') in any href", () => {
+    const links = buildSocialShareLinks(ARTICLE, ALL_ENABLED);
+
+    for (const link of links) {
+      // The canonical URL's own scheme separator is fine; what we must
+      // never see is the raw article title/excerpt text unescaped inside
+      // the query string (e.g. a literal space or literal "&" that isn't
+      // part of the query-string delimiter grammar).
+      expect(link.href).not.toContain("Hello & World");
+      expect(link.href).not.toContain("<b>markup</b>");
+    }
+  });
+
+  test("disabled platforms are excluded from the result", () => {
+    const links = buildSocialShareLinks(ARTICLE, {
+      ...ALL_ENABLED,
+      whatsapp: false,
+      x: false
+    });
+    const platforms = links.map((link) => link.platform);
+
+    expect(platforms).not.toContain("whatsapp");
+    expect(platforms).not.toContain("x_twitter");
+    expect(platforms).toContain("telegram");
+    expect(platforms).toContain("facebook");
+    expect(platforms).toContain("linkedin");
+    expect(platforms).toContain("email");
+  });
+
+  test("no platform is ever included outside the fixed six-platform allowlist", () => {
+    const links = buildSocialShareLinks(ARTICLE, ALL_ENABLED);
+    const allowlist = new Set([
+      "whatsapp",
+      "telegram",
+      "facebook",
+      "linkedin",
+      "x_twitter",
+      "email"
+    ]);
+
+    expect(links.length).toBe(6);
+    for (const link of links) {
+      expect(allowlist.has(link.platform)).toBe(true);
+    }
+  });
+
+  test("returns an empty array when the canonical URL is not a safe absolute http(s) URL", () => {
+    const links = buildSocialShareLinks(
+      { ...ARTICLE, canonicalUrl: "javascript:alert(1)" },
+      ALL_ENABLED
+    );
+    expect(links).toEqual([]);
+  });
+});
+
+describe("renderSocialShareButtonsHtml (Issue #642)", () => {
+  test("renders nothing when buttonsEnabled is false", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      { ...ALL_ENABLED, buttonsEnabled: false },
+      "/js/news-share.js"
+    );
+    expect(html).toBe("");
+  });
+
+  test("renders nothing when the canonical URL is unsafe", () => {
+    const html = renderSocialShareButtonsHtml(
+      { ...ARTICLE, canonicalUrl: "javascript:alert(1)" },
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    expect(html).toBe("");
+  });
+
+  test("escapes title/excerpt and includes rel=noopener noreferrer + accessible labels on every external link", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+
+    expect(html).toContain("Hello &amp; World");
+    expect(html).not.toContain("<b>markup</b>");
+    // Every static platform link must carry rel="noopener noreferrer" and
+    // target="_blank" (issue: "Add rel=noopener noreferrer for external
+    // share links").
+    const anchorMatches = [...html.matchAll(/<a\b[^>]*>/g)];
+    expect(anchorMatches.length).toBeGreaterThan(0);
+    for (const [anchorTag] of anchorMatches) {
+      expect(anchorTag).toContain('rel="noopener noreferrer"');
+      expect(anchorTag).toContain('target="_blank"');
+      expect(anchorTag).toContain("aria-label=");
+    }
+  });
+
+  test("native share button is present but `hidden` server-side (revealed only client-side when supported)", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    expect(html).toContain(
+      'class="news-share__native js-news-share-native" hidden'
+    );
+  });
+
+  test("native share button is entirely absent when NEWS_SHARE_NATIVE_ENABLED=false", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      { ...ALL_ENABLED, native: false },
+      "/js/news-share.js"
+    );
+    expect(html).not.toContain("js-news-share-native");
+  });
+
+  test("copy-link button is always present when buttonsEnabled is true, regardless of other platform flags", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      {
+        buttonsEnabled: true,
+        native: false,
+        whatsapp: false,
+        telegram: false,
+        facebook: false,
+        linkedin: false,
+        x: false,
+        email: false,
+        instagramNativeOnly: false
+      },
+      "/js/news-share.js"
+    );
+
+    expect(html).toContain("js-news-share-copy");
+  });
+
+  test("disabled platforms produce no <a> link for that platform", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      { ...ALL_ENABLED, whatsapp: false },
+      "/js/news-share.js"
+    );
+    expect(html).not.toContain("news-share__link--whatsapp");
+    expect(html).toContain("news-share__link--telegram");
+  });
+
+  test("never emits a fake Instagram share link/button", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    expect(html).not.toContain("instagram.com");
+    expect(html).not.toContain("news-share__link--instagram");
+  });
+
+  test("Instagram note text changes based on whether native share is enabled", () => {
+    const withNative = renderSocialShareButtonsHtml(
+      ARTICLE,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    expect(withNative).toContain("Instagram: use the Share button above");
+
+    const withoutNative = renderSocialShareButtonsHtml(
+      ARTICLE,
+      { ...ALL_ENABLED, native: false },
+      "/js/news-share.js"
+    );
+    expect(withoutNative).toContain("Instagram: use Copy link");
+  });
+
+  test("Instagram note is omitted entirely when NEWS_SHARE_INSTAGRAM_NATIVE_ONLY=false", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      { ...ALL_ENABLED, instagramNativeOnly: false },
+      "/js/news-share.js"
+    );
+    expect(html).not.toContain("Instagram");
+  });
+
+  test("only one <script> tag is emitted, pointing at the given same-origin scriptSrc — no third-party script", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    const scriptTags = [...html.matchAll(/<script\b[^>]*>/g)];
+
+    expect(scriptTags.length).toBe(1);
+    expect(scriptTags[0]![0]).toContain('src="/js/news-share.js"');
+    expect(html).not.toMatch(/<script[^>]*src="https?:\/\//);
+  });
+
+  test("uses the canonical URL, never a raw querystring-bearing URL, in data-share-url/href", () => {
+    const trackedArticle = {
+      ...ARTICLE,
+      canonicalUrl: "https://news.example.test/articles/hello-world"
+    };
+    const html = renderSocialShareButtonsHtml(
+      trackedArticle,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    expect(html).toContain(`data-share-url="${trackedArticle.canonicalUrl}"`);
+    expect(html).not.toContain("?utm_");
+    expect(html).not.toContain("?admin_preview");
+    expect(html).not.toContain("session_id");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a public share widget (native Web Share API, copy-link, WhatsApp, Telegram, Facebook, LinkedIn, X, email) to the public article detail routes `/news/{slug}` and `/blog/{tenantCode}/{slug}`.
- Instagram has no supported web-share intent URL, so it is never rendered as a (fake) button — only a short accessibility note pointing users to native share (when enabled) or copy-link.
- Expands `renderPublicPageShell` with `og:title`/`og:description`/`og:url`/`og:site_name` and `twitter:title`/`twitter:description`/`twitter:card` (always present now — `summary` without an image, `summary_large_image` with one). `og:image`/`twitter:image` remain gated on a verified R2 media object per Issue #636 (unchanged).
- Every share link/attribute is built from the server-resolved canonical URL only (never the request's raw querystring/tracking/session parameters), `encodeURIComponent`-encoded, from a fixed six-platform allowlist. External links carry `rel="noopener noreferrer" target="_blank"`.
- Native share + copy-link ship as one same-origin static script (`public/js/news-share.js`, loaded via `<script src>`, never inline) — adds zero Content-Security-Policy surface (no hash/nonce bookkeeping) and loads no third-party script. The native-share button is server-rendered `hidden` and only revealed client-side after real feature detection (`navigator.share` + secure context).
- New per-platform config: `NEWS_SHARE_BUTTONS_ENABLED`, `NEWS_SHARE_NATIVE_ENABLED`, `NEWS_SHARE_WHATSAPP_ENABLED`, `NEWS_SHARE_TELEGRAM_ENABLED`, `NEWS_SHARE_FACEBOOK_ENABLED`, `NEWS_SHARE_LINKEDIN_ENABLED`, `NEWS_SHARE_X_ENABLED`, `NEWS_SHARE_EMAIL_ENABLED`, `NEWS_SHARE_INSTAGRAM_NATIVE_ONLY` — all default `true` (deliberate deviation from this repo's usual opt-in-off convention, since this feature collects no data and loads no external script; see header comment in `news-share-config.ts`).
- No new migration — pure UI/rendering/config, no new persisted data.

Closes #642

## Test plan

- [x] `bun run lint` / `bun run format`
- [x] `bun run check:docs`, `bun run config:docs:check` (registry/.env.example/doc 18 three-way parity)
- [x] `bun run api:spec:check`, `bun run api:docs:check` (no API surface changed)
- [x] `bun run repo:inventory:check` (regenerated)
- [x] `bun run modules:dag:check`, `bun run i18n:pot:check`, `bun run i18n:parity:check`, `bun run logging:lint:check`
- [x] `bun run typecheck` — clean except one pre-existing, unrelated gap (`tests/e2e/admin-a11y-smoke.e2e.ts` missing `@axe-core/playwright` types in this sandbox — not touched by this PR)
- [x] `bun run db:migrate` — 0 applied, 47 skipped (no new migration needed)
- [x] `bun test` — 2648 pass / 0 fail / 8 skip across 203 files (full suite against real PostgreSQL)
- [x] `bun run build` — server build succeeds; `public/js/news-share.js` present in `dist/client/js/news-share.js`
- [x] New unit tests: `news-share-config.test.ts`, `social-share-links.test.ts` (URL encoding, allowlist, disabled-platform combinations, accessible labels, no fake Instagram link, no third-party script), `news-share-client-script.test.ts` (structural checks on the static client script)
- [x] New integration test: `news-portal-share-buttons.integration.test.ts` (real `/news/{slug}` + `/blog/{tenantCode}/{slug}` routes — default-enabled widget + OG/Twitter tags, master-switch/per-platform disable, draft never renders it, canonical URL used even with tracking querystring on the request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)