### PR TITLE
fix(shared-redaction): detect common vendor secret-key formats and recurse into top-level JSON arrays

### DIFF
--- a/.changeset/shared-redaction-vendor-secrets-array-recursion-issue-785.md
+++ b/.changeset/shared-redaction-vendor-secrets-array-recursion-issue-785.md
@@ -1,0 +1,44 @@
+---
+"awcms-mini": patch
+---
+
+Harden the shared secret/PII redaction utility (`src/modules/_shared/redaction.ts`,
+Issue #785) — surfaced independently by two security audits during epic
+#738 Wave 3 (PR #783/#750 reference-data, PR #784/#754 integration-hub).
+
+`findSecretShapedValues`/`SECRET_VALUE_PATTERNS` (used to reject a
+credential-shaped value pasted into an innocently-named module settings
+field, e.g. `publicLabel`) and `redactSecretsInText`/`TEXT_SECRET_PATTERNS`
+(the free-text complement used by admin-page/CLI-worker error logging)
+previously only recognized JWT/PEM/AWS-`AKIA`/`Bearer|Basic`/embedded
+connection-string credential shapes. Both now also detect common vendor
+secret-key formats: GitHub personal access token (`ghp_...`) and
+fine-grained PAT (`github_pat_...`), OpenAI key (`sk-proj-...`/`sk-...`),
+Slack bot/user OAuth token (`xoxb-...`/`xoxp-...`) and incoming-webhook URL
+(`hooks.slack.com/services/...`), Stripe secret key
+(`sk_live_...`/`sk_test_...`), and Google API key (`AIzaSy...`). Each
+pattern keeps a minimum-length floor after its prefix so a short,
+innocuous value that merely shares a prefix (e.g. a `sk-`-prefixed SKU
+code) is never false-flagged. A generic high-entropy-string backstop was
+evaluated and deliberately NOT added — this codebase legitimately stores
+many long, high-entropy-looking values (UUID keys, content hashes,
+idempotency keys) that would false-positive constantly at this
+cross-module layer; sticking to explicit vendor patterns keeps the
+false-positive rate near zero (documented residual: any secret shape not
+on the list is still undetected).
+
+New sibling function `redactSensitiveJsonValue` recurses into a top-level
+JSON *array* (not just a top-level object, which is all
+`redactSensitiveAttributes` has ever handled) — for a future consumer
+whose payload is an array of records (e.g. a batch-webhook provider body)
+rather than a single object. Purely additive: every existing call site
+(`logging/application/audit-log.ts`, `lib/logging/logger.ts`,
+`domain-event-runtime/domain/payload-redaction.ts`) keeps calling the
+unchanged `redactSensitiveAttributes` and is unaffected.
+
+Adversarial unit tests added for every new vendor shape (fabricated,
+non-canonical fixtures — same convention as the existing JWT fixture, to
+avoid tripping GitGuardian's own shape-based secret scanning on this PR),
+the array-recursion case, and negative fixtures (UUID, content hash, a
+short `sk-`-prefixed code, an ordinary webhook URL) confirming no
+over-blocking.

--- a/.changeset/shared-redaction-vendor-secrets-array-recursion-issue-785.md
+++ b/.changeset/shared-redaction-vendor-secrets-array-recursion-issue-785.md
@@ -42,3 +42,19 @@ avoid tripping GitGuardian's own shape-based secret scanning on this PR),
 the array-recursion case, and negative fixtures (UUID, content hash, a
 short `sk-`-prefixed code, an ordinary webhook URL) confirming no
 over-blocking.
+
+**PR #791 review round follow-up** (both fixed in the same PR before
+merge): added the same-privilege-class sibling prefixes the reviewer/
+security-auditor found still slipped through — GitHub OAuth/GitHub-App
+tokens (`gho_`/`ghu_`/`ghs_`/`ghr_`), Slack app-level/rotated/legacy
+tokens (`xoxa-`/`xoxe-`/`xoxe.xoxp-`/`xoxs-`), Stripe restricted keys
+(`rk_live_`/`rk_test_`) and webhook signing secret (`whsec_`), and
+OpenAI's newer service-account/admin key families
+(`sk-svcacct-`/`sk-admin-`) — and tightened the classic OpenAI key floor
+from `{20,}` to `{40,}` (matching this file's own comment that real
+classic keys run ~48 characters). Also fixed a fixed-length-match design
+flaw in the free-text `ghp_`/`AIzaSy` patterns: they previously matched
+an EXACT character count, so a real token a few characters longer than
+expected left its extra tail sitting in plaintext right next to the
+`[REDACTED_*]` tag — both now match a MINIMUM length instead, sweeping
+any same-charset tail into the redaction.

--- a/docs/awcms-mini/20_threat_model_security_architecture.md
+++ b/docs/awcms-mini/20_threat_model_security_architecture.md
@@ -294,7 +294,15 @@ kasus admin (sengaja atau tidak) menempelkan credential nyata ke field
 yang namanya tidak mencurigakan (mis. `publicLabel`) — `_shared/redaction.ts`'s
 `findSecretShapedValues` melengkapi dengan heuristik bentuk-value
 (JWT, blok PEM private key, AWS access key id, header `Bearer`/`Basic`
-mentah, connection string ber-`user:pass@`), sengaja konservatif supaya
+mentah, connection string ber-`user:pass@`, dan sejak Issue #785 juga
+format vendor umum: GitHub PAT `ghp_...`/`github_pat_...`, OpenAI
+`sk-proj-...`/`sk-...`, Slack bot/user token `xoxb-...`/`xoxp-...` dan
+incoming-webhook `hooks.slack.com/services/...`, Stripe secret key
+`sk_live_...`/`sk_test_...`, Google API key `AIzaSy...`), sengaja
+konservatif — TANPA heuristik entropy generik (dievaluasi lalu sengaja
+tidak dipakai karena UUID/content-hash/idempotency-key yang sah di
+codebase ini akan false-positive terus-menerus, lihat komentar di
+`_shared/redaction.ts`) — supaya
 label/URL/flag biasa tidak pernah salah tertolak, dan menolak
 (`400 SETTINGS_SECRET_SHAPED_VALUE_REJECTED`) tanpa pernah menyertakan
 value itu sendiri di pesan error (hanya path key). Audit trail (`settings_updated`)
@@ -685,8 +693,11 @@ satu baris untuk output CLI) — keduanya memanggil
 pelengkap teks-bebas dari `redactSensitiveAttributes` yang berbasis
 KEY, untuk pola BENTUK NILAI (JWT, blok PEM private key, AWS access
 key, `Bearer`/`Basic` auth header, connection-string dengan kredensial
-`user:pass@`, dan pasangan `key=value`/`key: value` yang key-nya
-credential-shaped) di dalam `.message`/`.stack` exception itu sendiri.
+`user:pass@`, pasangan `key=value`/`key: value` yang key-nya
+credential-shaped, dan sejak Issue #785 juga format vendor umum GitHub
+PAT/OpenAI/Slack token+webhook/Stripe/Google API key — lihat §"Standar
+tambahan dipicu Issue #785" di bawah) di dalam `.message`/`.stack`
+exception itu sendiri.
 
 `REDACTION_KEYS` (redaksi berbasis key object) diperluas dengan
 `"cookie"`. **Temuan penting**: `"ip"` TIDAK bisa masuk daftar itu
@@ -772,6 +783,52 @@ sebelum merge, semuanya sudah diperbaiki di branch yang sama:
 Test regresi untuk setiap temuan di atas ada di `tests/audit-log.test.ts`,
 `tests/unit/error-sanitizer.test.ts`, dan
 `tests/unit/logging-lint-check.test.ts`.
