### PR TITLE
fix(identity-access): thread hierarchy-aware same_scope_only SoD matching into checkHighRiskSoDConflicts chokepoint

### DIFF
--- a/.changeset/sod-hierarchy-aware-matching-chokepoint-issue-802.md
+++ b/.changeset/sod-hierarchy-aware-matching-chokepoint-issue-802.md
@@ -1,0 +1,49 @@
+---
+"awcms-mini": patch
+---
+
+Fix (Issue #802, follow-up to #794/PR #800, epic #738 platform-evolution):
+close the residual `checkHighRiskSoDConflicts` hierarchy-matching gap Issue
+#794 explicitly left open. `detectSoDConflicts`'s `"same_scope_only"`
+hierarchy-aware matching (#794) was previously wired ONLY into
+`createBusinessScopeAssignment` — the OTHER `same_scope_only` call site,
+`checkHighRiskSoDConflicts` (`src/modules/identity-access/application/high-risk-sod-guard.ts`),
+wired at the generic `authorizeInTransaction` chokepoint (`access-guard.ts`)
+shared by ~124 route files, still compared `sodScopeType`/`sodScopeId` by
+exact equality only — an actor holding `.revoke` via an ordinary RBAC role
+plus a business-scope `.create` fact at an ancestor `organization_unit`
+could revoke a descendant-scope assignment without tripping
+`business_scope_assignment_scope_maker_checker` through this path. Because
+`detectSoDConflicts` found no match, this near-miss also generated ZERO
+telemetry (`sod_conflicts_detected_total` never fired), contradicting
+#794's own "if not fixed, at minimum add monitoring" fallback requirement.
+
+Investigation found the real exploitable surface much narrower than "124
+route files": only ONE caller of `authorizeInTransaction`,
+`.../business-scope/assignments/[id]/revoke.ts`, has ever populated
+`resourceAttributes.sodScopeType`/`.sodScopeId` — every other caller
+already gets `requestedScope: null`, which a `same_scope_only` rule already
+treats as `indeterminate: true` (default-deny), not a silent gap.
+
+`checkHighRiskSoDConflicts`/`authorizeInTransaction` now accept an OPTIONAL
+`hierarchyPort` parameter, resolved LAZILY only when both a
+`requestedScope` is supplied and a `hierarchyPort` is passed — every other
+caller today passes neither, so their behavior is byte-for-byte unchanged
+(zero new queries, zero regression risk across the other ~123 route
+files). Only `revoke.ts` now composes the real `BusinessScopeHierarchyPort`
+(the same `organization_structure` adapter composition
+`assignments/index.ts` already uses for the create path, factored into
+`src/pages/api/v1/identity/business-scope/hierarchy-port-composition.ts`
+so both routes share one composition root instead of duplicating it) and
+passes it in. Since the detection gap is closed at the source, the
+previously-silent near-miss now correctly fires
+`recordSoDConflictEvaluation`/`sod_conflicts_detected_total` through the
+already-existing mechanism — no separate monitoring code needed.
+
+Added an adversarial integration test proving a `.create` grant at a
+parent `organization_unit` (via a business-scope assignment) plus
+`.revoke` via an ordinary RBAC role can no longer revoke a DIFFERENT
+subject's assignment at a hierarchy-descendant unit through this
+chokepoint (`tests/integration/business-scope-organization-structure-wiring.integration.test.ts`,
+"Issue #802 adversarial" — now `403 SOD_CONFLICT`, recorded with
+`trigger_context: "high_risk_decision"`).

--- a/docs/awcms-mini/20_threat_model_security_architecture.md
+++ b/docs/awcms-mini/20_threat_model_security_architecture.md
@@ -1159,16 +1159,48 @@ structure-wiring.integration.test.ts`, skenario "create di unit induk +
   revoke di unit anak") dan unit test murni
   (`tests/unit/sod-conflict-evaluation.test.ts`). Tidak melintasi batas
   tenant/RLS dan tidak melewati default-deny ABAC — tetap butuh permission
-  pemberian assignment yang sah. **Celah residual yang TETAP ada, didokumentasikan
-  eksplisit, BUKAN diklaim selesai**: `checkHighRiskSoDConflicts`
-  (`application/high-risk-sod-guard.ts`) — chokepoint `same_scope_only`
-  LAIN, dipasang di `authorizeInTransaction` generik yang dipakai ~124
-  route file lintas banyak modul, kebanyakan tanpa konsep hierarki sama
-  sekali — tidak punya hierarchy port sama sekali, sehingga tetap
-  membandingkan `sodScopeType`/`sodScopeId` persis. Menyalurkan resolusi
-  hierarki ke chokepoint sebegitu generik adalah perubahan jauh lebih besar
-  dan tidak atomic, sengaja di luar scope issue #794 ini — dicatat di sini,
-  bukan diam-diam diserap ke klaim perbaikan ini.
+  pemberian assignment yang sah. **Celah residual di `checkHighRiskSoDGuard`
+  chokepoint — DITUTUP Issue #802** (sebelumnya didokumentasikan di sini
+  sebagai "TETAP ada, sengaja di luar scope #794"): `checkHighRiskSoDConflicts`
+  (`application/high-risk-sod-guard.ts`), chokepoint `same_scope_only` LAIN
+  yang dipasang di `authorizeInTransaction` generik dipakai ~124 route file
+  lintas banyak modul, sebelumnya tidak punya hierarchy port sama sekali —
+  tetap membandingkan `sodScopeType`/`sodScopeId` persis, sehingga celah
+  yang sama dengan #794 tetap bisa dieksploitasi lewat jalur ini (satu
+  aktor menggenggam `.revoke` lewat role RBAC biasa + fact `.create`
+  business-scope pada unit induk bisa `.revoke` assignment pada unit anak
+  tanpa memicu rule). Karena `detectSoDConflicts` mengembalikan nol
+  kecocokan pada near-miss ini, `recordSoDConflictEvaluation`/counter
+  `sod_conflicts_detected_total` juga TIDAK PERNAH terpicu — bertentangan
+  dengan syarat fallback eksplisit #794 sendiri ("bila tidak diperbaiki,
+  minimal tambahkan monitoring"), yang saat itu belum benar-benar
+  dikerjakan. **Investigasi Issue #802 menemukan blast radius sebenarnya
+  jauh lebih kecil dari "124 route file"**: dari SEMUA route yang memanggil
+  `authorizeInTransaction`, hanya SATU (`.../business-scope/assignments/
+[id]/revoke.ts`) yang pernah mengisi `resourceAttributes.sodScopeType`/
+  `.sodScopeId` sama sekali — setiap caller LAIN yang tidak mengisinya
+  membuat `extractRequestedScope` selalu `null`, yang UNTUK rule
+  `same_scope_only` sudah berarti `indeterminate: true` (default-deny,
+  bukan celah) sejak awal. Jadi celah nyata hari ini hanya ada di SATU
+  call site, bukan tersebar di 124. Diperbaiki dengan menambahkan parameter
+  `hierarchyPort` OPSIONAL ke `checkHighRiskSoDConflicts`/
+  `authorizeInTransaction` — di-resolve LAZY, hanya dipanggil ketika
+  `requestedScope` benar-benar ada DAN caller menyediakan `hierarchyPort`;
+  123+ caller lain yang tidak menyediakannya berperilaku identik
+  byte-for-byte dengan sebelum #802 (nol query tambahan, nol perubahan
+  perilaku, nol risiko regresi). Hanya `revoke.ts` (satu-satunya instance
+  celah nyata) kini menyusun `BusinessScopeHierarchyPort` yang sama
+  (`organization_structure`'s adapter, difaktorkan ke
+  `src/pages/api/v1/identity/business-scope/hierarchy-port-composition.ts`
+  agar dipakai bersama oleh route create DAN revoke, bukan diduplikasi) dan
+  meneruskannya. Karena celah ditutup di jalur deteksi itu sendiri, near-miss
+  yang tadinya nol-telemetri sekarang otomatis MEMICU
+  `recordSoDConflictEvaluation`/`sod_conflicts_detected_total` lewat
+  mekanisme yang sudah ada — tidak perlu metric terpisah lagi. Dibuktikan
+  lewat test adversarial baru di `tests/integration/business-scope-
+organization-structure-wiring.integration.test.ts` ("Issue #802
+  adversarial") yang membuktikan revoke lintas unit induk/anak lewat
+  chokepoint ini sendiri kini DITOLAK (403 SOD_CONFLICT) dan tercatat.
 - **Tiga rule fixture SoD** (bukan katalog domain lengkap) — dua dimiliki
   `identity_access` sendiri (maker/checker atas mekanisme exception itu
   sendiri, dan atas assignment create/revoke pada scope yang sama), satu

--- a/docs/awcms-mini/20_threat_model_security_architecture.md
+++ b/docs/awcms-mini/20_threat_model_security_architecture.md
@@ -1163,8 +1163,10 @@ structure-wiring.integration.test.ts`, skenario "create di unit induk +
   chokepoint — DITUTUP Issue #802** (sebelumnya didokumentasikan di sini
   sebagai "TETAP ada, sengaja di luar scope #794"): `checkHighRiskSoDConflicts`
   (`application/high-risk-sod-guard.ts`), chokepoint `same_scope_only` LAIN
-  yang dipasang di `authorizeInTransaction` generik dipakai ~124 route file
-  lintas banyak modul, sebelumnya tidak punya hierarchy port sama sekali —
+  yang dipasang di `authorizeInTransaction` generik dipakai banyak route
+  file lintas banyak modul (jumlah pasti terus bertambah — re-grep caller
+  `authorizeInTransaction` daripada percaya angka manapun di sini),
+  sebelumnya tidak punya hierarchy port sama sekali —
   tetap membandingkan `sodScopeType`/`sodScopeId` persis, sehingga celah
   yang sama dengan #794 tetap bisa dieksploitasi lewat jalur ini (satu
   aktor menggenggam `.revoke` lewat role RBAC biasa + fact `.create`
@@ -1175,14 +1177,15 @@ structure-wiring.integration.test.ts`, skenario "create di unit induk +
   dengan syarat fallback eksplisit #794 sendiri ("bila tidak diperbaiki,
   minimal tambahkan monitoring"), yang saat itu belum benar-benar
   dikerjakan. **Investigasi Issue #802 menemukan blast radius sebenarnya
-  jauh lebih kecil dari "124 route file"**: dari SEMUA route yang memanggil
-  `authorizeInTransaction`, hanya SATU (`.../business-scope/assignments/
-[id]/revoke.ts`) yang pernah mengisi `resourceAttributes.sodScopeType`/
-  `.sodScopeId` sama sekali — setiap caller LAIN yang tidak mengisinya
-  membuat `extractRequestedScope` selalu `null`, yang UNTUK rule
-  `same_scope_only` sudah berarti `indeterminate: true` (default-deny,
-  bukan celah) sejak awal. Jadi celah nyata hari ini hanya ada di SATU
-  call site, bukan tersebar di 124. Diperbaiki dengan menambahkan parameter
+  jauh lebih kecil dari total fan-out chokepoint ini**: dari SEMUA route
+  yang memanggil `authorizeInTransaction`, hanya SATU (`.../business-scope/
+assignments/[id]/revoke.ts`) yang pernah mengisi
+  `resourceAttributes.sodScopeType`/`.sodScopeId` sama sekali — setiap
+  caller LAIN yang tidak mengisinya membuat `extractRequestedScope` selalu
+  `null`, yang UNTUK rule `same_scope_only` sudah berarti
+  `indeterminate: true` (default-deny, bukan celah) sejak awal. Jadi celah
+  nyata hari ini hanya ada di SATU call site, bukan tersebar luas.
+  Diperbaiki dengan menambahkan parameter
   `hierarchyPort` OPSIONAL ke `checkHighRiskSoDConflicts`/
   `authorizeInTransaction` — di-resolve LAZY, hanya dipanggil ketika
   `requestedScope` benar-benar ada DAN caller menyediakan `hierarchyPort`;

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -525,20 +525,45 @@ fact whose scope is a genuine ancestor/descendant of the requested scope,
 not only an EXACT `(scopeType, scopeId)` equal one — e.g. a subject holding
 `business_scope_assignments.create` at a parent `organization_unit` can no
 longer be granted `.revoke` at a hierarchically-related child unit without
-tripping `business_scope_assignment_scope_maker_checker`. **Remaining, documented
-gap**: `checkHighRiskSoDConflicts` (`application/high-risk-sod-guard.ts`),
-the OTHER `same_scope_only` call site wired at the generic
+tripping `business_scope_assignment_scope_maker_checker`. **Gap at the OTHER
+`same_scope_only` call site — CLOSED by Issue #802**: `checkHighRiskSoDConflicts`
+(`application/high-risk-sod-guard.ts`), wired at the generic
 `authorizeInTransaction` chokepoint (used by ~124 route files for many
-modules, most with no hierarchy concept at all), has no hierarchy port
-plumbed in at all — it still compares `sodScopeType`/`sodScopeId` by exact
-equality only. Threading hierarchy resolution through that fully generic
-chokepoint (which would require every one of its many callers to supply a
-hierarchy port, or resolve one per-request, for scope types the vast
-majority of them don't even have) is a materially larger, non-atomic
-change deliberately left out of issue #794's scope — tracked in
-`docs/awcms-mini/20_threat_model_security_architecture.md`'s SoD threat
-table as a distinct residual limitation, not silently absorbed into this
-fix's claim.
+modules, most with no hierarchy concept at all), previously had no hierarchy
+port plumbed in at all and still compared `sodScopeType`/`sodScopeId` by
+exact equality only — the exact same gap #794 fixed for the create path,
+reachable here too (an actor holding `.revoke` via an ordinary RBAC role
+plus a business-scope `.create` fact at an ancestor unit could revoke a
+descendant-scope assignment without tripping the rule). Issue #802's
+investigation found the actual blast radius much narrower than "124 route
+files, all affected": of every caller of `authorizeInTransaction`, only
+ONE — `.../business-scope/assignments/[id]/revoke.ts` — has ever populated
+`resourceAttributes.sodScopeType`/`.sodScopeId` at all; every other caller
+always gets `requestedScope: null` from `extractRequestedScope`, which a
+`same_scope_only` rule already treats as `indeterminate: true`
+(default-deny) regardless of hierarchy — never a silent gap for those
+callers. The fix threads an OPTIONAL `hierarchyPort` parameter through
+`checkHighRiskSoDConflicts`/`authorizeInTransaction`, resolved LAZILY only
+when both a `requestedScope` is supplied and a `hierarchyPort` is passed —
+every other caller today passes neither, so behavior for them is
+byte-for-byte unchanged (zero new queries, zero regression risk across the
+other ~123 route files). Only `revoke.ts` now composes the real
+`BusinessScopeHierarchyPort` (the same `organization_structure` adapter
+composition `assignments/index.ts` already uses for the create path,
+factored into a shared
+`src/pages/api/v1/identity/business-scope/hierarchy-port-composition.ts`
+so both routes share one composition root) and passes it in. Because the
+detection gap itself is closed, the near-miss that previously generated
+ZERO telemetry (`sod_conflicts_detected_total` never fired since
+`detectSoDConflicts` found no match) now correctly fires through the
+SAME, already-existing `recordSoDConflictEvaluation`/counter call —
+satisfying #794's own "if not fixed directly, at minimum add monitoring"
+fallback without needing a separate metric. Proven end-to-end by the
+"Issue #802 adversarial" test in `tests/integration/business-scope-
+organization-structure-wiring.integration.test.ts` (create at a parent
+`organization_unit` + ordinary-RBAC `.revoke`, attempting to revoke a
+different subject's assignment at a child unit through THIS chokepoint —
+now `403 SOD_CONFLICT`, recorded with `trigger_context: "high_risk_decision"`).
 
 ### ABAC extension (`domain/access-control.ts`)
 
@@ -602,7 +627,11 @@ the realistic case of both conflicting permissions being held through an
 ordinary role like the setup wizard's "owner"). A cheap code-defined
 `Set` membership short-circuit (`SOD_RELEVANT_PERMISSION_KEYS`) means
 extending this chokepoint costs nothing measurable for the hundreds of
-endpoints this feature does not touch.
+endpoints this feature does not touch. `checkHighRiskSoDConflicts` also
+accepts an OPTIONAL `hierarchyPort` (Issue #802, see the "Hierarchy-aware
+SoD matching" section above) for hierarchy-aware `same_scope_only`
+matching — omitted by every caller except `revoke.ts` today, with
+byte-for-byte unchanged behavior when omitted.
 
 **Scope of "chokepoint" — accurate claim, not "every endpoint in this
 codebase".** `authorizeInTransaction` is used by 124 route files, but 13

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -528,15 +528,17 @@ longer be granted `.revoke` at a hierarchically-related child unit without
 tripping `business_scope_assignment_scope_maker_checker`. **Gap at the OTHER
 `same_scope_only` call site — CLOSED by Issue #802**: `checkHighRiskSoDConflicts`
 (`application/high-risk-sod-guard.ts`), wired at the generic
-`authorizeInTransaction` chokepoint (used by ~124 route files for many
-modules, most with no hierarchy concept at all), previously had no hierarchy
+`authorizeInTransaction` chokepoint (used by a large and growing number of
+route files across many modules, most with no hierarchy concept at all —
+re-grep `authorizeInTransaction` callers for the current count rather than
+trusting any number cited here), previously had no hierarchy
 port plumbed in at all and still compared `sodScopeType`/`sodScopeId` by
 exact equality only — the exact same gap #794 fixed for the create path,
 reachable here too (an actor holding `.revoke` via an ordinary RBAC role
 plus a business-scope `.create` fact at an ancestor unit could revoke a
 descendant-scope assignment without tripping the rule). Issue #802's
-investigation found the actual blast radius much narrower than "124 route
-files, all affected": of every caller of `authorizeInTransaction`, only
+investigation found the actual blast radius much narrower than the
+chokepoint's total fan-out suggests: of every caller of `authorizeInTransaction`, only
 ONE — `.../business-scope/assignments/[id]/revoke.ts` — has ever populated
 `resourceAttributes.sodScopeType`/`.sodScopeId` at all; every other caller
 always gets `requestedScope: null` from `extractRequestedScope`, which a

--- a/src/modules/identity-access/application/access-guard.ts
+++ b/src/modules/identity-access/application/access-guard.ts
@@ -1,6 +1,7 @@
 import type { AstroCookies } from "astro";
 
 import { fail } from "../../_shared/api-response";
+import type { BusinessScopeHierarchyPort } from "../../_shared/ports/business-scope-hierarchy-port";
 import {
   SESSION_COOKIE_NAME,
   TENANT_COOKIE_NAME
@@ -61,13 +62,21 @@ export type AuthorizeResult =
  * endpoints inline; it is centralized here so every guarded endpoint stays
  * consistent, always enforces tenant module state, and always records a
  * decision log.
+ *
+ * `options.hierarchyPort` (Issue #802) is OPTIONAL and forwarded verbatim to
+ * `checkHighRiskSoDConflicts` for hierarchy-aware `same_scope_only` SoD
+ * matching — see that function's own header for why this must stay
+ * optional (this file is imported by ~124 route files, only one of which,
+ * `revoke.ts`, has any hierarchy port to offer today). Every existing
+ * 5-argument call site is unaffected.
  */
 export async function authorizeInTransaction(
   tx: Bun.SQL,
   tenantId: string,
   tokenHash: string,
   now: Date,
-  guard: AccessRequest
+  guard: AccessRequest,
+  options?: { hierarchyPort?: BusinessScopeHierarchyPort }
 ): Promise<AuthorizeResult> {
   const context = await resolveTenantContext(tx, tenantId, tokenHash, now);
 
@@ -134,7 +143,8 @@ export async function authorizeInTransaction(
       tenantId,
       context,
       guard,
-      now
+      now,
+      options?.hierarchyPort
     );
 
     if (sodCheck.blocked) {

--- a/src/modules/identity-access/application/access-guard.ts
+++ b/src/modules/identity-access/application/access-guard.ts
@@ -66,8 +66,9 @@ export type AuthorizeResult =
  * `options.hierarchyPort` (Issue #802) is OPTIONAL and forwarded verbatim to
  * `checkHighRiskSoDConflicts` for hierarchy-aware `same_scope_only` SoD
  * matching — see that function's own header for why this must stay
- * optional (this file is imported by ~124 route files, only one of which,
- * `revoke.ts`, has any hierarchy port to offer today). Every existing
+ * optional (this file is imported by a large and growing number of route
+ * files, only one of which, `revoke.ts`, has any hierarchy port to offer
+ * today). Every existing
  * 5-argument call site is unaffected.
  */
 export async function authorizeInTransaction(

--- a/src/modules/identity-access/application/high-risk-sod-guard.ts
+++ b/src/modules/identity-access/application/high-risk-sod-guard.ts
@@ -76,8 +76,9 @@
  * because threading a real hierarchy port (`organization_structure`'s
  * adapter, needed to resolve `organization_unit`/`legal_entity` scopes) in
  * here directly would mean this shared `application` file — imported by
- * `access-guard.ts`, itself the chokepoint for ~124 unrelated route files —
- * importing an Optional module's code from Core, which
+ * `access-guard.ts`, itself the chokepoint for a large and growing number
+ * of unrelated route files (re-grep `authorizeInTransaction` callers for
+ * the current count) — importing an Optional module's code from Core, which
  * `business-scope-hierarchy-port-adapter.ts`'s own header and `module.ts`'s
  * `capabilities.consumes` entry both document as forbidden (ADR-0013 §1);
  * only a route (a real composition root) may choose which adapter to wire
@@ -85,13 +86,13 @@
  *
  * The fix threads an OPTIONAL `hierarchyPort` parameter through
  * `checkHighRiskSoDConflicts`/`authorizeInTransaction` instead of a
- * required one: when omitted (all but one of the ~124 callers today —
+ * required one: when omitted (every caller today except one —
  * `extractRequestedScope` returns `null` unless a caller populates
  * `resourceAttributes.sodScopeType`/`sodScopeId`, and only
  * `.../business-scope/assignments/[id]/revoke.ts` does), behavior is
  * byte-for-byte identical to before this issue — no new query, no new
- * import, no risk of regressing any of the other ~123 route files this
- * chokepoint serves. Only `revoke.ts` — the one caller that already sets
+ * import, no risk of regressing any of the chokepoint's other callers.
+ * Only `revoke.ts` — the one caller that already sets
  * `sodScopeType`/`sodScopeId` and is therefore the only real instance of
  * this gap today (verified: it is the sole caller of this chokepoint that
  * supplies a `requestedScope` at all) — now composes and passes the real
@@ -100,8 +101,9 @@
  * factored into `business-scope-hierarchy-port-composition.ts` so both
  * routes share one composition root instead of duplicating it), resolving
  * this scope's ancestors/descendants to populate `RequestedScope.relatedScopes`
- * the same way #794 already does for the create path. See
- * `tests/integration/high-risk-sod-guard-hierarchy.integration.test.ts`
+ * the same way #794 already does for the create path. See the "Issue #802
+ * adversarial" test in
+ * `tests/integration/business-scope-organization-structure-wiring.integration.test.ts`
  * for the adversarial proof: an actor holding `.create` at a parent
  * `organization_unit` can no longer `.revoke` an assignment at a
  * descendant unit without tripping

--- a/src/modules/identity-access/application/high-risk-sod-guard.ts
+++ b/src/modules/identity-access/application/high-risk-sod-guard.ts
@@ -67,9 +67,49 @@
  * "ordinary RBAC alone" test for the proof this now catches a conflict
  * held ENTIRELY through ordinary role grants, with no business-scope
  * assignment involved at all.
+ *
+ * **Hierarchy-aware `same_scope_only` matching at THIS chokepoint too
+ * (Issue #802, closing the residual gap Issue #794/PR #800 explicitly left
+ * open here).** PR #800 made `same_scope_only` matching hierarchy-aware
+ * only for `business-scope-assignment-service.ts`'s `createBusinessScopeAssignment`
+ * — this chokepoint kept doing exact `(scopeType, scopeId)` equality only,
+ * because threading a real hierarchy port (`organization_structure`'s
+ * adapter, needed to resolve `organization_unit`/`legal_entity` scopes) in
+ * here directly would mean this shared `application` file — imported by
+ * `access-guard.ts`, itself the chokepoint for ~124 unrelated route files —
+ * importing an Optional module's code from Core, which
+ * `business-scope-hierarchy-port-adapter.ts`'s own header and `module.ts`'s
+ * `capabilities.consumes` entry both document as forbidden (ADR-0013 §1);
+ * only a route (a real composition root) may choose which adapter to wire
+ * in for a given tenant.
+ *
+ * The fix threads an OPTIONAL `hierarchyPort` parameter through
+ * `checkHighRiskSoDConflicts`/`authorizeInTransaction` instead of a
+ * required one: when omitted (all but one of the ~124 callers today —
+ * `extractRequestedScope` returns `null` unless a caller populates
+ * `resourceAttributes.sodScopeType`/`sodScopeId`, and only
+ * `.../business-scope/assignments/[id]/revoke.ts` does), behavior is
+ * byte-for-byte identical to before this issue — no new query, no new
+ * import, no risk of regressing any of the other ~123 route files this
+ * chokepoint serves. Only `revoke.ts` — the one caller that already sets
+ * `sodScopeType`/`sodScopeId` and is therefore the only real instance of
+ * this gap today (verified: it is the sole caller of this chokepoint that
+ * supplies a `requestedScope` at all) — now composes and passes the real
+ * `BusinessScopeHierarchyPort` (same composition
+ * `business-scope/assignments/index.ts` already uses for the #794 path,
+ * factored into `business-scope-hierarchy-port-composition.ts` so both
+ * routes share one composition root instead of duplicating it), resolving
+ * this scope's ancestors/descendants to populate `RequestedScope.relatedScopes`
+ * the same way #794 already does for the create path. See
+ * `tests/integration/high-risk-sod-guard-hierarchy.integration.test.ts`
+ * for the adversarial proof: an actor holding `.create` at a parent
+ * `organization_unit` can no longer `.revoke` an assignment at a
+ * descendant unit without tripping
+ * `business_scope_assignment_scope_maker_checker` through THIS chokepoint.
  */
 import { listModules } from "../../index";
 import { recordCounter } from "../../../lib/observability/metrics-port";
+import type { BusinessScopeHierarchyPort } from "../../_shared/ports/business-scope-hierarchy-port";
 import type { AccessRequest, TenantContext } from "../domain/access-control";
 import { permissionKey } from "../domain/access-control";
 import {
@@ -122,13 +162,21 @@ function extractRequestedScope(guard: AccessRequest): RequestedScope | null {
  * function can only additionally DENY (deny-overrides-allow, never
  * upgrades a deny to an allow), consistent with `evaluateAccess`'s own
  * default-deny chain.
+ *
+ * `hierarchyPort` (Issue #802) is OPTIONAL and looked up LAZILY — only
+ * queried when both (a) `requestedScope` was actually supplied (true for
+ * exactly one caller today, `revoke.ts`) and (b) the cheap
+ * `SOD_RELEVANT_PERMISSION_KEYS` short-circuit above already passed — so
+ * every other caller of this chokepoint pays zero extra cost and sees zero
+ * behavior change, whether or not it ever passes a `hierarchyPort` at all.
  */
 export async function checkHighRiskSoDConflicts(
   tx: Bun.SQL,
   tenantId: string,
   context: TenantContext,
   guard: AccessRequest,
-  now: Date
+  now: Date,
+  hierarchyPort?: BusinessScopeHierarchyPort
 ): Promise<HighRiskSoDCheckResult> {
   const requestedPermissionKey = permissionKey(
     guard.moduleKey,
@@ -140,7 +188,32 @@ export async function checkHighRiskSoDConflicts(
     return { blocked: false };
   }
 
-  const requestedScope = extractRequestedScope(guard);
+  const extractedScope = extractRequestedScope(guard);
+  // Hierarchy-aware `same_scope_only` matching (Issue #802) — reuses the
+  // same `RequestedScope.relatedScopes` mechanism #794/PR #800 introduced
+  // for `createBusinessScopeAssignment`. `resolution.resolved === false`
+  // (unknown scope type, deleted scope, wrong tenant, or no `hierarchyPort`
+  // supplied at all) leaves `requestedScope` as exact-match-only, exactly
+  // today's pre-#802 behavior — never a crash, never a wider grant.
+  let requestedScope = extractedScope;
+  if (extractedScope && hierarchyPort) {
+    const resolution = await hierarchyPort.resolveScope(
+      tx,
+      tenantId,
+      extractedScope.scopeType,
+      extractedScope.scopeId
+    );
+    if (resolution.resolved) {
+      requestedScope = {
+        ...extractedScope,
+        relatedScopes: [
+          ...resolution.ancestorScopes,
+          ...resolution.descendantScopes
+        ]
+      };
+    }
+  }
+
   const subjectFacts = await resolveSoDAssignmentFacts(
     tx,
     tenantId,

--- a/src/pages/api/v1/identity/business-scope/assignments/[id]/revoke.ts
+++ b/src/pages/api/v1/identity/business-scope/assignments/[id]/revoke.ts
@@ -18,6 +18,10 @@ import {
   saveIdempotencyRecord
 } from "../../../../../../../modules/_shared/idempotency";
 import { revokeBusinessScopeAssignment } from "../../../../../../../modules/identity-access/application/business-scope-assignment-service";
+import {
+  buildBusinessScopeHierarchyPort,
+  resolveOrganizationStructureEnabled
+} from "../../hierarchy-port-composition";
 
 const IDEMPOTENCY_SCOPE = "identity_access_business_scope_assignment_revoke";
 
@@ -82,14 +86,37 @@ export const POST: APIRoute = async ({ request, cookies, locals, params }) => {
     `) as { scope_type: string; scope_id: string }[];
     const target = targetRows[0];
 
