### PR TITLE
fix(release): changeset-policy-check.ts crashes with ENOENT on a release-consumption PR

### DIFF
--- a/.changeset/changeset-policy-check-deleted-files-crash-810.md
+++ b/.changeset/changeset-policy-check-deleted-files-crash-810.md
@@ -1,0 +1,12 @@
+---
+"awcms-mini": patch
+---
+
+Fix `scripts/changeset-policy-check.ts` crashing with `ENOENT` on any
+release-consumption PR (Issue #810). `git diff --name-only` doesn't
+distinguish added vs. deleted paths, so the changed-`.changeset/*.md`-file
+detection included paths deleted by the PR (e.g. consumed changesets removed
+by `bun run changeset:version`), then tried to read their content for
+frontmatter validation and crashed. Now cross-references
+`git diff --name-only --diff-filter=D` and skips frontmatter validation for
+deleted paths instead of erroring.

--- a/.changeset/changeset-policy-check-deleted-files-crash-810.md
+++ b/.changeset/changeset-policy-check-deleted-files-crash-810.md
@@ -7,6 +7,18 @@ release-consumption PR (Issue #810). `git diff --name-only` doesn't
 distinguish added vs. deleted paths, so the changed-`.changeset/*.md`-file
 detection included paths deleted by the PR (e.g. consumed changesets removed
 by `bun run changeset:version`), then tried to read their content for
-frontmatter validation and crashed. Now cross-references
-`git diff --name-only --diff-filter=D` and skips frontmatter validation for
-deleted paths instead of erroring.
+frontmatter validation and crashed.
+
+The first fix attempt (skip frontmatter validation for deleted paths) had a
+security side effect a review pass caught before merge: it made the
+pre-existing "any touched `.changeset/*.md` path counts as satisfied" logic
+silently PASS a PR that *deletes* an existing pending changeset instead of
+adding a new one, converting an accidental crash (fail-closed) into a
+silent bypass (fail-open) of the "changeset required" gate. Replaced with a
+narrow, content-verified release-consumption carve-out: the requirement is
+waived only when a `.changeset/*.md` file was genuinely deleted, the ONLY
+non-exempt file touched is `package.json`, and that file's diff changes
+nothing but its `version` field (verified via `git show` on both sides,
+failing closed on any ambiguity). Added a CLI-level regression suite that
+spawns the real script against disposable git repos to exercise this
+wiring directly, including a reproduction of the exploit confirmed blocked.

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -145,7 +145,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 
 ## Tests
 
-327 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
+328 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
 
 | Directory     | Test files |
 | ------------- | ---------- |
@@ -153,7 +153,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 | `e2e`         | 9          |
 | `integration` | 96         |
 | `modules`     | 5          |
-| `unit`        | 171        |
+| `unit`        | 172        |
 
 ## Routes / Operations (summary)
 

--- a/scripts/changeset-policy-check.ts
+++ b/scripts/changeset-policy-check.ts
@@ -33,8 +33,10 @@
 export type ChangesetPolicyResult = {
   requiresChangeset: boolean;
   changesetFilesAdded: string[];
+  changesetFilesDeleted: string[];
   nonExemptFiles: string[];
   violation: string | null;
+  isReleaseConsumption: boolean;
 };
 
 export type ChangesetFrontmatterResult = {
@@ -72,18 +74,55 @@ function isExempt(file: string): boolean {
 }
 
 /**
+ * The ONLY non-exempt path a genuine `bun run changeset:version`
+ * release-consumption commit ever touches (`CHANGELOG.md` is already
+ * exempt via `/\.md$/`, `.changeset/*.md` deletions are already exempt via
+ * `/^\.changeset\//`). Deliberately a single hardcoded path, not a
+ * pattern — see `evaluateChangesetPolicy`'s release-consumption carve-out
+ * below for why this must stay narrow.
+ */
+const RELEASE_CONSUMPTION_NON_EXEMPT_FILE = "package.json";
+
+/**
  * Pure decision function — takes the PR's changed-file list (repo-relative
- * paths, as `git diff --name-only` reports them) and decides whether a new
- * changeset was required and, if so, whether one was actually added.
+ * paths, as `git diff --name-only` reports them), which of those were
+ * DELETED (`git diff --diff-filter=D`), and whether `package.json`'s diff
+ * (if touched) changes ONLY its `version` field — and decides whether a
+ * new changeset was required and, if so, whether one was actually added.
+ *
+ * SECURITY (Issue #810 follow-up, security-auditor Critical on PR #811's
+ * first attempt): a naive "any `.changeset/*.md` path touched" check
+ * (added OR deleted) lets a PR satisfy the policy by DELETING an existing,
+ * still-pending changeset instead of adding a new one — silently bypassing
+ * the "changeset required" gate for a real behavior change. The only
+ * legitimate reason to have zero genuinely-ADDED changesets while
+ * genuinely-DELETING one or more is a release-consumption commit, which is
+ * narrowly and verifiably characterized by: (a) the only non-exempt file
+ * touched is `package.json`, AND (b) that file's diff changes nothing but
+ * its `version` field (not `scripts`/`dependencies`/anything else that
+ * would itself need its own changeset), AND (c) at least one
+ * `.changeset/*.md` file was actually deleted (proving real consumption
+ * happened, not just a hand-edited version bump). All three must hold —
+ * dropping any one of them re-opens the exact bypass this comment
+ * describes.
  */
 export function evaluateChangesetPolicy(
-  changedFiles: string[]
+  changedFiles: string[],
+  deletedFiles: Iterable<string> = [],
+  packageJsonVersionOnlyChange = false
 ): ChangesetPolicyResult {
-  const changesetFilesAdded = changedFiles.filter(
+  const deletedSet = new Set(deletedFiles);
+  const changesetFilesTouched = changedFiles.filter(
     (file) =>
       file.startsWith(".changeset/") &&
       file.endsWith(".md") &&
       file !== ".changeset/README.md"
+  );
+  const changesetFilesAdded = changesetFilesTouched.filter(
+    (file) => !deletedSet.has(file)
+  );
+  const changesetFilesDeleted = changesetFilesTouched.filter((file) =>
+    deletedSet.has(file)
   );
 
   const nonExemptFiles = changedFiles.filter((file) => !isExempt(file));
@@ -93,8 +132,27 @@ export function evaluateChangesetPolicy(
     return {
       requiresChangeset,
       changesetFilesAdded,
+      changesetFilesDeleted,
       nonExemptFiles,
-      violation: null
+      violation: null,
+      isReleaseConsumption: false
+    };
+  }
+
+  const isReleaseConsumption =
+    changesetFilesDeleted.length > 0 &&
+    nonExemptFiles.length === 1 &&
+    nonExemptFiles[0] === RELEASE_CONSUMPTION_NON_EXEMPT_FILE &&
+    packageJsonVersionOnlyChange;
+
+  if (isReleaseConsumption) {
+    return {
+      requiresChangeset,
+      changesetFilesAdded,
+      changesetFilesDeleted,
+      nonExemptFiles,
+      violation: null,
+      isReleaseConsumption: true
     };
   }
 
@@ -104,6 +162,7 @@ export function evaluateChangesetPolicy(
   return {
     requiresChangeset,
     changesetFilesAdded,
+    changesetFilesDeleted,
     nonExemptFiles,
     violation:
       `PR ini mengubah ${nonExemptFiles.length} file yang bukan docs/agent-tooling ` +
@@ -111,7 +170,8 @@ export function evaluateChangesetPolicy(
       `changeset (bun run changeset) yang menjelaskan tingkat bump SemVer + ringkasan ` +
       `perubahan — lihat docs/awcms-mini/09_roadmap_repository_commit.md §Versioning ` +
       "dengan Changesets, atau jika perubahan ini murni docs/chore, konfirmasi tidak " +
-      "ada file lain yang keliru ikut ter-stage."
+      "ada file lain yang keliru ikut ter-stage.",
+    isReleaseConsumption: false
   };
 }
 
@@ -196,9 +256,11 @@ async function getChangedFiles(baseRef: string): Promise<string[]> {
 /**
  * `git diff --name-only` doesn't distinguish added/modified/deleted paths
  * — a release-consumption PR that DELETES every consumed `.changeset/*.md`
- * file (and adds none) makes `evaluateChangesetPolicy`'s `changesetFilesAdded`
- * list include paths that no longer exist on disk. Used below to skip
- * frontmatter validation for those, instead of crashing on ENOENT.
+ * file (and adds none) needs to be told apart from a PR that deletes a
+ * still-pending changeset to dodge the policy. Feeds
+ * `evaluateChangesetPolicy`'s release-consumption carve-out and lets the
+ * frontmatter-validation loop below skip paths that no longer exist
+ * instead of crashing on ENOENT.
  */
 async function getDeletedFiles(baseRef: string): Promise<Set<string>> {
   const proc = Bun.spawn(
@@ -225,22 +287,83 @@ async function getDeletedFiles(baseRef: string): Promise<Set<string>> {
   );
 }
 
+async function readGitFile(ref: string, path: string): Promise<string | null> {
+  const proc = Bun.spawn(["git", "show", `${ref}:${path}`], {
+    stdout: "pipe",
+    stderr: "pipe"
+  });
+  const [stdout, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    proc.exited
+  ]);
+  return exitCode === 0 ? stdout : null;
+}
+
+/**
+ * True only if `package.json` changed between `baseRef` and `HEAD` AND
+ * that change is EXCLUSIVELY to the top-level `version` field — the narrow
+ * signature of a `bun run changeset:version` release-consumption commit,
+ * never a general `package.json` edit (dependency bump, script change,
+ * etc.) that would still need its own changeset. Fails closed (`false`) on
+ * any ambiguity (missing file, unparsable JSON, non-object) — an
+ * indeterminate result must never grant the release-consumption exemption.
+ */
+async function isPackageJsonVersionOnlyChange(
+  baseRef: string
+): Promise<boolean> {
+  const [oldRaw, newRaw] = await Promise.all([
+    readGitFile(baseRef, "package.json"),
+    readGitFile("HEAD", "package.json")
+  ]);
+  if (oldRaw === null || newRaw === null) return false;
+
+  let oldJson: unknown;
+  let newJson: unknown;
+  try {
+    oldJson = JSON.parse(oldRaw);
+    newJson = JSON.parse(newRaw);
+  } catch {
+    return false;
+  }
+  if (
+    typeof oldJson !== "object" ||
+    oldJson === null ||
+    typeof newJson !== "object" ||
+    newJson === null
+  ) {
+    return false;
+  }
+
+  const oldRecord = oldJson as Record<string, unknown>;
+  const newRecord = newJson as Record<string, unknown>;
+  if (oldRecord.version === newRecord.version) {
+    // package.json changed but version didn't -- not a version bump at all.
+    return false;
+  }
+
+  const oldRest = { ...oldRecord };
+  const newRest = { ...newRecord };
+  delete oldRest.version;
+  delete newRest.version;
+  return JSON.stringify(oldRest) === JSON.stringify(newRest);
+}
+
 if (import.meta.main) {
   const baseRef = process.env.CHANGESET_POLICY_BASE_REF ?? "origin/main";
 
   const changedFiles = await getChangedFiles(baseRef);
-  const result = evaluateChangesetPolicy(changedFiles);
   const deletedFiles = await getDeletedFiles(baseRef);
+  const packageJsonVersionOnlyChange = changedFiles.includes("package.json")
+    ? await isPackageJsonVersionOnlyChange(baseRef)
+    : false;
+  const result = evaluateChangesetPolicy(
+    changedFiles,
+    deletedFiles,
+    packageJsonVersionOnlyChange
+  );
 
   const frontmatterProblems: string[] = [];
   for (const file of result.changesetFilesAdded) {
-    // A changeset PATH can appear in `changesetFilesAdded` because it was
-    // deleted (e.g. a release-consumption PR removing consumed changesets)
-    // rather than added — only validate frontmatter for paths that still
-    // exist in the working tree.
-    if (deletedFiles.has(file)) {
-      continue;
-    }
     const content = await Bun.file(file).text();
     const check = validateChangesetFrontmatter(content);
     if (!check.ok) {
@@ -261,15 +384,15 @@ if (import.meta.main) {
     }
   }
 
-  const changesetFilesActuallyAdded = result.changesetFilesAdded.filter(
-    (file) => !deletedFiles.has(file)
-  );
-
   if (result.violation || frontmatterProblems.length > 0) {
     process.exitCode = 1;
+  } else if (result.isReleaseConsumption) {
+    console.log(
+      `changesets:policy:check OK — release-consumption commit terdeteksi (package.json version-only, ${result.changesetFilesDeleted.length} changeset dikonsumsi), changeset baru tidak wajib.`
+    );
   } else if (result.requiresChangeset) {
     console.log(
-      `changesets:policy:check OK — ${changesetFilesActuallyAdded.length} changeset baru valid untuk ${result.nonExemptFiles.length} file non-docs/chore yang berubah.`
+      `changesets:policy:check OK — ${result.changesetFilesAdded.length} changeset baru valid untuk ${result.nonExemptFiles.length} file non-docs/chore yang berubah.`
     );
   } else {
     console.log(

--- a/scripts/changeset-policy-check.ts
+++ b/scripts/changeset-policy-check.ts
@@ -193,14 +193,54 @@ async function getChangedFiles(baseRef: string): Promise<string[]> {
     .filter((line) => line.length > 0);
 }
 
+/**
+ * `git diff --name-only` doesn't distinguish added/modified/deleted paths
+ * — a release-consumption PR that DELETES every consumed `.changeset/*.md`
+ * file (and adds none) makes `evaluateChangesetPolicy`'s `changesetFilesAdded`
+ * list include paths that no longer exist on disk. Used below to skip
+ * frontmatter validation for those, instead of crashing on ENOENT.
+ */
+async function getDeletedFiles(baseRef: string): Promise<Set<string>> {
+  const proc = Bun.spawn(
+    ["git", "diff", "--name-only", "--diff-filter=D", `${baseRef}...HEAD`],
+    { stdout: "pipe", stderr: "pipe" }
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited
+  ]);
+
+  if (exitCode !== 0) {
+    throw new Error(
+      `git diff --name-only --diff-filter=D ${baseRef}...HEAD gagal (exit ${exitCode}): ${stderr.trim()}`
+    );
+  }
+
+  return new Set(
+    stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+  );
+}
+
 if (import.meta.main) {
   const baseRef = process.env.CHANGESET_POLICY_BASE_REF ?? "origin/main";
 
   const changedFiles = await getChangedFiles(baseRef);
   const result = evaluateChangesetPolicy(changedFiles);
+  const deletedFiles = await getDeletedFiles(baseRef);
 
   const frontmatterProblems: string[] = [];
   for (const file of result.changesetFilesAdded) {
+    // A changeset PATH can appear in `changesetFilesAdded` because it was
+    // deleted (e.g. a release-consumption PR removing consumed changesets)
+    // rather than added — only validate frontmatter for paths that still
+    // exist in the working tree.
+    if (deletedFiles.has(file)) {
+      continue;
+    }
     const content = await Bun.file(file).text();
     const check = validateChangesetFrontmatter(content);
     if (!check.ok) {
@@ -221,11 +261,15 @@ if (import.meta.main) {
     }
   }
 
+  const changesetFilesActuallyAdded = result.changesetFilesAdded.filter(
+    (file) => !deletedFiles.has(file)
+  );
+
   if (result.violation || frontmatterProblems.length > 0) {
     process.exitCode = 1;
   } else if (result.requiresChangeset) {
     console.log(
-      `changesets:policy:check OK — ${result.changesetFilesAdded.length} changeset baru valid untuk ${result.nonExemptFiles.length} file non-docs/chore yang berubah.`
+      `changesets:policy:check OK — ${changesetFilesActuallyAdded.length} changeset baru valid untuk ${result.nonExemptFiles.length} file non-docs/chore yang berubah.`
     );
   } else {
     console.log(

--- a/tests/unit/changeset-policy-check-cli.test.ts
+++ b/tests/unit/changeset-policy-check-cli.test.ts
@@ -1,0 +1,202 @@
+/**
+ * CLI-wiring proof for Issue #810/#811 — spawns the REAL
+ * `scripts/changeset-policy-check.ts` (exactly what `bun run
+ * changesets:policy:check` runs) as a genuine separate `bun` process
+ * against a disposable temp git repo, and asserts on its actual exit code.
+ *
+ * `tests/unit/changeset-policy-check.test.ts` already thoroughly tests
+ * `evaluateChangesetPolicy`/`validateChangesetFrontmatter` as pure
+ * functions. This file exists because the bug class that actually shipped
+ * here (PR #811) lived entirely in the IMPERATIVE git-I/O wiring around
+ * those pure functions — `getDeletedFiles`, `isPackageJsonVersionOnlyChange`,
+ * and how their results get threaded into `evaluateChangesetPolicy` — none
+ * of which a pure-function unit test can exercise. A correctly-implemented,
+ * correctly-unit-tested pure decision function can still be wired up wrong
+ * (this repo's own precedent: PR #769/#770's "validator exists but
+ * unwired" pattern) — spawning the actual CLI against a real git history is
+ * the only way to prove the wiring itself.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SCRIPT_PATH = join(REPO_ROOT, "scripts", "changeset-policy-check.ts");
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+type CliResult = { exitCode: number; stdout: string; stderr: string };
+
+async function git(cwd: string, args: string[]): Promise<void> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe"
+  });
+  const [stderr, exitCode] = await Promise.all([
+    new Response(proc.stderr).text(),
+    proc.exited
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+  }
+}
+
+async function gitRevParse(cwd: string, ref: string): Promise<string> {
+  const proc = Bun.spawn(["git", "rev-parse", ref], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe"
+  });
+  const [stdout] = await Promise.all([
+    new Response(proc.stdout).text(),
+    proc.exited
+  ]);
+  return stdout.trim();
+}
+
+async function initRepo(): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "awcms-mini-changeset-policy-test-"));
+  tmpDirs.push(dir);
+  await git(dir, ["init", "-q"]);
+  await git(dir, ["config", "user.email", "test@example.com"]);
+  await git(dir, ["config", "user.name", "Test"]);
+  await git(dir, ["config", "commit.gpgsign", "false"]);
+  return dir;
+}
+
+async function runCli(cwd: string, baseSha: string): Promise<CliResult> {
+  const proc = Bun.spawn(["bun", SCRIPT_PATH], {
+    cwd,
+    env: { ...process.env, CHANGESET_POLICY_BASE_REF: baseSha },
+    stdout: "pipe",
+    stderr: "pipe"
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+describe("changesets:policy:check CLI — release-consumption commit (Issue #810)", () => {
+  test("a real bun run changeset:version-shaped commit (package.json version-only bump + deleted changesets) passes without a new changeset", async () => {
+    const dir = await initRepo();
+
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "awcms-mini", version: "0.1.0" }, null, 2)
+    );
+    Bun.spawnSync(["mkdir", "-p", join(dir, ".changeset")]);
+    writeFileSync(
+      join(dir, ".changeset", "foo.md"),
+      '---\n"awcms-mini": patch\n---\n\nFix a bug.\n'
+    );
+    await git(dir, ["add", "-A"]);
+    await git(dir, ["commit", "-q", "-m", "initial"]);
+    const baseSha = await gitRevParse(dir, "HEAD");
+
+    // The release-consumption step: bump ONLY the version field, delete
+    // the consumed changeset, update CHANGELOG.md.
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "awcms-mini", version: "0.2.0" }, null, 2)
+    );
+    rmSync(join(dir, ".changeset", "foo.md"));
+    writeFileSync(
+      join(dir, "CHANGELOG.md"),
+      "# Changelog\n\n## 0.2.0\n\nFix a bug.\n"
+    );
+    await git(dir, ["add", "-A"]);
+    await git(dir, ["commit", "-q", "-m", "chore(release): v0.2.0"]);
+
+    const result = await runCli(dir, baseSha);
+
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("release-consumption");
+  });
+});
+
+describe("changesets:policy:check CLI — SECURITY regression (Issue #810 follow-up, security-auditor Critical on PR #811)", () => {
+  test("deleting an existing pending changeset instead of adding one does NOT bypass the policy for an unrelated source change", async () => {
+    const dir = await initRepo();
+
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "awcms-mini", version: "0.1.0" }, null, 2)
+    );
+    Bun.spawnSync(["mkdir", "-p", join(dir, ".changeset"), join(dir, "src")]);
+    writeFileSync(
+      join(dir, ".changeset", "existing-real.md"),
+      '---\n"awcms-mini": minor\n---\n\nUnrelated pending feature.\n'
+    );
+    await git(dir, ["add", "-A"]);
+    await git(dir, ["commit", "-q", "-m", "initial"]);
+    const baseSha = await gitRevParse(dir, "HEAD");
+
+    // A real behavior change (src/a.ts) that DELETES a pending changeset
+    // instead of adding a new one -- must still be rejected. package.json
+    // is untouched, so the release-consumption carve-out cannot apply.
+    writeFileSync(join(dir, "src", "a.ts"), "export const a = 1;\n");
+    rmSync(join(dir, ".changeset", "existing-real.md"));
+    await git(dir, ["add", "-A"]);
+    await git(dir, ["commit", "-q", "-m", "feat: add a"]);
+
+    const result = await runCli(dir, baseSha);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("tidak menambah changeset baru");
+  });
+
+  test("deleting a pending changeset AND bumping package.json's version (but touching scripts/dependencies too) still requires a changeset", async () => {
+    const dir = await initRepo();
+
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify(
+        { name: "awcms-mini", version: "0.1.0", scripts: { build: "old" } },
+        null,
+        2
+      )
+    );
+    Bun.spawnSync(["mkdir", "-p", join(dir, ".changeset")]);
+    writeFileSync(
+      join(dir, ".changeset", "existing-real.md"),
+      '---\n"awcms-mini": minor\n---\n\nUnrelated pending feature.\n'
+    );
+    await git(dir, ["add", "-A"]);
+    await git(dir, ["commit", "-q", "-m", "initial"]);
+    const baseSha = await gitRevParse(dir, "HEAD");
+
+    // package.json's version DID change, but so did `scripts` -- this is
+    // NOT a version-only change, so it must not qualify for the
+    // release-consumption carve-out even though a changeset was deleted.
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify(
+        { name: "awcms-mini", version: "0.2.0", scripts: { build: "new" } },
+        null,
+        2
+      )
+    );
+    rmSync(join(dir, ".changeset", "existing-real.md"));
+    await git(dir, ["add", "-A"]);
+    await git(dir, ["commit", "-q", "-m", "sneaky change"]);
+
+    const result = await runCli(dir, baseSha);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("tidak menambah changeset baru");
+  });
+});

--- a/tests/unit/changeset-policy-check.test.ts
+++ b/tests/unit/changeset-policy-check.test.ts
@@ -79,6 +79,79 @@ describe("evaluateChangesetPolicy", () => {
     expect(result.requiresChangeset).toBe(true);
     expect(result.nonExemptFiles).toEqual(["src/lib/config/registry.ts"]);
   });
+
+  test("release-consumption commit (package.json version-only + deleted changesets) does not require a new changeset", () => {
+    const result = evaluateChangesetPolicy(
+      [
+        "package.json",
+        "CHANGELOG.md",
+        ".changeset/foo.md",
+        ".changeset/bar.md"
+      ],
+      [".changeset/foo.md", ".changeset/bar.md"],
+      true
+    );
+
+    expect(result.requiresChangeset).toBe(true);
+    expect(result.isReleaseConsumption).toBe(true);
+    expect(result.violation).toBeNull();
+    expect(result.changesetFilesAdded).toEqual([]);
+    expect(result.changesetFilesDeleted).toEqual([
+      ".changeset/foo.md",
+      ".changeset/bar.md"
+    ]);
+  });
+
+  test("SECURITY (Issue #810 follow-up): deleting an existing changeset instead of adding one still requires a changeset when other non-exempt files changed", () => {
+    // Reproduces the security-auditor's PR #811 Critical finding: a PR
+    // that makes a real source change and deletes (rather than adds) a
+    // changeset must NOT be treated as satisfying the policy.
+    const result = evaluateChangesetPolicy(
+      ["src/a.ts", ".changeset/existing-real.md"],
+      [".changeset/existing-real.md"],
+      false
+    );
+
+    expect(result.requiresChangeset).toBe(true);
+    expect(result.isReleaseConsumption).toBe(false);
+    expect(result.changesetFilesAdded).toEqual([]);
+    expect(result.changesetFilesDeleted).toEqual([
+      ".changeset/existing-real.md"
+    ]);
+    expect(result.violation).not.toBeNull();
+  });
+
+  test("package.json changed but NOT version-only (e.g. a script/dependency edit) is never treated as release-consumption, even with a deleted changeset", () => {
+    const result = evaluateChangesetPolicy(
+      ["package.json", ".changeset/existing-real.md"],
+      [".changeset/existing-real.md"],
+      false // isPackageJsonVersionOnlyChange computed false by the caller
+    );
+
+    expect(result.requiresChangeset).toBe(true);
+    expect(result.isReleaseConsumption).toBe(false);
+    expect(result.violation).not.toBeNull();
+  });
+
+  test("package.json version-only change with NO deleted changeset is not release-consumption (no real consumption happened)", () => {
+    const result = evaluateChangesetPolicy(["package.json"], [], true);
+
+    expect(result.requiresChangeset).toBe(true);
+    expect(result.isReleaseConsumption).toBe(false);
+    expect(result.violation).not.toBeNull();
+  });
+
+  test("release-consumption carve-out never applies when any OTHER non-exempt file is touched alongside package.json", () => {
+    const result = evaluateChangesetPolicy(
+      ["package.json", "src/a.ts", ".changeset/foo.md"],
+      [".changeset/foo.md"],
+      true
+    );
+
+    expect(result.requiresChangeset).toBe(true);
+    expect(result.isReleaseConsumption).toBe(false);
+    expect(result.violation).not.toBeNull();
+  });
 });
 
 describe("validateChangesetFrontmatter", () => {


### PR DESCRIPTION
## Summary

Discovered live while producing the v0.24.0 release (PR #809): CI's
"Changeset required for behavior changes" check crashed instead of running:

\`\`\`
ENOENT: no such file or directory, open '.changeset/actions-cache-6-1-0.md'
error: script "changesets:policy:check" exited with code 1
\`\`\`

**Root cause**: \`scripts/changeset-policy-check.ts\` builds its changed-file
list from \`git diff --name-only\`, which doesn't distinguish added vs.
deleted paths. A release-consumption PR (\`bun run changeset:version\`)
necessarily *deletes* every consumed \`.changeset/*.md\` file — but the
script's \`changesetFilesAdded\` filter only checks the path pattern, so it
includes deleted paths too, then tries to \`Bun.file(file).text()\` each one
for frontmatter validation, crashing with ENOENT on anything that was
deleted rather than added. This means any future release-consumption PR
would hit the exact same crash.

**Fix**: cross-reference \`git diff --name-only --diff-filter=D\` and skip
frontmatter validation for deleted paths. Also fixes the success-log
message to count only genuinely-added changesets. No change to
\`evaluateChangesetPolicy\`'s pure decision logic or public signature.

Closes #810

## Test plan

- [x] \`bun run check\` — 3573 pass / 0 fail, build succeeded (includes the
      existing \`tests/unit/changeset-policy-check.test.ts\` suite, unaffected
      by this fix since it only tests the pure functions).
- [x] Manually reproduced the exact crash locally against PR #809's diff
      before the fix, and confirmed \`CHANGESET_POLICY_BASE_REF=origin/main
      bun scripts/changeset-policy-check.ts\` now passes cleanly with the fix
      applied.
- [ ] CI's own "Changeset required for behavior changes" check on *this* PR
      is a live regression test — pending.
- [ ] reviewer + security-auditor pass — next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)