### PR TITLE
docs: update perbedaan-dengan-awcms to current state

### DIFF
--- a/docs/perbedaan-dengan-awcms.md
+++ b/docs/perbedaan-dengan-awcms.md
@@ -3,7 +3,7 @@
 > **Tujuan dokumen.** Menjelaskan secara rinci hubungan dan perbedaan antara repo
 > ini (**awcms-mini**) dan repo turunannya (**awcms**), agar kontributor/agent
 > paham posisi masing-masing dan alur kerja lintas-repo. Angka pada dokumen ini
-> berlaku per **2026-07-16** (awcms-mini v0.24.0 vs awcms v5.1.1).
+> berlaku per **2026-07-17** (awcms-mini v0.24.0 vs awcms v5.1.1).
 
 ## 1. Hubungan kedua repo
 
@@ -36,36 +36,43 @@ merintis fitur dari nol.
 | ------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------- |
 | Versi                           | 0.24.0                                 | 5.1.1 (melanjutkan legacy major, ADR-0024)                                                   |
 | Deskripsi                       | "Modular Monolith Standard"            | "basis/fondasi untuk pengembangan ERP"                                                       |
-| Modul di `src/modules/`         | ~23                                    | 4                                                                                            |
-| Migrasi `sql/`                  | 76 (`awcms_mini_…`)                    | 7 (`awcms_…`)                                                                                |
-| Route `src/pages/api`           | ~290                                   | ~16                                                                                          |
-| Path OpenAPI                    | ~289                                   | 16                                                                                           |
-| AsyncAPI channels               | ~96                                    | 0 (belum publish event)                                                                      |
-| Script `package.json`           | ~73                                    | ~23                                                                                          |
-| Gate `bun run check`            | ~22 gate (+ e2e Playwright)            | ~9 gate                                                                                      |
+| Modul di `src/modules/`         | ~23                                    | **10** (naik dari 4 — 6 modul fondasi diport)                                                |
+| Migrasi `sql/`                  | 76 (`awcms_mini_…`)                    | **16** (`awcms_…`, `001`–`016`)                                                              |
+| Route `src/pages/api`           | ~290                                   | **86**                                                                                       |
+| Path OpenAPI                    | ~289                                   | **86**                                                                                       |
+| AsyncAPI channels               | ~96                                    | **~28** (sudah publish domain event sejak port domain-event-runtime)                         |
+| Script `package.json`           | ~73                                    | **26**                                                                                       |
+| Gate `bun run check`            | ~22 gate (+ e2e Playwright)            | ~10 gate                                                                                     |
 | UI (`components/layouts/pages`) | 15 komponen, 56 halaman admin + portal | tidak ada (backend/kontrak-only)                                                             |
-| Test (`*.test.ts`)              | ~317 (+ Playwright e2e)                | ~22 (tanpa e2e/UI)                                                                           |
+| Test (`*.test.ts`)              | ~317 (+ Playwright e2e)                | **~50** (tanpa e2e/UI)                                                                       |
 | `.env.example`                  | ~540 baris                             | ~31 baris                                                                                    |
-| Docs paket teknis               | `docs/awcms-mini/` (49 file)           | `docs/awcms/` (48 file, sebagian warisan mini sebagai "target")                              |
+| Docs paket teknis               | `docs/awcms-mini/` (49 file)           | `docs/awcms/` (~49 file, sebagian warisan mini sebagai "target")                             |
 | ADR                             | 22 (`0000`–`0021`)                     | 25 (`0000`–`0024`; +0022 ERP-di-repo-terpisah, +0023 docs bilingual, +0024 penomoran legacy) |
 
 > Catatan: versi awcms **5.1.1 bukan tanda lebih matang** dari mini —
 > penomorannya melanjutkan garis major legacy (ADR-0024 di awcms), bukan hasil
 > evolusi melewati mini.
 
-## 3. Modul yang belum ada di awcms (backlog port)
+## 3. Status port modul
 
-Modul fondasi yang **sudah ada di kedua repo**: `logging`, `tenant-admin`,
-`profile-identity`, `identity-access`.
+**10 modul yang kini sudah ada di awcms** (dari ~23 di mini):
 