-    const auth = await authorizeInTransaction(tx, tenantId, tokenHash, now, {
-      moduleKey: "identity_access",
-      activityCode: "business_scope_assignments",
-      action: "revoke",
-      resourceAttributes: target
-        ? { sodScopeType: target.scope_type, sodScopeId: target.scope_id }
-        : undefined
-    });
+    // Hierarchy-aware `same_scope_only` SoD matching at this chokepoint too
+    // (Issue #802): this route is the ONLY caller of `authorizeInTransaction`
+    // that populates `sodScopeType`/`sodScopeId` today, so it is the sole
+    // real instance of the gap #794/PR #800 left open here — compose the
+    // same real `BusinessScopeHierarchyPort`
+    // `business-scope/assignments/index.ts` already uses for the create
+    // path, so a subject holding `.create` at a parent scope can no longer
+    // `.revoke` at a hierarchically-descendant scope without tripping
+    // `business_scope_assignment_scope_maker_checker`.
+    const organizationStructureEnabled =
+      await resolveOrganizationStructureEnabled(tx, tenantId);
+
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      {
+        moduleKey: "identity_access",
+        activityCode: "business_scope_assignments",
+        action: "revoke",
+        resourceAttributes: target
+          ? { sodScopeType: target.scope_type, sodScopeId: target.scope_id }
+          : undefined
+      },
+      {
+        hierarchyPort: buildBusinessScopeHierarchyPort(
+          organizationStructureEnabled
+        )
+      }
+    );
 
     if (!auth.allowed) {
       return auth.denied;

--- a/src/pages/api/v1/identity/business-scope/assignments/index.ts
+++ b/src/pages/api/v1/identity/business-scope/assignments/index.ts
@@ -12,75 +12,24 @@ import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../../../modules/identity-access/application/access-guard";
-import { resolveModuleEnabled } from "../../../../../../modules/identity-access/application/auth-context";
 import {
   computeRequestHash,
   findIdempotencyRecord,
   saveIdempotencyRecord
 } from "../../../../../../modules/_shared/idempotency";
-import { defaultBusinessScopeHierarchyPortAdapter } from "../../../../../../modules/identity-access/application/business-scope-hierarchy-port-adapter";
-import { organizationStructureHierarchyPortAdapter } from "../../../../../../modules/organization-structure/application/organization-structure-hierarchy-port-adapter";
-import type { BusinessScopeHierarchyPort } from "../../../../../../modules/_shared/ports/business-scope-hierarchy-port";
 import {
   createBusinessScopeAssignment,
   listBusinessScopeAssignments
 } from "../../../../../../modules/identity-access/application/business-scope-assignment-service";
 import { collectSoDRuleDescriptors } from "../../../../../../modules/identity-access/domain/sod-rule-registry";
 import { listModules } from "../../../../../../modules";
+import {
+  buildBusinessScopeHierarchyPort,
+  resolveOrganizationStructureEnabled
+} from "../hierarchy-port-composition";
 
 const IDEMPOTENCY_SCOPE = "identity_access_business_scope_assignment_create";
 const SOD_RULES = collectSoDRuleDescriptors(listModules());
-const ORGANIZATION_STRUCTURE_MODULE_KEY = "organization_structure";
-
-/**
- * The REAL `BusinessScopeHierarchyPort` composition (Issue #786, follow-up
- * to #746/#749 — the reviewer's non-blocking note on PR #779 that
- * `organizationStructureHierarchyPortAdapter` had zero production callers).
- * This route is the sole composition root for `createBusinessScopeAssignment`
- * today (`identity_access`'s own `application`/`domain` tree never imports
- * `organization_structure` — that would be a Core-depends-on-Optional
- * violation, ADR-0013 §1 — and is exactly what
- * `tests/unit/module-boundary-cycles.test.ts` structurally forbids).
- *
- * `organizationStructureEnabled` is resolved PER TENANT
- * (`resolveModuleEnabled`, the same tenant-module-enablement signal
- * `authorizeInTransaction` already enforces for every guarded endpoint,
- * Issue #515) — when `organization_structure` is disabled for this tenant,
- * `legal_entity`/`organization_unit` scope references are treated exactly
- * like any other scope type this module doesn't own: `resolved: false`,
- * default-deny, never a stale read of leftover rows from a module the
- * tenant has turned off. When enabled, the real adapter is tried FIRST;
- * since it already returns `resolved: false` for any scope type it doesn't
- * own (`"office"` included), falling through to identity-access's own flat
- * adapter is always safe — neither adapter needs to know the other exists.
- */
-function buildHierarchyPort(
-  organizationStructureEnabled: boolean
-): BusinessScopeHierarchyPort {
-  return {
-    async resolveScope(tx, tenantId, scopeType, scopeId) {
-      if (organizationStructureEnabled) {
-        const organizationResolution =
-          await organizationStructureHierarchyPortAdapter.resolveScope(
-            tx,
-            tenantId,
-            scopeType,
-            scopeId
-          );
-        if (organizationResolution.resolved) {
-          return organizationResolution;
-        }
-      }
-
-      return defaultBusinessScopeHierarchyPortAdapter.resolveScope(
-        tx,
-        tenantId,
-        scopeType,
-        scopeId
-      );
-    }
-  };
-}
 
 /** `GET /api/v1/identity/business-scope/assignments` (Issue #746) — list this tenant's business-scope assignments, optionally filtered by `status`/`tenantUserId`/`scopeType`. */
 export const GET: APIRoute = async ({ request, cookies, url }) => {
@@ -229,11 +178,8 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
       });
     }
 