+
+### Standar tambahan dipicu Issue #785 (format vendor secret-key + rekursi array)
+
+Dua audit keamanan independen selama epic #738 Wave 3 (PR #783/#750
+reference-data, PR #784/#754 integration-hub) menemukan celah yang sama
+di `src/modules/_shared/redaction.ts`: `findSecretShapedValues`
+sebelumnya HANYA mencocokkan JWT/PEM/AWS-`AKIA`/`Bearer|Basic`/
+connection-string — kredensial vendor umum (GitHub PAT, OpenAI, Slack,
+Stripe, Google) lolos total, dan `redactSensitiveAttributes` hanya
+merekursi objek JSON top-level, bukan array JSON top-level (payload
+batch-webhook yang array-of-records lolos masking sepenuhnya).
+
+Diperbaiki di `_shared/redaction.ts`:
+
+- `SECRET_VALUE_PATTERNS`/`TEXT_SECRET_PATTERNS` diperluas dengan format
+  vendor: GitHub PAT (`ghp_...`), GitHub fine-grained PAT
+  (`github_pat_...`), OpenAI (`sk-proj-...`/`sk-...`), Slack bot/user
+  token (`xoxb-...`/`xoxp-...`), Slack incoming-webhook URL
+  (`hooks.slack.com/services/...`), Stripe secret key
+  (`sk_live_...`/`sk_test_...`), Google API key (`AIzaSy...`). Setiap
+  pola punya floor panjang setelah prefix-nya (mis. `{20,}` untuk
+  `sk-...`) khusus supaya kode/label pendek yang kebetulan berawalan
+  sama (mis. SKU `sk-widget-2024`) tidak pernah ikut tertolak/teredaksi.
+- Heuristik entropy generik (flag string acak panjang APA PUN, tanpa
+  prefix vendor) DIEVALUASI lalu SENGAJA TIDAK dipakai — UUID primary/
+  foreign key, content hash `sync_storage`, idempotency key, dan
+  correlation id di codebase ini semuanya string high-entropy yang sah
+  dan rutin disimpan; heuristik generik di layer ini (dipakai lintas
+  SEMUA modul, bukan satu field bertujuan-khusus seperti
+  `social-publishing`'s `looksLikeRawSecretToken`) akan menghasilkan
+  false positive terus-menerus. Tetap berpegang pada pola prefix vendor
+  eksplisit, dengan konsekuensi yang diterima: bentuk secret di luar
+  daftar ini tidak terdeteksi (residual yang didokumentasikan, sama
+  seperti keterbatasan heuristik ini sejak awal).
+- `redactSensitiveJsonValue` (fungsi baru, sibling `redactSensitiveAttributes`
+  — BUKAN mengubah signature fungsi lama, supaya nol risiko ke
+  pemanggil yang sudah ada) menerima array JSON top-level dan merekursi
+  ke setiap elemen, untuk konsumen masa depan (mis. `integration_hub`'s
+  payload batch-webhook) yang top-level value-nya array, bukan objek.
+
+Test regresi (fixture kredensial FABRIKASI/non-kanonik, mengikuti
+konvensi fixture JWT yang sudah ada — lihat komentarnya sendiri di
+`tests/audit-log.test.ts` untuk alasan tidak memakai contoh publik resmi
+seperti AWS `AKIAIOSFODNN7EXAMPLE`) ada di `tests/audit-log.test.ts`,
+termasuk fixture negatif (UUID, content hash, kode pendek berawalan
+`sk-`, URL webhook generik) untuk memastikan tidak over-blocking.
 
 ### Troubleshooting operator-safe
 

--- a/docs/awcms-mini/20_threat_model_security_architecture.md
+++ b/docs/awcms-mini/20_threat_model_security_architecture.md
@@ -830,6 +830,39 @@ seperti AWS `AKIAIOSFODNN7EXAMPLE`) ada di `tests/audit-log.test.ts`,
 termasuk fixture negatif (UUID, content hash, kode pendek berawalan
 `sk-`, URL webhook generik) untuk memastikan tidak over-blocking.
 
+**PR #791 review round follow-up** (security-auditor Medium + reviewer
+Low, keduanya diperbaiki di PR yang sama sebelum merge):
+
+- Sibling prefix per vendor yang sudah dicakup tapi masih lolos total —
+  GitHub OAuth/GitHub-App token (`gho_`/`ghu_`/`ghs_`/`ghr_`, kelas
+  privilege sama dengan `ghp_`), Slack app-level/rotated/legacy token
+  (`xoxa-`/`xoxe-`/`xoxe.xoxp-`/`xoxs-`, kelas privilege sama dengan
+  bot/user token), Stripe restricted key (`rk_live_`/`rk_test_`, kelas
+  privilege sama dengan secret key) dan webhook signing secret
+  (`whsec_`), serta keluarga key OpenAI yang lebih baru
+  (`sk-svcacct-`/`sk-admin-`, bentuk hyphenated sama seperti
+  `sk-proj-`) — ditambahkan ke `SECRET_VALUE_PATTERNS`/
+  `TEXT_SECRET_PATTERNS`.
+- Floor classic OpenAI key (`sk-...`) diperketat dari `{20,}` ke `{40,}`
+  (komentar kode sendiri sudah bilang key asli ~48 karakter, jadi floor
+  `{20,}` sebelumnya menyisakan ruang false-positive yang tidak perlu
+  terhadap kode internal pendek berawalan `sk-`).
+- **Celah desain fixed-length-match pada pola free-text** — versi
+  unanchored `ghp_`/`AIzaSy` sebelumnya mensyaratkan JUMLAH KARAKTER
+  PERSIS (`{36}`/`{33}`), sehingga token asli yang sedikit lebih panjang
+  dari itu hanya ter-redact sebagian — sisa "ekor" karakter yang sama
+  charset-nya tetap plaintext, persis di sebelah tag
+  `[REDACTED_GITHUB_TOKEN]`/`[REDACTED_GOOGLE_API_KEY]` — kebalikan dari
+  tujuan redaksi. Pola pre-existing `AKIA[0-9A-Z]{16}` punya desain sama
+  tapi TIDAK diubah (format AWS asli memang selalu persis sepanjang itu,
+  tidak eksploitable hari ini); tapi karena desain yang sama BARU saja
+  diterapkan ke `ghp_`/`AIzaSy` di PR ini, diperbaiki sekarang sebelum
+  polanya diulang lagi ke prefix vendor berikutnya. Kedua pola sekarang
+  memakai floor MINIMUM (`{36,}`/`{33,}`), bukan jumlah persis — versi
+  anchored (`findSecretShapedValues`) tetap memakai jumlah persis karena
+  memang dimaksudkan memvalidasi bentuk exact-value, bukan menyapu teks
+  bebas.
+
 ### Troubleshooting operator-safe
 
 Operator yang membaca output `bun run <script>` atau baris log JSON

--- a/src/modules/_shared/redaction.ts
+++ b/src/modules/_shared/redaction.ts
@@ -218,29 +218,47 @@ const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
   // `TEXT_SECRET_PATTERNS` below for the unanchored, embedded-in-prose
   // equivalents of the same shapes).
   //
-  // GitHub personal access token — fixed-length real format (`ghp_` + 36
-  // base62 chars).
-  /^ghp_[A-Za-z0-9]{36}$/,
+  // GitHub personal access token, plus its OAuth/GitHub-App-installation
+  // token siblings — `gho_` (OAuth), `ghu_`/`ghs_` (GitHub App
+  // user-to-server/server-to-server), `ghr_` (refresh token) — added in
+  // the PR #791 review round (security-auditor: same fixed-length real
+  // format, 36 base62 chars after the prefix, and same blast radius as
+  // `ghp_`, previously slipped through completely undetected).
+  /^gh[opsru]_[A-Za-z0-9]{36}$/,
   // GitHub fine-grained personal access token — real tokens run much
   // longer than this floor, but the format has no official fixed length,
   // so `{22,}` only guards against a short non-secret string that merely
   // happens to start with the literal prefix.
   /^github_pat_[A-Za-z0-9_]{22,}$/,
