### PR TITLE
fix(release): changeset:tag silently skips the private package, no tag ever created

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": { "version": true, "tag": true }
 }


### PR DESCRIPTION
## Summary

\`bun run changeset:tag\` has been exiting 0 with zero output, creating no
git tag at all — discovered while producing the v0.24.0 release (PR #809).

**Root cause**: \`.changeset/config.json\` had no \`privatePackages\` key.
\`@changesets/config\`'s default resolution for an absent key is
\`{ version: true, tag: false }\`. \`package.json\` correctly has
\`"private": true\`, but \`@changesets/cli\`'s \`tag()\` command skips any
private package unless \`config.privatePackages.tag\` is explicitly
\`true\` — silently, with no error or log line.

**Confirmed via \`git ls-remote --tags\`**: this repo has never actually
pushed a real \`vX.Y.Z\` release tag — only 3 legacy \`awcms-mini@0.0.x\`
tags exist despite \`CHANGELOG.md\` showing ~24 versions of history. This
means \`.github/workflows/release.yml\`'s full build/SBOM/cosign-sign/
GitHub-Release pipeline (Issue #692/PR #715) has **never actually
triggered for a real release**.

**Fix**: add \`"privatePackages": { "version": true, "tag": true }\` to
\`.changeset/config.json\`. Verified locally that \`bun run changeset:tag\`
now creates a real \`v0.24.0\` tag — this repo has no workspace config, so
\`@changesets/cli\`'s \`tag()\` command reports \`tool: "root"\` and correctly
uses the \`v\${version}\` format (not \`<name>@\${version}\`), matching
\`release.yml\`'s \`push: tags: v*.*.*\` trigger and
\`scripts/release-verify.ts\`'s expected format — no additional tag-prefix
config needed, just the one missing key.

Closes #813

## Test plan

- [x] \`bun run check\` — 3581 pass / 0 fail, build succeeded.
- [x] Manually verified: before the fix, \`bun run changeset:tag\` created
      no tag. After the fix (on this branch), it correctly created a local
      \`v0.24.0\` tag (deleted before pushing — the actual release tag will
      be created fresh after this PR merges and a rehearsal run succeeds,
      per the \`awcms-mini-release\` skill's own "rehearse before the first
      production tag" rule).
- [x] No workspace config in this repo (no \`pnpm-workspace.yaml\`,
      \`lerna.json\`, or \`package.json\` \`workspaces\` field) — confirmed
      \`@changesets/cli\` reports \`tool: "root"\`, so the tag format is
      \`vX.Y.Z\` by the library's own logic, not something this fix needs to
      configure separately.
- [ ] reviewer + security-auditor pass — next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)