-    const organizationStructureEnabled = await resolveModuleEnabled(
-      tx,
-      tenantId,
-      ORGANIZATION_STRUCTURE_MODULE_KEY
-    );
+    const organizationStructureEnabled =
+      await resolveOrganizationStructureEnabled(tx, tenantId);
 
     const result = await createBusinessScopeAssignment(
       tx,
@@ -250,7 +196,9 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
         reason
       },
       {
-        hierarchyPort: buildHierarchyPort(organizationStructureEnabled),
+        hierarchyPort: buildBusinessScopeHierarchyPort(
+          organizationStructureEnabled
+        ),
         sodRules: SOD_RULES
       },
       now,

--- a/src/pages/api/v1/identity/business-scope/hierarchy-port-composition.ts
+++ b/src/pages/api/v1/identity/business-scope/hierarchy-port-composition.ts
@@ -1,0 +1,57 @@
+import { resolveModuleEnabled } from "../../../../../modules/identity-access/application/auth-context";
+import { defaultBusinessScopeHierarchyPortAdapter } from "../../../../../modules/identity-access/application/business-scope-hierarchy-port-adapter";
+import { organizationStructureHierarchyPortAdapter } from "../../../../../modules/organization-structure/application/organization-structure-hierarchy-port-adapter";
+import type { BusinessScopeHierarchyPort } from "../../../../../modules/_shared/ports/business-scope-hierarchy-port";
+
+const ORGANIZATION_STRUCTURE_MODULE_KEY = "organization_structure";
+
+/**
+ * The REAL `BusinessScopeHierarchyPort` composition (Issue #786, follow-up
+ * to #746/#749; factored out of `assignments/index.ts` by Issue #802 so
+ * `assignments/[id]/revoke.ts` can share the exact same composition root
+ * instead of duplicating it). `identity_access`'s own `application`/`domain`
+ * tree never imports `organization_structure` — that would be a
+ * Core-depends-on-Optional violation, ADR-0013 §1 — so only a route (a
+ * real composition root, this file's callers) may decide which adapter to
+ * wire in for a given tenant.
+ *
+ * The real adapter is tried FIRST when `organization_structure` is enabled
+ * for this tenant; since it already returns `resolved: false` for any
+ * scope type it doesn't own (`"office"` included), falling through to
+ * identity-access's own flat adapter is always safe.
+ */
+export function buildBusinessScopeHierarchyPort(
+  organizationStructureEnabled: boolean
+): BusinessScopeHierarchyPort {
+  return {
+    async resolveScope(tx, tenantId, scopeType, scopeId) {
+      if (organizationStructureEnabled) {
+        const organizationResolution =
+          await organizationStructureHierarchyPortAdapter.resolveScope(
+            tx,
+            tenantId,
+            scopeType,
+            scopeId
+          );
+        if (organizationResolution.resolved) {
+          return organizationResolution;
+        }
+      }
+
+      return defaultBusinessScopeHierarchyPortAdapter.resolveScope(
+        tx,
+        tenantId,
+        scopeType,
+        scopeId
+      );
+    }
+  };
+}
+
+/** Resolves whether `organization_structure` is enabled for `tenantId`, the input `buildBusinessScopeHierarchyPort` needs — thin wrapper kept here so both composition-root routes call it identically. */
+export async function resolveOrganizationStructureEnabled(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<boolean> {
+  return resolveModuleEnabled(tx, tenantId, ORGANIZATION_STRUCTURE_MODULE_KEY);
+}

--- a/tests/integration/business-scope-organization-structure-wiring.integration.test.ts
+++ b/tests/integration/business-scope-organization-structure-wiring.integration.test.ts
@@ -58,6 +58,7 @@ import {
   GET as listAssignments,
   POST as createAssignment
 } from "../../src/pages/api/v1/identity/business-scope/assignments/index";
+import { POST as revokeAssignment } from "../../src/pages/api/v1/identity/business-scope/assignments/[id]/revoke";
 import { POST as disableModule } from "../../src/pages/api/v1/tenant/modules/[moduleKey]/disable";
 import { hashPassword } from "../../src/lib/auth/password";
 
@@ -171,6 +172,24 @@ async function createSecondTenantUser(
   }
 
   return tenantUserRows[0]!.id;
+}
+
+async function loginAsSecondTenantUser(
+  tenantId: string,
+  loginIdentifier: string
+): Promise<{ token: string }> {
+  const login = await invoke<{ data: { token: string } }>(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId
+    },
+    body: { loginIdentifier, password: SECOND_USER_PASSWORD },
+    cookies: createCookieJar()
+  });
+  expect(login.status).toBe(200);
+  return { token: login.body.data.token };
 }
 
 async function createRoleWithPermissions(
@@ -574,6 +593,148 @@ suite(
 
       expect(result.status).toBe(200);
       expect(result.body.data.assignment.scopeType).toBe("office");
+    });
+
+    test("Issue #802 adversarial: hierarchy-aware same_scope_only matching now also trips at the checkHighRiskSoDConflicts CHOKEPOINT (POST .../assignments/{id}/revoke), not only at assignment-create time — an actor holding create at a parent organization_unit (via a business-scope assignment) plus revoke via ordinary RBAC can no longer revoke a DIFFERENT subject's assignment at a descendant unit", async () => {
+      const owner = await bootstrap();
+      const { legalEntityId, unitId: parentUnitId } =
+        await seedLegalEntityWithUnit(owner.tenantId);
+      const childUnitId = await seedChildUnit(
+        owner.tenantId,
+        legalEntityId,
+        parentUnitId
+      );
+      const admin = getAdminSql();
+
+      // The ACTOR starts with NO role at all, so granting them `.create`
+      // at the parent unit below does not itself collide with anything
+      // (a null-scope RBAC fact would ALREADY conflict with a same-scope
+      // grant at ANY scope, per `sod-conflict-evaluation.ts`'s own
+      // "null-scope fact conflicts everywhere" rule — unrelated to this
+      // issue's hierarchy gap, and not what this test is proving).
+      const actorId = await createSecondTenantUser(
+        owner.tenantId,
+        "acme-chokepoint-actor@example.com"
+      );
+
+      const creatorRole = await createRoleWithPermissions(
+        owner.tenantId,
+        "org_chokepoint_creator",
+        "Org Chokepoint Creator",
+        ["identity_access.business_scope_assignments.create"]
+      );
+      const actorCreateGrant = await invoke<{
+        data: { assignment: { id: string } };
+      }>(createAssignment, {
+        method: "POST",
+        path: "/api/v1/identity/business-scope/assignments",
+        headers: authHeaders(owner, "org-chokepoint-actor-grant"),
+        body: {
+          tenantUserId: actorId,
+          roleId: creatorRole,
+          scopeType: "organization_unit",
+          scopeId: parentUnitId
+        }
+      });
+      expect(actorCreateGrant.status).toBe(200);
+
+      // ONLY AFTER the actor already holds the scoped `.create` fact above
+      // is `.revoke` granted PERMANENTLY via an ordinary RBAC role —
+      // exactly the issue's own narrative ("an actor holding an ordinary
+      // RBAC `.revoke`-type permission plus a business-scope `.create`
+      // fact"). An ordinary role assignment (`awcms_mini_access_
+      // assignments`) is never itself SoD-gated (only the discrete
+      // business-scope-assignment create/revoke actions are), so this step
+      // is a plain admin-seeded grant, not a bypass of anything.
+      const revokerRole = await createRoleWithPermissions(
+        owner.tenantId,
+        "org_chokepoint_revoker",
+        "Org Chokepoint Revoker",
+        ["identity_access.business_scope_assignments.revoke"]
+      );
+      await admin`
+        INSERT INTO awcms_mini_access_assignments (tenant_id, tenant_user_id, role_id)
+        VALUES (${owner.tenantId}, ${actorId}, ${revokerRole})
+      `;
+      const actorSession = await loginAsSecondTenantUser(
+        owner.tenantId,
+        "acme-chokepoint-actor@example.com"
+      );
+
+      // The TARGET: a DIFFERENT subject's assignment at the CHILD unit —
+      // any role, since only its `(scopeType, scopeId)` matters to the SoD
+      // check, not what it grants.
+      const victimId = await createSecondTenantUser(
+        owner.tenantId,
+        "acme-chokepoint-victim@example.com"
+      );
+      const targetAssignment = await invoke<{
+        data: { assignment: { id: string } };
+      }>(createAssignment, {
+        method: "POST",
+        path: "/api/v1/identity/business-scope/assignments",
+        headers: authHeaders(owner, "org-chokepoint-target"),
+        body: {
+          tenantUserId: victimId,
+          scopeType: "organization_unit",
+          scopeId: childUnitId,
+          reason: "Target assignment for the #802 chokepoint adversarial test."
+        }
+      });
+      expect(targetAssignment.status).toBe(200);
+
+      // Before Issue #802: `checkHighRiskSoDConflicts` only ever compared
+      // `(scopeType, scopeId)` by EXACT equality, so `parentUnitId !==
+      // childUnitId` meant no conflict was ever detected here, and this
+      // revoke would have succeeded (200) despite the actor holding
+      // `.create` at the target's own ancestor unit. After the fix, the
+      // chokepoint resolves the target's ancestor/descendant scopes
+      // through the real `organization_structure` hierarchy adapter and
+      // finds the actor's `.create` fact among them — a genuine
+      // `same_scope_only` conflict, denied.
+      const revokeAttempt = await invoke(revokeAssignment, {
+        method: "POST",
+        path: `/api/v1/identity/business-scope/assignments/${targetAssignment.body.data.assignment.id}/revoke`,
+        headers: {
+          ...authHeaders(owner, "org-chokepoint-revoke-attempt"),
+          authorization: `Bearer ${actorSession.token}`
+        },
+        params: { id: targetAssignment.body.data.assignment.id },
+        body: { revokeReason: "Attempting cross-hierarchy revoke." }
+      });
+
+      expect(revokeAttempt.status).toBe(403);
+      expect(
+        (revokeAttempt.body as { error: { code: string } }).error.code
+      ).toBe("SOD_CONFLICT");
+
+      // The target assignment is untouched (still active) and the
+      // conflict evaluation was recorded against the real chokepoint's own
+      // `trigger_context` — proving `sod_conflicts_detected_total` (and
+      // `recordSoDConflictEvaluation`) now DO fire for this near-miss,
+      // closing the zero-telemetry gap Issue #802 also reported.
+      const targetRow = (await admin`
+        SELECT status FROM awcms_mini_business_scope_assignments
+        WHERE id = ${targetAssignment.body.data.assignment.id}
+      `) as { status: string }[];
+      expect(targetRow[0]!.status).toBe("active");
+
+      const evaluations = (await admin`
+        SELECT conflict_detected, resolved_via, trigger_context
+        FROM awcms_mini_sod_conflict_evaluations
+        WHERE tenant_id = ${owner.tenantId}
+          AND rule_key = 'identity_access.business_scope_assignment_scope_maker_checker'
+          AND trigger_context = 'high_risk_decision'
+      `) as {
+        conflict_detected: boolean;
+        resolved_via: string;
+        trigger_context: string;
+      }[];
+      expect(evaluations.length).toBeGreaterThan(0);
+      expect(evaluations.every((row) => row.conflict_detected)).toBe(true);
+      expect(evaluations.every((row) => row.resolved_via === "denied")).toBe(
+        true
+      );
     });
   }
 );


