### PR TITLE
feat(master-data): add schema for versioned Indonesia administrative regions

### DIFF
--- a/.changeset/idn-admin-regions-schema-issue-657.md
+++ b/.changeset/idn-admin-regions-schema-issue-657.md
@@ -1,0 +1,33 @@
+---
+"awcms-mini": minor
+---
+
+Add the versioned PostgreSQL schema for Indonesia administrative region
+datasets (Issue #657, epic #654 — master data wilayah administratif
+Indonesia dari `cahyadsn/wilayah`, following #655's module scaffold and
+#656's vendored source data). Migration `sql/054` adds two GLOBAL
+reference tables (no `tenant_id`, no RLS — identical for every tenant):
+
+- `awcms_mini_idn_region_datasets` — one row per imported dataset
+  version, recording upstream provenance (repository, source path,
+  commit SHA, license, file checksum), row count, lifecycle `status`
+  (`validated`/`active`/`superseded`/`rejected`), and validation summary.
+  "Only one dataset can be active at a time" is enforced with a partial
+  unique index on `status` `WHERE status = 'active'`.
+- `awcms_mini_idn_admin_regions` — one row per normalized administrative
+  region (province/regency/district/village) belonging to a dataset.
+  Unique `(dataset_id, code)`, a `(dataset_id, parent_code)` parent-lookup
+  index, and a `(dataset_id, normalized_name)` search index.
+
+Both tables are added to `RLS_FREE_TABLES`/`ALLOWED_GLOBAL_TABLE_GRANTS`
+in `scripts/security-readiness.ts` and to `RLS_EXEMPT_TABLES` in
+`scripts/repo-inventory-generate.ts`. `awcms_mini_app` is granted ZERO
+access on either table in this migration (no runtime code path reads or
+writes them yet — schema only) — future issues (#660 import, #661
+activate/rollback, #662 lookup API) each add exactly the grant their own
+new code path needs.
+
+No parser/normalizer (#658), validation gate (#659), import pipeline
+(#660), activation/rollback (#661), lookup API (#662), or admin UI (#663)
+yet — those land in later issues of the same epic (see
+`.claude/skills/awcms-mini-idn-admin-regions/SKILL.md`).

--- a/.claude/skills/awcms-mini-idn-admin-regions/SKILL.md
+++ b/.claude/skills/awcms-mini-idn-admin-regions/SKILL.md
@@ -56,7 +56,7 @@ menginvestigasi ulang dari nol.
 | ----- | ---------------------------------------------------------------------------------------------- | --------------------------------- |
 | #655  | Scaffold modul `idn_admin_regions` (descriptor, permission catalog, README)                    | **Selesai** — lihat §655 di bawah |
 | #656  | Vendor source metadata + license `cahyadsn/wilayah` di bawah `data/idn-admin-regions/`         | **Selesai** — lihat §656 di bawah |
-| #657  | Schema PostgreSQL versioned (`awcms_mini_idn_region_datasets`, `awcms_mini_idn_admin_regions`) | Belum dikerjakan                  |
+| #657  | Schema PostgreSQL versioned (`awcms_mini_idn_region_datasets`, `awcms_mini_idn_admin_regions`) | **Selesai** — lihat §657 di bawah |
 | #658  | Parser & normalizer SQL dump upstream `cahyadsn/wilayah` (MySQL-style insert dumps)            | Belum dikerjakan                  |
 | #659  | Validation gate repository untuk file dataset yang di-vendor/dinormalisasi                     | Belum dikerjakan                  |
 | #660  | Import pipeline PostgreSQL (dry-run/commit)                                                    | Belum dikerjakan                  |
@@ -248,22 +248,141 @@ db/wilayah_penduduk.sql,db/wilayah_luas.sql}`.
 - Tidak ada perubahan `src/`, migration, endpoint, atau test kode —
   murni vendoring data + metadata provenance, sesuai scope issue.
 
-## Catatan untuk issue lanjutan (#657-#664)
+## §657 — Schema PostgreSQL versioned (Selesai)
 
-- **#657 (schema)**: dua tabel — `awcms_mini_idn_region_datasets`
-  (metadata dataset per-import: source repo/path/commit SHA/license/
-  checksum/status/row count) dan `awcms_mini_idn_admin_regions` (region
-  ternormalisasi: code/parent_code/level/region_type/nama). **Global
-  reference data, BUKAN tenant-scoped** — TIDAK ada kolom `tenant_id`,
-  TIDAK ada RLS tenant-isolation (beda dari template
-  `awcms-mini-new-migration` standar yang mengasumsikan tenant-scoped by
-  default) — baca skill itu sendiri §"Tabel BARU tanpa tenant_id/RLS"
-  untuk kewajiban grant eksplisit + entry `RLS_FREE_TABLES`/
-  `ALLOWED_GLOBAL_TABLE_GRANTS` di `scripts/security-readiness.ts`. Unique
-  index `(dataset_id, code)`, index `(dataset_id, parent_code)`, "hanya
-  satu dataset aktif" (kemungkinan partial unique index `WHERE
-status='active'` pada `dataset_id` atau kolom serupa — implementor
-  memutuskan bentuk persis saat issue itu dikerjakan).
+Implementasi lengkap: migration `sql/054_awcms_mini_idn_admin_regions_schema.sql`
+menambah dua tabel — `awcms_mini_idn_region_datasets` (metadata satu baris
+per dataset/versi yang diimpor: `dataset_code` unik, source
+repo/path/commit SHA/license/checksum, `row_count`, `status`,
+`validation_summary` jsonb, `created_at`/`created_by`,
+`activated_at`/`activated_by`) dan `awcms_mini_idn_admin_regions` (satu
+baris per region ternormalisasi milik satu `dataset_id`: `code`/
+`code_compact`/`parent_code`/`level`/`region_type`/`local_term`/
+`official_name`/`normalized_name`/`full_path_code`/`full_path_name`/
+`province_code`/`regency_code`/`district_code`/`village_code`/
+`source_row_hash`/`metadata` jsonb). Kolom persis sesuai daftar di body
+issue #657 sendiri — tidak ditambah/dikurangi.
+
+### Keputusan/judgment call issue ini (mengikat untuk issue lanjutan)
+
+1. **Global reference data, BUKAN tenant-scoped** — TIDAK ada kolom
+   `tenant_id`, TIDAK ada RLS, TIDAK ada `CREATE POLICY` (beda dari
+   template default `awcms-mini-new-migration`, yang mengasumsikan
+   tenant-scoped). Kedua tabel ditambahkan ke `RLS_FREE_TABLES` DAN
+   `ALLOWED_GLOBAL_TABLE_GRANTS` di `scripts/security-readiness.ts` —
+   tanpa keduanya `checkRlsEnabled`/`checkRuntimeRoleGlobalTableGrants`
+   akan gagal begitu tabel ini ada di database migrated. Diverifikasi
+   langsung: `bun run security:readiness` terhadap DB nyata setelah
+   migration di-apply — kedua check PASS.
+2. **`awcms_mini_app` diberi NOL grant pada kedua tabel ini** — bukan
+   grant read-only "jaga-jaga". `ALTER DEFAULT PRIVILEGES` migration 013
+   otomatis meng-grant `SELECT, INSERT, UPDATE, DELETE` ke `awcms_mini_app`
+   begitu `CREATE TABLE` jalan (persis seperti 9 tabel global lain sebelum
+   migration 045 menyempitkannya) — migration `054` langsung
+   `REVOKE ALL ... FROM awcms_mini_app` pada kedua tabel di transaction
+   yang sama. Alasan: issue ini SCHEMA ONLY, tidak ada jalur kode apa pun
+   yang membaca/menulis tabel ini sekarang (`awcms_mini_worker`/
+   `awcms_mini_setup` sudah otomatis nol karena tidak ada
+   `ALTER DEFAULT PRIVILEGES` untuk mereka). Diverifikasi via `psql \dp`
+   terhadap DB nyata setelah migrate: hanya role owner (`awcms-mini`) yang
+   muncul di access privileges, `awcms_mini_app` sudah hilang sepenuhnya
+   dari ACL. Issue lanjutan menambah grant PERSIS yang jalur kode barunya
+   butuhkan, di migration mereka sendiri — jangan asumsikan
+   `awcms_mini_app` sudah punya SELECT/INSERT di sini, tambahkan
+   eksplisit (#660 import perlu INSERT+UPDATE, #661 activate/rollback
+   perlu UPDATE pada `status`/`activated_at`/`activated_by`, #662 lookup
+   API perlu SELECT).
+3. **"Hanya satu dataset aktif" via partial unique index pada kolom
+   `status` itu sendiri** —
+   `CREATE UNIQUE INDEX ... ON awcms_mini_idn_region_datasets (status)
+WHERE status = 'active'`. Karena setiap baris yang ter-index oleh
+   partial index ini pasti bernilai `'active'` (sama persis), constraint
+   unique pada kolom itu berarti maksimal SATU baris bisa punya
+   `status = 'active'` — trik idiom Postgres standar untuk "singleton
+   flag" tanpa perlu kolom boolean/computed terpisah. Index yang sama
+   sekaligus jadi index tercepat untuk query default #662 ("cari dataset
+   aktif"). Diverifikasi via integration test nyata (insert baris aktif
+   kedua ditolak, insert baris `validated`/`superseded` lain tetap boleh,
+   dan setelah baris pertama di-`UPDATE ... SET status='superseded'`
+   slot aktif terbuka lagi untuk baris lain).
+4. **CHECK constraint `status`** dibatasi ke
+   `('validated','active','superseded','rejected')` — nilai `validated`/
+   `active` diambil LANGSUNG dari kalimat eksplisit body issue #660
+   ("Leave dataset as `validated`, not `active`") dan #661 ("Only one
+   dataset can be active at a time" + rollback mengaktifkan kembali
+   dataset sebelumnya). `superseded` menampung dataset yang PERNAH aktif
+   lalu digantikan/di-rollback (mempertahankan `activated_at`/
+   `activated_by` historis — lihat catatan #661 "Dataset source metadata
+   remains immutable after activation", hanya `status` yang berubah).
+   `rejected` disediakan untuk kemungkinan mencatat percobaan impor yang
+   gagal validasi. **Daftar ini bukan final** — issue #659/#660/#661
+   boleh menambah `ALTER TABLE ... DROP/ADD CONSTRAINT` di migration baru
+   kalau butuh nilai lifecycle tambahan yang tidak diantisipasi issue
+   schema-only ini; ini BUKAN mengedit migration `054` yang sudah rilis.
+5. **CHECK constraint `region_type`** dibatasi ke
+   `('province','regency','district','village')` — istilah PERSIS yang
+   sudah dipakai `src/modules/idn-admin-regions/README.md` sejak #655.
+   `level` (smallint) di-CHECK `BETWEEN 1 AND 4`, mencerminkan 4 tingkat
+   hierarki yang sama secara numerik (province=1..village=4) — disinkron
+   manual oleh penulis baris (#658 normalizer / #660 importer), BUKAN
+   generated column, karena pemetaan ini fakta domain tetap, bukan
+   turunan dari kolom lain di baris yang sama.
+6. **Index**: unique `(dataset_id, code)` (persis acceptance criteria —
+   `code` hanya unik DALAM satu dataset, dataset baru boleh punya baris
+   `code` yang sama seperti dataset lama karena me-reimpor hierarki dari
+   nol), index `(dataset_id, parent_code)` (parent lookup), index
+   `(dataset_id, normalized_name)` (search index — diberi awalan
+   `dataset_id` karena setiap query nyata selalu dataset-scoped, sesuai
+   default #662 "query dataset aktif kecuali diminta eksplisit"). Tidak
+   pakai `pg_trgm`/GIN — repo ini belum punya precedent extension
+   tersebut di manapun di `sql/`, dan acceptance criteria tidak meminta
+   fuzzy substring search; btree biasa cukup untuk equality/prefix/ORDER
+   BY yang #662 kemungkinan besar butuhkan.
+7. **Tidak ada kolom soft-delete** (`deleted_at`/`deleted_by`/dst.) pada
+   kedua tabel — daftar kolom di body issue #657 sendiri sudah eksplisit
+   dan tidak menyebutkannya; dataset/region di sini berperilaku lebih
+   dekat ke "riwayat versi append-only" (tidak ada issue manapun di epic
+   ini yang menghapus dataset) daripada master data yang bisa
+   diarsipkan. `created_by`/`activated_by` sengaja `uuid` polos tanpa FK
+   — pola yang SAMA dipakai di seluruh repo ini untuk kolom actor-id
+   (`awcms_mini_offices.created_by`, `awcms_mini_email_messages.created_by`,
+   dst.), bukan pengecualian baru.
+8. **Migration test**: `tests/integration/idn-admin-regions-schema.integration.test.ts`
+   — karena tabel ini TIDAK tenant-scoped, test ini TIDAK menguji isolasi
+   RLS (beda dari kebanyakan `*-schema.integration.test.ts` lain di repo
+   ini) — sebaliknya membuktikan KETIADAAN `tenant_id`/RLS secara
+   eksplisit, plus constraint nyata: unique `(dataset_id, code)`, index
+   parent lookup, index search `normalized_name`, single-active-dataset,
+   CHECK `status`/`region_type`/`level`, dan nol grant `awcms_mini_app`.
+   Semua query test lewat `getAdminSql()` (koneksi migration owner) —
+   BUKAN `getTestSql()` (role `awcms_mini_app`) — karena `awcms_mini_app`
+   memang sengaja nol akses pada tabel ini di issue ini (lihat poin 2 di
+   atas); pola yang sama dipakai
+   `module-management-schema.integration.test.ts` sebelum modul itu
+   punya service pertamanya (Issue #513).
+9. **Data provenance nyata dari #656 dipakai di test** — konstanta
+   commit SHA (`cae306278e5be616c83ba2d8096b00767f45b5fe`) dan checksum
+   `db/wilayah.sql` (`data/idn-admin-regions/manifest.json`) disalin
+   verbatim ke dalam test sebagai bukti bahwa `source_commit_sha`/
+   `source_file_sha256` (`text`, tanpa batasan panjang) benar-benar bisa
+   menampung nilai asli tersebut, bukan hanya placeholder pendek.
+
+### File yang dibuat/diubah (referensi cepat)
+
+- `sql/054_awcms_mini_idn_admin_regions_schema.sql`.
+- `scripts/security-readiness.ts` (`RLS_FREE_TABLES` +
+  `ALLOWED_GLOBAL_TABLE_GRANTS` — dua entry baru, nol grant).
+- Test: `tests/integration/idn-admin-regions-schema.integration.test.ts`.
+- Docs: `.claude/skills/awcms-mini-idn-admin-regions/SKILL.md` (file ini),
+  `src/modules/idn-admin-regions/README.md` (status tabel),
+  `docs/awcms-mini/04_erd_data_dictionary.md` (entri baru + table
+  ownership matrix), `docs/awcms-mini/repo-inventory.md` (regenerated).
+- Changeset: `.changeset/idn-admin-regions-schema-issue-657.md`.
+- Tidak ada perubahan OpenAPI/AsyncAPI — tidak ada endpoint/event baru di
+  issue ini (lookup API adalah #662).
+
+## Catatan untuk issue lanjutan (#658-#664)
+
 - **#658 (parser)**: HARUS bisa jalan tanpa runtime MySQL (acceptance
   criteria eksplisit) — parser dump SQL MySQL-style insert secara string,
   BUKAN eksekusi SQL apa pun (baik terhadap Postgres maupun MySQL).

--- a/docs/awcms-mini/04_erd_data_dictionary.md
+++ b/docs/awcms-mini/04_erd_data_dictionary.md
@@ -328,6 +328,73 @@ menegakkannya).
   (`ad-placement-policy.ts`'s `AD_PLACEMENT_PRESETS`), sama pola
   `homepage-section-policy.ts`'s `HomepageSectionType` whitelist.
 
+### Master Data — Indonesia Administrative Regions (Issue #657, epic #654, `sql/054`)
+
+Master data wilayah administratif Indonesia (provinsi/kabupaten-kota/
+kecamatan/desa-kelurahan) untuk modul `idn_admin_regions` (`type: "base"`),
+disumber dari repository third-party `cahyadsn/wilayah` (MIT License,
+divendor Issue #656). Lihat
+`.claude/skills/awcms-mini-idn-admin-regions/SKILL.md` §657 dan
+`src/modules/idn-admin-regions/README.md` untuk rasional lengkap.
+
+**GLOBAL reference data, BUKAN tenant-scoped** — beda dari hampir semua
+tabel lain di dokumen ini: TIDAK ada kolom `tenant_id`, TIDAK ada RLS.
+Dataset wilayah identik untuk semua tenant, sama alasan
+`awcms_mini_permissions`/`awcms_mini_modules` global — kedua tabel di
+bawah terdaftar di `RLS_FREE_TABLES` DAN `ALLOWED_GLOBAL_TABLE_GRANTS` di
+`scripts/security-readiness.ts`.
+
+- **`awcms_mini_idn_region_datasets`** — satu baris per versi dataset yang
+  diimpor. `dataset_code` unik global. `source_repository`/`source_path`/
+  `source_commit_sha`/`source_license` (default `'MIT'`)/
+  `source_file_sha256` merekam provenance upstream persis (repo, path,
+  commit SHA, lisensi — acceptance criteria eksplisit issue #657); nilai
+  ini harus bisa menampung fakta nyata `data/idn-admin-regions/manifest.json`
+  (commit SHA 40 karakter hex, checksum SHA-256 — dibuktikan lewat
+  integration test yang menyalin nilai asli tersebut). `status` di-`CHECK`
+  ke `('validated','active','superseded','rejected')` — `validated`/
+  `active` diambil dari kalimat eksplisit body issue #660/#661,
+  `superseded` menampung dataset yang pernah aktif lalu digantikan/
+  di-rollback (mempertahankan `activated_at`/`activated_by` historis).
+  **"Hanya satu dataset aktif"** ditegakkan lewat partial unique index
+  `CREATE UNIQUE INDEX ... ON awcms_mini_idn_region_datasets (status)
+WHERE status = 'active'` — karena semua baris yang ter-index pasti
+  bernilai `'active'`, unique constraint pada nilai itu berarti maksimal
+  satu baris; index yang sama sekaligus jadi index tercepat untuk query
+  default #662 ("dataset aktif").
+- **`awcms_mini_idn_admin_regions`** — satu baris per region ternormalisasi
+  milik satu `dataset_id` (FK ke tabel di atas). `code` hanya unik DALAM
+  satu dataset (unique index `(dataset_id, code)` — dataset baru boleh
+  memakai ulang `code` yang sama dari dataset lama, karena setiap import
+  membuat baris baru, tidak pernah menimpa baris dataset lama — inilah
+  yang membuat rollback #661 mungkin). `level` (smallint, `CHECK BETWEEN 1
+AND 4`) dan `region_type` (`CHECK IN
+('province','regency','district','village')`) mencerminkan 4 tingkat
+  hierarki administratif. `parent_code`/`province_code`/`regency_code`/
+  `district_code`/`village_code`/`full_path_code`/`full_path_name`
+  seluruhnya nullable — baris tingkat provinsi hanya mengisi
+  `province_code` (dirinya sendiri), baris desa mengisi keempatnya.
+  `source_row_hash` untuk mendukung diff antar-versi dataset (#661).
+  Index `(dataset_id, parent_code)` (parent lookup) dan
+  `(dataset_id, normalized_name)` (search index — btree biasa, bukan
+  `pg_trgm`/GIN; repo ini belum punya precedent extension tersebut dan
+  acceptance criteria tidak meminta fuzzy substring search).
+
+**Least-privilege grant**: `awcms_mini_app` diberi NOL grant pada kedua
+tabel di migration `054` sendiri (`REVOKE ALL` segera setelah
+`CREATE TABLE`, membatalkan grant blanket default `ALTER DEFAULT
+PRIVILEGES` migration 013) — issue #657 adalah schema-only, belum ada
+jalur kode apa pun yang membaca/menulis tabel ini. Issue lanjutan (#660
+import, #661 activate/rollback, #662 lookup API) masing-masing menambah
+grant persis yang jalur kode barunya butuhkan, di migration mereka
+sendiri.
+
+Tidak ada kolom soft-delete (`deleted_at` dst.) pada kedua tabel — daftar
+kolom di body issue #657 sudah eksplisit dan tidak menyebutkannya; tidak
+ada issue manapun di epic ini yang menghapus dataset/region (lebih dekat
+ke riwayat versi append-only). Tidak ada data pribadi disimpan di kedua
+tabel.
+
 ## Konten multi-bahasa (translatable content)
 
 Berbeda dari **string UI statis** (label/tombol/pesan error) yang memakai katalog `.po` gettext di sisi aplikasi (doc 14 §i18n), **data input pengguna** yang perlu tampil multi-bahasa disimpan **di database, satu nilai per bahasa aktif**. Base generik sudah punya satu contoh nyata (`awcms_mini_email_templates.subject_template`/`text_body_template`/`html_body_template`, `sql/021`, Issue #498 — lihat §Email di atas) — bukan lagi sekadar konvensi belum-terpakai; ini **standar** yang wajib diikuti aplikasi turunan (mis. modul domain seperti `blog_content`, epic #536) saat menambah field konten translatable baru.

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -29,7 +29,7 @@
 
 ## Migrations
 
-53 migration files in `sql/` (`001_awcms_mini_foundation_schema.sql` .. `053_awcms_mini_social_publishing_schema.sql`).
+54 migration files in `sql/` (`001_awcms_mini_foundation_schema.sql` .. `054_awcms_mini_idn_admin_regions_schema.sql`).
 
 | #   | File                                                              |
 | --- | ----------------------------------------------------------------- |
@@ -86,10 +86,11 @@
 | 051 | `051_awcms_mini_blog_content_internal_tag_links_schema.sql`       |
 | 052 | `052_awcms_mini_blog_content_internal_tag_links_permissions.sql`  |
 | 053 | `053_awcms_mini_social_publishing_schema.sql`                     |
+| 054 | `054_awcms_mini_idn_admin_regions_schema.sql`                     |
 
 ## Tables & Row-Level Security
 
-84 tables created across all migrations; 76 carry a `tenant_id` column; 75 have an `ENABLE ROW LEVEL SECURITY` statement; 9 are on the reviewed RLS-exempt allow-list.
+86 tables created across all migrations; 76 carry a `tenant_id` column; 75 have an `ENABLE ROW LEVEL SECURITY` statement; 11 are on the reviewed RLS-exempt allow-list.
 
 No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` statement, or is on the reviewed exempt allow-list below.
 
@@ -106,16 +107,18 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 | `awcms_mini_module_navigation`    | Module registry — global catalog (doc 16 §Registry global, RLS-free).                                                                                                                         |
 | `awcms_mini_module_jobs`          | Module registry — global catalog (doc 16 §Registry global, RLS-free).                                                                                                                         |
 | `awcms_mini_module_health_checks` | Module registry — global catalog (doc 16 §Registry global, RLS-free).                                                                                                                         |
+| `awcms_mini_idn_region_datasets`  | Indonesia administrative region dataset metadata (cahyadsn/wilayah) — global reference data, identical for every tenant (doc 04 §Master Data — Indonesia Administrative Regions, Issue #657). |
+| `awcms_mini_idn_admin_regions`    | Indonesia administrative region records (cahyadsn/wilayah) — global reference data, identical for every tenant (doc 04 §Master Data — Indonesia Administrative Regions, Issue #657).          |
 
 ## Tests
 
-238 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
+239 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
 
 | Directory     | Test files |
 | ------------- | ---------- |
 | `(root)`      | 46         |
 | `e2e`         | 9          |
-| `integration` | 77         |
+| `integration` | 78         |
 | `modules`     | 5          |
 | `unit`        | 101        |
 

--- a/scripts/repo-inventory-generate.ts
+++ b/scripts/repo-inventory-generate.ts
@@ -103,7 +103,11 @@ export const RLS_EXEMPT_TABLES: Readonly<Record<string, string>> = {
   awcms_mini_module_jobs:
     "Module registry — global catalog (doc 16 §Registry global, RLS-free).",
   awcms_mini_module_health_checks:
-    "Module registry — global catalog (doc 16 §Registry global, RLS-free)."
+    "Module registry — global catalog (doc 16 §Registry global, RLS-free).",
+  awcms_mini_idn_region_datasets:
+    "Indonesia administrative region dataset metadata (cahyadsn/wilayah) — global reference data, identical for every tenant (doc 04 §Master Data — Indonesia Administrative Regions, Issue #657).",
+  awcms_mini_idn_admin_regions:
+    "Indonesia administrative region records (cahyadsn/wilayah) — global reference data, identical for every tenant (doc 04 §Master Data — Indonesia Administrative Regions, Issue #657)."
 };
 
 type TableInfo = {

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -388,6 +388,13 @@ export function checkLoginLockoutImplemented(): SecurityCheckResult {
  *   job/command catalog, instance-level health check history), synced from
  *   trusted descriptors, never tenant-writable. Same reasoning as
  *   `awcms_mini_modules` above.
+ * - `awcms_mini_idn_region_datasets`, `awcms_mini_idn_admin_regions`
+ *   (sql/054, Issue #657, epic #654) — Indonesia administrative region
+ *   master data sourced from the third-party `cahyadsn/wilayah` dataset.
+ *   Identical for every tenant (a region hierarchy doesn't vary per
+ *   tenant), so this is global reference data, not tenant-scoped — same
+ *   reasoning as `awcms_mini_permissions` above. See
+ *   `.claude/skills/awcms-mini-idn-admin-regions/SKILL.md`.
  */
 const RLS_FREE_TABLES = new Set([
   "awcms_mini_schema_migrations",
@@ -398,7 +405,9 @@ const RLS_FREE_TABLES = new Set([
   "awcms_mini_module_dependencies",
   "awcms_mini_module_navigation",
   "awcms_mini_module_jobs",
-  "awcms_mini_module_health_checks"
+  "awcms_mini_module_health_checks",
+  "awcms_mini_idn_region_datasets",
+  "awcms_mini_idn_admin_regions"
 ]);
 
 export async function checkRlsEnabled(): Promise<SecurityCheckResult> {
@@ -539,8 +548,10 @@ export async function checkAppDbUserNotSuperuser(): Promise<SecurityCheckResult>
 
 /**
  * Issue #683 (epic #679) — the exact approved grant matrix from
- * `sql/045_awcms_mini_db_role_separation.sql`'s header, restricted to the 9
- * GLOBAL (non-RLS) tables in `RLS_FREE_TABLES` above. Tenant-scoped tables
+ * `sql/045_awcms_mini_db_role_separation.sql`'s header, restricted to the
+ * GLOBAL (non-RLS) tables in `RLS_FREE_TABLES` above (9 as of Issue #683,
+ * plus 2 more added by Issue #657 — see `RLS_FREE_TABLES`'s own doc comment
+ * for the up-to-date membership). Tenant-scoped tables
  * are deliberately out of scope here — RLS/FORCE RLS is the real boundary
  * for those (see `checkRlsEnabled`), and the existing `ALTER DEFAULT
  * PRIVILEGES` convenience is meant to auto-grant `awcms_mini_app` on every
@@ -590,13 +601,22 @@ const ALLOWED_GLOBAL_TABLE_GRANTS: Record<string, Record<string, string[]>> = {
   },
   awcms_mini_module_health_checks: {
     awcms_mini_app: ["SELECT", "INSERT", "UPDATE", "DELETE"]
-  }
+  },
+  // Issue #657 (epic #654) — schema-only, no runtime code path reads or
+  // writes either table yet (import is #660, activate/rollback is #661,
+  // the read-only lookup API is #662). `sql/054` REVOKEs the blanket
+  // default-privileges grant `awcms_mini_app` would otherwise inherit, so
+  // it has zero access here. Future issues each add exactly the grant
+  // their own new code path needs, in their own migration.
+  awcms_mini_idn_region_datasets: {},
+  awcms_mini_idn_admin_regions: {}
 };
 
 /**
  * Reads the REAL grants (`pg_class.relacl` via `aclexplode`, not a static
  * assumption) for `awcms_mini_app`/`awcms_mini_worker`/`awcms_mini_setup` on
- * every `awcms_mini_%` table, keeps only the 9 global (non-RLS) ones, and
+ * every `awcms_mini_%` table, keeps only the global (non-RLS) ones (see
+ * `RLS_FREE_TABLES` above for the current membership), and
  * flags any grant not in `ALLOWED_GLOBAL_TABLE_GRANTS` above. `pg_class` is
  * readable by any role (same reasoning `checkRlsEnabled` already relies on),
  * so this works whichever role `DATABASE_URL` connects as — it does not

--- a/sql/054_awcms_mini_idn_admin_regions_schema.sql
+++ b/sql/054_awcms_mini_idn_admin_regions_schema.sql
@@ -1,0 +1,173 @@
+-- Issue #657 (epic #654, master data wilayah administratif Indonesia) —
+-- versioned PostgreSQL schema for the `idn_admin_regions` module (scaffolded
+-- by #655, source data vendored by #656). Two tables:
+--
+--   1. `awcms_mini_idn_region_datasets` — one row per IMPORTED dataset
+--      (an import "batch"/version). Records upstream provenance (repository,
+--      source path, commit SHA, license — the same facts
+--      `src/modules/idn-admin-regions/domain/source-provenance.ts` and
+--      `data/idn-admin-regions/manifest.json` already carry) plus lifecycle
+--      status and validation summary.
+--   2. `awcms_mini_idn_admin_regions` — one row per normalized administrative
+--      region (province/regency/district/village), belonging to exactly one
+--      dataset via `dataset_id`. A region's identity (`code`) is only unique
+--      WITHIN a dataset — re-importing a new dataset version creates an
+--      entirely new set of region rows, never overwrites the previous
+--      dataset's rows in place (this is what makes rollback in #661 possible:
+--      the previous dataset's rows are still there, untouched).
+--
+-- This issue is SCHEMA ONLY (see the issue body's own scope) — no parser
+-- (#658), no validation gate (#659), no import pipeline (#660), no
+-- activation/rollback/diff (#661), no lookup API (#662). Nothing in this
+-- migration writes a row; it only creates the tables/constraints/indexes
+-- future issues will read and write.
+--
+-- GLOBAL REFERENCE DATA, NOT TENANT-SCOPED (deliberate, matches
+-- `src/modules/idn-admin-regions/README.md`'s own "Not rebuilt" section and
+-- `.claude/skills/awcms-mini-idn-admin-regions/SKILL.md`): administrative
+-- region data is identical for every tenant, the same way
+-- `awcms_mini_modules`/`awcms_mini_permissions` are global rather than
+-- per-tenant. Neither table below has a `tenant_id` column, RLS, or a
+-- tenant-isolation policy — that is intentional, not an oversight. Per
+-- `.claude/skills/awcms-mini-new-migration/SKILL.md`'s "Tabel BARU tanpa
+-- tenant_id/RLS" section, both tables are added to `RLS_FREE_TABLES` in
+-- `scripts/security-readiness.ts` (so `checkRlsEnabled` does not flag them
+-- as unenforced tenant-scoped tables) and to `ALLOWED_GLOBAL_TABLE_GRANTS`
+-- (so `checkRuntimeRoleGlobalTableGrants` — Issue #683, epic #679 — has an
+-- explicit allowlist entry for them).
+--
+-- LEAST-PRIVILEGE GRANTS (same convention as
+-- `sql/045_awcms_mini_db_role_separation.sql`): migration 013's
+-- `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE,
+-- DELETE ON TABLES TO awcms_mini_app` fires automatically for these two
+-- BRAND NEW tables the moment `CREATE TABLE` runs, exactly like it did for
+-- the 9 existing global tables before migration 045 narrowed them. As of
+-- THIS issue, no runtime code path reads or writes either table yet
+-- (`awcms_mini_worker`/`awcms_mini_setup` never had a rule granting them
+-- anything on new tables to begin with, so they already have zero access).
+-- Both `REVOKE ALL ... FROM awcms_mini_app` below immediately follow the
+-- `CREATE TABLE`, in the same transaction, so `awcms_mini_app` ends this
+-- migration with ZERO grants on either table — future issues that add real
+-- code (Issue #660's import pipeline needs INSERT on both tables and UPDATE
+-- on the dataset row; Issue #661's activate/rollback needs UPDATE on
+-- `awcms_mini_idn_region_datasets.status`/`activated_at`/`activated_by`;
+-- Issue #662's read-only lookup API needs SELECT on both) each add exactly
+-- the grant their own new code path needs, in their own migration, rather
+-- than this schema-only issue guessing ahead of time which rights will
+-- actually be exercised.
+
+CREATE TABLE IF NOT EXISTS awcms_mini_idn_region_datasets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  dataset_code text NOT NULL,
+  source_type text NOT NULL DEFAULT 'third_party_github_repository',
+  source_repository text NOT NULL,
+  source_path text NOT NULL,
+  source_commit_sha text NOT NULL,
+  source_license text NOT NULL DEFAULT 'MIT',
+  source_reference text,
+  source_file_sha256 text NOT NULL,
+  row_count integer NOT NULL,
+  status text NOT NULL,
+  validation_summary jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  activated_at timestamptz,
+  activated_by uuid,
+  CONSTRAINT awcms_mini_idn_region_datasets_dataset_code_key UNIQUE (dataset_code),
+  CONSTRAINT awcms_mini_idn_region_datasets_row_count_check CHECK (row_count >= 0),
+  -- Lifecycle values implied by the epic's own issue bodies: #660 ("Leave
+  -- dataset as `validated`, not `active`" after a committed import), #661
+  -- ("Only one dataset can be active at a time" / rollback reactivates the
+  -- previously active dataset). `superseded` covers a dataset that WAS
+  -- active and was replaced by activation of a different dataset or rolled
+  -- back away from (its `activated_at`/`activated_by` stay populated as a
+  -- historical record — see the "Dataset source metadata remains immutable
+  -- after activation" note in #661 — only `status` changes).
+  -- `rejected` is reserved for a future issue that may want to persist a
+  -- failed-validation import attempt for audit purposes. This list is NOT
+  -- necessarily final: if #659/#660/#661 need an additional lifecycle
+  -- state this schema-only issue did not anticipate, a later migration can
+  -- `ALTER TABLE ... DROP CONSTRAINT ... ADD CONSTRAINT ...` — schema
+  -- migrations are additive/sequential in this repo (see
+  -- `.claude/skills/awcms-mini-new-migration/SKILL.md`), never edited in
+  -- place once released.
+  CONSTRAINT awcms_mini_idn_region_datasets_status_check
+    CHECK (status IN ('validated', 'active', 'superseded', 'rejected'))
+);
+
+COMMENT ON TABLE awcms_mini_idn_region_datasets IS
+  'Global reference data (Issue #657, epic #654) — one row per imported Indonesia administrative region dataset version (cahyadsn/wilayah, MIT). NOT tenant-scoped, no RLS — see sql/054''s header and scripts/security-readiness.ts''s RLS_FREE_TABLES.';
+
+-- Enforces "only one dataset can be active at a time" (#657/#661 acceptance
+-- criteria) at the database level: a partial unique index over the rows
+-- matching `status = 'active'`, indexed on the `status` column itself. Every
+-- indexed row necessarily has the same value ('active'), so a second such
+-- row would collide on that value and be rejected by Postgres as a unique
+-- violation — i.e. at most one row can ever satisfy `status = 'active'`.
+-- This also doubles as the fastest possible index for the #662 lookup API's
+-- default "active dataset" query (`WHERE status = 'active'`).
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_idn_region_datasets_single_active
+  ON awcms_mini_idn_region_datasets (status)
+  WHERE status = 'active';
+
+CREATE TABLE IF NOT EXISTS awcms_mini_idn_admin_regions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  dataset_id uuid NOT NULL REFERENCES awcms_mini_idn_region_datasets (id),
+  code text NOT NULL,
+  code_compact text,
+  parent_code text,
+  level smallint NOT NULL,
+  region_type text NOT NULL,
+  local_term text,
+  official_name text NOT NULL,
+  normalized_name text NOT NULL,
+  full_path_code text,
+  full_path_name text,
+  province_code text,
+  regency_code text,
+  district_code text,
+  village_code text,
+  source_row_hash text NOT NULL,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  -- Four-tier Indonesia administrative hierarchy (province / regency-or-city
+  -- / district / village-or-urban-village), matching the terminology
+  -- `src/modules/idn-admin-regions/README.md` already uses. `level` mirrors
+  -- `region_type` numerically (1=province .. 4=village) purely so ORDER
+  -- BY/comparisons don't need a CASE over `region_type` — both are kept in
+  -- sync by whatever writes the row (#658's normalizer / #660's importer),
+  -- not by a generated column, since the mapping is a stable domain fact,
+  -- not a computation over other columns in this same row.
+  CONSTRAINT awcms_mini_idn_admin_regions_level_check CHECK (level BETWEEN 1 AND 4),
+  CONSTRAINT awcms_mini_idn_admin_regions_region_type_check
+    CHECK (region_type IN ('province', 'regency', 'district', 'village'))
+);
+
+COMMENT ON TABLE awcms_mini_idn_admin_regions IS
+  'Global reference data (Issue #657, epic #654) — normalized Indonesia administrative regions for one dataset version. NOT tenant-scoped, no RLS — see sql/054''s header and scripts/security-readiness.ts''s RLS_FREE_TABLES. No personal data.';
+
+-- Acceptance criteria: "Unique index exists on (dataset_id, code)" — a
+-- region's code is only guaranteed unique WITHIN its own dataset (two
+-- different dataset versions may legitimately both contain the same
+-- upstream code).
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_mini_idn_admin_regions_dataset_code_key
+  ON awcms_mini_idn_admin_regions (dataset_id, code);
+
+-- Acceptance criteria: "Parent lookup index exists on (dataset_id,
+-- parent_code)" — the child-lookup path a hierarchy browser (#662 lookup
+-- API, #663 admin UI) needs ("list children of this region").
+CREATE INDEX IF NOT EXISTS awcms_mini_idn_admin_regions_dataset_parent_idx
+  ON awcms_mini_idn_admin_regions (dataset_id, parent_code);
+
+-- Acceptance criteria: "Search index exists for normalized_name" — scoped by
+-- dataset_id first since every real query is dataset-scoped (#662's own
+-- documented default: query the active dataset unless a specific
+-- dataset/version is requested via `dataset=<code>`).
+CREATE INDEX IF NOT EXISTS awcms_mini_idn_admin_regions_dataset_name_idx
+  ON awcms_mini_idn_admin_regions (dataset_id, normalized_name);
+
+-- Least-privilege: see this file's header. Nothing reads or writes these
+-- tables yet, so `awcms_mini_app` ends this migration with zero grants —
+-- future issues add exactly the grant their own new code path needs.
+REVOKE ALL ON awcms_mini_idn_region_datasets FROM awcms_mini_app;
+REVOKE ALL ON awcms_mini_idn_admin_regions FROM awcms_mini_app;

--- a/src/modules/idn-admin-regions/README.md
+++ b/src/modules/idn-admin-regions/README.md
@@ -60,18 +60,24 @@ migration `sql/048_awcms_mini_idn_admin_regions_permissions.sql` (see
 `data/idn-admin-regions/` (outside `src/`, since they are not TypeScript
 source) — see that directory's own `README.md`/`NOTICE.md` and
 `.claude/skills/awcms-mini-idn-admin-regions/SKILL.md` §656 for details.
-**Still no dataset schema, no parser/normalizer, no import pipeline, no
-activation/rollback, no lookup API, and no admin UI yet** — every one of
-those is a later issue, listed below. `application/` is currently empty
-(`.gitkeep` only) — there is no application-layer logic to write until a
-later issue gives this module its first real database table or endpoint
-to orchestrate.
+Issue #657 then added the versioned PostgreSQL schema (migration
+`sql/054_awcms_mini_idn_admin_regions_schema.sql`) — two GLOBAL reference
+tables (`awcms_mini_idn_region_datasets`, `awcms_mini_idn_admin_regions`),
+neither `tenant_id`-scoped nor RLS-protected (see §Not rebuilt below and
+`.claude/skills/awcms-mini-idn-admin-regions/SKILL.md` §657 for the full
+design rationale, including how "only one active dataset" and
+least-privilege runtime-role grants are enforced). **Still no
+parser/normalizer, no import pipeline, no activation/rollback, no lookup
+API, and no admin UI** — every one of those is a later issue, listed
+below. `application/` is currently empty (`.gitkeep` only) — there is no
+application-layer logic to write until a later issue gives this module
+its first real read/write code path.
 
 | Issue | Scope                                                                                          | Status      |
 | ----- | ---------------------------------------------------------------------------------------------- | ----------- |
 | #655  | Scaffold `idn_admin_regions` module (this issue)                                               | **Done**    |
 | #656  | Vendor `cahyadsn/wilayah` source metadata + license under `data/idn-admin-regions/`            | **Done**    |
-| #657  | Versioned PostgreSQL schema (`awcms_mini_idn_region_datasets`, `awcms_mini_idn_admin_regions`) | Not started |
+| #657  | Versioned PostgreSQL schema (`awcms_mini_idn_region_datasets`, `awcms_mini_idn_admin_regions`) | **Done**    |
 | #658  | SQL parser/normalizer for upstream MySQL-style dump files                                      | Not started |
 | #659  | Repository validation gate for vendored/normalized dataset files                               | Not started |
 | #660  | PostgreSQL import pipeline (dry-run/commit)                                                    | Not started |

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -517,7 +517,8 @@ describe("database migration runner helpers", () => {
       "050_awcms_mini_blog_posts_seo_image.sql",
       "051_awcms_mini_blog_content_internal_tag_links_schema.sql",
       "052_awcms_mini_blog_content_internal_tag_links_permissions.sql",
-      "053_awcms_mini_social_publishing_schema.sql"
+      "053_awcms_mini_social_publishing_schema.sql",
+      "054_awcms_mini_idn_admin_regions_schema.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/idn-admin-regions-schema.integration.test.ts
+++ b/tests/integration/idn-admin-regions-schema.integration.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Integration tests for the `idn_admin_regions` module's versioned schema
+ * (Issue #657, epic #654 — master data wilayah administratif Indonesia,
+ * `sql/054`) against a real PostgreSQL. Schema-only issue — no import
+ * pipeline (#660), activation/rollback (#661), or lookup API (#662) exists
+ * yet, so every query here goes through `getAdminSql()` (the migration
+ * owner connection), the same pattern
+ * `module-management-schema.integration.test.ts` used before Issue #513
+ * gave that registry its first real service — see `sql/054`'s header for
+ * why `awcms_mini_app` deliberately has zero grants on these two tables as
+ * of this issue.
+ *
+ * These tables are GLOBAL reference data, not tenant-scoped (deliberate —
+ * see `sql/054`'s header and `src/modules/idn-admin-regions/README.md`), so
+ * unlike most `*-schema.integration.test.ts` files in this directory there
+ * is no RLS-isolation test here. Instead this asserts the ABSENCE of
+ * tenant_id/RLS and exercises the real constraints the issue's acceptance
+ * criteria calls out: unique `(dataset_id, code)`, the parent-lookup index,
+ * the normalized_name search index, and the single-active-dataset
+ * constraint.
+ *
+ * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  getAdminSql,
+  integrationEnabled,
+  resetDatabase
+} from "./harness";
+
+// Copied verbatim from data/idn-admin-regions/manifest.json (Issue #656) —
+// proves this schema can actually hold the exact real upstream provenance
+// values that a future #660 import would write, not placeholder-shaped
+// stand-ins. See src/modules/idn-admin-regions/domain/source-provenance.ts
+// for the repository/path/license as trusted code constants.
+const REAL_SOURCE_REPOSITORY = "https://github.com/cahyadsn/wilayah";
+const REAL_SOURCE_PATH = "https://github.com/cahyadsn/wilayah/tree/master/db";
+const REAL_SOURCE_COMMIT_SHA = "cae306278e5be616c83ba2d8096b00767f45b5fe";
+const REAL_SOURCE_LICENSE = "MIT";
+const REAL_SOURCE_FILE_SHA256 =
+  "c4c3396d9380d4edee072af1d9dff83573b574d7cd00a6562cf82e200e954031";
+
+async function insertDataset(
+  overrides: Partial<{
+    datasetCode: string;
+    status: string;
+    rowCount: number;
+  }> = {}
+): Promise<string> {
+  const admin = getAdminSql();
+  const datasetCode = overrides.datasetCode ?? "idn_admin_regions_2026_07";
+  const status = overrides.status ?? "validated";
+  const rowCount = overrides.rowCount ?? 91000;
+
+  const rows = (await admin`
+    INSERT INTO awcms_mini_idn_region_datasets
+      (dataset_code, source_repository, source_path, source_commit_sha,
+       source_license, source_file_sha256, row_count, status)
+    VALUES
+      (${datasetCode}, ${REAL_SOURCE_REPOSITORY}, ${REAL_SOURCE_PATH},
+       ${REAL_SOURCE_COMMIT_SHA}, ${REAL_SOURCE_LICENSE},
+       ${REAL_SOURCE_FILE_SHA256}, ${rowCount}, ${status})
+    RETURNING id
+  `) as { id: string }[];
+
+  return rows[0]!.id;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite(
+  "idn_admin_regions schema (Issue #657, epic #654) — real Postgres",
+  () => {
+    beforeAll(async () => {
+      await applyMigrations();
+    });
+
+    beforeEach(async () => {
+      await resetDatabase();
+    });
+
+    test("awcms_mini_idn_region_datasets has no tenant_id column and RLS is not enabled (global reference data)", async () => {
+      const admin = getAdminSql();
+
+      const columns = (await admin`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'awcms_mini_idn_region_datasets' AND column_name = 'tenant_id'
+    `) as { column_name: string }[];
+      expect(columns).toHaveLength(0);
+
+      const relRows = (await admin`
+      SELECT relrowsecurity, relforcerowsecurity FROM pg_class
+      WHERE relname = 'awcms_mini_idn_region_datasets'
+    `) as { relrowsecurity: boolean; relforcerowsecurity: boolean }[];
+      expect(relRows[0]!.relrowsecurity).toBe(false);
+      expect(relRows[0]!.relforcerowsecurity).toBe(false);
+    });
+
+    test("awcms_mini_idn_admin_regions has no tenant_id column and RLS is not enabled (global reference data)", async () => {
+      const admin = getAdminSql();
+
+      const columns = (await admin`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'awcms_mini_idn_admin_regions' AND column_name = 'tenant_id'
+    `) as { column_name: string }[];
+      expect(columns).toHaveLength(0);
+
+      const relRows = (await admin`
+      SELECT relrowsecurity, relforcerowsecurity FROM pg_class
+      WHERE relname = 'awcms_mini_idn_admin_regions'
+    `) as { relrowsecurity: boolean; relforcerowsecurity: boolean }[];
+      expect(relRows[0]!.relrowsecurity).toBe(false);
+      expect(relRows[0]!.relforcerowsecurity).toBe(false);
+    });
+
+    test("dataset metadata holds the real upstream provenance (repository, source path, commit SHA, license)", async () => {
+      const admin = getAdminSql();
+      const datasetId = await insertDataset();
+
+      const rows = (await admin`
+      SELECT source_repository, source_path, source_commit_sha, source_license,
+             source_file_sha256, source_type, row_count, status
+      FROM awcms_mini_idn_region_datasets WHERE id = ${datasetId}
+    `) as {
+        source_repository: string;
+        source_path: string;
+        source_commit_sha: string;
+        source_license: string;
+        source_file_sha256: string;
+        source_type: string;
+        row_count: number;
+        status: string;
+      }[];
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.source_repository).toBe(REAL_SOURCE_REPOSITORY);
+      expect(rows[0]!.source_path).toBe(REAL_SOURCE_PATH);
+      expect(rows[0]!.source_commit_sha).toBe(REAL_SOURCE_COMMIT_SHA);
+      expect(rows[0]!.source_license).toBe(REAL_SOURCE_LICENSE);
+      expect(rows[0]!.source_file_sha256).toBe(REAL_SOURCE_FILE_SHA256);
+      // Default applies when not explicitly supplied at insert time.
+      expect(rows[0]!.source_type).toBe("third_party_github_repository");
+      expect(rows[0]!.status).toBe("validated");
+    });
+
+    test("dataset_code is unique", async () => {
+      await insertDataset({ datasetCode: "dup_dataset" });
+
+      let didThrow = false;
+      try {
+        await insertDataset({ datasetCode: "dup_dataset" });
+      } catch {
+        didThrow = true;
+      }
+      expect(didThrow).toBe(true);
+    });
+
+    test("only one dataset can be active at a time", async () => {
+      const admin = getAdminSql();
+      const firstId = await insertDataset({
+        datasetCode: "dataset_a",
+        status: "active"
+      });
+
+      // A second dataset trying to become active concurrently must be
+      // rejected by the partial unique index on (status) WHERE status='active'.
+      let didThrow = false;
+      try {
+        await insertDataset({ datasetCode: "dataset_b", status: "active" });
+      } catch {
+        didThrow = true;
+      }
+      expect(didThrow).toBe(true);
+
+      // A second dataset with a non-active status is fine.
+      const secondId = await insertDataset({
+        datasetCode: "dataset_c",
+        status: "validated"
+      });
+      expect(secondId).not.toBe(firstId);
+
+      // Rolling the first dataset back to a non-active status frees the slot
+      // up for another dataset to become active.
+      await admin`
+      UPDATE awcms_mini_idn_region_datasets SET status = 'superseded'
+      WHERE id = ${firstId}
+    `;
+      const thirdId = await insertDataset({
+        datasetCode: "dataset_d",
+        status: "active"
+      });
+      expect(thirdId).not.toBe(firstId);
+    });
+
+    test("status rejects an unknown lifecycle value", async () => {
+      let didThrow = false;
+      try {
+        await insertDataset({ datasetCode: "bogus_status", status: "bogus" });
+      } catch {
+        didThrow = true;
+      }
+      expect(didThrow).toBe(true);
+    });
+
+    test("unique index exists on (dataset_id, code) and rejects a duplicate code within the same dataset", async () => {
+      const admin = getAdminSql();
+      const datasetId = await insertDataset();
+
+      await admin`
+      INSERT INTO awcms_mini_idn_admin_regions
+        (dataset_id, code, level, region_type, official_name, normalized_name, source_row_hash)
+      VALUES
+        (${datasetId}, '11', 1, 'province', 'ACEH', 'aceh', 'hash-11')
+    `;
+
+      let didThrow = false;
+      try {
+        await admin`
+        INSERT INTO awcms_mini_idn_admin_regions
+          (dataset_id, code, level, region_type, official_name, normalized_name, source_row_hash)
+        VALUES
+          (${datasetId}, '11', 1, 'province', 'ACEH DUPLICATE', 'aceh duplicate', 'hash-11-dup')
+      `;
+      } catch {
+        didThrow = true;
+      }
+      expect(didThrow).toBe(true);
+
+      // The same code IS allowed again under a different dataset (a new
+      // dataset version re-imports the full hierarchy from scratch).
+      const otherDatasetId = await insertDataset({
+        datasetCode: "other_dataset"
+      });
+      const rows = await admin`
+      INSERT INTO awcms_mini_idn_admin_regions
+        (dataset_id, code, level, region_type, official_name, normalized_name, source_row_hash)
+      VALUES
+        (${otherDatasetId}, '11', 1, 'province', 'ACEH', 'aceh', 'hash-11')
+      RETURNING id
+    `;
+      expect(rows).toHaveLength(1);
+    });
+
+    test("parent lookup index exists on (dataset_id, parent_code) and supports child lookup", async () => {
+      const admin = getAdminSql();
+      const datasetId = await insertDataset();
+
+      const indexRows = (await admin`
+      SELECT indexdef FROM pg_indexes
+      WHERE tablename = 'awcms_mini_idn_admin_regions'
+        AND indexdef ILIKE '%(dataset_id, parent_code)%'
+    `) as { indexdef: string }[];
+      expect(indexRows.length).toBeGreaterThan(0);
+
+      await admin`
+      INSERT INTO awcms_mini_idn_admin_regions
+        (dataset_id, code, parent_code, level, region_type, official_name, normalized_name, source_row_hash)
+      VALUES
+        (${datasetId}, '11', NULL, 1, 'province', 'ACEH', 'aceh', 'hash-11'),
+        (${datasetId}, '11.01', '11', 2, 'regency', 'KABUPATEN ACEH SELATAN', 'kabupaten aceh selatan', 'hash-11-01'),
+        (${datasetId}, '11.02', '11', 2, 'regency', 'KABUPATEN ACEH TENGGARA', 'kabupaten aceh tenggara', 'hash-11-02')
+    `;
+
+      const children = (await admin`
+      SELECT code FROM awcms_mini_idn_admin_regions
+      WHERE dataset_id = ${datasetId} AND parent_code = '11'
+      ORDER BY code
+    `) as { code: string }[];
+      expect(children.map((row) => row.code)).toEqual(["11.01", "11.02"]);
+    });
+
+    test("search index exists for normalized_name", async () => {
+      const admin = getAdminSql();
+
+      const indexRows = (await admin`
+      SELECT indexdef FROM pg_indexes
+      WHERE tablename = 'awcms_mini_idn_admin_regions'
+        AND indexdef ILIKE '%normalized_name%'
+    `) as { indexdef: string }[];
+      expect(indexRows.length).toBeGreaterThan(0);
+    });
+
+    test("level rejects a value outside 1..4 and region_type rejects an unknown value", async () => {
+      const admin = getAdminSql();
+      const datasetId = await insertDataset();
+
+      let didThrowLevel = false;
+      try {
+        await admin`
+        INSERT INTO awcms_mini_idn_admin_regions
+          (dataset_id, code, level, region_type, official_name, normalized_name, source_row_hash)
+        VALUES
+          (${datasetId}, '99', 5, 'province', 'BOGUS', 'bogus', 'hash-99')
+      `;
+      } catch {
+        didThrowLevel = true;
+      }
+      expect(didThrowLevel).toBe(true);
+
+      let didThrowType = false;
+      try {
+        await admin`
+        INSERT INTO awcms_mini_idn_admin_regions
+          (dataset_id, code, level, region_type, official_name, normalized_name, source_row_hash)
+        VALUES
+          (${datasetId}, '98', 1, 'kelurahan_bogus', 'BOGUS', 'bogus', 'hash-98')
+      `;
+      } catch {
+        didThrowType = true;
+      }
+      expect(didThrowType).toBe(true);
+    });
+
+    test("awcms_mini_app has zero grants on either table (least privilege, no runtime code path yet)", async () => {
+      const admin = getAdminSql();
+
+      const rows = (await admin`
+      SELECT c.relname AS table_name, p.privilege_type AS privilege
+      FROM pg_class c
+      CROSS JOIN LATERAL aclexplode(c.relacl) AS p
+      JOIN pg_roles a ON a.oid = p.grantee
+      WHERE c.relname IN ('awcms_mini_idn_region_datasets', 'awcms_mini_idn_admin_regions')
+        AND a.rolname = 'awcms_mini_app'
+    `) as { table_name: string; privilege: string }[];
+
+      expect(rows).toHaveLength(0);
+    });
+  }
+);


### PR DESCRIPTION
## Summary

- Adds `sql/054_awcms_mini_idn_admin_regions_schema.sql` (Issue #657, epic #654 — master data wilayah administratif Indonesia, following #655's module scaffold and #656's vendored `cahyadsn/wilayah` source data) — two **global reference tables**, neither `tenant_id`-scoped nor RLS-protected (region data is identical for every tenant):
  - `awcms_mini_idn_region_datasets` — one row per imported dataset version: upstream provenance (repository, source path, commit SHA, license, file checksum), `row_count`, lifecycle `status` (`validated`/`active`/`superseded`/`rejected`), `validation_summary`. **Only one dataset can be active at a time** is enforced with a partial unique index on `status` `WHERE status = 'active'` — every row the index covers necessarily has the same value, so a second such row collides as a unique violation.
  - `awcms_mini_idn_admin_regions` — one row per normalized administrative region (province/regency/district/village) belonging to a dataset. Unique `(dataset_id, code)`, parent-lookup index `(dataset_id, parent_code)`, search index `(dataset_id, normalized_name)`.
- **Least privilege**: both tables added to `RLS_FREE_TABLES`/`ALLOWED_GLOBAL_TABLE_GRANTS` in `scripts/security-readiness.ts` and to `RLS_EXEMPT_TABLES` in `scripts/repo-inventory-generate.ts`. `awcms_mini_app` ends the migration with **zero grants** on either table (`REVOKE ALL` right after `CREATE TABLE`, undoing migration 013's blanket default-privileges grant) — this issue is schema-only, no runtime code path reads/writes these tables yet. Verified live: `bun run security:readiness` passes, and `psql \dp` confirms only the owner role remains in each table's ACL.
- Migration test: `tests/integration/idn-admin-regions-schema.integration.test.ts` — asserts the *absence* of `tenant_id`/RLS (these tables are deliberately global), plus the real constraints: unique `(dataset_id, code)`, parent-lookup index, `normalized_name` search index, single-active-dataset enforcement (including the reopen-the-slot-after-supersede path), `status`/`region_type`/`level` CHECK constraints, and zero `awcms_mini_app` grants. Seeds dataset rows with the *real* provenance values from `data/idn-admin-regions/manifest.json` (commit SHA, checksum) to prove the schema actually fits them.
- Docs: `.claude/skills/awcms-mini-idn-admin-regions/SKILL.md` (new §657 section with full design rationale), `src/modules/idn-admin-regions/README.md` (status table), `docs/awcms-mini/04_erd_data_dictionary.md` (new entry), `docs/awcms-mini/repo-inventory.md` (regenerated).
- Fixed one incidental pre-existing-in-worktree issue: `tests/foundation.test.ts`'s hardcoded migration-file-list assertion needed the new `054` entry appended (mechanical, no logic change).
- Changeset: `.changeset/idn-admin-regions-schema-issue-657.md` (minor).

This issue is **schema only** — no parser/normalizer (#658), validation gate (#659), import pipeline (#660), activation/rollback (#661), lookup API (#662), or admin UI (#663) yet.

## Test plan

- [x] `bun run db:migrate` — migration 054 applies cleanly against a real Postgres, no changes to prior migrations.
- [x] `bun run security:readiness` — RLS-enabled check and runtime-role-grants check both PASS with the two new tables included.
- [x] `bun test tests/integration/idn-admin-regions-schema.integration.test.ts` — 11/11 pass (no tenant_id/RLS, unique `(dataset_id, code)`, parent-lookup index, search index, single-active-dataset, CHECK constraints, zero grants).
- [x] `bun run check` (lint, docs checks, OpenAPI/AsyncAPI spec check, repo-inventory check, module DAG check, i18n checks, config docs check, logging lint check, typecheck, full test suite, build) — all green: 3073 pass / 0 fail / 8 skip across 3081 tests, build succeeds.

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)