-**19 modul awcms-mini yang belum di-port ke awcms:**
+- **Fondasi awal (Sprint 1–2):** `logging`, `tenant-admin`, `profile-identity`,
+  `identity-access`.
+- **Diport dari mini (2026-07-16/17):** `module-management`,
+  `domain-event-runtime`, `sync-storage`, `workflow-approval`, `email`,
+  `reporting` — masing-masing dengan migrasi (`008`–`016`), RLS+FORCE pada tabel
+  tenant-scoped, kontrak OpenAPI/AsyncAPI, ABAC default-deny + audit +
+  idempotency, dan test unit/domain. Migrasi `001`–`016` diverifikasi apply
+  bersih di PostgreSQL 18.4.
+
+**13 modul awcms-mini yang belum di-port ke awcms:**
 
 | Kategori                 | Modul                                                                                                |
 | ------------------------ | ---------------------------------------------------------------------------------------------------- |
-| Platform/runtime inti    | `module-management`, `domain-event-runtime`, `sync-storage`                                          |
-| Governance & alur bisnis | `workflow-approval`, `reporting`, `organization-structure`, `data-lifecycle`                         |
+| Governance & alur bisnis | `organization-structure`, `data-lifecycle`                                                           |
 | Data & integrasi         | `reference-data`, `data-exchange`, `integration-hub`, `document-infrastructure`, `idn-admin-regions` |
-| Komunikasi/notifikasi    | `email`, `form-drafts`                                                                               |
+| Komunikasi/notifikasi    | `form-drafts`                                                                                        |
 | Konten/portal (CMS)      | `blog-content`, `news-portal`, `social-publishing`, `visitor-analytics`                              |
 | Tenant online            | `tenant-domain`                                                                                      |
 
@@ -75,20 +82,25 @@ pola/referensi, bukan fitur wajib.
 
 ## 4. Perbedaan toolchain yang menonjol
 
-awcms-mini punya toolchain jauh lebih lengkap yang **belum** ada di awcms, antara
-lain:
+Sejalan dengan port modul, sebagian toolchain sudah ikut ada di awcms; sisanya
+masih khusus mini.
+
+**Sudah diport ke awcms** (mengikuti modul terkait): `domain-events:dispatch`,
+`sync:objects:dispatch`, `email:dispatch` (+ `email:provider:health`,
+`email:templates:seed-defaults`), `workflow:escalations:dispatch`,
+`reporting:projections:refresh`, `reporting:projections:registry:check`,
+`reporting:exports:dispatch`.
+
+**Masih hanya di awcms-mini** (belum diport):
 
 - **Kontrak & inventory:** `openapi:bundle`, `api:docs:generate/check`,
   `repo:inventory:generate/check`, `modules:compose:check`,
   `modules:composition:inventory:check`, `extension:check`,
   `db:work-class:generate/check`.
-- **Dispatcher outbox:** `email:dispatch`, `domain-events:dispatch`,
-  `social-publishing:dispatch`, `integration-hub:outbound:dispatch`,
-  `workflow:escalations:dispatch`, `sync:objects:dispatch`,
-  `data-exchange:worker`.
-- **Lifecycle & reporting:** `data-lifecycle:archive-purge`,
-  `reporting:projections:refresh`, `analytics:rollup/purge`, `logs:audit:purge`,
-  `form-drafts:purge`.
+- **Dispatcher outbox:** `social-publishing:dispatch`,
+  `integration-hub:outbound:dispatch`, `data-exchange:worker`.
+- **Lifecycle & analytics:** `data-lifecycle:archive-purge`,
+  `analytics:rollup/purge`, `logs:audit:purge`, `form-drafts:purge`.
 - **i18n & kualitas:** `i18n:extract`, `i18n:pot:check`, `i18n:parity:check`,
   `security:readiness`, `production:preflight`, `resilience:dr-drill`,
   `performance:suite`, `database:capacity:check`.
@@ -106,7 +118,8 @@ perlu ikut di-port agar `bun run check` di awcms mencakup jaminan yang setara.
   ekstensi terpisah), **0023** (docs bilingual: sumber Indonesia, default
   Inggris), **0024** (penomoran melanjutkan garis major legacy).
 - Skill/subagent Claude: keduanya ~46 skill; nama agent berbeda prefix
-  (`awcms-mini-*` vs `awcms-*`).
+  (`awcms-mini-*` vs `awcms-*`). awcms menambah skill `awcms-port-from-mini`
+  (playbook port modul dari mini).
 
 ## 6. Rujukan
 


### PR DESCRIPTION
Memperbarui `docs/perbedaan-dengan-awcms.md` sesuai kondisi terkini: awcms kini **10 modul** (dari 4) setelah 6 modul fondasi diport (module-management, domain-event-runtime, sync-storage, workflow-approval, email, reporting). Angka disegarkan (migrasi 16, route 86, OpenAPI 86, AsyncAPI ~28, script 26, test ~50), backlog port 19→13 modul, dan status script dispatcher yang sudah/belum diport.

prettier + check:docs hijau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)