### PR TITLE
docs(agent): warn awcms-mini-coder against the background-notification stall

### DIFF
--- a/.claude/agents/awcms-mini-coder.md
+++ b/.claude/agents/awcms-mini-coder.md
@@ -25,5 +25,7 @@ Aturan wajib (ringkas dari AGENTS.md — patuhi semuanya):
 
 Validasi sebelum selesai: `bun run db:migrate`, `bun run api:spec:check`, `bun test`, `bun run build` (yang tersedia). Bila command gagal: laporkan command, error summary, likely cause, status partial/blocked, next step — jangan klaim sukses.
 
+**Jangan background lalu menunggu notifikasi test/check Anda sendiri** (mis. `nohup bun run check > log &` lalu "saya akan menunggu monitor memberi tahu saya") — notifikasi task background hanya sampai ke orchestrator yang menjalankan Anda, TIDAK PERNAH ke Anda sendiri, jadi Anda akan diam selamanya menunggu sesuatu yang tak pernah datang. Jalankan command panjang secara sinkron/foreground (tunggu langsung sampai selesai dalam giliran yang sama), atau kalau harus background, poll PID-nya sendiri secara sinkron dalam giliran yang sama (`while ps -p <PID> > /dev/null; do sleep 15; done`) sebelum melanjutkan — jangan pernah mengakhiri giliran sambil menunggu proses background milik sendiri selesai.
+
 Akhiri SELALU dengan laporan implementasi:
 Summary / Files changed / Commands run / Test results / Security notes / Documentation updates / Remaining limitations / Next recommended step.


### PR DESCRIPTION
## Summary
- Multiple parallel-wave `awcms-mini-coder` agent instances this session backgrounded their own `bun run check`/`bun run test`, then ended their turn saying "I'll wait for the monitor to notify me" — but background-task completion notifications only reach the orchestrator that spawned the agent, never the subagent itself. Each instance silently stalled indefinitely until the orchestrator noticed and manually resumed it via a follow-up message.
- Adds explicit guidance to the agent definition: run long validation commands synchronously in the same turn, or if backgrounding is unavoidable, poll the PID synchronously (foreground wait loop) before ending the turn — never end a turn waiting on a background process of one's own.

Docs-only (`.claude/**/*.md`), exempt from the changeset policy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)