### PR TITLE
chore(codeql): close 2 unused-local-variable coverage gaps

### DIFF
--- a/.changeset/codeql-unused-local-variable-807.md
+++ b/.changeset/codeql-unused-local-variable-807.md
@@ -1,0 +1,22 @@
+---
+"awcms-mini": patch
+---
+
+Fix 2 open CodeQL `js/unused-local-variable` alerts (#52, #53) by closing the
+real coverage gaps they flagged, instead of just deleting the unused import:
+
+- `tests/integration/reference-data.integration.test.ts`: the imported
+  `listValueSets` (`GET /api/v1/reference-data/value-sets`) handler was never
+  called — the test titled "create, list, deprecate" only ever exercised the
+  codes-within-a-value-set list, not the value-set-level list endpoint or its
+  `status`/`scope` filters. Added assertions that the created value set
+  appears in the list, and that `status=active`/`status=deprecated` correctly
+  include/exclude it after deprecation.
+- `tests/integration/integration-hub.integration.test.ts`: the imported
+  `listSubscriptions` (`GET /api/v1/integration-hub/subscriptions`) handler
+  was never called — the end-to-end worker-role test created a subscription
+  and verified dispatch via raw SQL, but never exercised the real REST list
+  endpoint. Added an assertion that the created subscription appears in the
+  list with the correct `targetAdapterKey`.
+
+No application code changed — test-only.

--- a/tests/integration/integration-hub.integration.test.ts
+++ b/tests/integration/integration-hub.integration.test.ts
@@ -627,6 +627,21 @@ suite("integration_hub (Issue #754)", () => {
         });
         expect(subscriptionResult.status).toBe(200);
 
+        const subscriptionListResult = await invoke<{
+          data: { subscriptions: { id: string; targetAdapterKey: string }[] };
+        }>(listSubscriptions, {
+          method: "GET",
+          path: "/api/v1/integration-hub/subscriptions",
+          headers: authHeaders(owner)
+        });
+        expect(subscriptionListResult.status).toBe(200);
+        expect(
+          subscriptionListResult.body.data.subscriptions.map((s) => s.id)
+        ).toContain(subscriptionResult.body.data.subscription.id);
+        expect(
+          subscriptionListResult.body.data.subscriptions[0]!.targetAdapterKey
+        ).toBe("generic_http_webhook");
+
         const payload = { hello: "world" };
         const rawBody = JSON.stringify(payload);
         const timestamp = String(Math.floor(Date.now() / 1000));

--- a/tests/integration/reference-data.integration.test.ts
+++ b/tests/integration/reference-data.integration.test.ts
@@ -259,6 +259,18 @@ suite("reference_data integration", () => {
     expect(list.status).toBe(200);
     expect(list.body.data.codes.map((c) => c.code)).toEqual(["IDR"]);
 
+    const valueSetList = await invoke<{
+      data: { valueSets: { key: string; status: string }[] };
+    }>(listValueSets, {
+      method: "GET",
+      path: "/api/v1/reference-data/value-sets",
+      headers: authHeaders(owner)
+    });
+    expect(valueSetList.status).toBe(200);
+    expect(
+      valueSetList.body.data.valueSets.find((v) => v.key === "currency")?.status
+    ).toBe("active");
+
     const key = idKey();
     const deprecate1 = await invoke(deprecateValueSet, {
       method: "DELETE",
@@ -308,6 +320,32 @@ suite("reference_data integration", () => {
     `) as { deprecated_at: Date | null }[];
     expect(rows).toHaveLength(1);
     expect(rows[0]!.deprecated_at).not.toBeNull();
+
+    // `status` filter on the list endpoint reflects the deprecation: gone
+    // from `active`, present under `deprecated`.
+    const activeAfter = await invoke<{
+      data: { valueSets: { key: string }[] };
+    }>(listValueSets, {
+      method: "GET",
+      path: "/api/v1/reference-data/value-sets?status=active",
+      headers: authHeaders(owner)
+    });
+    expect(activeAfter.status).toBe(200);
+    expect(activeAfter.body.data.valueSets.map((v) => v.key)).not.toContain(
+      "currency"
+    );
+
+    const deprecatedAfter = await invoke<{
+      data: { valueSets: { key: string }[] };
+    }>(listValueSets, {
+      method: "GET",
+      path: "/api/v1/reference-data/value-sets?status=deprecated",
+      headers: authHeaders(owner)
+    });
+    expect(deprecatedAfter.status).toBe(200);
+    expect(deprecatedAfter.body.data.valueSets.map((v) => v.key)).toContain(
+      "currency"
+    );
   });
 
   test("tenant override policy gate: 'none' forbids both override and extension via the real endpoint", async () => {

--- a/tests/integration/reference-data.integration.test.ts
+++ b/tests/integration/reference-data.integration.test.ts
@@ -271,6 +271,22 @@ suite("reference_data integration", () => {
       valueSetList.body.data.valueSets.find((v) => v.key === "currency")?.status
     ).toBe("active");
 
+    // `status=active` genuinely INCLUDES `currency` while it's still
+    // active (checked here, before deprecation below) -- the later
+    // post-deprecation check only proves the EXCLUDE side, so both
+    // directions of the filter need a check at their own point in time.
+    const activeBefore = await invoke<{
+      data: { valueSets: { key: string }[] };
+    }>(listValueSets, {
+      method: "GET",
+      path: "/api/v1/reference-data/value-sets?status=active",
+      headers: authHeaders(owner)
+    });
+    expect(activeBefore.status).toBe(200);
+    expect(activeBefore.body.data.valueSets.map((v) => v.key)).toContain(
+      "currency"
+    );
+
     const key = idKey();
     const deprecate1 = await invoke(deprecateValueSet, {
       method: "DELETE",


### PR DESCRIPTION
## Summary

Fixes the 2 currently-open CodeQL code-scanning alerts:

- Alert #52: `js/unused-local-variable` — `listValueSets` unused import in
  `tests/integration/reference-data.integration.test.ts:28`
- Alert #53: `js/unused-local-variable` — `listSubscriptions` unused import
  in `tests/integration/integration-hub.integration.test.ts:40`

Per the `awcms-mini-codeql-triage` skill's documented pattern ("this rule
sometimes flags a genuine coverage gap in test files, not dead code"), I
checked whether each unused import matched a capability the test suite
already claimed to cover before deleting it. Both were real gaps:

- `listValueSets` (`GET /api/v1/reference-data/value-sets`): the test titled
  "create, **list**, deprecate" only ever called `listCodes` (codes *within*
  a value set), never the value-set-level list endpoint or its `status`/
  `scope` query-param filters. Added assertions that the created value set
  appears in the list, and that `status=active`/`status=deprecated` correctly
  include/exclude it after deprecation.
- `listSubscriptions` (`GET /api/v1/integration-hub/subscriptions`): the
  least-privilege-worker-role end-to-end test created a subscription and
  verified dispatch entirely via raw SQL against the DB tables, never through
  the real REST list endpoint. Added an assertion that the created
  subscription appears in the list with the correct `targetAdapterKey`.

No application code changed — test-only, and both fixes close real coverage
gaps rather than just satisfying the linter.

Closes #807

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run check` locally — 3573 pass / 0 fail / build succeeds
      (integration tests are skipped locally without `DATABASE_URL`; CI's
      Quality job runs them against a real Postgres service container).
- [ ] CI's Quality job (real integration test run) — pending.
- [ ] CodeQL re-scan confirms alerts #52/#53 move to `fixed` — pending.
- [ ] reviewer + security-auditor pass — next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)