### PR TITLE
CodeQL triage: resolve 15 open code-scanning alerts

### DIFF
--- a/.changeset/codeql-triage-batch-issue-788.md
+++ b/.changeset/codeql-triage-batch-issue-788.md
@@ -1,0 +1,12 @@
+---
+"awcms-mini": patch
+---
+
+Triage 15 open CodeQL code-scanning alerts (Issue #788): remove genuinely
+dead test imports, close 3 real test-coverage gaps the alerts incidentally
+surfaced (news-media R2 deletion assertion, social-publishing rule-list
+tenant-isolation test, LinkedIn API version resolver unit tests), and
+dismiss 2 confirmed false positives (Bun.SQL tagged-template parameter
+binding misread as implicit string coercion) plus 1 won't-fix (a
+build-time extension-seam conditional that's genuinely trivial in this
+base repo by design). No production behavior change.

--- a/.claude/skills/awcms-mini-codeql-triage/SKILL.md
+++ b/.claude/skills/awcms-mini-codeql-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: awcms-mini-codeql-triage
-description: Triase dan perbaiki temuan CodeQL code scanning AWCMS-Mini (github.com/ahliweb/awcms-mini/security/code-scanning). Gunakan saat diminta "analisis code scanning"/"perbaiki CodeQL", saat sebuah PR gagal check CodeQL, atau saat menemukan alert baru. Mendokumentasikan empat false-positive nyata yang sudah ditemukan (name-heuristic password, incompatible-types typeof/null, URL substring-sanitization di test mock, dan dua kasus dismiss resmi tanpa reformulasi kode) supaya tidak diinvestigasi ulang dari nol.
+description: Triase dan perbaiki temuan CodeQL code scanning AWCMS-Mini (github.com/ahliweb/awcms-mini/security/code-scanning). Gunakan saat diminta "analisis code scanning"/"perbaiki CodeQL", saat sebuah PR gagal check CodeQL, atau saat menemukan alert baru. Mendokumentasikan enam false-positive nyata yang sudah ditemukan (name-heuristic password, incompatible-types typeof/null, URL substring-sanitization di test mock, dua kasus dismiss resmi tanpa reformulasi kode, Bun.SQL tagged-template null-cast, dan build-time extension seam trivial-conditional) plus pola "unused-local-variable di test kadang menandai coverage gap" — supaya tidak diinvestigasi ulang dari nol.
 ---
 
 # AWCMS-Mini — Triase CodeQL Code Scanning
@@ -153,6 +153,106 @@ harus persis `"false positive"`/`"won't fix"`/`"used in tests"` dengan spasi,
 BUKAN `false_positive` dengan underscore — API menolak keduanya kalau
 salah format; `dismissed_comment` dibatasi 280 karakter, taruh alasan
 lengkap di skill ini, bukan di comment).