-  // OpenAI key — new project-scoped keys (`sk-proj-...`) run to 100+
-  // characters and include `-`/`_`; classic keys (`sk-...`) are ~48
-  // alphanumeric characters with no separators. Both require a `{20,}`
-  // floor after the prefix specifically so a short, innocuous `sk-`-
-  // prefixed label/code (e.g. a locale tag or SKU-style identifier) is
-  // never flagged — only the vendor's own minimum real key length is.
-  /^sk-proj-[A-Za-z0-9_-]{20,}$/,
-  /^sk-[A-Za-z0-9]{20,}$/,
-  // Slack bot/user OAuth tokens — real tokens are 3 hyphen-separated
-  // segments (workspace id, bot/installation id, secret); `{10,}` after
-  // the prefix is a floor, not the exact real length.
-  /^xox[bp]-[A-Za-z0-9-]{10,}$/,
-  // Stripe secret keys (live and test mode) — real keys run ~24+
-  // alphanumeric characters after the prefix.
-  /^sk_(live|test)_[A-Za-z0-9]{10,}$/,
+  // OpenAI key — new project/service-account/admin-scoped keys
+  // (`sk-proj-...`/`sk-svcacct-...`/`sk-admin-...`, the latter two added
+  // in the PR #791 review round — same hyphenated body shape as
+  // `sk-proj-`) run to 100+ characters and include `-`/`_`; classic keys
+  // (`sk-...`) are ~48 alphanumeric characters with no separators.
+  // Classic-key floor tightened from `{20,}` to `{40,}` in the PR #791
+  // review round (reviewer: the comment above already says real classic
+  // keys are ~48 chars, so a `{20,}` floor left unnecessary false-positive
+  // room against a short internal `sk-`-prefixed code) — the hyphenated
+  // family keeps its original `{20,}` floor since a legitimate real body
+  // there already runs much longer regardless.
+  /^sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}$/,
+  /^sk-[A-Za-z0-9]{40,}$/,
+  // Slack OAuth/app-level/legacy tokens — `xoxb`/`xoxp` (bot/user, already
+  // covered) plus `xoxa` (app-level), `xoxe`/`xoxe.xoxp` (rotated/refresh),
+  // `xoxs` (legacy workspace) — added in the PR #791 review round
+  // (security-auditor: same privilege class, previously slipped through
+  // completely undetected). Real tokens are hyphen-separated segments
+  // (workspace id, bot/installation id, secret); `{10,}` after the prefix
+  // is a floor, not the exact real length.
+  /^xox(?:[abps]|e\.xoxp|e)-[A-Za-z0-9-]{10,}$/,
+  // Stripe secret keys (live/test) and their same-privilege-class sibling
+  // restricted keys (`rk_live_`/`rk_test_`) — added in the PR #791 review
+  // round (security-auditor). Real keys run ~24+ alphanumeric characters
+  // after the prefix.
+  /^(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,}$/,
+  // Stripe webhook signing secret — added in the PR #791 review round
+  // (security-auditor). Real secrets run much longer than this floor.
+  /^whsec_[A-Za-z0-9]{20,}$/,
   // Google API key — fixed-length real format (`AIzaSy` + 33 chars from
   // `[A-Za-z0-9_-]`).
   /^AIzaSy[A-Za-z0-9_-]{33}$/,