### PR DESCRIPTION
## Summary

Closes #802

PR #800 (Issue #794) made `detectSoDConflicts`'s `same_scope_only` matching
hierarchy-aware only for `createBusinessScopeAssignment`. The OTHER
`same_scope_only` call site, `checkHighRiskSoDConflicts`
(`src/modules/identity-access/application/high-risk-sod-guard.ts`), wired at
the generic `authorizeInTransaction` chokepoint used by ~124 route files,
still compared `sodScopeType`/`sodScopeId` by exact equality only — the same
gap #794 fixed for the create path, reachable here too (an actor holding
`.revoke` via an ordinary RBAC role plus a business-scope `.create` fact at
an ancestor unit could revoke a descendant-scope assignment without
tripping `business_scope_assignment_scope_maker_checker`). Because
`detectSoDConflicts` found no match in that near-miss, it also produced
ZERO telemetry, contradicting #794's own explicit "if not fixed, at least
add monitoring" fallback.

**Chosen approach**: threading hierarchy resolution into the chokepoint
(the issue's option 1), made safe by first checking the actual blast
radius. Of all callers of `authorizeInTransaction`, only ONE —
`.../business-scope/assignments/[id]/revoke.ts` — has ever populated
`resourceAttributes.sodScopeType`/`.sodScopeId`; every other caller already
gets `requestedScope: null`, which a `same_scope_only` rule already treats
as `indeterminate: true` (default-deny), not a silent gap. So instead of a
required hierarchy-port dependency threaded through all ~124 callers, this
adds an OPTIONAL `hierarchyPort` parameter to
`checkHighRiskSoDConflicts`/`authorizeInTransaction`, resolved LAZILY only
when both a `requestedScope` is supplied and a `hierarchyPort` is passed.
Every caller except `revoke.ts` passes neither, so behavior is
byte-for-byte unchanged there — zero new queries, zero regression risk.
Only `revoke.ts` now composes the real `BusinessScopeHierarchyPort` (the
same `organization_structure` adapter composition
`assignments/index.ts` already uses for the create path, factored into a
shared `hierarchy-port-composition.ts` so both routes share one
composition root instead of duplicating it) and passes it in.

Since the detection gap is closed at the source, the previously-silent
near-miss now correctly fires the already-existing
`recordSoDConflictEvaluation`/`sod_conflicts_detected_total` — no separate
monitoring code needed to satisfy #794's fallback requirement.

## Changes

- `src/modules/identity-access/application/high-risk-sod-guard.ts` —
  optional `hierarchyPort` param, lazy hierarchy resolution into
  `RequestedScope.relatedScopes`.
- `src/modules/identity-access/application/access-guard.ts` — optional
  `options.hierarchyPort` threaded through `authorizeInTransaction`,
  forwarded to the SoD check.
- `src/pages/api/v1/identity/business-scope/hierarchy-port-composition.ts`
  (new) — shared composition root factored out of
  `assignments/index.ts`, now also used by `assignments/[id]/revoke.ts`.
- `src/pages/api/v1/identity/business-scope/assignments/index.ts` — uses
  the shared composition helper (no behavior change).
- `src/pages/api/v1/identity/business-scope/assignments/[id]/revoke.ts` —
  composes and passes the real hierarchy port, closing the gap.
- `tests/integration/business-scope-organization-structure-wiring.integration.test.ts`
  — new adversarial test proving the fix through the real endpoint.
- `docs/awcms-mini/20_threat_model_security_architecture.md` and
  `src/modules/identity-access/README.md` — residual-gap entry updated to
  reflect closure.
- New changeset.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` (full suite, isolated Postgres DB) — 4594 pass, 8 skip, 0
      fail, 19571 expect() calls across 4602 tests / 318 files
- [x] `bun run build`
- [x] New adversarial integration test: actor holds `.create` at a parent
      `organization_unit` (business-scope assignment) + `.revoke`
      permanently via ordinary RBAC → attempting to revoke a DIFFERENT
      subject's assignment at a hierarchy-descendant unit through
      `POST .../assignments/{id}/revoke` is now `403 SOD_CONFLICT`,
      recorded with `trigger_context: "high_risk_decision"`.
- [x] `bun run lint` (prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)