+
+### 5. `js/implicit-operand-conversion` — Bun.SQL tagged template dengan argumen yang provably-always-`null`
+
+Ditemukan 2026-07-14 (alert #48, #49), Issue #788: dua instance pada baris
+yang sama, `business-scope-facts.ts:59`
+(`AND (${excludeAssignmentId}::uuid IS NULL OR id <> ${excludeAssignmentId})`
+di dalam `` tx`...` ``, sebuah Bun.SQL tagged template). CodeQL menganggap
+`${excludeAssignmentId}` di-stringify seperti template literal biasa
+(`` `${null}` `` → `"null"`), padahal **tagged template TIDAK melakukan
+implicit toString** — nilai substitusi diteruskan mentah ke fungsi tag
+(`tx`), yang mem-bind-nya sebagai parameter SQL asli (`NULL` sungguhan,
+bukan string `"null"`). CodeQL hanya menandai baris ini karena satu-satunya
+call site `fetchActiveAssignmentRows` (fungsi privat, satu caller) selalu
+memanggilnya dengan literal `null` — dataflow-nya "provably always null" di
+sini, tapi konversi implisit yang dituduh tetap tidak pernah terjadi
+(bukan soal apakah nilainya null, tapi bukan JS's implicit-toString sama
+sekali karena tagged template). Bukti definitif false positive: pola
+identik persis (`${excludeAssignmentId}::uuid IS NULL OR bsa.id <>
+${excludeAssignmentId}`) ada di baris 186 file yang SAMA (fungsi
+`resolveSoDAssignmentFacts`, dipanggil dari 2 caller eksternal — juga
+selalu dengan literal `null` di kedua caller saat ini) dan 12+ file lain
+di repo memakai pola `${x ?? null}::uuid IS NULL OR ...` yang sama —
+semuanya tidak di-flag CodeQL. Ini murni artefak heuristik per-call-site,
+bukan sinyal bug sistematis.
+
+**Fix**: dismiss resmi (bukan reformulasi) — reformulasi kode (mis. cabang
+if/else terpisah untuk null vs non-null) hanya menambah kompleksitas nyata
+untuk kode yang sudah benar dan konsisten dengan 12+ file lain di repo.
+
+**Pencegahan**: kalau CodeQL menandai `js/implicit-operand-conversion` pada
+sebuah `` tx`...${x}...` `` (Bun.SQL/postgres.js tagged template), cek dulu
+apakah ekspresi itu benar-benar di dalam tagged template (bukan
+concatenation string biasa) — kalau ya, implicit-toString tidak pernah
+terjadi secara runtime, dan alert ini adalah false positive berbasis
+pola string-interpolation generik yang tidak paham parameter binding SQL
+client library. Cari pola identik di file lain sebagai bukti sebelum
+dismiss.
+
+### 6. `js/trivial-conditional` — nilai build-time extension seam yang sengaja selalu satu cabang di base repo
+
+Ditemukan 2026-07-14 (alert #44), Issue #788:
+`scripts/validate-module-composition.ts:41`,
+`applicationModuleRegistry ? ... : ...` — CodeQL benar bahwa
+`applicationModuleRegistry` (diimpor dari
+`src/modules/application-registry.ts`) SELALU `undefined` di repo dasar
+ini, sesuai desain (Issue #740, epic #738 `platform-evolution`): file itu
+adalah _build-time extension seam_ yang sebuah aplikasi turunan REPLACE
+seluruhnya dengan `ApplicationModuleRegistry` sungguhan. CodeQL cuma
+melihat kode yang ter-checked-in di REPO INI, jadi kondisinya memang
+trivial DI SINI — tapi genuinely conditional begitu file itu diganti oleh
+repo turunan. Bukti pembeda: 5 file lain
+(`src/modules/index.ts`, `module-composition-inventory-generate.ts`,
+`extension-check.ts`, `modules-sync.ts`) juga meng-import
+`applicationModuleRegistry` tapi HANYA meneruskannya sebagai _value_ ke
+fungsi lain (never in a truthy/boolean context) — tidak ada satu pun yang
+di-flag; hanya `validate-module-composition.ts` yang memakainya dalam
+ekspresi ternary boolean-context, satu-satunya tempat trivial-conditional
+bisa terdeteksi.
+
+**Fix**: dismiss (won't-fix) — bukan bug, dan reformulasi apa pun (mis.
+`!= null` alih-alih truthy check) tidak menghilangkan kesimpulan CodeQL
+karena akar masalahnya adalah NILAI-nya provably-constant di repo ini,
+bukan operator pembandingnya.
+
+**Pencegahan**: pola "build-time extension point/seam yang sengaja
+`undefined`/no-op di base repo, real value di repo turunan" akan selalu
+memicu `js/trivial-conditional` di base repo begitu nilainya dipakai dalam
+boolean context — ini SEHAT (bukan alasan untuk menghapus fitur
+ekstensibilitasnya), dismiss dengan menjelaskan desain seam-nya, jangan
+coba "memperbaiki" trivialitasnya.
+
+### Pola tambahan: `js/unused-local-variable` di test kadang menandai coverage gap, bukan sekadar dead code
+
+Dari 11 alert `js/unused-local-variable` di Issue #788 (semua di file
+test), 8 memang leftover import/variable murni (aman dihapus). Tapi 3
+adalah TEST HELPER YANG DITULIS DENGAN BENAR tapi tidak pernah dipanggil
+— masing-masing menunjuk ke satu jalur test yang seharusnya ada tapi
+hilang:
+
+- `createCategoryTerm` (`news-portal-homepage-sections.integration.test.ts`)
+  — hanya ada test REJECT untuk `category_grid` (categorySlug tidak ada),
+  tidak ada test ACCEPT (categorySlug valid) — helper-nya sudah ditulis
+  lengkap, cuma tidak pernah dipanggil dari sebuah test.
+- Destructured `has` di test "stale orphaned ... gets its R2 object
+  deleted" (`news-media-r2-reconciliation-job.integration.test.ts`) — judul
+  test menjanjikan verifikasi penghapusan objek R2 tapi body hanya mengecek
+  counter (`result.staleOrphaned.deleted`) dan status DB, tidak pernah
+  memanggil `has(key)` untuk membuktikan objeknya benar-benar hilang dari
+  R2 (dan tidak pernah `put()` objeknya lebih dulu).
+- `resolveLinkedInApiVersion` (`linkedin-provider-config.test.ts`) — semua
+  fungsi lain yang diexport modul itu punya `describe` block sendiri,
+  hanya fungsi ini yang diimpor tapi tidak pernah diuji langsung.
+
+**Aturan triase**: sebelum menghapus binding `js/unused-local-variable` di
+file test, cek APAKAH nama binding itu match sebuah kapabilitas/skenario
+yang disebut di judul test lain, docstring file, atau nama fungsi lain di
+modul yang sama — kalau ya, kemungkinan besar itu coverage gap (helper
+ditulis untuk test yang lalu terlupa/terpotong), bukan dead code murni.
+Wire ke assertion baru yang sesuai (menutup gap SEKALIGUS menghilangkan
+alert) alih-alih sekadar menghapus.
 
 ## Verifikasi
 

--- a/src/modules/reporting/application/projection-rebuild.ts
+++ b/src/modules/reporting/application/projection-rebuild.ts
@@ -78,7 +78,6 @@ import {
   findRunningRebuild,
   getRebuildRunById,
   markRebuildCancelled,
-  requestRebuildCancellation,
   type RebuildRunRow
 } from "./rebuild-run-store";
 

--- a/tests/e2e/admin-a11y-smoke.e2e.ts
+++ b/tests/e2e/admin-a11y-smoke.e2e.ts
@@ -29,7 +29,7 @@
  *
  * Run: `bun run test:e2e tests/e2e/admin-a11y-smoke.e2e.ts`.
  */
-import { test, expect, type Page } from "@playwright/test";
+import { test, type Page } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 
 import { seedOwnerTenant } from "./helpers/seed-owner-tenant";

--- a/tests/integration/domain-event-runtime.integration.test.ts
+++ b/tests/integration/domain-event-runtime.integration.test.ts
@@ -15,7 +15,6 @@
  * asserted via manual try/catch instead.
  */
 import {
-  afterAll,
   afterEach,
   beforeAll,
   beforeEach,

--- a/tests/integration/news-media-r2-reconciliation-job.integration.test.ts
+++ b/tests/integration/news-media-r2-reconciliation-job.integration.test.ts
@@ -495,7 +495,7 @@ suite("news media R2 lifecycle cleanup & reconciliation (Issue #690)", () => {
   });
 
   test("stale orphaned: a status='orphaned' row past its grace period gets its R2 object deleted and the row soft-deleted", async () => {
-    const { server, has } = startFakeR2Server();
+    const { server, has, put } = startFakeR2Server();
     const appSql = getTestSql();
     const workerSql = getWorkerTestSql();
     const r2Client = buildClient(server.port);
@@ -506,6 +506,7 @@ suite("news media R2 lifecycle cleanup & reconciliation (Issue #690)", () => {
           mimeType: "image/jpeg"
         })
       );
+      put(created.objectKey);
       await withTenant(appSql, TENANT_A, (tx) =>
         markNewsMediaObjectOrphaned(tx, TENANT_A, created.id)
       );
@@ -521,6 +522,9 @@ suite("news media R2 lifecycle cleanup & reconciliation (Issue #690)", () => {
 
       expect(result.staleOrphaned.total).toBe(1);
       expect(result.staleOrphaned.deleted).toBe(1);
+      // The whole point of this test: the R2 object itself must actually be
+      // gone, not just the DB row's bookkeeping counters.
+      expect(has(created.objectKey)).toBe(false);
 
       const softDeleted = await withTenant(appSql, TENANT_A, (tx) =>
         fetchNewsMediaObjectById(tx, TENANT_A, created.id, {

--- a/tests/integration/news-portal-ad-placements.integration.test.ts
+++ b/tests/integration/news-portal-ad-placements.integration.test.ts
@@ -14,14 +14,7 @@
  *
  * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
  */
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test
-} from "bun:test";
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   applyMigrations,

--- a/tests/integration/news-portal-homepage-sections.integration.test.ts
+++ b/tests/integration/news-portal-homepage-sections.integration.test.ts
@@ -9,14 +9,7 @@
  *
  * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
  */
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test
-} from "bun:test";
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   applyMigrations,
@@ -419,6 +412,23 @@ suite("news_portal homepage sections (Issue #637)", () => {
       }
     });
     expect(rejected.status).toBe(422);
+  });
+
+  test("category_grid accepts a categorySlug that exists for this tenant", async () => {
+    const owner = await bootstrap();
+    const category = await createCategoryTerm(owner, "front-page-category");
+
+    const response = await invoke(createSection, {
+      method: "POST",
+      path: "/api/v1/news-portal/homepage-sections",
+      headers: authHeaders(owner),
+      body: {
+        sectionKey: "front-page-categories-ok",
+        sectionType: "category_grid",
+        config: { categorySlugs: [category.slug] }
+      }
+    });
+    expect(response.status).toBe(200);
   });
 
   test("category_grid rejects a categorySlug that does not exist for this tenant", async () => {

--- a/tests/integration/social-publishing.integration.test.ts
+++ b/tests/integration/social-publishing.integration.test.ts
@@ -30,14 +30,10 @@ import {
 } from "./harness";
 
 import { getDatabaseClient } from "../../src/lib/database/client";
-import { withTenant } from "../../src/lib/database/tenant-context";
 
 import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
 import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
-import {
-  GET as listPosts,
-  POST as createPost
-} from "../../src/pages/api/v1/blog/posts/index";
+import { POST as createPost } from "../../src/pages/api/v1/blog/posts/index";
 import { POST as publishPost } from "../../src/pages/api/v1/blog/posts/[id]/publish";
 
 import {
@@ -862,6 +858,57 @@ suite("social_publishing outbox foundation (Issue #643)", () => {
     expect(rule.status).toBe(200);
     expect(rule.body.data.requiresApproval).toBe(true);
     expect(rule.body.data.isEnabled).toBe(true);
+  });
+
+  test("rule list only returns this tenant's own rules (RLS)", async () => {
+    const owner = await bootstrap();
+    const account = await invoke<{ data: { id: string } }>(connectAccount, {
+      method: "POST",
+      path: "/api/v1/social-publishing/accounts",
+      headers: { ...authHeaders(owner), "idempotency-key": "connect-r-list-1" },
+      body: CONNECT_BODY
+    });
+    await invoke(createRule, {
+      method: "POST",
+      path: "/api/v1/social-publishing/rules",
+      headers: authHeaders(owner),
+      body: {
+        socialAccountId: account.body.data.id,
+        triggerEvent: "post_published"
+      }
+    });
+
+    const otherTenant =
+      await seedSecondTenantWithSocialPublishingAccess("rule-list-b");
+    const otherAccount = await invoke<{ data: { id: string } }>(
+      connectAccount,
+      {
+        method: "POST",
+        path: "/api/v1/social-publishing/accounts",
+        headers: {
+          ...authHeaders(otherTenant),
+          "idempotency-key": "connect-r-list-2"
+        },
+        body: CONNECT_BODY
+      }
+    );
+    await invoke(createRule, {
+      method: "POST",
+      path: "/api/v1/social-publishing/rules",
+      headers: authHeaders(otherTenant),
+      body: {
+        socialAccountId: otherAccount.body.data.id,
+        triggerEvent: "post_published"
+      }
+    });
+
+    const list = await invoke<{ data: { rules: unknown[] } }>(listRules, {
+      method: "GET",
+      path: "/api/v1/social-publishing/rules",
+      headers: authHeaders(owner)
+    });
+    expect(list.status).toBe(200);
+    expect(list.body.data.rules.length).toBe(1);
   });
 
   // -------------------------------------------------------------------

--- a/tests/integration/visitor-analytics-api.integration.test.ts
+++ b/tests/integration/visitor-analytics-api.integration.test.ts
@@ -150,9 +150,6 @@ function authHeaders(tenantId: string, token: string): Record<string, string> {
   };
 }
 
-const HUMAN_UA =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
-
 async function seedSession(
   tenantId: string,
   overrides: Partial<{

--- a/tests/unit/linkedin-provider-config.test.ts
+++ b/tests/unit/linkedin-provider-config.test.ts
@@ -51,6 +51,20 @@ describe("isValidLinkedInApiVersion (Issue #645)", () => {
   });
 });
 
+describe("resolveLinkedInApiVersion (Issue #645)", () => {
+  test("trims the configured value", () => {
+    expect(
+      resolveLinkedInApiVersion({
+        LINKEDIN_API_VERSION: " 202506 "
+      } as NodeJS.ProcessEnv)
+    ).toBe("202506");
+  });
+
+  test('empty string when unset (never "undefined")', () => {
+    expect(resolveLinkedInApiVersion({} as NodeJS.ProcessEnv)).toBe("");
+  });
+});
+
 describe("resolveLinkedInRequiredScopes (Issue #645)", () => {
   test("parses a comma-separated list, trims, drops empties", () => {
     expect(


### PR DESCRIPTION
## Summary

- Triages and resolves all 15 currently-open CodeQL code-scanning alerts (`js/unused-local-variable` x11, `js/implicit-operand-conversion` x2, `js/trivial-conditional` x1, plus one duplicate rebuild-related import) per the `awcms-mini-codeql-triage` skill's investigate-first process.
- 11 unused-local-variable alerts: most are genuine leftover imports (`afterAll`, `expect`, `withTenant`, `listPosts`, `HUMAN_UA`) removed with zero behavior change. Three (`createCategoryTerm`, the destructured `has` in the R2 reconciliation test, `resolveLinkedInApiVersion`) turned out to be dead-but-correctly-written test helpers pointing at a real coverage gap — wired into new assertions instead of deleted (category_grid accept-path test, R2 stale-orphaned physical-deletion assertion, direct `resolveLinkedInApiVersion` unit tests).
- 2 `js/implicit-operand-conversion` alerts on `business-scope-facts.ts:59` dismissed as false positive via the GitHub API: Bun.SQL tagged templates bind values as SQL parameters (never JS-stringify them); CodeQL's heuristic proves the call site's argument is always literal `null` and flags the interpolation, but the identical pattern at line 186 of the same file and 12+ other files across the repo goes unflagged, confirming this is a per-call-site analysis artifact, not a real bug.
- 1 `js/trivial-conditional` alert on `scripts/validate-module-composition.ts:41` dismissed as won't-fix: `applicationModuleRegistry` is intentionally `undefined` in this base repository by design (a build-time extension seam a derived repo replaces wholesale, ADR-0013/#740) — the ternary is genuinely conditional in a derived repo, just statically resolved here.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` / `check:docs` / `api:spec:check` / `api:docs:check` / `repo:inventory:check` / `modules:dag:check` / `modules:compose:check` / `modules:composition:inventory:check` / `extension:check` / `data-lifecycle:registry:check` / `reporting:projections:registry:check` / `identity-access:sod-registry:check` / `i18n:pot:check` / `i18n:parity:check` / `config:docs:check` / `logging:lint:check` / `db:work-class:check` — all OK
- [x] `bun run build` — clean
- [x] `bun run changesets:policy:check` — no changeset required (test/tooling-only)
- [x] Full `bun test` against an isolated database (`awcms_mini_codeql_788`): 4100 pass, 128 fail — every failure traced to shared-Postgres connection exhaustion from other agents' concurrent test runs during this session (`PostgresError: remaining connection slots are reserved for roles with the SUPERUSER attribute` / `too many clients already`), not a single genuine assertion failure. Confirmed by re-running each touched file individually when connection headroom was available: 100% pass, including the 3 new/rewired assertions.

Closes #788