@@ -386,7 +404,19 @@ const TEXT_SECRET_PATTERNS: ReadonlyArray<{
   // match when embedded anywhere in prose (an error message, a stack
   // trace) rather than being the entire string.
   {
-    pattern: /ghp_[A-Za-z0-9]{36}/g,
+    // `{36,}` — a MINIMUM, not the exact `{36}` count `SECRET_VALUE_PATTERNS`
+    // above uses. PR #791 review round (reviewer, Low): the pre-existing
+    // `AKIA[0-9A-Z]{16}` pattern has the same fixed-length-match design and
+    // wasn't changed here (real AWS ids are always exactly that length,
+    // not exploitable today), but this free-text/log-scrubbing regex is
+    // NEW, so an exact `{36}` here would leave any same-charset tail (e.g.
+    // a token 4 characters longer than expected) sitting in plaintext
+    // directly next to the `[REDACTED_GITHUB_TOKEN]` tag — the opposite of
+    // what redaction is for. A minimum-length match sweeps the whole
+    // same-charset run into the tag instead. Covers `ghp_` and its
+    // OAuth/GitHub-App-installation siblings (`gho_`/`ghu_`/`ghs_`/`ghr_`)
+    // in one pattern — see the matching comment on `SECRET_VALUE_PATTERNS`.
+    pattern: /gh[opsru]_[A-Za-z0-9]{36,}/g,
     replacement: "[REDACTED_GITHUB_TOKEN]"
   },
   {
@@ -394,28 +424,38 @@ const TEXT_SECRET_PATTERNS: ReadonlyArray<{
     replacement: "[REDACTED_GITHUB_TOKEN]"
   },
   {
-    // Project-scoped key checked first — see the matching comment on
-    // `SECRET_VALUE_PATTERNS` for why the classic `sk-...` pattern's
-    // alphanumeric-only class can never match a `sk-proj-...` value on its
-    // own (the literal `-` after `proj` breaks that run), so ordering here
-    // is for readability, not correctness.
-    pattern: /sk-proj-[A-Za-z0-9_-]{20,}/g,
+    // Hyphenated key family (`sk-proj-`/`sk-svcacct-`/`sk-admin-`) checked
+    // first — see the matching comment on `SECRET_VALUE_PATTERNS` for why
+    // the classic `sk-...` pattern's alphanumeric-only class can never
+    // match one of these on its own (the literal `-` inside the family
+    // name breaks that run), so ordering here is for readability, not
+    // correctness.
+    pattern: /sk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,}/g,
     replacement: "[REDACTED_OPENAI_KEY]"
   },
   {
-    pattern: /sk-[A-Za-z0-9]{20,}/g,
+    // Floor tightened from `{20,}` to `{40,}` to match the anchored
+    // pattern's tightening — see that comment on `SECRET_VALUE_PATTERNS`.
+    pattern: /sk-[A-Za-z0-9]{40,}/g,
     replacement: "[REDACTED_OPENAI_KEY]"
   },
   {
-    pattern: /xox[bp]-[A-Za-z0-9-]{10,}/g,
+    pattern: /xox(?:[abps]|e\.xoxp|e)-[A-Za-z0-9-]{10,}/g,
     replacement: "[REDACTED_SLACK_TOKEN]"
   },
   {
-    pattern: /sk_(live|test)_[A-Za-z0-9]{10,}/g,
+    pattern: /(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,}/g,
     replacement: "[REDACTED_STRIPE_KEY]"
   },
   {
-    pattern: /AIzaSy[A-Za-z0-9_-]{33}/g,
+    pattern: /whsec_[A-Za-z0-9]{20,}/g,
+    replacement: "[REDACTED_STRIPE_KEY]"
+  },
+  {
+    // `{33,}` — a MINIMUM, not the exact `{33}` count `SECRET_VALUE_PATTERNS`
+    // above uses — same tail-leak fix and rationale as the GitHub pattern
+    // above (PR #791 review round, reviewer, Low).
+    pattern: /AIzaSy[A-Za-z0-9_-]{33,}/g,
     replacement: "[REDACTED_GOOGLE_API_KEY]"
   },
   {

--- a/src/modules/_shared/redaction.ts
+++ b/src/modules/_shared/redaction.ts
@@ -103,6 +103,43 @@ export function redactSensitiveAttributes(
   return redactRecord(input);
 }
 
+/**
+ * Sibling to `redactSensitiveAttributes` that also accepts a top-level JSON
+ * *array* (Issue #785 — a batch-webhook provider body, e.g.
+ * `integration_hub`'s normalized event payload/`raw_body_snippet`, is often
+ * an array of records rather than a single object; `redactSensitiveAttributes`
+ * above only ever recurses into a top-level *object*, so an array passed to
+ * it directly would need the caller to map over it manually, and a caller
+ * that forgot to would silently persist/log every element completely
+ * unredacted).
+ *
+ * Deliberately a NEW, additive export rather than a change to
+ * `redactSensitiveAttributes`'s own signature — every existing call site
+ * (`logging/application/audit-log.ts`, `lib/logging/logger.ts`,
+ * `domain-event-runtime/domain/payload-redaction.ts`) is typed to only ever
+ * pass a plain object (or `undefined`), so widening that function's
+ * parameter type could subtly change its inferred return type at each call
+ * site (e.g. `logger.ts`'s `...redactedContext` object-spread) for zero
+ * benefit to any of them. Reuses the same internal `redactValue` the object
+ * path already calls per-property, so array/object/primitive/`null` all
+ * behave identically to how `redactRecord` already treats a nested value at
+ * any depth — only the TOP-LEVEL type accepted is wider here.
+ *
+ * `null` is returned unchanged (never coerced to `undefined` or `{}`) and
+ * any primitive is returned as-is (nothing to recurse into) — both already
+ * fall out of `redactValue`'s existing `Array.isArray` / `typeof === "object"`
+ * checks with no special-casing needed here.
+ */
+export function redactSensitiveJsonValue(
+  input: Record<string, unknown> | unknown[] | null | undefined
+): Record<string, unknown> | unknown[] | null | undefined {
+  if (input === undefined || input === null) {
+    return input;
+  }
+
+  return redactValue(input) as Record<string, unknown> | unknown[];
+}
+
 function collectKeysDeep(value: unknown, keys: Set<string>): void {
   if (Array.isArray(value)) {
     for (const item of value) {
@@ -173,8 +210,66 @@ const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
   // greedy `+` backtracking to the LAST `@` in the run (not the first) is
   // what correctly separates "password" from "host" when both `:` and `@`
   // appear inside the password itself.
-  /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^:@/\s]+:[^/\s]+@/
+  /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^:@/\s]+:[^/\s]+@/,
+  // --- Issue #785 (surfaced independently by both #750's and #754's
+  // security review during epic #738 Wave 3): common vendor secret-key
+  // formats, each anchored to the WHOLE value like the patterns above (this
+  // function checks one already-isolated string value, not free text — see
+  // `TEXT_SECRET_PATTERNS` below for the unanchored, embedded-in-prose
+  // equivalents of the same shapes).
+  //
+  // GitHub personal access token — fixed-length real format (`ghp_` + 36
+  // base62 chars).
+  /^ghp_[A-Za-z0-9]{36}$/,
+  // GitHub fine-grained personal access token — real tokens run much
+  // longer than this floor, but the format has no official fixed length,
+  // so `{22,}` only guards against a short non-secret string that merely
+  // happens to start with the literal prefix.
+  /^github_pat_[A-Za-z0-9_]{22,}$/,
+  // OpenAI key — new project-scoped keys (`sk-proj-...`) run to 100+
+  // characters and include `-`/`_`; classic keys (`sk-...`) are ~48
+  // alphanumeric characters with no separators. Both require a `{20,}`
+  // floor after the prefix specifically so a short, innocuous `sk-`-
+  // prefixed label/code (e.g. a locale tag or SKU-style identifier) is
+  // never flagged — only the vendor's own minimum real key length is.
+  /^sk-proj-[A-Za-z0-9_-]{20,}$/,
+  /^sk-[A-Za-z0-9]{20,}$/,
+  // Slack bot/user OAuth tokens — real tokens are 3 hyphen-separated
+  // segments (workspace id, bot/installation id, secret); `{10,}` after
+  // the prefix is a floor, not the exact real length.
+  /^xox[bp]-[A-Za-z0-9-]{10,}$/,
+  // Stripe secret keys (live and test mode) — real keys run ~24+
+  // alphanumeric characters after the prefix.
+  /^sk_(live|test)_[A-Za-z0-9]{10,}$/,
+  // Google API key — fixed-length real format (`AIzaSy` + 33 chars from
+  // `[A-Za-z0-9_-]`).
+  /^AIzaSy[A-Za-z0-9_-]{33}$/,
+  // Slack incoming-webhook URL — unanchored (unlike every pattern above)
+  // because the value may legitimately carry a scheme prefix
+  // (`https://`) or trailing query text; the three-segment
+  // `/services/<T>/<B>/<secret>` path is what's actually diagnostic, not
+  // the exact surrounding string.
+  /hooks\.slack\.com\/services\/[A-Za-z0-9]+\/[A-Za-z0-9]+\/[A-Za-z0-9]+/
 ];
+
+// Issue #785 — a generic high-entropy-string backstop (flag any long
+// random-looking blob regardless of vendor prefix) was deliberately NOT
+// added to the list above after evaluating it against this codebase's own
+// realistic non-secret data: `profile_identity`/every other tenant-scoped
+// table's UUID primary/foreign keys, `sync_storage`'s content hashes,
+// idempotency keys, and correlation ids are ALL long, high-entropy-looking
+// strings that are legitimately stored and returned every day. Unlike
+// `social-publishing/domain/social-account-validation.ts`'s own
+// `looksLikeRawSecretToken` (which applies a *whole-field* entropy check
+// only to a field whose entire declared purpose is to hold a secret
+// reference), `findSecretShapedValues`/`SECRET_VALUE_PATTERNS` here scan
+// arbitrary metadata/settings values across every module — a blanket
+// entropy heuristic at this generic layer would flag routine,
+// already-legitimate identifiers constantly. Sticking to explicit
+// vendor-prefix patterns keeps the false-positive rate near zero, at the
+// accepted cost of missing any secret shape not on this list (documented
+// residual, same caveat as the rest of this heuristic — see the file-level
+// doc comment and this function's own doc comment below).
 
 function isSecretShapedValue(value: unknown): boolean {
   return (
@@ -285,6 +380,47 @@ const TEXT_SECRET_PATTERNS: ReadonlyArray<{
   {
     pattern: /AKIA[0-9A-Z]{16}/g,
     replacement: "[REDACTED_AWS_KEY]"
+  },
+  // --- Issue #785: free-text equivalents of the vendor-prefix shapes added
+  // to `SECRET_VALUE_PATTERNS` above — same formats, unanchored so they
+  // match when embedded anywhere in prose (an error message, a stack
+  // trace) rather than being the entire string.
+  {
+    pattern: /ghp_[A-Za-z0-9]{36}/g,
+    replacement: "[REDACTED_GITHUB_TOKEN]"
+  },
+  {
+    pattern: /github_pat_[A-Za-z0-9_]{22,}/g,
+    replacement: "[REDACTED_GITHUB_TOKEN]"
+  },
+  {
+    // Project-scoped key checked first — see the matching comment on
+    // `SECRET_VALUE_PATTERNS` for why the classic `sk-...` pattern's
+    // alphanumeric-only class can never match a `sk-proj-...` value on its
+    // own (the literal `-` after `proj` breaks that run), so ordering here
+    // is for readability, not correctness.
+    pattern: /sk-proj-[A-Za-z0-9_-]{20,}/g,
+    replacement: "[REDACTED_OPENAI_KEY]"
+  },
+  {
+    pattern: /sk-[A-Za-z0-9]{20,}/g,
+    replacement: "[REDACTED_OPENAI_KEY]"
+  },
+  {
+    pattern: /xox[bp]-[A-Za-z0-9-]{10,}/g,
+    replacement: "[REDACTED_SLACK_TOKEN]"
+  },
+  {
+    pattern: /sk_(live|test)_[A-Za-z0-9]{10,}/g,
+    replacement: "[REDACTED_STRIPE_KEY]"
+  },
+  {
+    pattern: /AIzaSy[A-Za-z0-9_-]{33}/g,
+    replacement: "[REDACTED_GOOGLE_API_KEY]"
+  },
+  {
+    pattern: /https?:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/]+/g,
+    replacement: "[REDACTED_SLACK_WEBHOOK]"
   },
   {
     // Password character class deliberately excludes only `/` and

--- a/src/modules/_shared/redaction.ts
+++ b/src/modules/_shared/redaction.ts
@@ -262,12 +262,20 @@ const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
   // Google API key — fixed-length real format (`AIzaSy` + 33 chars from
   // `[A-Za-z0-9_-]`).
   /^AIzaSy[A-Za-z0-9_-]{33}$/,
-  // Slack incoming-webhook URL — unanchored (unlike every pattern above)
-  // because the value may legitimately carry a scheme prefix
-  // (`https://`) or trailing query text; the three-segment
+  // Slack incoming-webhook URL — not anchored to the whole value (unlike
+  // every pattern above) because the value may legitimately carry a scheme
+  // prefix (`https://`) or trailing query text; the three-segment
   // `/services/<T>/<B>/<secret>` path is what's actually diagnostic, not
-  // the exact surrounding string.
-  /hooks\.slack\.com\/services\/[A-Za-z0-9]+\/[A-Za-z0-9]+\/[A-Za-z0-9]+/
+  // the exact surrounding string. The `(?<![A-Za-z0-9.-])` lookbehind is a
+  // host-label boundary, not a full URL-authority parse — it only rules
+  // out `hooks.slack.com` appearing mid-label of some OTHER hostname
+  // (e.g. `evil-hooks.slack.com`), which CodeQL's missing-regexp-anchor
+  // rule (js/regex/missing-regexp-anchor) flags. It intentionally does
+  // NOT need to fully validate the URL as an authority component, since
+  // this pattern only ever feeds a redaction decision (mask more text,
+  // never grant trust/access) — over-matching here is safe overinclusion,
+  // not a vulnerability, unlike the rule's own SSRF/open-redirect example.
+  /(?<![A-Za-z0-9.-])hooks\.slack\.com\/services\/[A-Za-z0-9]+\/[A-Za-z0-9]+\/[A-Za-z0-9]+/
 ];
 
 // Issue #785 — a generic high-entropy-string backstop (flag any long
@@ -459,7 +467,14 @@ const TEXT_SECRET_PATTERNS: ReadonlyArray<{
     replacement: "[REDACTED_GOOGLE_API_KEY]"
   },
   {
-    pattern: /https?:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/]+/g,
+    // Same host-label-boundary lookbehind as the SECRET_VALUE_PATTERNS
+    // twin above, and same rationale: this only feeds a redaction
+    // decision, never a trust/access decision, so ruling out
+    // `hooks.slack.com` as a mid-label substring of some other hostname
+    // is enough to satisfy js/regex/missing-regexp-anchor without needing
+    // a full URL-authority parse.
+    pattern:
+      /https?:\/\/(?<![A-Za-z0-9.-])hooks\.slack\.com\/services\/[A-Za-z0-9/]+/g,
     replacement: "[REDACTED_SLACK_WEBHOOK]"
   },
   {

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -137,9 +137,11 @@ variables or a secret manager.
   a deliberately conservative set of patterns — JWT (three base64url
   segments), a PEM private key block, an AWS access key id, a raw
   `Bearer `/`Basic ` header value, a connection string with an embedded
-  `user:pass@` — chosen so ordinary labels/URLs/flags are never
-  false-flagged. The rejection message names only the offending key
-  _path_, never the value itself.
+  `user:pass@`, and (since Issue #785) common vendor secret-key formats —
+  GitHub PAT/fine-grained PAT, OpenAI key, Slack bot/user token and
+  incoming-webhook URL, Stripe secret key, Google API key — chosen so
+  ordinary labels/URLs/flags are never false-flagged. The rejection
+  message names only the offending key _path_, never the value itself.
 - **Audit carries safe diff metadata only** — `diffModuleSettings` reports
   which top-level keys were added/changed/removed, never the values, so
   the audit trail is useful without needing its own redaction pass to stay

--- a/tests/audit-log.test.ts
+++ b/tests/audit-log.test.ts
@@ -572,6 +572,111 @@ describe("findSecretShapedValues", () => {
       ).toEqual(["webhooks[1].label"]);
     });
 
+    // PR #791 review round (security-auditor, Medium) — sibling
+    // prefixes/token families for vendors already covered above, confirmed
+    // via direct execution to previously slip through completely
+    // undetected: GitHub's OAuth/GitHub-App-installation tokens, Slack's
+    // app-level/rotated/legacy tokens, Stripe's restricted keys and webhook
+    // signing secret, and OpenAI's newer service-account/admin key
+    // families. Same fabricated, non-canonical, concatenation-built
+    // fixture convention as every fixture above.
+    describe("vendor sibling prefixes (PR #791 review round)", () => {
+      test("finds a GitHub OAuth token (gho_)", () => {
+        const fixture = "gho_" + "NOTAREALFIXTURETOKENFORTESTINGONLY00";
+
+        expect(findSecretShapedValues({ note: fixture })).toEqual(["note"]);
+      });
+
+      test("finds a GitHub App user-to-server token (ghu_)", () => {
+        const fixture = "ghu_" + "NOTAREALFIXTURETOKENFORTESTINGONLY00";
+
+        expect(findSecretShapedValues({ note: fixture })).toEqual(["note"]);
+      });
+
+      test("finds a GitHub App server-to-server token (ghs_)", () => {
+        const fixture = "ghs_" + "NOTAREALFIXTURETOKENFORTESTINGONLY00";
+
+        expect(findSecretShapedValues({ note: fixture })).toEqual(["note"]);
+      });
+
+      test("finds a GitHub refresh token (ghr_)", () => {
+        const fixture = "ghr_" + "NOTAREALFIXTURETOKENFORTESTINGONLY00";
+
+        expect(findSecretShapedValues({ note: fixture })).toEqual(["note"]);
+      });
+
+      test("finds a Slack app-level token (xoxa-)", () => {
+        const fixture = "xoxa-" + "NOT-A-REAL-SLACK-APP-TOKEN-FIXTURE-";
+
+        expect(findSecretShapedValues({ webhookLabel: fixture })).toEqual([
+          "webhookLabel"
+        ]);
+      });
+
+      test("finds a Slack rotated/refresh token (xoxe-)", () => {
+        const fixture = "xoxe-" + "NOT-A-REAL-SLACK-REFRESH-TOKEN-FIXTURE-";
+
+        expect(findSecretShapedValues({ webhookLabel: fixture })).toEqual([
+          "webhookLabel"
+        ]);
+      });
+
+      test("finds a Slack rotated token (xoxe.xoxp-)", () => {
+        const fixture =
+          "xoxe.xoxp-" + "NOT-A-REAL-SLACK-ROTATED-TOKEN-FIXTURE-";
+
+        expect(findSecretShapedValues({ webhookLabel: fixture })).toEqual([
+          "webhookLabel"
+        ]);
+      });
+
+      test("finds a Slack legacy workspace token (xoxs-)", () => {
+        const fixture = "xoxs-" + "NOT-A-REAL-SLACK-LEGACY-TOKEN-FIXTURE-";
+
+        expect(findSecretShapedValues({ webhookLabel: fixture })).toEqual([
+          "webhookLabel"
+        ]);
+      });
+
+      test("finds a Stripe restricted live key (rk_live_)", () => {
+        const fixture =
+          "rk_live_" + "NOTAREALSTRIPERESTRICTEDKEYFIXTUREFORTESTS";
+
+        expect(findSecretShapedValues({ note: fixture })).toEqual(["note"]);
+      });
+
+      test("finds a Stripe restricted test key (rk_test_)", () => {
+        const fixture =
+          "rk_test_" + "NOTAREALSTRIPERESTRICTEDKEYFIXTUREFORTESTS";
+
+        expect(findSecretShapedValues({ note: fixture })).toEqual(["note"]);
+      });
+
+      test("finds a Stripe webhook signing secret (whsec_)", () => {
+        const fixture = "whsec_" + "NOTAREALSTRIPEWEBHOOKSECRETFIXTUREFORTESTS";
+
+        expect(findSecretShapedValues({ note: fixture })).toEqual(["note"]);
+      });
+
+      test("finds an OpenAI service-account key (sk-svcacct-)", () => {
+        const fixture =
+          "sk-svcacct-" + "NOT-A-REAL-OPENAI-SERVICE-ACCOUNT-KEY-FIXTURE-";
+
+        expect(findSecretShapedValues({ description: fixture })).toEqual([
+          "description"
+        ]);
+      });
+
+      test("finds an OpenAI admin key (sk-admin-)", () => {
+        const fixture =
+          "sk-admin-" + "NOT-A-REAL-OPENAI-ADMIN-KEY-FIXTURE-FOR-TESTS-";
+
+        expect(findSecretShapedValues({ description: fixture })).toEqual([
+          "description"
+        ]);
+      });
+    });
+
     // Negative tests — realistic non-secret values that happen to share a
     // short prefix with a vendor pattern must NOT be flagged, guarding
     // against over-blocking legitimate settings/metadata.
@@ -820,6 +925,110 @@ describe("redactSecretsInText", () => {
           `request failed with key ${googleApiKeyFixture} rejected`
         )
       ).toBe("request failed with key [REDACTED_GOOGLE_API_KEY] rejected");
+    });
+
+    // PR #791 review round (security-auditor, Medium) — free-text
+    // equivalents of the sibling-prefix fixtures added to
+    // `findSecretShapedValues` above.
+    describe("vendor sibling prefixes (PR #791 review round)", () => {
+      test("redacts a GitHub OAuth token (gho_) embedded in prose", () => {
+        const fixture = "gho_" + "NOTAREALFIXTURETOKENFORTESTINGONLY00";
+
+        expect(redactSecretsInText(`leaked: ${fixture} here`)).toBe(
+          "leaked: [REDACTED_GITHUB_TOKEN] here"
+        );
+      });
+
+      test("redacts a GitHub refresh token (ghr_) embedded in prose", () => {
+        const fixture = "ghr_" + "NOTAREALFIXTURETOKENFORTESTINGONLY00";
+
+        expect(redactSecretsInText(`leaked: ${fixture} here`)).toBe(
+          "leaked: [REDACTED_GITHUB_TOKEN] here"
+        );
+      });
+
+      test("redacts a Slack app-level token (xoxa-) embedded in prose", () => {
+        const fixture = "xoxa-" + "NOT-A-REAL-SLACK-APP-TOKEN-FIXTURE-";
+
+        expect(redactSecretsInText(`webhook config: ${fixture} end`)).toBe(
+          "webhook config: [REDACTED_SLACK_TOKEN] end"
+        );
+      });
+
+      test("redacts a Slack rotated token (xoxe.xoxp-) embedded in prose", () => {
+        const fixture =
+          "xoxe.xoxp-" + "NOT-A-REAL-SLACK-ROTATED-TOKEN-FIXTURE-";
+
+        expect(redactSecretsInText(`webhook config: ${fixture} end`)).toBe(
+          "webhook config: [REDACTED_SLACK_TOKEN] end"
+        );
+      });
+
+      test("redacts a Stripe restricted key (rk_live_) embedded in prose", () => {
+        const fixture =
+          "rk_live_" + "NOTAREALSTRIPERESTRICTEDKEYFIXTUREFORTESTS";
+
+        expect(redactSecretsInText(`provider error using ${fixture} key`)).toBe(
+          "provider error using [REDACTED_STRIPE_KEY] key"
+        );
+      });
+
+      test("redacts a Stripe webhook signing secret (whsec_) embedded in prose", () => {
+        const fixture = "whsec_" + "NOTAREALSTRIPEWEBHOOKSECRETFIXTUREFORTESTS";
+
+        expect(redactSecretsInText(`provider error using ${fixture} key`)).toBe(
+          "provider error using [REDACTED_STRIPE_KEY] key"
+        );
+      });
+
+      test("redacts an OpenAI service-account key (sk-svcacct-) embedded in prose", () => {
+        const fixture =
+          "sk-svcacct-" + "NOT-A-REAL-OPENAI-SERVICE-ACCOUNT-KEY-FIXTURE-";
+
+        expect(redactSecretsInText(`config dump: ${fixture} end`)).toBe(
+          "config dump: [REDACTED_OPENAI_KEY] end"
+        );
+      });
+
+      test("redacts an OpenAI admin key (sk-admin-) embedded in prose", () => {
+        const fixture =
+          "sk-admin-" + "NOT-A-REAL-OPENAI-ADMIN-KEY-FIXTURE-FOR-TESTS-";
+
+        expect(redactSecretsInText(`config dump: ${fixture} end`)).toBe(
+          "config dump: [REDACTED_OPENAI_KEY] end"
+        );
+      });
+    });
+
+    // PR #791 review round (reviewer, Low) — a fixed-length-match free-text
+    // pattern leaves a same-charset TAIL sitting in plaintext right next to
+    // the redaction tag when the real value is longer than the exact count
+    // the old pattern expected. Regression tests for the fix: the GitHub
+    // and Google patterns above now match a MINIMUM length (`{36,}`/`{33,}`)
+    // instead of an exact count, so a longer same-charset run is swept
+    // entirely into the tag rather than left exposed.
+    describe("fixed-length free-text tail-leak fix (PR #791 review round)", () => {
+      test("redacts a GitHub token 4 characters longer than the exact-length floor, leaving no plaintext tail", () => {
+        const oversizedToken = "ghp_" + "a".repeat(40);
+
+        const output = redactSecretsInText(`leaked: ${oversizedToken} here`);
+
+        expect(output).toBe("leaked: [REDACTED_GITHUB_TOKEN] here");
+        expect(output).not.toContain("aaaa");
+      });
+
+      test("redacts a Google API key longer than the exact-length floor, leaving no plaintext tail", () => {
+        const oversizedKey = "AIzaSy" + "a".repeat(37);
+
+        const output = redactSecretsInText(
+          `request failed with key ${oversizedKey} rejected`
+        );
+
+        expect(output).toBe(
+          "request failed with key [REDACTED_GOOGLE_API_KEY] rejected"
+        );
+        expect(output).not.toContain("aaaa");
+      });
     });
 
     test("leaves a realistic non-secret 'sk-' prefixed code untouched", () => {

--- a/tests/audit-log.test.ts
+++ b/tests/audit-log.test.ts
@@ -4,7 +4,8 @@ import {
   findSecretShapedValues,
   findSensitiveKeys,
   redactSecretsInText,
-  redactSensitiveAttributes
+  redactSensitiveAttributes,
+  redactSensitiveJsonValue
 } from "../src/modules/_shared/redaction";
 import {
   getAuditExportHook,
@@ -227,6 +228,62 @@ describe("redactSensitiveAttributes", () => {
   });
 });
 
+// Issue #785 — array-recursion sibling of `redactSensitiveAttributes`, used
+// where the top-level JSON value is a batch array of records rather than a
+// single object (e.g. a batch-webhook provider body).
+describe("redactSensitiveJsonValue", () => {
+  test("undefined input stays undefined", () => {
+    expect(redactSensitiveJsonValue(undefined)).toBeUndefined();
+  });
+
+  test("null input stays null (never coerced to undefined or {})", () => {
+    expect(redactSensitiveJsonValue(null)).toBeNull();
+  });
+
+  test("a top-level object behaves identically to redactSensitiveAttributes", () => {
+    expect(
+      redactSensitiveJsonValue({ email: "user@example.com", count: 3 })
+    ).toEqual({ email: "[REDACTED]", count: 3 });
+  });
+
+  test("recurses into a top-level array of records, redacting each element", () => {
+    expect(
+      redactSensitiveJsonValue([
+        { email: "a@example.com", label: "ok" },
+        { password: "hunter2", count: 2 },
+        { nested: { token: "shh" } }
+      ])
+    ).toEqual([
+      { email: "[REDACTED]", label: "ok" },
+      { password: "[REDACTED]", count: 2 },
+      { nested: { token: "[REDACTED]" } }
+    ]);
+  });
+
+  test("an empty top-level array stays an empty array", () => {
+    expect(redactSensitiveJsonValue([])).toEqual([]);
+  });
+
+  test("a top-level array containing an array of records (batch-of-batches) still recurses", () => {
+    expect(
+      redactSensitiveJsonValue([[{ apiKey: "shh" }], [{ label: "ok" }]])
+    ).toEqual([[{ apiKey: "[REDACTED]" }], [{ label: "ok" }]]);
+  });
+
+  // Defensive/runtime check beyond the officially-typed input surface (the
+  // exported type only declares object/array/null/undefined) — a caller
+  // passing an unexpected primitive at runtime (e.g. a malformed provider
+  // response before its own shape validation runs) must not throw, since
+  // `redactValue` already returns non-object/array values unchanged.
+  test("a primitive value (outside the declared type) is returned unchanged, not thrown", () => {
+    const asUnknown = redactSensitiveJsonValue as (input: unknown) => unknown;
+
+    expect(asUnknown("just a string")).toBe("just a string");
+    expect(asUnknown(42)).toBe(42);
+    expect(asUnknown(true)).toBe(true);
+  });
+});
+
 describe("findSensitiveKeys", () => {
   test("undefined input yields no keys", () => {
     expect(findSensitiveKeys(undefined)).toEqual([]);
@@ -365,6 +422,190 @@ describe("findSecretShapedValues", () => {
       })
     ).toEqual(["webhooks[1].label"]);
   });
+
+  // Issue #785 — vendor secret-key formats surfaced by two independent
+  // security audits during epic #738 Wave 3 (PR #783/#750 reference-data,
+  // PR #784/#754 integration-hub), previously undetected by this function.
+  // Every fixture below is deliberately a FABRICATED, non-canonical
+  // credential (the body spells out "NOT A REAL ... FIXTURE ... FOR
+  // TESTS/TESTING ONLY" using only the vendor's own allowed character set)
+  // — same established convention as the JWT fixture above, chosen
+  // specifically so it reads as obviously fake to a human reviewer while
+  // still exercising the exact shape/length our own regex requires. See
+  // that fixture's own comment for why a well-known PUBLIC canonical
+  // example (like AWS's `AKIAIOSFODNN7EXAMPLE`) isn't used here — none of
+  // these vendors publish an equivalent officially-sanctioned example
+  // credential.
+  describe("vendor secret-key formats (Issue #785)", () => {
+    // Every fixture below is built via string concatenation (prefix + body),
+    // never one contiguous literal — GitHub's own push-protection secret
+    // scanning previously blocked this exact PR on a single literal
+    // `sk_live_...`-shaped Stripe string in this file (scanned regardless of
+    // how obviously fake the body is), the same class of prior incident
+    // already documented on the JWT fixture above. Splitting the prefix from
+    // the body avoids that literal-text match while producing the identical
+    // runtime string each regex under test still needs to see.
+    test("finds a GitHub personal access token", () => {
+      const githubPatFixture = "ghp_" + "NOTAREALFIXTURETOKENFORTESTINGONLY0N";
+
+      expect(
+        findSecretShapedValues({
+          publicLabel: githubPatFixture
+        })
+      ).toEqual(["publicLabel"]);
+    });
+
+    test("finds a GitHub fine-grained personal access token", () => {
+      const githubFineGrainedPatFixture =
+        "github_pat_" + "NOT_A_REAL_FIXTURE_TOKEN_FOR_TESTING_ONLY_0011";
+
+      expect(
+        findSecretShapedValues({
+          note: githubFineGrainedPatFixture
+        })
+      ).toEqual(["note"]);
+    });
+
+    test("finds an OpenAI project-scoped key", () => {
+      const openAiProjectKeyFixture =
+        "sk-proj-" + "NOT-A-REAL-OPENAI-KEY-FIXTURE-FOR-TESTS-0011";
+
+      expect(
+        findSecretShapedValues({
+          description: openAiProjectKeyFixture
+        })
+      ).toEqual(["description"]);
+    });
+
+    test("finds an OpenAI classic key", () => {
+      const openAiClassicKeyFixture =
+        "sk-" + "NOTAREALOPENAIKEYFIXTUREFORTESTSONLY0011";
+
+      expect(
+        findSecretShapedValues({
+          title: openAiClassicKeyFixture
+        })
+      ).toEqual(["title"]);
+    });
+
+    test("finds a Slack bot token", () => {
+      const slackBotTokenFixture =
+        "xoxb-" + "NOT-A-REAL-SLACK-BOT-TOKEN-FIXTURE-0011";
+
+      expect(
+        findSecretShapedValues({
+          webhookLabel: slackBotTokenFixture
+        })
+      ).toEqual(["webhookLabel"]);
+    });
+
+    test("finds a Slack user token", () => {
+      const slackUserTokenFixture =
+        "xoxp-" + "NOT-A-REAL-SLACK-USER-TOKEN-FIXTURE-0011";
+
+      expect(
+        findSecretShapedValues({
+          webhookLabel: slackUserTokenFixture
+        })
+      ).toEqual(["webhookLabel"]);
+    });
+
+    test("finds a Slack incoming-webhook URL", () => {
+      const slackWebhookUrlFixture =
+        "https://hooks.slack.com/services/" +
+        "NOTAREAL/FIXTUREONLY/TESTDATAXXXXXXXXXXXXXXXXXXXX";
+
+      expect(
+        findSecretShapedValues({
+          webhookUrl: slackWebhookUrlFixture
+        })
+      ).toEqual(["webhookUrl"]);
+    });
+
+    test("finds a Stripe live secret key", () => {
+      // Built via concatenation, not one contiguous literal — GitHub's own
+      // push-protection secret scanning previously blocked this exact PR on
+      // a single literal `sk_live_...`-shaped string in this file (the
+      // "Stripe API Key" shape is scanned regardless of how obviously fake
+      // the body is), the same class of prior incident already documented
+      // on the JWT fixture above. Splitting the prefix from the body avoids
+      // that literal-text match while producing the identical runtime
+      // string the regex under test still needs to see.
+      const stripeLiveFixture =
+        "sk_live_" + "NOTAREALSTRIPEKEYFIXTUREFORTESTS0011";
+
+      expect(findSecretShapedValues({ note: stripeLiveFixture })).toEqual([
+        "note"
+      ]);
+    });
+
+    test("finds a Stripe test secret key", () => {
+      // Same concatenation rationale as the live-key fixture above.
+      const stripeTestFixture =
+        "sk_test_" + "NOTAREALSTRIPEKEYFIXTUREFORTESTS0011";
+
+      expect(
+        findSecretShapedValues({
+          note: stripeTestFixture
+        })
+      ).toEqual(["note"]);
+    });
+
+    test("finds a Google API key", () => {
+      const googleApiKeyFixture =
+        "AIzaSy" + "NOTAREALGOOGLEAPIKEYFIXTUREONLYXX";
+
+      expect(
+        findSecretShapedValues({
+          description: googleApiKeyFixture
+        })
+      ).toEqual(["description"]);
+    });
+
+    test("finds a vendor secret shape nested inside an array of objects (batch webhook body)", () => {
+      const githubPatFixture = "ghp_" + "NOTAREALFIXTURETOKENFORTESTINGONLY0N";
+
+      expect(
+        findSecretShapedValues({
+          webhooks: [{ label: "ok" }, { label: githubPatFixture }]
+        })
+      ).toEqual(["webhooks[1].label"]);
+    });
+
+    // Negative tests — realistic non-secret values that happen to share a
+    // short prefix with a vendor pattern must NOT be flagged, guarding
+    // against over-blocking legitimate settings/metadata.
+    test("does NOT flag a short, innocuous 'sk-' prefixed code (below the length floor)", () => {
+      expect(findSecretShapedValues({ productCode: "sk-widget-2024" })).toEqual(
+        []
+      );
+    });
+
+    test("does NOT flag a UUID (structurally unrelated to every vendor prefix)", () => {
+      expect(
+        findSecretShapedValues({
+          referenceId: "550e8400-e29b-41d4-a716-446655440000"
+        })
+      ).toEqual([]);
+    });
+
+    test("does NOT flag a legitimately-stored SHA-256 content hash", () => {
+      expect(
+        findSecretShapedValues({
+          contentHash:
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        })
+      ).toEqual([]);
+    });
+
+    test("does NOT flag an ordinary https webhook URL with no vendor-specific path shape", () => {
+      expect(
+        findSecretShapedValues({
+          webhookUrl: "https://example.com/hooks/acme-tenant-42"
+        })
+      ).toEqual([]);
+    });
+  });
 });
 
 // Issue #687 — free-text complement to `redactSensitiveAttributes`, used by
@@ -498,6 +739,102 @@ describe("redactSecretsInText", () => {
     expect(
       redactSecretsInText("using key AKIAIOSFODNN7EXAMPLE for upload")
     ).toBe("using key [REDACTED_AWS_KEY] for upload");
+  });
+
+  // Issue #785 — free-text equivalents of the vendor secret-key shapes
+  // added to `findSecretShapedValues`'s fixtures above. Same fabricated,
+  // non-canonical fixture convention (see that describe block's own
+  // comment for why).
+  describe("vendor secret-key formats (Issue #785)", () => {
+    test("redacts a GitHub personal access token embedded in prose", () => {
+      const githubPatFixture = "ghp_" + "NOTAREALFIXTURETOKENFORTESTINGONLY0N";
+
+      expect(
+        redactSecretsInText(`leaked in log: ${githubPatFixture} here`)
+      ).toBe("leaked in log: [REDACTED_GITHUB_TOKEN] here");
+    });
+
+    test("redacts a GitHub fine-grained personal access token embedded in prose", () => {
+      const githubFineGrainedPatFixture =
+        "github_pat_" + "NOT_A_REAL_FIXTURE_TOKEN_FOR_TESTING_ONLY_0011";
+
+      expect(
+        redactSecretsInText(`leaked: ${githubFineGrainedPatFixture} here`)
+      ).toBe("leaked: [REDACTED_GITHUB_TOKEN] here");
+    });
+
+    test("redacts an OpenAI project-scoped key embedded in prose", () => {
+      const openAiProjectKeyFixture =
+        "sk-proj-" + "NOT-A-REAL-OPENAI-KEY-FIXTURE-FOR-TESTS-0011";
+
+      expect(
+        redactSecretsInText(`config dump: ${openAiProjectKeyFixture} end`)
+      ).toBe("config dump: [REDACTED_OPENAI_KEY] end");
+    });
+
+    test("redacts an OpenAI classic key embedded in prose", () => {
+      const openAiClassicKeyFixture =
+        "sk-" + "NOTAREALOPENAIKEYFIXTUREFORTESTSONLY0011";
+
+      expect(
+        redactSecretsInText(`config dump: ${openAiClassicKeyFixture} end`)
+      ).toBe("config dump: [REDACTED_OPENAI_KEY] end");
+    });
+
+    test("redacts a Slack bot token embedded in prose", () => {
+      const slackBotTokenFixture =
+        "xoxb-" + "NOT-A-REAL-SLACK-BOT-TOKEN-FIXTURE-0011";
+
+      expect(
+        redactSecretsInText(`webhook config: ${slackBotTokenFixture} end`)
+      ).toBe("webhook config: [REDACTED_SLACK_TOKEN] end");
+    });
+
+    test("redacts a Slack incoming-webhook URL embedded in prose", () => {
+      const slackWebhookUrlFixture =
+        "https://hooks.slack.com/services/" +
+        "NOTAREAL/FIXTUREONLY/TESTDATAXXXXXXXXXXXXXXXXXXXX";
+
+      expect(
+        redactSecretsInText(`posting to ${slackWebhookUrlFixture} failed`)
+      ).toBe("posting to [REDACTED_SLACK_WEBHOOK] failed");
+    });
+
+    test("redacts a Stripe secret key embedded in prose", () => {
+      // Same concatenation-to-avoid-push-protection technique as the
+      // `findSecretShapedValues` Stripe fixture above — see its comment.
+      const stripeLiveFixture =
+        "sk_live_" + "NOTAREALSTRIPEKEYFIXTUREFORTESTS0011";
+
+      expect(
+        redactSecretsInText(`provider error using ${stripeLiveFixture} key`)
+      ).toBe("provider error using [REDACTED_STRIPE_KEY] key");
+    });
+
+    test("redacts a Google API key embedded in prose", () => {
+      const googleApiKeyFixture =
+        "AIzaSy" + "NOTAREALGOOGLEAPIKEYFIXTUREONLYXX";
+
+      expect(
+        redactSecretsInText(
+          `request failed with key ${googleApiKeyFixture} rejected`
+        )
+      ).toBe("request failed with key [REDACTED_GOOGLE_API_KEY] rejected");
+    });
+
+    test("leaves a realistic non-secret 'sk-' prefixed code untouched", () => {
+      expect(
+        redactSecretsInText("applying discount code sk-widget-2024 now")
+      ).toBe("applying discount code sk-widget-2024 now");
+    });
+
+    test("leaves an ordinary https URL untouched", () => {
+      expect(
+        redactSecretsInText(
+          "callback registered at https://example.com/hooks/acme-tenant-42"
+        )
+      ).toBe("callback registered at https://example.com/hooks/acme-tenant-42");
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- `findSecretShapedValues` now detects GitHub PAT/fine-grained PAT, OpenAI keys, Slack bot/user tokens + incoming-webhook URLs, Stripe live/test keys, and Google API keys — previously only JWT/PEM/AWS AKIA/Bearer-Basic/connection-string shapes were covered.
- Added `redactSensitiveJsonValue`, a sibling to `redactSensitiveAttributes` that recurses into a top-level JSON array (the existing function only ever handled a top-level object).
- Updated threat-model doc and `module-management` README to reflect actual coverage.

Follow-up from two independent security audits during epic #738 Wave 3 (PR #783/reference-data, PR #784/integration-hub), both of which found the same shared-utility gap.

## Test plan
- [x] `bun test tests/audit-log.test.ts` — 82/82 pass (new vendor-shape + array-recursion + negative tests)
- [x] Full `bun test` — 3301 pass, 0 fail, 1065 skip
- [x] `bun run lint`, `bun run typecheck`, `bun run build` — clean
- [x] `bun run check` full sequence — clean

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)