### PR TITLE
fix(identity-access): make same_scope_only SoD conflict matching hierarchy-aware

### DIFF
--- a/.changeset/sod-hierarchy-aware-matching-issue-794.md
+++ b/.changeset/sod-hierarchy-aware-matching-issue-794.md
@@ -1,0 +1,46 @@
+---
+"awcms-mini": patch
+---
+
+Fix (Issue #794, follow-up to #786/#790, epic #738 platform-evolution): make
+`detectSoDConflicts`'s `"same_scope_only"` segregation-of-duties matching
+hierarchy-aware. Before this fix, a `same_scope_only` rule (e.g.
+`identity_access.business_scope_assignment_scope_maker_checker`) matched
+only on EXACT `(scopeType, scopeId)` equality — a subject holding
+`business_scope_assignments.create` at a parent `organization_unit` could
+be granted `.revoke` at a hierarchically-related child unit without
+tripping the conflict rule, even though both scopes belong to the same
+business hierarchy the rule was meant to bound. This was purely theoretical
+before PR #790 wired the real `organizationStructureHierarchyPortAdapter`
+into production (the hierarchy port always resolved `false` for
+`legal_entity`/`organization_unit` before that) — #790 made it practically
+reachable.
+
+`detectSoDConflicts` (`src/modules/identity-access/domain/sod-conflict-evaluation.ts`)
+now accepts an optional `RequestedScope.relatedScopes` list; a held fact
+whose scope appears in that list (the requested scope's own
+`ancestorScopes`/`descendantScopes`) is now treated as a scope match, same
+as exact equality or the existing null-scope "ordinary RBAC grant matches
+every scope" case. `createBusinessScopeAssignment`
+(`application/business-scope-assignment-service.ts`) wires this from the
+hierarchy-port resolution it already fetches to validate the requested
+scope — no additional hierarchy-port call is introduced. A caller that
+never resolves hierarchy (e.g. identity-access's own flat "office" scope
+adapter) simply omits `relatedScopes`, so its exact-match-only behavior is
+unchanged.
+
+Not exploitable across tenant/RLS boundaries and does not bypass ABAC
+default-deny — the documented residual limitation (the generic
+`authorizeInTransaction`/`checkHighRiskSoDConflicts` chokepoint used by
+~124 route files across many modules still has no hierarchy port wired in
+and still compares scope by exact equality) is called out explicitly in
+`src/modules/identity-access/README.md` and
+`docs/awcms-mini/20_threat_model_security_architecture.md`, not silently
+absorbed into this fix's claim.
+
+Added an adversarial integration test proving a `.create` grant at a
+parent `organization_unit` now blocks a subsequent `.revoke` grant at a
+real hierarchy-descendant child unit
+(`tests/integration/business-scope-organization-structure-wiring.integration.test.ts`),
+plus pure unit tests for the new `relatedScopes` matching
+(`tests/unit/sod-conflict-evaluation.test.ts`).

--- a/docs/awcms-mini/20_threat_model_security_architecture.md
+++ b/docs/awcms-mini/20_threat_model_security_architecture.md
@@ -1136,20 +1136,39 @@ default-deny, audit) yang sudah berlaku sama di sini.
   (scope type lain, atau modul nonaktif untuk tenant itu) — diverifikasi
   end-to-end lewat `tests/integration/business-scope-organization-
 structure-wiring.integration.test.ts` (bukan hanya unit test adapter
-  itu sendiri). **Catatan jujur, diperbarui pasca-audit PR #790**:
-  pencocokan konflik SoD (`same_scope_only`) tetap berbasis kesetaraan
-  `(scopeType, scopeId)` persis — belum mengonsultasikan
-  `ancestorScopes`/`descendantScopes` yang kini benar-benar dihitung
-  adapter. Sebelum PR ini, batasan tersebut murni teoritis (scope
-  `legal_entity`/`organization_unit` tidak pernah benar-benar resolve);
-  PR #790 membuatnya nyata dapat dijangkau — subjek yang menggenggam
-  `business_scope_assignments.create` pada `organization_unit` induk kini
-  bisa mendapat `.revoke` pada unit anak yang berelasi hierarkis tanpa
-  memicu rule `same_scope_only` (`business_scope_assignment_scope_maker_
-checker`). Tidak melintasi batas tenant/RLS dan tidak melewati
-  default-deny ABAC — tetap butuh permission pemberian assignment yang
-  sah. Dilacak sebagai Issue #794 (severity Medium, bukan blocker
-  go-live per gerbang doc 07, karena hanya Critical yang memblokir).
+  itu sendiri). **Diperbaiki di Issue #794** (severity Medium, bukan
+  blocker go-live per gerbang doc 07 — dilacak sejak audit PR #790 sampai
+  ditutup): pencocokan konflik SoD (`same_scope_only`) pada
+  `createBusinessScopeAssignment` sebelumnya berbasis kesetaraan
+  `(scopeType, scopeId)` persis saja — tidak mengonsultasikan
+  `ancestorScopes`/`descendantScopes` yang sudah dihitung adapter. Sebelum
+  PR #790, batasan itu murni teoritis (scope `legal_entity`/
+  `organization_unit` tidak pernah benar-benar resolve); PR #790
+  membuatnya nyata dapat dijangkau — subjek yang menggenggam
+  `business_scope_assignments.create` pada `organization_unit` induk bisa
+  mendapat `.revoke` pada unit anak yang berelasi hierarkis tanpa memicu
+  rule `same_scope_only` (`business_scope_assignment_scope_maker_checker`).
+  `detectSoDConflicts` (`domain/sod-conflict-evaluation.ts`) kini menerima
+  `RequestedScope.relatedScopes` opsional — `createBusinessScopeAssignment`
+  mengisinya dari resolusi hierarki yang SUDAH diambil untuk validasi
+  keberadaan scope (tidak ada panggilan hierarchy-port tambahan) — fact
+  yang dipegang pada scope ancestor/descendant kini juga dihitung sebagai
+  kecocokan scope, bukan hanya id yang identik. Dibuktikan lewat test
+  adversarial baru (`tests/integration/business-scope-organization-
+structure-wiring.integration.test.ts`, skenario "create di unit induk +
+  revoke di unit anak") dan unit test murni
+  (`tests/unit/sod-conflict-evaluation.test.ts`). Tidak melintasi batas
+  tenant/RLS dan tidak melewati default-deny ABAC — tetap butuh permission
+  pemberian assignment yang sah. **Celah residual yang TETAP ada, didokumentasikan
+  eksplisit, BUKAN diklaim selesai**: `checkHighRiskSoDConflicts`
+  (`application/high-risk-sod-guard.ts`) — chokepoint `same_scope_only`
+  LAIN, dipasang di `authorizeInTransaction` generik yang dipakai ~124
+  route file lintas banyak modul, kebanyakan tanpa konsep hierarki sama
+  sekali — tidak punya hierarchy port sama sekali, sehingga tetap
+  membandingkan `sodScopeType`/`sodScopeId` persis. Menyalurkan resolusi
+  hierarki ke chokepoint sebegitu generik adalah perubahan jauh lebih besar
+  dan tidak atomic, sengaja di luar scope issue #794 ini — dicatat di sini,
+  bukan diam-diam diserap ke klaim perbaikan ini.
 - **Tiga rule fixture SoD** (bukan katalog domain lengkap) — dua dimiliki
   `identity_access` sendiri (maker/checker atas mekanisme exception itu
   sendiri, dan atas assignment create/revoke pada scope yang sama), satu

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -513,13 +513,32 @@ module-composition validator (Issue #740), the same shape `blog_content`
 already declares for its own optional `news_media`/`social_publishing`
 consumption — this is a documentation/build-time-validation entry, not the
 runtime wiring itself. **Scope note**: this wiring makes scope EXISTENCE/
-VALIDITY resolution real for `legal_entity`/`organization_unit` — it does
-NOT make SoD conflict MATCHING (`domain/sod-conflict-evaluation.ts`)
-hierarchy-aware; `detectSoDConflicts`'s `"same_scope_only"` rule still
-compares `(scopeType, scopeId)` by exact equality, never consulting
-`ancestorScopes`/`descendantScopes` — a true hierarchy-aware conflict check
-(e.g. "held at a parent org unit conflicts with a child") remains a
-distinct, not-yet-built feature.
+VALIDITY resolution real for `legal_entity`/`organization_unit`.
+**Hierarchy-aware SoD matching (Issue #794, fixing a gap #786 deliberately
+left open and #790 made practically reachable)**: `createBusinessScopeAssignment`
+(`application/business-scope-assignment-service.ts`) now passes the
+requested scope's already-resolved `ancestorScopes`/`descendantScopes` (no
+extra hierarchy-port call — it reuses the resolution already fetched to
+validate scope existence) as `RequestedScope.relatedScopes` into
+`detectSoDConflicts`; a `"same_scope_only"` rule now also matches a held
+fact whose scope is a genuine ancestor/descendant of the requested scope,
+not only an EXACT `(scopeType, scopeId)` equal one — e.g. a subject holding
+`business_scope_assignments.create` at a parent `organization_unit` can no
+longer be granted `.revoke` at a hierarchically-related child unit without
+tripping `business_scope_assignment_scope_maker_checker`. **Remaining, documented
+gap**: `checkHighRiskSoDConflicts` (`application/high-risk-sod-guard.ts`),
+the OTHER `same_scope_only` call site wired at the generic
+`authorizeInTransaction` chokepoint (used by ~124 route files for many
+modules, most with no hierarchy concept at all), has no hierarchy port
+plumbed in at all — it still compares `sodScopeType`/`sodScopeId` by exact
+equality only. Threading hierarchy resolution through that fully generic
+chokepoint (which would require every one of its many callers to supply a
+hierarchy port, or resolve one per-request, for scope types the vast
+majority of them don't even have) is a materially larger, non-atomic
+change deliberately left out of issue #794's scope — tracked in
+`docs/awcms-mini/20_threat_model_security_architecture.md`'s SoD threat
+table as a distinct residual limitation, not silently absorbed into this
+fix's claim.
 
 ### ABAC extension (`domain/access-control.ts`)
 

--- a/src/modules/identity-access/application/business-scope-assignment-service.ts
+++ b/src/modules/identity-access/application/business-scope-assignment-service.ts
@@ -192,7 +192,21 @@ export async function createBusinessScopeAssignment(
     return { ok: false, reason: "self_grant_denied" };
   }
 
-  const requestedScope = { scopeType: input.scopeType, scopeId: input.scopeId };
+  // Hierarchy-aware `same_scope_only` SoD matching (Issue #794): reuse the
+  // resolution already fetched above (no second hierarchy-port call) so a
+  // held fact at an ancestor/descendant of the requested scope is treated
+  // as the SAME business hierarchy, not silently exempted just because its
+  // `scopeId` differs. A flat adapter (e.g. "office") always resolves
+  // empty ancestor/descendant lists, so this is a no-op for that scope
+  // type — exact-match-only behavior is unchanged there.
+  const requestedScope = {
+    scopeType: input.scopeType,
+    scopeId: input.scopeId,
+    relatedScopes: [
+      ...resolution.ancestorScopes,
+      ...resolution.descendantScopes
+    ]
+  };
   const conflicts: SoDConflictSummary[] = [];
 
   if (input.roleId) {

--- a/src/modules/identity-access/domain/sod-conflict-evaluation.ts
+++ b/src/modules/identity-access/domain/sod-conflict-evaluation.ts
@@ -23,6 +23,30 @@
  * indeterminate exactly like a confirmed conflict, per the same
  * default-deny principle, rather than this pure function silently deciding
  * "no requestedScope means no conflict".
+ *
+ * **Hierarchy-aware `same_scope_only` matching (Issue #794, fixing a gap
+ * documented — but not yet closed — at #790's audit time).** Before this
+ * fix, `same_scope_only` matched a held fact's scope against
+ * `requestedScope` by EXACT `(scopeType, scopeId)` equality only, never
+ * consulting the ancestor/descendant references
+ * `BusinessScopeHierarchyPort.resolveScope` already computes. That made a
+ * "same scope" rule silently NOT bound a genuinely-related business
+ * hierarchy: a subject holding `business_scope_assignments.create` at a
+ * parent `organization_unit` could be granted `.revoke` at a
+ * hierarchically-related child unit without tripping
+ * `business_scope_assignment_scope_maker_checker` — purely theoretical
+ * before PR #790 (the org-structure hierarchy adapter always resolved
+ * `false` for those scope types), practically reachable after. Fixed by
+ * accepting an optional `RequestedScope.relatedScopes` list — the
+ * requested scope's OWN `ancestorScopes`/`descendantScopes` (the caller,
+ * `business-scope-assignment-service.ts`, already resolves this once via
+ * the hierarchy port to validate the scope exists; no second I/O call is
+ * introduced here) — and treating a held fact whose scope appears in that
+ * list as a scope match, same as exact equality or the pre-existing
+ * null-scope "ordinary RBAC grant matches every scope" rule. A caller
+ * that never resolves hierarchy (e.g. identity-access's own flat "office"
+ * adapter) simply omits `relatedScopes`, preserving exact-match-only
+ * behavior unchanged for that scope type.
  */
 import type { SoDRuleDescriptor } from "../../_shared/module-contract";
 
@@ -57,6 +81,17 @@ export type SoDAssignmentFact = {
 export type RequestedScope = {
   scopeType: string;
   scopeId: string;
+  /**
+   * Other scope references considered part of the SAME business hierarchy
+   * as `(scopeType, scopeId)` for a `"same_scope_only"` rule's purposes —
+   * typically the requested scope's own `ancestorScopes`/`descendantScopes`
+   * from `BusinessScopeHierarchyPort.resolveScope` (Issue #794). Optional
+   * and empty by default: a caller that resolves scope through a flat
+   * adapter (no real hierarchy, e.g. `"office"`) omits this entirely,
+   * which is exactly equivalent to passing `[]` — exact `(scopeType,
+   * scopeId)` equality is still the only match for that case.
+   */
+  relatedScopes?: readonly { scopeType: string; scopeId: string }[];
 };
 
 export type SoDConflictMatch = {
@@ -118,7 +153,16 @@ export function detectSoDConflicts(
             // to any business scope) conflicts at EVERY requested scope.
             (fact.scopeType === null && fact.scopeId === null) ||
             (fact.scopeType === requestedScope.scopeType &&
-              fact.scopeId === requestedScope.scopeId)
+              fact.scopeId === requestedScope.scopeId) ||
+            // Hierarchy-aware match (Issue #794): a fact held at a scope
+            // the caller has already resolved as an ancestor/descendant of
+            // the requested scope is the SAME business hierarchy this rule
+            // is meant to bound, not a merely-coincidentally-different one.
+            (requestedScope.relatedScopes ?? []).some(
+              (related) =>
+                related.scopeType === fact.scopeType &&
+                related.scopeId === fact.scopeId
+            )
         );
 
         if (scopedMatch) {

--- a/tests/integration/business-scope-organization-structure-wiring.integration.test.ts
+++ b/tests/integration/business-scope-organization-structure-wiring.integration.test.ts
@@ -12,15 +12,18 @@
  * HONEST SCOPE NOTE (do not overclaim — see this repo's own recurring
  * "issue requirement + false in-code claim of compliance" failure pattern,
  * `docs/awcms-mini/20_threat_model_security_architecture.md`'s Wave-3
- * findings): `detectSoDConflicts` (`domain/sod-conflict-evaluation.ts`)
- * matches a `"same_scope_only"` rule by EXACT `(scopeType, scopeId)`
- * equality — it does NOT consult `resolution.ancestorScopes`/
- * `descendantScopes` at all today (verified: nothing outside the port/
- * adapter files themselves reads those fields). This issue wires the
- * SCOPE VALIDITY step (`resolveScope(...).resolved`) to the real,
- * hierarchy-walking adapter — it does NOT add hierarchy-aware (ancestor/
- * descendant) SoD conflict MATCHING, which remains a distinct, not-yet-built
- * feature. The tests below prove: (1) `legal_entity`/`organization_unit`
+ * findings): at the time THIS issue (#786) shipped, `detectSoDConflicts`
+ * (`domain/sod-conflict-evaluation.ts`) matched a `"same_scope_only"` rule
+ * by EXACT `(scopeType, scopeId)` equality only — it did not consult
+ * `resolution.ancestorScopes`/`descendantScopes` at all (verified: nothing
+ * outside the port/adapter files themselves read those fields). This issue
+ * wired the SCOPE VALIDITY step (`resolveScope(...).resolved`) to the real,
+ * hierarchy-walking adapter — it deliberately did NOT add hierarchy-aware
+ * (ancestor/descendant) SoD conflict MATCHING, left as a distinct
+ * not-yet-built feature, tracked and later closed by Issue #794 (see
+ * `hierarchy-aware SoD conflict matching` test below, and
+ * `sod-conflict-evaluation.ts`'s own header for the fix). The tests in
+ * THIS describe block prove: (1) `legal_entity`/`organization_unit`
  * scope references now resolve through the REAL adapter (previously
  * impossible — the old hardcoded flat adapter returns `resolved: false`
  * for every scope type except `"office"`), genuinely reading
@@ -31,7 +34,9 @@
  * per-tenant module enablement gates which adapter answers — disabling
  * `organization_structure` for a tenant makes its scope types unresolved
  * again, exactly like any other module the composition root doesn't
- * recognize, and the flat "office" adapter keeps working unaffected.
+ * recognize, and the flat "office" adapter keeps working unaffected; (4)
+ * (Issue #794) a `same_scope_only` conflict now ALSO trips across a real
+ * ancestor/descendant organization-unit pair, not just identical scope ids.
  *
  * Skipped unless DATABASE_URL is set (see tests/integration/harness.ts).
  */
@@ -217,6 +222,39 @@ async function seedLegalEntityWithUnit(
   return { legalEntityId, unitId: unitRows[0]!.id };
 }
 
+/**
+ * Adds a CHILD organization unit under `parentUnitId`, with a current
+ * (`effective_to IS NULL`) hierarchy edge row seeded directly (same
+ * "raw admin SQL, not the real reparent route — keep this file's scope
+ * narrow" convention `seedLegalEntityWithUnit` above documents) — enough
+ * for `organizationStructureHierarchyPortAdapter.resolveScope` to walk a
+ * real ancestor/descendant chain, without re-testing
+ * `organization-unit-hierarchy-service.ts`'s own reparent validation
+ * (already covered elsewhere).
+ */
+async function seedChildUnit(
+  tenantId: string,
+  legalEntityId: string,
+  parentUnitId: string
+): Promise<string> {
+  const admin = getAdminSql();
+
+  const unitRows = (await admin`
+    INSERT INTO awcms_mini_organization_units (tenant_id, legal_entity_id, code, name)
+    VALUES (${tenantId}, ${legalEntityId}, 'branch_a_child', 'Branch A Child')
+    RETURNING id
+  `) as { id: string }[];
+  const childUnitId = unitRows[0]!.id;
+
+  await admin`
+    INSERT INTO awcms_mini_organization_unit_hierarchies
+      (tenant_id, organization_unit_id, parent_organization_unit_id)
+    VALUES (${tenantId}, ${childUnitId}, ${parentUnitId})
+  `;
+
+  return childUnitId;
+}
+
 const suite = integrationEnabled ? describe : describe.skip;
 
 suite(
@@ -391,6 +429,82 @@ suite(
         SELECT conflict_detected FROM awcms_mini_sod_conflict_evaluations
         WHERE tenant_id = ${owner.tenantId} AND trigger_context = 'assignment_create'
       `) as { conflict_detected: boolean }[];
+      expect(evaluations.length).toBeGreaterThan(0);
+      expect(evaluations[0]!.conflict_detected).toBe(true);
+    });
+
+    test("Issue #794 adversarial: same_scope_only conflict now trips across a HIERARCHY-RELATED organization_unit pair — subject holding create at a parent unit CANNOT be granted revoke at a child unit either (previously silently allowed since only exact (scopeType, scopeId) equality was checked)", async () => {
+      const owner = await bootstrap();
+      const { legalEntityId, unitId: parentUnitId } =
+        await seedLegalEntityWithUnit(owner.tenantId);
+      const childUnitId = await seedChildUnit(
+        owner.tenantId,
+        legalEntityId,
+        parentUnitId
+      );
+      const subjectId = await createSecondTenantUser(
+        owner.tenantId,
+        "acme-org-subject-hierarchy@example.com"
+      );
+
+      const creatorRole = await createRoleWithPermissions(
+        owner.tenantId,
+        "org_scope_creator_hierarchy",
+        "Org Scope Creator Hierarchy",
+        ["identity_access.business_scope_assignments.create"]
+      );
+      const revokerRole = await createRoleWithPermissions(
+        owner.tenantId,
+        "org_scope_revoker_hierarchy",
+        "Org Scope Revoker Hierarchy",
+        ["identity_access.business_scope_assignments.revoke"]
+      );
+
+      // Subject is granted `.create` at the PARENT unit.
+      const first = await invoke<{ data: { assignment: { id: string } } }>(
+        createAssignment,
+        {
+          method: "POST",
+          path: "/api/v1/identity/business-scope/assignments",
+          headers: authHeaders(owner, "org-wiring-sod-hierarchy-1"),
+          body: {
+            tenantUserId: subjectId,
+            roleId: creatorRole,
+            scopeType: "organization_unit",
+            scopeId: parentUnitId
+          }
+        }
+      );
+      expect(first.status).toBe(200);
+
+      // Attempting to ALSO grant `.revoke` at the CHILD unit — a DIFFERENT
+      // scopeId, but the same business hierarchy (child of the parent the
+      // subject already holds `.create` at) — must now be blocked by
+      // `business_scope_assignment_scope_maker_checker` even though the
+      // two scope ids are not identical.
+      const conflicting = await invoke(createAssignment, {
+        method: "POST",
+        path: "/api/v1/identity/business-scope/assignments",
+        headers: authHeaders(owner, "org-wiring-sod-hierarchy-2"),
+        body: {
+          tenantUserId: subjectId,
+          roleId: revokerRole,
+          scopeType: "organization_unit",
+          scopeId: childUnitId
+        }
+      });
+
+      expect(conflicting.status).toBe(409);
+      expect((conflicting.body as { error: { code: string } }).error.code).toBe(
+        "SOD_CONFLICT"
+      );
+
+      const admin = getAdminSql();
+      const evaluations = (await admin`
+        SELECT conflict_detected, rule_key FROM awcms_mini_sod_conflict_evaluations
+        WHERE tenant_id = ${owner.tenantId} AND trigger_context = 'assignment_create'
+          AND rule_key = 'identity_access.business_scope_assignment_scope_maker_checker'
+      `) as { conflict_detected: boolean; rule_key: string }[];
       expect(evaluations.length).toBeGreaterThan(0);
       expect(evaluations[0]!.conflict_detected).toBe(true);
     });

--- a/tests/unit/sod-conflict-evaluation.test.ts
+++ b/tests/unit/sod-conflict-evaluation.test.ts
@@ -142,6 +142,68 @@ describe("detectSoDConflicts", () => {
     expect(otherScope).toHaveLength(1);
   });
 
+  test("same_scope_only: a fact held at a scope listed in requestedScope.relatedScopes (an ancestor/descendant of the requested scope) is treated as a scope match (Issue #794 — hierarchy-aware matching)", () => {
+    const parentAncestorMatch = detectSoDConflicts(
+      [SCOPED_RULE],
+      "test_module.gadgets.revoke",
+      {
+        scopeType: "organization_unit",
+        scopeId: "child-unit",
+        relatedScopes: [
+          { scopeType: "organization_unit", scopeId: "parent-unit" }
+        ]
+      },
+      [
+        {
+          permissionKey: "test_module.gadgets.create",
+          scopeType: "organization_unit",
+          scopeId: "parent-unit"
+        }
+      ]
+    );
+    expect(parentAncestorMatch).toHaveLength(1);
+    expect(parentAncestorMatch[0]!.indeterminate).toBe(false);
+
+    // A fact at a scope NOT in relatedScopes and not exactly equal is still
+    // no conflict — relatedScopes narrows to genuinely-related scopes only,
+    // it is not a wildcard.
+    const unrelatedScope = detectSoDConflicts(
+      [SCOPED_RULE],
+      "test_module.gadgets.revoke",
+      {
+        scopeType: "organization_unit",
+        scopeId: "child-unit",
+        relatedScopes: [
+          { scopeType: "organization_unit", scopeId: "parent-unit" }
+        ]
+      },
+      [
+        {
+          permissionKey: "test_module.gadgets.create",
+          scopeType: "organization_unit",
+          scopeId: "cousin-unit"
+        }
+      ]
+    );
+    expect(unrelatedScope).toHaveLength(0);
+  });
+
+  test("same_scope_only: an EMPTY/omitted relatedScopes preserves exact-match-only behavior — a caller that never resolves hierarchy (e.g. the flat office adapter) sees no change", () => {
+    const noRelatedScopes = detectSoDConflicts(
+      [SCOPED_RULE],
+      "test_module.gadgets.revoke",
+      { scopeType: "office", scopeId: "scope-a", relatedScopes: [] },
+      [
+        {
+          permissionKey: "test_module.gadgets.create",
+          scopeType: "office",
+          scopeId: "scope-b"
+        }
+      ]
+    );
+    expect(noRelatedScopes).toHaveLength(0);
+  });
+
   test('same_scope_only: no requestedScope supplied is INDETERMINATE, not silently "no conflict" — default-deny', () => {
     const matches = detectSoDConflicts(
       [SCOPED_RULE],


### PR DESCRIPTION
## Summary

- `detectSoDConflicts` (`src/modules/identity-access/domain/sod-conflict-evaluation.ts`) matched a `"same_scope_only"` SoD rule on exact `(scopeType, scopeId)` equality only, never consulting the `ancestorScopes`/`descendantScopes` that `BusinessScopeHierarchyPort.resolveScope` already computes.
- Concrete impact: a subject holding `business_scope_assignments.create` at a parent `organization_unit` could be granted `.revoke` at a hierarchically-related child unit without tripping `business_scope_assignment_scope_maker_checker` — purely theoretical before PR #790 wired the real `organizationStructureHierarchyPortAdapter` into production, practically reachable after.
- Fix direction chosen: **(1) make the matching itself hierarchy-aware**, not just document-as-accepted-risk. This was architecturally clean because `createBusinessScopeAssignment` already fetches the requested scope's hierarchy resolution once (to validate scope existence) — no new I/O is needed, just threading the already-computed ancestor/descendant references into `detectSoDConflicts` via a new optional `RequestedScope.relatedScopes` field.
- Documented remaining, distinct residual gap: `checkHighRiskSoDConflicts` (`application/high-risk-sod-guard.ts`), the *other* `same_scope_only` call site wired at the generic `authorizeInTransaction` chokepoint (shared by ~124 route files across many modules with no hierarchy concept), has no hierarchy port plumbed in at all and still compares scope by exact equality — threading hierarchy through that fully generic chokepoint is a materially larger, non-atomic change, deliberately out of this issue's scope, and called out explicitly (not silently absorbed) in `src/modules/identity-access/README.md` and `docs/awcms-mini/20_threat_model_security_architecture.md`.

## Test plan

- [x] New adversarial integration test: `.create` at a parent `organization_unit` blocks a subsequent `.revoke` grant at a real hierarchy-descendant child unit (`tests/integration/business-scope-organization-structure-wiring.integration.test.ts`)
- [x] New pure unit tests for `relatedScopes` hierarchy matching, including the "empty/omitted relatedScopes preserves exact-match-only behavior" regression guard (`tests/unit/sod-conflict-evaluation.test.ts`)
- [x] Full sibling suite re-run clean: `business-scope-assignments.integration.test.ts`, `business-scope-sod-chokepoint.integration.test.ts`, `business-scope-organization-structure-wiring.integration.test.ts` — all pass
- [x] `bun run lint`, `bun run check:docs`, `bun run api:spec:check`, `bun run identity-access:sod-registry:check`, `bun run typecheck`, `bun run build` all pass
- [x] `bun run test` re-run 3x against a real Postgres instance shared with other concurrent agents in this environment; remaining failures each time were unrelated modules failing on `sorry, too many clients already` / connection-slot exhaustion (pure environmental contention, verified via `pg_stat_activity`), never in identity-access/SoD/business-scope files
- [x] Changeset added (`.changeset/sod-hierarchy-aware-matching-issue-794.md`)
- [x] Docs updated: `docs/awcms-mini/20_threat_model_security_architecture.md` (updated the existing Issue #794-tracked gap entry to "fixed", added the residual `checkHighRiskSoDConflicts` limitation) and `src/modules/identity-access/README.md`

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)