### PR TITLE
fix(epic-818): wave 1 — keamanan data-exchange, audit login, DoS clamp, perf fan-out + index, gate paritas CI

### DIFF
--- a/.changeset/bounded-page-clamp-819.md
+++ b/.changeset/bounded-page-clamp-819.md
@@ -1,0 +1,21 @@
+---
+"awcms-mini": patch
+---
+
+fix(blog-content): clamp `?page=` at both ends on public blog/news routes (Issue #819)
+
+`boundedPage` clamped only the lower bound and did not guard `NaN`, on routes
+that are public and unauthenticated. `?page=1e8` reached `OFFSET 1e9` (a
+deep-offset scan holding a pool connection for one credential-less GET) and
+`?page=abc` reached `OFFSET NaN` → 500.
+
+Page-number bounds now live in a shared helper
+(`src/modules/_shared/offset-pagination.ts`): `boundedPageNumber` clamps to
+`[1, 10_000]`, truncates fractions, and returns page 1 for `NaN`/`±Infinity`;
+`parsePageParam` is used by the six public `/blog/{tenantCode}` and `/news`
+routes so the clamped value is also what renders into pagination nav links.
+The admin blog post/page lists use the same helper (they shared the
+copy-pasted pattern).
+
+Behaviour change: a non-numeric or out-of-range `?page=` now renders page 1
+(or an empty page 10,000) instead of a 500.

--- a/.changeset/ci-check-parity-gate-823.md
+++ b/.changeset/ci-check-parity-gate-823.md
@@ -1,0 +1,31 @@
+---
+"awcms-mini": patch
+---
+
+Tutup celah "CI diam-diam menjalankan subset `bun run check`" untuk keempat
+kalinya (Issue #823, epic #818). Lima langkah ada di komposit `check` tetapi tak
+pernah dicerminkan ke `.github/workflows/ci.yml`: `api:docs:check`,
+`repo:inventory:check`, `i18n:pot:check`, `config:docs:check`, dan
+`logging:lint:check`. Kelimanya lolos saat dipasang, jadi ini risiko laten
+(regresi inventory/API-docs/i18n/config-docs/logging bisa merge hijau), bukan
+drift aktif.
+
+Menambal lima langkah itu saja tidak cukup — daftar di `ci.yml` adalah cermin
+manual dari `check`, dan cermin itu sudah melenceng empat kali
+(#685/#740/#745/#746/#750) meski `ci.yml` memuat komentar peringatan panjang di
+tiap langkah. Karena itu ditambahkan gate sesungguhnya:
+`tests/unit/ci-check-parity.test.ts` mengurai komposit `check` dari
+`package.json` lalu memastikan setiap langkahnya benar-benar dijalankan
+`ci.yml`, sehingga menambah langkah `check` tanpa memasangnya di CI langsung
+merah. Pemeriksaannya sengaja satu arah (`check` ⊆ `ci.yml`) karena CI memang
+menjalankan lebih banyak (`db:migrate`, performance suite, DR drill); langkah
+yang CI jalankan dengan bentuk perintah berbeda (`bun test`, `build`)
+didaftarkan eksplisit di `RUN_DIFFERENTLY`, dan entri usang di daftar itu ikut
+gagal supaya pengecualian tidak bertahan diam-diam setelah alasannya hilang.
+
+Gate-nya diverifikasi benar-benar menangkap drift: menyisipkan langkah palsu ke
+`check` membuat test merah dengan pesan yang menyebut langkah itu, dan hijau
+kembali setelah dipulihkan.
+
+Branch protection `main` (bagian kedua Issue #823) tetap butuh aksi owner dan
+tidak termasuk perubahan ini.

--- a/.changeset/data-exchange-preview-guard-820-831.md
+++ b/.changeset/data-exchange-preview-guard-820-831.md
@@ -1,0 +1,16 @@
+---
+"awcms-mini": patch
+---
+
+fix(data-exchange): tutup empat cacat raw-value guard pada preview import (#820) dan klamp `offset` (#831)
+
+`GET /api/v1/data-exchange/imports/{id}/preview` mengembalikan nilai staged mentah hanya bila descriptor pemiliknya menyatakannya, dan hanya kepada pemegang izin yang **descriptor itu sendiri** sebutkan. Empat cacat yang saling menguat (laten — belum ada modul yang mendaftarkan descriptor sensitif; ini perangkap untuk turunan pertama):
+
+- **Default-allow dibalik jadi default-deny**: `sensitiveFields` kini **wajib** (registry gate menolak descriptor tanpanya — nyatakan `{ fieldNames: [] }` bila memang tak ada yang sensitif). Descriptor tanpa policy kini di-mask seluruhnya dan tak ada izin yang membukanya; sebelumnya lalai mendeklarasikan justru **membuka** semua nilai tanpa cek izin sama sekali.
+- **`sensitiveFields.rawValuePermission` kini benar-benar ditegakkan**: sebelumnya divalidasi saat registrasi tapi nol enforcement site — route memakai konstanta hardcoded `data_exchange.preview_errors.read` yang jauh lebih luas, sehingga deklarasi izin sempit descriptor (mis. `profile_identity.identifiers.reveal_raw`) diabaikan diam-diam.
+- **Descriptor tak terselesaikan kini fail-closed**: `authorizeExchangeDescriptorPermission` tidak lagi menerima `null` (fail-open yang bertentangan dengan komentarnya sendiri). Batch yang modul pemiliknya di-disable setelah staging kini ditolak `409 INVALID_STATE` pada preview/commit/retry/download — sebelumnya batch justru menjadi **lebih terbuka** setelah modulnya dimatikan.
+- **`naturalKey` ikut di-mask** bila `sensitiveFields.naturalKeyField` menyebut field yang sensitif — kunci dedup import profil lazimnya justru email/NIK.
+
+Perubahan perilaku untuk aplikasi turunan: `ExchangeDescriptor.sensitiveFields` wajib; `ExchangeSensitiveFieldPolicy` menerima `naturalKeyField` opsional; `authorizeExchangeDescriptorPermission` menerima `ExchangeDescriptor` non-nullable.
+
+`offset` preview kini diklamp atas ke `PREVIEW_OFFSET_MAX` (= `MAX_EXCHANGE_ROW_COUNT`, sehingga tak menyembunyikan baris yang bisa dijangkau) — sebelumnya hanya dicek `>= 0` sementara `limit` tepat di baris berikutnya sudah diklamp, jadi `?offset=5000000` diteruskan apa adanya ke Postgres.

--- a/.changeset/login-audit-unknown-tenant-fk.md
+++ b/.changeset/login-audit-unknown-tenant-fk.md
@@ -1,0 +1,23 @@
+---
+"awcms-mini": patch
+---
+
+Perbaiki regresi yang diperkenalkan Issue #821: audit `login_failed` /
+`mfa_challenge_failed` ditulis dengan `tenant_id` dari header **sebelum**
+memastikan tenant itu ada. `awcms_mini_audit_events.tenant_id` adalah
+`NOT NULL REFERENCES awcms_mini_tenants (id)`, sehingga header tenant yang
+berbentuk UUID valid tetapi tidak terdaftar membuat INSERT audit melanggar
+foreign key, membatalkan transaksi, dan mengubah 403/401 yang dimaksud menjadi
+**500** — dapat dipicu siapa pun tanpa autentikasi, jadi cara murah untuk
+memaksa 500 beruntun.
+
+Sekarang audit tenant-scoped hanya ditulis bila tenant-nya benar-benar ada;
+selain itu percobaannya tetap terlihat lewat structured log (yang memang tidak
+tenant-scoped). Secara definisi tidak ada jejak tenant-scoped yang bisa ditulis
+untuk tenant yang tidak ada. Recorder out-of-band memeriksa ulang keberadaan
+tenant sendiri, karena ia berjalan setelah transaksi login gagal dan tidak
+boleh memercayai apa pun yang dihitung transaksi itu.
+
+Ditemukan oleh review bot pada PR #839 — reviewer maupun security-auditor
+melewatkannya. Test regresinya diverifikasi menangkap cacat aslinya (merah saat
+guard dicabut, hijau setelah dipulihkan).

--- a/.changeset/olive-doors-invent.md
+++ b/.changeset/olive-doors-invent.md
@@ -1,0 +1,32 @@
+---
+"awcms-mini": patch
+---
+
+Audit successful and failed password sign-ins (Issue #821).
+
+`POST /api/v1/auth/login` imported `recordAuditEvent` but only ever called it
+for `mfa_challenge_issued`, so neither a successful nor a failed password login
+left any trace — no audit trail existed for brute-force or credential-stuffing
+against the endpoint, and doc 01's base-ready requirement "Audit log high-risk
+tersedia" was unmet in code.
+
+The endpoint now writes exactly one `login_succeeded` or `login_failed` audit
+row per attempt, carrying the tenant, identity, method, source fingerprint,
+user agent, correlation ID, and — on failure — the deny reason
+(`invalid_credentials` / `locked` / `tenant_inactive` /
+`password_login_disabled`). `POST /api/v1/auth/mfa/totp/verify` gained the
+matching `mfa_challenge_failed` row, the one auth outcome in that route that
+was still untraced.
+
+Notes:
+
+- Failed logins stay on the record even when the login transaction is rolled
+  back: an exception unwinding it is re-recorded out of band as
+  `login_failed` / `internal_error`, and the original error is rethrown
+  untouched.
+- Audit content cannot be used to enumerate accounts: the attacker-supplied
+  `loginIdentifier` is never persisted, and an unknown account produces the
+  same `invalid_credentials` reason as a real account with a wrong password.
+- Source IPs are persisted as a keyed `ipHash`, never in the clear — rows stay
+  groupable by source without the audit trail becoming an address log.
+- No request or response shape changed; no migration.

--- a/.changeset/olive-pandas-guess.md
+++ b/.changeset/olive-pandas-guess.md
@@ -1,0 +1,27 @@
+---
+"awcms-mini": patch
+---
+
+perf(db): add missing indexes for blog admin lists, the scheduled-publish job, and four unindexed FK columns (Issue #830)
+
+Migration `077_awcms_mini_performance_missing_indexes.sql` — pure DDL, no
+application code change.
+
+- `awcms_mini_blog_posts (tenant_id, updated_at DESC) WHERE deleted_at IS NULL`
+  and the same on `awcms_mini_blog_pages`. Both admin list screens end in
+  `ORDER BY updated_at DESC` but migration 026 created no `updated_at` index at
+  all, so every page load was a Seq Scan of the tenant's whole post/page set
+  plus a top-N heapsort. Measured on a 60k-row seed: root plan cost 3835 -> 2.9,
+  execution 19.9ms -> 0.07ms, buffers 1655 -> 23.
+- `awcms_mini_blog_posts (tenant_id, scheduled_at) WHERE status = 'scheduled' AND deleted_at IS NULL`
+  for the periodic scheduled-publish job. The existing
+  `(tenant_id, status, published_at DESC)` index was already being used, but it
+  cannot apply the `scheduled_at <= now()` bound, so the job read the heap for
+  every scheduled post and discarded the not-yet-due ones; work grew with the
+  future-scheduled backlog rather than with the number of due posts.
+- Indexes on four FK columns that had no covering index at all, so a parent
+  DELETE forced a full child seq scan: `awcms_mini_abac_decision_logs.tenant_user_id`,
+  `awcms_mini_visitor_sessions.identity_id`, `awcms_mini_sync_outbox.node_id`
+  (its sibling `sync_inbox` already had the equivalent), and
+  `awcms_mini_blog_ads.tenant_id` (also read-path: every `ads-directory.ts`
+  query and the RLS policy filter on it, on a table with no index beyond its PK).

--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -1,0 +1,23 @@
+---
+"awcms-mini": patch
+---
+
+Collapse the module health fan-out from O(modules) to O(1) (Issue #824).
+
+`fetchModuleMatrix` and `admin/modules.astro` resolved health by calling
+`fetchModuleHealthReport` once per registered module, and each call ran its own
+registry lookup, migration scan, permission-catalog query and settings lookup —
+94 queries to render one admin screen at 23 modules, growing with every module
+added. Those four inputs are now prefetched once per render
+(`prepareModuleHealthContext`) and shared across modules, and multi-module
+callers use the new `fetchModuleHealthReports` batch entry point.
+
+Separately, `readYamlCached` populated its cache only after awaiting, so the 22
+modules declaring the same ~1 MB `openapi.yaml` each read and parsed that file
+concurrently on a cold render. It now caches the in-flight promise, so
+concurrent callers join one parse; `listMigrationFileNames` is cached the same
+way (it was re-`readdir`-ing on every signal).
+
+Measured per render at 23 modules: 94 → 6 queries, ~3.8s → ~0.36s cold, ~10ms →
+~6ms warm. No behaviour change — the same signals, order, statuses and generic
+(never raw) error details. `includeHealth: false` still runs zero health work.

--- a/.changeset/pr-839-audit-findings.md
+++ b/.changeset/pr-839-audit-findings.md
@@ -1,0 +1,54 @@
+---
+"awcms-mini": patch
+---
+
+Perbaiki tiga temuan security-auditor pada PR #839 (epic #818).
+
+**Gate `requiredPermission` deskriptor kini ditegakkan di halaman admin
+(HIGH).** `src/pages/admin/data-exchange/imports/[id].astro` tidak melewati
+route API mana pun — ia melakukan query dan proyeksi staged row sendiri — dan
+mereplikasi gate raw-value dengan benar tapi **tidak pernah** memutuskan
+`ExchangeDescriptor.requiredPermission`, izin milik modul pemilik yang
+ditegakkan keenam route API. Deskriptor dengan `requiredPermission:
+"hr.payroll.read"` karenanya ditegakkan di seluruh permukaan API dan nol di
+UI: pemegang `data_exchange.imports.read` generik bisa membaca konten staged
+modul lain (natural key, validation error, laporan rekonsiliasi) langsung dari
+halaman. Halaman kini memanggil `isDescriptorPermissionGranted` — keputusan
+yang sama dengan route, dibagi dari satu tempat — dan deskriptor yang tidak
+lagi resolve (modul pemilik dinonaktifkan setelah staging) kini **deny**, bukan
+sekadar `maskAllFields`.
+
+**`AUTH_JWT_SECRET` tidak lagi deprecated, dan tidak lagi merosot senyap
+(HIGH).** Sejak Issue #821 variabel ini adalah kunci HMAC nyata untuk pseudonim
+IP (`ipHash`) di audit log, tapi registry menandainya `deprecated` dengan
+`removalVersion: "1.0.0"` ("terverifikasi mati / nol konsumen") sementara
+`client-fingerprint.ts` mem-fallback ke `?? ""`. Saat variabel itu benar-benar
+dihapus sesuai jadwal, `hashClientIp` akan merosot jadi SHA-256 tanpa garam —
+ruang IPv4 hanya 2^32, jadi **setiap `ipHash` di audit trail menjadi
+reversibel**, tanpa satu pun error. Dipilih **Opsi A** (mencabut deprecation)
+di atas Opsi B (var baru `AUTH_IP_HASH_KEY`): key separation di sini tidak
+membeli apa pun karena `AUTH_JWT_SECRET` terverifikasi tidak menandatangani
+apa pun (sesi = token opaque; `jwt-verify.ts` RS256 lewat JWKS penyedia), jadi
+tidak ada risiko cross-protocol — sementara var wajib baru memaksa perubahan
+pada setiap deployment yang sudah berjalan tanpa keuntungan keamanan. Fallback
+`?? ""` dihapus (lempar, jangan merosot senyap), dan `validate-env` kini
+menolak placeholder `.env.example` lewat `checkAuthJwtSecretNotDefault`
+(memakai ulang pola `checkSyncHmacSecretNotDefault`; `checkRequiredVars` hanya
+mengecek non-kosong, dan placeholder itu non-kosong).
+
+**Teks bebas tidak lagi meloloskan nilai yang di-mask (MEDIUM).**
+`maskSensitiveFields` mempertahankan `validationWarnings` utuh, padahal
+`maskAllFields` membuangnya dengan alasan eksplisit "warning adalah teks bebas
+yang mungkin diinterpolasi adapter dengan nilai mentah" — alasan yang berlaku
+identik di kedua jalur. Sebuah warning `"email x@y.com sudah terdaftar"`
+mengembalikan nilai yang baru saja di-mask dari `fields.email`. `commitError`
+(= `outcome.reason` adapter) dipertahankan utuh di **kedua** jalur termasuk
+default-deny. Keduanya kini dibuang/di-mask di kedua jalur; `commitStatus`
+tetap, jadi baris masih melaporkan BAHWA ia gagal, hanya bukan dengan nilai
+apa.
+
+Selain itu: komentar `login.ts` yang mengklaim respons login "byte-identical
+regardless of whether the identity exists" diperbaiki — klaim itu salah
+(`locked` dan `password_login_disabled` dapat dibedakan dan hanya tercapai bila
+identity ada). Oracle enumerasinya sendiri pre-existing dan dilacak di Issue
+#840; perilakunya sengaja tidak diubah di sini.

--- a/.changeset/pr-839-review-round2.md
+++ b/.changeset/pr-839-review-round2.md
@@ -1,0 +1,27 @@
+---
+"awcms-mini": patch
+---
+
+Perbaiki tiga temuan review PR #839.
+
+**`prepareModuleHealthContext` menjalankan 4 query lewat `Promise.all` di atas
+satu `tx`.** Satu koneksi Postgres melayani satu query pada satu waktu, dan pola
+persis ini pernah menyebabkan hang nyata di repo ini (lihat catatan di
+`reporting/application/projection-reconciliation.ts` — koneksi yang tersangkut
+lalu merusak `resetDatabase()` setiap test sesudahnya). Regresi dari perbaikan
+Issue #824; kemenangannya memang bukan konkurensi melainkan meruntuhkan fan-out
+per-modul menjadi empat query total, dan itu tetap utuh dengan await berurutan.
+
+**`readJsonBody(...) ?? {}` mengubah body yang absen/rusak/bukan-objek menjadi
+patch kosong yang sah** pada kedua route PATCH reference-data, sehingga body
+sampah lolos otorisasi + idempotency dan mendarat sebagai write sungguhan.
+Ditambahkan `readJsonObjectBody` + `invalidJsonObjectBodyResponse` di
+`lib/security/request-body-limit.ts`: `{}` tetap `ok` (objek kosong itu body
+sungguhan), sedangkan absen/malformed/`null`/array/skalar ditolak `400`.
+
+**`PATCH {}` — no-op yang terdokumentasi — tetap menjalankan `update*` tanpa
+syarat**, membuat `updated_at` naik, menulis ulang baris translation, memancarkan
+audit event dan domain event untuk request yang tidak mengubah apa pun. Kini
+di-short-circuit dan mengembalikan representasi saat ini. Refusal
+`managed_by_descriptor` (Issue #750) tetap diperiksa di jalur no-op agar jawaban
+endpoint tidak bergantung pada berapa field yang kebetulan dikirim pemanggil.

--- a/.changeset/pr-839-review-round4.md
+++ b/.changeset/pr-839-review-round4.md
@@ -1,0 +1,26 @@
+---
+"awcms-mini": patch
+---
+
+Perbaiki dua temuan review PR #839 ronde 4.
+
+**`sensitiveFields.naturalKeyField` tidak dideklarasikan di schema OpenAPI.**
+Descriptor default `data_exchange.reference_items` menyetelnya, sementara
+`DataExchangeDescriptor.sensitiveFields` adalah `additionalProperties: false`
+yang hanya memuat `fieldNames`/`rawValuePermission` — jadi
+`GET /api/v1/data-exchange/descriptors` melanggar kontraknya sendiri dan client
+ter-generate akan menolaknya. Ditambahkan gate
+`tests/unit/data-exchange-descriptor-contract-parity.test.ts` yang memvalidasi
+descriptor registry nyata terhadap schema nyata; validasi response-vs-schema
+umum difilekan sebagai #844.
+
+**Placeholder `AUTH_JWT_SECRET` diterima saat runtime.**
+`checkAuthJwtSecretNotDefault` benar dan tersambung, tetapi tidak ada yang
+memaksanya berjalan: `bun run dev`/`bun run start` memanggil server langsung,
+tidak pernah `config:validate`. Deployment hasil salin `.env.example` boot
+dengan tenang memakai nilai yang dipublikasikan di repo publik sebagai kunci
+HMAC `ipHash` — membuat setiap `ipHash` tersimpan bisa dibalik (ruang IPv4 2^32),
+yaitu satu-satunya properti yang jadi alasan pseudonym ini ada. Placeholder kini
+ditolak di titik pakai, sehingga tidak ada jalur boot yang bisa melewatinya.
+Nilainya dibaca dari `default` milik entri registry, bukan diketik ulang, agar
+tidak melenceng dari `.env.example`.

--- a/.changeset/pr-839-review-round5.md
+++ b/.changeset/pr-839-review-round5.md
@@ -1,0 +1,20 @@
+---
+"awcms-mini": patch
+---
+
+Perbaiki temuan review PR #839 ronde 5: replay idempotent pada
+`imports/{id}/commit` dan `imports/{id}/retry` tertahan gate descriptor.
+
+Branch fail-closed dari #820 Cacat 3 berjalan **sebelum**
+`findIdempotencyRecord`, sehingga client yang mencoba ulang commit dengan
+`Idempotency-Key` + request hash yang sama **setelah modulnya di-disable**
+mendapat `409` baru alih-alih response yang sudah tersimpan. Itu melanggar
+kontrak yang dinyatakan `_shared/idempotency.ts` secara eksplisit ("same key +
+same request hash -> replay the stored response").
+
+Replay **tidak menjalankan adapter sama sekali** — ia mengembalikan hasil yang
+sudah tercatat untuk key+hash itu, di bawah gate lengkap sebagaimana berlaku
+saat itu. Gate descriptor ada untuk menjaga **write**, jadi menggerbangi replay
+dengannya tidak mencegah apa pun sambil membuat satu key+hash menjawab berbeda
+seiring waktu. Replay kini berjalan lebih dulu di kedua route; gate fail-closed
+tetap utuh untuk key baru.

--- a/.changeset/pr-839-review-round6.md
+++ b/.changeset/pr-839-review-round6.md
@@ -1,0 +1,26 @@
+---
+"awcms-mini": patch
+---
+
+Perbaiki tiga temuan review PR #839 ronde 6.
+
+**Gate paritas CI (#823) sendiri bisa dibohongi prosa.** Ia memindai seluruh
+teks `ci.yml`, sehingga penyebutan `bun test` di komentar — atau bahkan di
+`name:` sebuah langkah — sudah memuaskannya walau step `run: bun test` aslinya
+dihapus. Gate itu hijau persis di skenario drift yang jadi alasan ia ada, yaitu
+kegagalan "gate hijau di atas cacat nyata" yang justru hendak ia akhiri. Kini
+YAML-nya diurai dan hanya badan `run:` yang diperiksa, ditambah meta-test yang
+memaku properti itu.
+
+**Field PATCH tak dikenal di-no-op-kan, bukan ditolak.** Kedua schema PATCH
+adalah `additionalProperties: false`, tetapi parser membaca kunci yang dikenalnya
+dan mengabaikan sisanya — typo klien (`validUntil` alih-alih `validTo`) terurai
+jadi patch kosong. Digabung dengan cabang no-op, typo itu menjawab `200` sambil
+tidak mengubah apa pun: request tampak diterima padahal tidak melakukan apa-apa.
+Kunci tak dikenal kini ditolak `400`. Parser ini sebelumnya tidak punya unit test
+sama sekali; kini ada.
+
+**`sensitiveFields` wajib di TypeScript tapi tidak di schema OpenAPI.** Registry
+menolak descriptor yang menghilangkannya (#820 Cacat 1), namun
+`DataExchangeDescriptor.required` tidak memuatnya — client ter-generate tetap
+menganggap policy masking opsional.

--- a/.changeset/pr-839-ssr-module-enabled.md
+++ b/.changeset/pr-839-ssr-module-enabled.md
@@ -1,0 +1,39 @@
+---
+"awcms-mini": patch
+---
+
+Sertakan state module-enabled dalam keputusan gate SSR data-exchange (temuan
+review bot pada PR #839).
+
+Gate SSR yang ditambahkan PR #839 hanya melakukan `permissions.has(key)`.
+Jalur API tidak begitu: `authorizeInTransaction` memanggil `resolveModuleEnabled`
+dan menolak `403 MODULE_DISABLED` **sebelum** RBAC dievaluasi, sementara
+`fetchGrantedPermissionKeys` — yang membangun permission set SSR — **tidak**
+memfilter modul yang disabled. Subject karenanya tetap memegang setiap
+permission key milik modul yang sudah dimatikan tenant, jadi
+`/admin/data-exchange/imports/[id]` **tetap merender staged row** sementara
+route preview/commit menjawab 403. SSR lebih longgar daripada API: kelas
+paritas yang sama dengan temuan `requiredPermission` asli, kambuh di sumbu
+berbeda.
+
+Cek module-enabled kini berada **di dalam** `isDescriptorPermissionGranted`
+(bukan di call site) sehingga tak ada pemanggil yang bisa melupakannya, dengan
+urutan yang sama seperti route: modul dulu, baru RBAC. Berlaku untuk
+`requiredPermission` **dan** `rawValuePermission` — jalur raw-value route
+adalah `authorizeDescriptorPermissionKey`, yang juga meresolusi state modul,
+jadi `permissions.has()` telanjang di halaman akan membuka nilai yang di-mask
+route begitu modul pendeklarasinya disabled. Halaman juga kini memeriksa
+`data_exchange` sendiri: konstanta `CAN_*`-nya semua tetap true untuk tenant
+yang mematikan modul itu.
+
+Test paritas SSR-vs-route diperluas ke sumbu ini — **terbukti merah** tanpa
+perbaikan (route menolak 403, SSR mengizinkan), hijau dengan. Test paritas
+sebelumnya lolos padahal celahnya ada karena ia hanya membandingkan satu sumbu
+(apakah caller memegang key), bukan setiap sumbu yang benar-benar dikonsultasi
+guard route.
+
+Celah yang sama ada di **54 halaman admin lain** (survei menyeluruh: 1 dari 55
+halaman pemuat data yang memeriksa module-enabled; middleware dan AdminLayout
+tidak memitigasi — filter nav layout hanya kosmetik dan bisa dilewati dengan
+mengetik URL). Di luar scope PR ini, dilacak di Issue #841 beserta opsi
+struktural, karena menambal 54 halaman satu per satu akan hanyut lagi.

--- a/.changeset/reference-data-partial-patch.md
+++ b/.changeset/reference-data-partial-patch.md
@@ -1,0 +1,31 @@
+---
+"awcms-mini": patch
+---
+
+fix(reference-data): `PATCH` on reference codes is now genuinely partial instead of behaving like `PUT`
+
+`PATCH /api/v1/reference-data/tenant-codes/{id}` and
+`PATCH /api/v1/reference-data/value-sets/{key}/codes/{code}` parsed their request
+body with per-field defaults, so any field omitted from the body was silently
+reset instead of preserved: `sortOrder` -> `0`, `metadata` -> `{}` (permanent
+data loss), `validFrom` -> `now()` (truncating a code's validity history), and
+`validTo` -> `null`. A client sending the normative partial `PATCH` — e.g. only
+`labels` to rename a code — lost the other four fields and received a `200` with
+no warning. Since reference data is load-bearing for downstream documents and
+transactions, a silently rewritten `validFrom`/`validTo` window is a correctness
+hazard, not just a cosmetic one.
+
+Both endpoints now merge the parsed patch onto the stored record, with an
+explicit and documented null-vs-absent contract:
+
+- **absent** field — the stored value is kept untouched;
+- **explicit `null`** — the field is cleared/reset (`sortOrder` -> `0`,
+  `metadata` -> `{}`, `validTo` -> `null`);
+- `labels` and `validFrom` reject `null` with a `400 VALIDATION_ERROR` (at least
+  one label is always required, and `valid_from` is `NOT NULL`) rather than being
+  silently defaulted;
+- `labels` still replaces all stored labels wholesale, and `metadata` still
+  replaces rather than deep-merges, when present.
+
+`labels` is no longer a required property of either request body — an empty
+`{}` body is a valid no-op. OpenAPI documents the semantics per field.

--- a/.claude/skills/awcms-mini-audit-log/SKILL.md
+++ b/.claude/skills/awcms-mini-audit-log/SKILL.md
@@ -41,6 +41,48 @@ Login failed/success · access assignment · profile merge · product price chan
 
 `password`, `passwordHash`, `token`, `accessToken`, `refreshToken`, `apiKey`, `secret`, `credential`, `authorization`, `npwp`, `nik`, `phone`, `whatsapp`, `email`, `cookie` (Issue #687), plus allowlist exact-match untuk key IP address (`ip`, `ipAddress`, `clientIp`, `remoteAddr`, `x-forwarded-for`, dst — sengaja BUKAN substring seperti key lain di atas, lihat `src/modules/_shared/redaction.ts` untuk kenapa: substring `"ip"` akan ikut meredaksi `description`/`shipping`/`recipient`).
 
+## Jangan tulis IP mentah — pakai `ipHash` (Issue #821)
+
+Attribut audit untuk aksi auth sering perlu menjawab "sumbernya siapa?"
+(forensik brute-force). **IP mentah tidak bisa dipakai**: `ip`/`ipAddress`/
+`clientIp`/`remoteAddr`/`x-forwarded-for` semuanya key sensitif (lihat
+allowlist exact-match di atas), jadi nilainya pasti jadi `"[REDACTED]"` —
+kolom permanen kosong. Mengganti nama key supaya lolos redaksi = regresi
+keamanan, **bukan** perbaikan.
+
+Pakai `hashClientIp()` + `summarizeUserAgent()` dari
+`src/lib/security/client-fingerprint.ts`: HMAC-SHA256 (key = `AUTH_JWT_SECRET`,
+env wajib yang sudah ada — jangan tambah secret baru) di bawah key `ipHash`,
+yang tidak match aturan redaksi mana pun. Nilainya stabil (baris audit bisa
+dikelompokkan per sumber) tapi alamatnya tidak bisa dipulihkan. HMAC, bukan
+digest polos: ruang IPv4 cuma 2^32, `sha256(ip)` tanpa key bisa dibalik dalam
+hitungan detik. `User-Agent` dipotong 256 char sebelum masuk `jsonb` — header
+attacker-controlled tidak boleh jadi write amplifier di endpoint publik.
+
+## Audit gagal harus selamat dari rollback (Issue #821)
+
+`withTenant` = `sql.begin`, jadi audit yang ditulis di dalamnya **ikut
+rollback** kalau transaksinya throw. Untuk jalur deny normal ini bukan masalah
+dan **tidak** perlu transaksi terpisah: setiap deny path `return` (bukan
+`throw`), jadi transaksinya selalu COMMIT — merutekan deny normal ke transaksi
+kedua justru melipatgandakan biaya koneksi tiap percobaan brute-force di
+endpoint publik. Yang perlu ditangani hanya kasus exception: `.catch()` di luar
+`withTenant`, tulis ulang audit di transaksi baru (best-effort, kegagalan
+sendiri di-swallow + `log()`), lalu **rethrow error aslinya apa adanya**. Pola
+lengkap: `recordLoginFailureOutOfBand` di `src/pages/api/v1/auth/login.ts`.
+
+## Audit auth tidak boleh jadi alat enumerasi akun
+
+Jangan pernah menyimpan `loginIdentifier` yang dikirim penyerang — biasanya
+email (PII, dan **tidak** tertangkap redaksi di bawah nama key itu). Alasan
+deny sudah dikolapskan di layer domain (`login-policy.ts`: akun tidak ada,
+password salah, identity/tenant-user inactive → semuanya
+`"invalid_credentials"`), jadi pakai alasan itu apa adanya — jangan dipecah
+lagi di route. `resourceId` boleh diisi saat identity ketemu: audit
+tenant-scoped + RLS, hanya terbaca operator yang toh sudah bisa membaca
+`awcms_mini_identities`, dan tanpa itu jejaknya kehilangan satu-satunya field
+yang menjawab "akun mana yang diserang".
+
 ## Verifikasi
 
 - Aksi high-risk menghasilkan satu audit event.

--- a/.claude/skills/awcms-mini-performance/SKILL.md
+++ b/.claude/skills/awcms-mini-performance/SKILL.md
@@ -31,8 +31,16 @@ Sumber kebenaran: **`docs/awcms-mini/16_backend_data_access_integration.md`** (l
 - [ ] **SSR reuse** — halaman admin fetch via fungsi application-layer di dalam satu `withTenant`, bukan round-trip HTTP ke API sendiri (pola `*-directory.ts`/`*-report.ts`).
 - [ ] **Locking** — `FOR UPDATE` hanya pada baris yang benar-benar dimutasi bersama (mis. stok); hindari lock rentang lebar.
 
+## Perangkap terverifikasi
+
+- [ ] **Fan-out per-entitas di `Promise.all`** (Issue #824, terukur) — `fetchModuleMatrix` memanggil `fetchModuleHealthReport` per modul; tiap panggilan 4 query sendiri ⇒ **94 query/render** di 23 modul, **tumbuh linear tiap modul baru**. Pola perbaikan: satu prefetch di luar loop (`prepareModuleHealthContext`), suapkan row ke fungsi yang jadi pure, sediakan entry point batch (`fetchModuleHealthReports`). Hasil: 94 → 6 query. Curigai signal yang **tidak menerima kunci entitas sama sekali** (`migrationsAppliedSignal(tx)`) — itu invariant, wajib di-hoist.
+- [ ] **Cache stampede: cache di-set SETELAH `await`** (Issue #824, penyebab dominan sebenarnya) — `readYamlCached` mengisi cache pasca-`await`, jadi 22 modul yang mendeklarasikan `openapi.yaml` (~1 MB) yang **sama** semuanya miss serentak di dalam satu `Promise.all` dan mem-parse file itu 22× paralel: **~5,6 detik CPU murni**, sementara query hanya ~10ms. Perbaikan: **cache Promise in-flight**, di-`set` sinkron sebelum `await` pertama, sehingga pemanggil lain ikut serta pada parse yang sama. Cold render 3,8s → 0,36s.
+- **Pelajaran metodologis:** "N+1 query" adalah hipotesis yang paling mudah dilihat, **bukan otomatis biaya terbesar**. Di #824 diagnosis awal (di issue) hanya menyebut fan-out query; ukuran nyata menunjukkan parse YAML jauh lebih mahal. **Selalu ukur cold vs warm render terpisah** — selisih besar antara keduanya menunjuk ke cache dingin/stampede, bukan ke DB. Jangan berhenti setelah hipotesis pertama terkonfirmasi.
+- **Timeout test yang "hilang saat rerun" bukan bukti flake infra** — saturasi/kerja berlebih terlihat identik dengan flake. Lihat memori `fetchmodulematrix-ci-timeout-flake`; jangan `gh run rerun` sebagai "perbaikan", dan jangan menaikkan timeout.
+
 ## Verifikasi
 
+- **Hitung query sebelum/sesudah, jangan diasumsikan** — bungkus `tx` dengan `Proxy` bertrap `apply` (tagged template = satu pemanggilan) di test integrasi sementara, catat juga durasi render **pertama** dan **kedua** di proses yang sama. Bandingkan terhadap baseline dengan `git stash push src/` lalu `git stash pop`.
 - `EXPLAIN ANALYZE` sebelum/sesudah menunjukkan perbaikan nyata (Seq→Index Scan, plan cost turun).
 - Benchmark p95 endpoint membaik; tak ada regresi fungsional (`bun run check` hijau).
 - Uji beban ringan: query saturasi kelas pool → `503`, mengering ke 0 (bukti backpressure, seperti verifikasi Issue 10.2).

--- a/.env.example
+++ b/.env.example
@@ -90,14 +90,14 @@ DATABASE_PGBOUNCER=false
 # DATABASE_CAPACITY_RESERVED_ADMIN_CONNECTIONS=5
 
 # Auth
-# DEPRECATED (Issue #689, target removal 1.0.0): still enforced non-empty at
-# boot (config:validate) for backward compatibility, but no code reads this
-# value — sessions are opaque tokens (`awcms_mini_sessions.token_hash`), not
-# JWT; the only JWT verification in this repo (src/lib/auth/jwt-verify.ts)
-# validates Google/OIDC ID tokens against the provider's own published JWKS,
-# never signs or checks anything with this secret. Nothing to migrate to —
-# session tokens are random bytes, not derived from a shared secret. See
-# src/lib/config/registry.ts's AUTH_JWT_SECRET entry.
+# REQUIRED, and MUST be changed from the placeholder below — config:validate
+# rejects both an unset value and this literal default. Despite its name it
+# does not sign session tokens (those are opaque random tokens, and
+# src/lib/auth/jwt-verify.ts checks provider ID tokens against published JWKS
+# with RS256): it is the HMAC key for the audit log's client-IP pseudonym
+# `ipHash` (src/lib/security/client-fingerprint.ts). Left at this placeholder
+# the key is public knowledge and every ipHash in the audit trail becomes
+# reversible. Rotating it breaks ipHash correlation across the rotation.
 AUTH_JWT_SECRET=change-me-in-production
 AUTH_SESSION_TTL_MIN=120
 AUTH_COOKIE_SECURE=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,29 @@ jobs:
       - name: API spec + route + AsyncAPI contract check
         run: bun run api:spec:check
 
+      # Issue #823 (epic #818): the five checks below were in `bun run check`
+      # but had never been mirrored here — the FOURTH recurrence of the
+      # "CI silently runs a subset of `bun run check`" class (#685/#740/#745/
+      # #746/#750). All five passed at the time they were wired in, so this
+      # was latent risk, not active drift. The parity test added in the same
+      # issue (tests/unit/ci-check-parity.test.ts) now fails loudly when a new
+      # `check` step is added without mirroring it here, which is what
+      # actually kills the class — this list alone has drifted four times.
+      - name: API reference docs check
+        run: bun run api:docs:check
+
+      - name: Repo inventory check
+        run: bun run repo:inventory:check
+
+      - name: i18n POT catalog check
+        run: bun run i18n:pot:check
+
+      - name: Config/env docs check
+        run: bun run config:docs:check
+
+      - name: Logging lint check
+        run: bun run logging:lint:check
+
       - name: Module dependency graph check
         run: bun run modules:dag:check
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ blob-report/
 
 # Claude Code user-local settings (jangan commit)
 .claude/settings.local.json
+
+# Worktree agent Claude Code (isolation: "worktree") — dibuat DI DALAM repo,
+# jadi tanpa aturan ini `git add -A` bisa meng-commit seluruh checkout agent.
+# Terungkap saat epic #818 gelombang 1 menjalankan 6 agent paralel.
+.claude/worktrees/

--- a/docs/awcms-mini/18_configuration_env_reference.md
+++ b/docs/awcms-mini/18_configuration_env_reference.md
@@ -79,25 +79,37 @@ untuk menyatakan "TIDAK ada").
 TIDAK PERNAH otomatis mengubah perilaku lulus/gagal `bun run
 config:validate` — lihat field `guidance` masing-masing entry untuk apa
 yang sebenarnya berubah (biasanya: belum ada, versi major berikutnya baru
-benar-benar menghapus variabelnya, sesuai `removalVersion`). Enam variabel
+benar-benar menghapus variabelnya, sesuai `removalVersion`). Lima variabel
 ditandai `deprecated` sejak issue ini (diverifikasi mati/menyesatkan lewat
 grep menyeluruh, bukan asumsi dari deskripsi issue saja — lihat entry
 masing-masing di `src/lib/config/registry.ts` untuk bukti lengkap):
 
 | Var                  | Kenapa                                                                                                     | Ganti dengan                                                                         |
 | -------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `AUTH_JWT_SECRET`    | Tidak pernah dibaca — sesi memakai token opaque (`awcms_mini_sessions.token_hash`), bukan JWT              | Tidak ada — token sesi acak kriptografis, tidak diturunkan dari secret bersama       |
 | `APP_TIMEZONE`       | Tidak pernah dibaca — `src/lib/i18n/format.ts` hardcode `Asia/Jakarta`; timezone per tenant dari DB        | Ubah timezone tenant lewat `/admin/settings` (`awcms_mini_tenant_settings.timezone`) |
 | `APP_DEFAULT_LOCALE` | Tidak pernah dibaca — `src/lib/i18n/locale.ts` hardcode `DEFAULT_LOCALE = "en"`; locale per tenant dari DB | Ubah `default_locale` tenant lewat Setup Wizard / data tenant, bukan env var         |
 | `AWCMS_MINI_NODE_ID` | Tidak pernah dibaca — identitas node berasal dari `awcms_mini_sync_nodes` (DB), bukan env var              | Tidak ada — node teregistrasi otomatis lewat header/HMAC saat request sync pertama   |
 | `STORAGE_DRIVER`     | Tidak pernah dibaca — switch lokal/R2 sesungguhnya adalah `R2_ENABLED`                                     | `R2_ENABLED=true`/`false`                                                            |
 | `LOCAL_STORAGE_PATH` | Tidak pernah dibaca — tidak ada kode yang menulis ke path ini                                              | Tidak ada                                                                            |
 
-`AUTH_JWT_SECRET`/`APP_TIMEZONE` **tetap** wajib non-kosong di
-`config:validate` untuk rilis ini (tidak ada perubahan perilaku boot pass/
-fail dibanding sebelum Issue #689 — setiap `.env` yang sudah lulus tetap
-lulus); `removalVersion: "1.0.0"` di registry menandai kapan penegakan
-wajib ini (dan variabelnya sendiri) direncanakan benar-benar dihapus.
+`AUTH_JWT_SECRET` **dicabut dari daftar deprecated** (security review PR
+#839): sejak Issue #821 variabel ini adalah kunci HMAC nyata untuk pseudonim
+IP (`ipHash`) di audit log — lihat `src/lib/security/client-fingerprint.ts`.
+Deskripsi lama ("tidak pernah dibaca") dan jadwal hapus `1.0.0` kini salah
+dan berbahaya: menghapusnya akan mendegradasi `ipHash` jadi digest tanpa
+garam (ruang IPv4 hanya 2^32 ⇒ setiap `ipHash` reversibel) tanpa satu pun
+error. Variabel ini sekarang wajib non-kosong **dan** wajib berbeda dari
+placeholder `.env.example` (`checkAuthJwtSecretNotDefault` di
+`scripts/validate-env.ts`, memakai pola yang sama dengan
+`checkSyncHmacSecretNotDefault`). Namanya dipertahankan apa adanya agar
+deployment yang sudah menyediakannya tidak perlu berubah; tidak ada risiko
+cross-protocol karena variabel ini memang tidak menandatangani apa pun.
+
+`APP_TIMEZONE` **tetap** wajib non-kosong di `config:validate` untuk rilis
+ini (tidak ada perubahan perilaku boot pass/fail dibanding sebelum Issue
+#689 — setiap `.env` yang sudah lulus tetap lulus); `removalVersion:
+"1.0.0"` di registry menandai kapan penegakan wajib ini (dan variabelnya
+sendiri) direncanakan benar-benar dihapus.
 Ketiga variabel lain sudah opsional hari ini dan tidak berubah.
 
 ### Inti aplikasi
@@ -215,40 +227,40 @@ benar-benar scale-out horizontal; lihat runbook untuk contoh perhitungan.
 
 ### Auth & keamanan
 
-| Var                                         | Wajib          | Default                                  | Sensitif | Fungsi                                                                                                                                |
-| ------------------------------------------- | -------------- | ---------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `AUTH_JWT_SECRET`                           | Ya             | –                                        | Ya       | **DEPRECATED** (Issue #689, target hapus `1.0.0`) — tidak pernah dibaca; sesi memakai token opaque, bukan JWT; lihat §Config registry |
-| `AUTH_SESSION_TTL_MIN`                      | –              | `120`                                    | –        | Umur sesi                                                                                                                             |
-| `AUTH_COOKIE_SECURE`                        | –              | `true`                                   | –        | Cookie hanya HTTPS di prod                                                                                                            |
-| `AUTH_LOGIN_MAX_ATTEMPTS`                   | –              | `5`                                      | –        | Lockout login (per identitas)                                                                                                         |
-| `AUTH_LOGIN_RATE_LIMIT_MAX`                 | –              | `20`                                     | –        | Rate limit login per sumber+tenant (Issue #437)                                                                                       |
-| `AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC`          | –              | `60`                                     | –        | Jendela waktu rate limit login (detik)                                                                                                |
-| `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`         | –              | `30`                                     | –        | Umur token reset password (Issue #496)                                                                                                |
-| `AUTH_PASSWORD_RESET_RATE_LIMIT_MAX`        | –              | `5`                                      | –        | Rate limit forgot/reset per sumber+tenant                                                                                             |
-| `AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC` | –              | `900`                                    | –        | Jendela waktu rate limit reset password (detik)                                                                                       |
-| `AUTH_ONLINE_SECURITY_ENABLED`              | –              | `false`                                  | –        | Gate full-online-only auth hardening (Issue #587) — lihat §Full-online auth security hardening di bawah                               |
-| `AUTH_ONLINE_SECURITY_PROFILE`              | –              | `disabled`                               | –        | `disabled` (default) atau `full_online`; wajib `full_online` bila `AUTH_ONLINE_SECURITY_ENABLED=true`                                 |
-| `TURNSTILE_ENABLED`                         | –              | `false`                                  | –        | Cloudflare Turnstile bot protection (Issue #588) — lihat §Full-online auth security hardening di bawah                                |
-| `TURNSTILE_SITE_KEY`                        | bila Turnstile | –                                        | –        | Site key publik (bukan secret) — dirender di widget `/login`                                                                          |
-| `TURNSTILE_SECRET_KEY`                      | bila Turnstile | –                                        | Ya       | Secret key — hanya untuk verifikasi server-side, tidak pernah ke klien                                                                |
-| `TURNSTILE_VERIFY_TIMEOUT_MS`               | –              | `5000`                                   | –        | Timeout panggilan siteverify Cloudflare (ms)                                                                                          |
-| `AUTH_MFA_ENABLED`                          | –              | `false`                                  | –        | MFA/TOTP login challenge (Issue #589) — lihat §Full-online auth security hardening di bawah                                           |
-| `AUTH_MFA_SECRET_ENCRYPTION_KEY`            | bila MFA       | –                                        | Ya       | Key AES-256-GCM (base64, 32 byte) untuk enkripsi-at-rest TOTP secret                                                                  |
-| `AUTH_MFA_TOTP_ISSUER`                      | –              | `AWCMS-Mini`                             | –        | Nama issuer yang tampil di aplikasi authenticator                                                                                     |
-| `AUTH_MFA_TOTP_PERIOD_SEC`                  | –              | `30`                                     | –        | Panjang time-step TOTP (detik)                                                                                                        |
-| `AUTH_MFA_TOTP_DIGITS`                      | –              | `6`                                      | –        | Jumlah digit kode TOTP (`6` atau `8`)                                                                                                 |
-| `AUTH_MFA_CHALLENGE_TTL_SEC`                | –              | `300`                                    | –        | Umur challenge MFA login (detik)                                                                                                      |
-| `AUTH_MFA_RATE_LIMIT_MAX`                   | –              | `5`                                      | –        | Rate limit `POST /auth/mfa/totp/verify` per sumber+tenant                                                                             |
-| `AUTH_MFA_RATE_LIMIT_WINDOW_SEC`            | –              | `300`                                    | –        | Jendela waktu rate limit verifikasi MFA (detik)                                                                                       |
-| `AUTH_GOOGLE_LOGIN_ENABLED`                 | –              | `false`                                  | –        | Google OIDC login (Issue #590) — lihat §Full-online auth security hardening di bawah                                                  |
-| `AUTH_GOOGLE_CLIENT_ID`                     | bila Google    | –                                        | –        | OAuth client ID dari Google Cloud Console                                                                                             |
-| `AUTH_GOOGLE_CLIENT_SECRET`                 | bila Google    | –                                        | Ya       | OAuth client secret — hanya untuk token exchange server-side                                                                          |
-| `AUTH_GOOGLE_ALLOWED_DOMAINS`               | –              | –                                        | –        | Daftar domain email (dipisah koma) yang boleh auto-link; kosong = auto-link selalu ditolak                                            |
-| `AUTH_GOOGLE_REDIRECT_PATH`                 | –              | `/api/v1/auth/providers/google/callback` | –        | Path callback OAuth di bawah `APP_URL`                                                                                                |
-| `AUTH_SSO_ENABLED`                          | –              | `false`                                  | –        | Generic tenant OIDC SSO (Issue #591) — lihat §Full-online auth security hardening di bawah                                            |
-| `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY`        | bila SSO       | –                                        | Ya       | Key AES-256-GCM (base64, 32 byte) untuk enkripsi-at-rest client secret provider — beda dari key MFA                                   |
-| `AUTH_SSO_DISCOVERY_TIMEOUT_MS`             | –              | `5000`                                   | –        | Timeout discovery/JWKS/token-exchange OIDC provider tenant (ms)                                                                       |
-| `AUTH_SSO_MAX_PROVIDERS_PER_TENANT`         | –              | `20`                                     | –        | Batas jumlah baris provider aktif per tenant (Issue #612) — membatasi total budget probing tenant                                     |
+| Var                                         | Wajib          | Default                                  | Sensitif | Fungsi                                                                                                                                                                           |
+| ------------------------------------------- | -------------- | ---------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH_JWT_SECRET`                           | Ya             | –                                        | Ya       | Kunci HMAC pseudonim IP (`ipHash`) di audit log — `src/lib/security/client-fingerprint.ts`. Bukan penanda tangan token sesi (sesi = token opaque). Wajib diubah dari placeholder |
+| `AUTH_SESSION_TTL_MIN`                      | –              | `120`                                    | –        | Umur sesi                                                                                                                                                                        |
+| `AUTH_COOKIE_SECURE`                        | –              | `true`                                   | –        | Cookie hanya HTTPS di prod                                                                                                                                                       |
+| `AUTH_LOGIN_MAX_ATTEMPTS`                   | –              | `5`                                      | –        | Lockout login (per identitas)                                                                                                                                                    |
+| `AUTH_LOGIN_RATE_LIMIT_MAX`                 | –              | `20`                                     | –        | Rate limit login per sumber+tenant (Issue #437)                                                                                                                                  |
+| `AUTH_LOGIN_RATE_LIMIT_WINDOW_SEC`          | –              | `60`                                     | –        | Jendela waktu rate limit login (detik)                                                                                                                                           |
+| `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`         | –              | `30`                                     | –        | Umur token reset password (Issue #496)                                                                                                                                           |
+| `AUTH_PASSWORD_RESET_RATE_LIMIT_MAX`        | –              | `5`                                      | –        | Rate limit forgot/reset per sumber+tenant                                                                                                                                        |
+| `AUTH_PASSWORD_RESET_RATE_LIMIT_WINDOW_SEC` | –              | `900`                                    | –        | Jendela waktu rate limit reset password (detik)                                                                                                                                  |
+| `AUTH_ONLINE_SECURITY_ENABLED`              | –              | `false`                                  | –        | Gate full-online-only auth hardening (Issue #587) — lihat §Full-online auth security hardening di bawah                                                                          |
+| `AUTH_ONLINE_SECURITY_PROFILE`              | –              | `disabled`                               | –        | `disabled` (default) atau `full_online`; wajib `full_online` bila `AUTH_ONLINE_SECURITY_ENABLED=true`                                                                            |
+| `TURNSTILE_ENABLED`                         | –              | `false`                                  | –        | Cloudflare Turnstile bot protection (Issue #588) — lihat §Full-online auth security hardening di bawah                                                                           |
+| `TURNSTILE_SITE_KEY`                        | bila Turnstile | –                                        | –        | Site key publik (bukan secret) — dirender di widget `/login`                                                                                                                     |
+| `TURNSTILE_SECRET_KEY`                      | bila Turnstile | –                                        | Ya       | Secret key — hanya untuk verifikasi server-side, tidak pernah ke klien                                                                                                           |
+| `TURNSTILE_VERIFY_TIMEOUT_MS`               | –              | `5000`                                   | –        | Timeout panggilan siteverify Cloudflare (ms)                                                                                                                                     |
+| `AUTH_MFA_ENABLED`                          | –              | `false`                                  | –        | MFA/TOTP login challenge (Issue #589) — lihat §Full-online auth security hardening di bawah                                                                                      |
+| `AUTH_MFA_SECRET_ENCRYPTION_KEY`            | bila MFA       | –                                        | Ya       | Key AES-256-GCM (base64, 32 byte) untuk enkripsi-at-rest TOTP secret                                                                                                             |
+| `AUTH_MFA_TOTP_ISSUER`                      | –              | `AWCMS-Mini`                             | –        | Nama issuer yang tampil di aplikasi authenticator                                                                                                                                |
+| `AUTH_MFA_TOTP_PERIOD_SEC`                  | –              | `30`                                     | –        | Panjang time-step TOTP (detik)                                                                                                                                                   |
+| `AUTH_MFA_TOTP_DIGITS`                      | –              | `6`                                      | –        | Jumlah digit kode TOTP (`6` atau `8`)                                                                                                                                            |
+| `AUTH_MFA_CHALLENGE_TTL_SEC`                | –              | `300`                                    | –        | Umur challenge MFA login (detik)                                                                                                                                                 |
+| `AUTH_MFA_RATE_LIMIT_MAX`                   | –              | `5`                                      | –        | Rate limit `POST /auth/mfa/totp/verify` per sumber+tenant                                                                                                                        |
+| `AUTH_MFA_RATE_LIMIT_WINDOW_SEC`            | –              | `300`                                    | –        | Jendela waktu rate limit verifikasi MFA (detik)                                                                                                                                  |
+| `AUTH_GOOGLE_LOGIN_ENABLED`                 | –              | `false`                                  | –        | Google OIDC login (Issue #590) — lihat §Full-online auth security hardening di bawah                                                                                             |
+| `AUTH_GOOGLE_CLIENT_ID`                     | bila Google    | –                                        | –        | OAuth client ID dari Google Cloud Console                                                                                                                                        |
+| `AUTH_GOOGLE_CLIENT_SECRET`                 | bila Google    | –                                        | Ya       | OAuth client secret — hanya untuk token exchange server-side                                                                                                                     |
+| `AUTH_GOOGLE_ALLOWED_DOMAINS`               | –              | –                                        | –        | Daftar domain email (dipisah koma) yang boleh auto-link; kosong = auto-link selalu ditolak                                                                                       |
+| `AUTH_GOOGLE_REDIRECT_PATH`                 | –              | `/api/v1/auth/providers/google/callback` | –        | Path callback OAuth di bawah `APP_URL`                                                                                                                                           |
+| `AUTH_SSO_ENABLED`                          | –              | `false`                                  | –        | Generic tenant OIDC SSO (Issue #591) — lihat §Full-online auth security hardening di bawah                                                                                       |
+| `AUTH_SSO_CREDENTIAL_ENCRYPTION_KEY`        | bila SSO       | –                                        | Ya       | Key AES-256-GCM (base64, 32 byte) untuk enkripsi-at-rest client secret provider — beda dari key MFA                                                                              |
+| `AUTH_SSO_DISCOVERY_TIMEOUT_MS`             | –              | `5000`                                   | –        | Timeout discovery/JWKS/token-exchange OIDC provider tenant (ms)                                                                                                                  |
+| `AUTH_SSO_MAX_PROVIDERS_PER_TENANT`         | –              | `20`                                     | –        | Batas jumlah baris provider aktif per tenant (Issue #612) — membatasi total budget probing tenant                                                                                |
 
 ### Full-online auth security hardening (opsional, Issue #587-#593)
 

--- a/docs/awcms-mini/api-reference.md
+++ b/docs/awcms-mini/api-reference.md
@@ -9548,15 +9548,15 @@ Distinct, more sensitive permission from exports.read (data_exchange.export_down
 
 **Responses**
 
-| Status | Description                                         | Schema                                 |
-| ------ | --------------------------------------------------- | -------------------------------------- |
-| 200    | Export file content.                                | string                                 |
-| 400    | Validation or request error.                        | [`ApiError`](#standard-error-envelope) |
-| 401    | Authentication required or expired.                 | [`ApiError`](#standard-error-envelope) |
-| 403    | Access denied by RBAC, ABAC, or tenant policy.      | [`ApiError`](#standard-error-envelope) |
-| 404    | Resource not found or hidden by soft-delete policy. | [`ApiError`](#standard-error-envelope) |
-| 409    | Export job is not completed.                        | [`ApiError`](#standard-error-envelope) |
-| 500    | Internal server error without stack trace.          | [`ApiError`](#standard-error-envelope) |
+| Status | Description                                                                                                       | Schema                                 |
+| ------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Export file content.                                                                                              | string                                 |
+| 400    | Validation or request error.                                                                                      | [`ApiError`](#standard-error-envelope) |
+| 401    | Authentication required or expired.                                                                               | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC, ABAC, or tenant policy.                                                                    | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found or hidden by soft-delete policy.                                                               | [`ApiError`](#standard-error-envelope) |
+| 409    | Export job is not completed, or its exportKey is no longer registered (owning module disabled after the job ran). | [`ApiError`](#standard-error-envelope) |
+| 500    | Internal server error without stack trace.                                                                        | [`ApiError`](#standard-error-envelope) |
 
 ### `GET /api/v1/data-exchange/imports` — List staged import batches
 
@@ -9685,15 +9685,15 @@ High-risk mutation -- requires Idempotency-Key. Never blocks on the actual per-r
 
 **Responses**
 
-| Status | Description                                                                           | Schema                                                   |
-| ------ | ------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| 200    | Commit triggered.                                                                     | [`ApiSuccess`](#standard-success-envelope)&lt;object&gt; |
-| 400    | Validation or request error.                                                          | [`ApiError`](#standard-error-envelope)                   |
-| 401    | Authentication required or expired.                                                   | [`ApiError`](#standard-error-envelope)                   |
-| 403    | Access denied by RBAC, ABAC, or tenant policy.                                        | [`ApiError`](#standard-error-envelope)                   |
-| 404    | Resource not found or hidden by soft-delete policy.                                   | [`ApiError`](#standard-error-envelope)                   |
-| 409    | Batch is not in previewed status, or Idempotency-Key reused with a different request. | [`ApiError`](#standard-error-envelope)                   |
-| 500    | Internal server error without stack trace.                                            | [`ApiError`](#standard-error-envelope)                   |
+| Status | Description                                                                                                                                                         | Schema                                                   |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| 200    | Commit triggered.                                                                                                                                                   | [`ApiSuccess`](#standard-success-envelope)&lt;object&gt; |
+| 400    | Validation or request error.                                                                                                                                        | [`ApiError`](#standard-error-envelope)                   |
+| 401    | Authentication required or expired.                                                                                                                                 | [`ApiError`](#standard-error-envelope)                   |
+| 403    | Access denied by RBAC, ABAC, or tenant policy.                                                                                                                      | [`ApiError`](#standard-error-envelope)                   |
+| 404    | Resource not found or hidden by soft-delete policy.                                                                                                                 | [`ApiError`](#standard-error-envelope)                   |
+| 409    | Batch is not in previewed status, its importKey is no longer registered (owning module disabled after staging), or Idempotency-Key reused with a different request. | [`ApiError`](#standard-error-envelope)                   |
+| 500    | Internal server error without stack trace.                                                                                                                          | [`ApiError`](#standard-error-envelope)                   |
 
 ### `POST /api/v1/data-exchange/imports/{id}/pause` — Pause an in-progress commit
 
@@ -9728,29 +9728,30 @@ Requires Idempotency-Key. The worker skips a paused batch entirely.
 - **operationId**: `dataExchangeImportsPreview`
 - **Security**: bearerAuth + tenantHeader
 
-Zero domain mutation. Sensitive fields are masked unless the caller also holds data_exchange.preview_errors.read.
+Zero domain mutation. Raw staged values are revealed only when the batch's descriptor declares a sensitiveFields policy AND the caller holds the permission THAT descriptor names in sensitiveFields.rawValuePermission -- never a generic data_exchange permission. A descriptor declaring no policy is masked entirely (default-deny), and a batch whose importKey no longer resolves (its owning module was disabled after staging) is refused with 409.
 
 **Parameters**
 
-| Name               | In     | Required | Type                                                    | Description                                 |
-| ------------------ | ------ | -------- | ------------------------------------------------------- | ------------------------------------------- |
-| `id`               | path   | yes      | string (uuid)                                           |                                             |
-| `proposedAction`   | query  | no       | enum(`create`, `update`, `skip`, `conflict`, `invalid`) |                                             |
-| `offset`           | query  | no       | integer                                                 |                                             |
-| `limit`            | query  | no       | integer                                                 |                                             |
-| `X-Correlation-ID` | header | no       | string                                                  | Optional server-side trace correlation ID.  |
-| `X-Request-ID`     | header | no       | string                                                  | Optional client-generated request trace ID. |
+| Name               | In     | Required | Type                                                    | Description                                                                                                                                                         |
+| ------------------ | ------ | -------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`               | path   | yes      | string (uuid)                                           |                                                                                                                                                                     |
+| `proposedAction`   | query  | no       | enum(`create`, `update`, `skip`, `conflict`, `invalid`) |                                                                                                                                                                     |
+| `offset`           | query  | no       | integer                                                 | Clamped to the maximum below, which equals the hard cap on rows per batch -- no batch can hold a row beyond it. The response echoes the effective (clamped) offset. |
+| `limit`            | query  | no       | integer                                                 |                                                                                                                                                                     |
+| `X-Correlation-ID` | header | no       | string                                                  | Optional server-side trace correlation ID.                                                                                                                          |
+| `X-Request-ID`     | header | no       | string                                                  | Optional client-generated request trace ID.                                                                                                                         |
 
 **Responses**
 
-| Status | Description                                         | Schema                                                   |
-| ------ | --------------------------------------------------- | -------------------------------------------------------- |
-| 200    | Preview page.                                       | [`ApiSuccess`](#standard-success-envelope)&lt;object&gt; |
-| 400    | Validation or request error.                        | [`ApiError`](#standard-error-envelope)                   |
-| 401    | Authentication required or expired.                 | [`ApiError`](#standard-error-envelope)                   |
-| 403    | Access denied by RBAC, ABAC, or tenant policy.      | [`ApiError`](#standard-error-envelope)                   |
-| 404    | Resource not found or hidden by soft-delete policy. | [`ApiError`](#standard-error-envelope)                   |
-| 500    | Internal server error without stack trace.          | [`ApiError`](#standard-error-envelope)                   |
+| Status | Description                                                                                                            | Schema                                                   |
+| ------ | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| 200    | Preview page.                                                                                                          | [`ApiSuccess`](#standard-success-envelope)&lt;object&gt; |
+| 400    | Validation or request error.                                                                                           | [`ApiError`](#standard-error-envelope)                   |
+| 401    | Authentication required or expired.                                                                                    | [`ApiError`](#standard-error-envelope)                   |
+| 403    | Access denied by RBAC, ABAC, or tenant policy.                                                                         | [`ApiError`](#standard-error-envelope)                   |
+| 404    | Resource not found or hidden by soft-delete policy.                                                                    | [`ApiError`](#standard-error-envelope)                   |
+| 409    | The batch's importKey is no longer registered -- its owning module was disabled or removed after the batch was staged. | [`ApiError`](#standard-error-envelope)                   |
+| 500    | Internal server error without stack trace.                                                                             | [`ApiError`](#standard-error-envelope)                   |
 
 ### `POST /api/v1/data-exchange/imports/{id}/resume` — Resume a paused commit
 
@@ -9798,15 +9799,15 @@ High-risk mutation -- requires Idempotency-Key. Resumes from the batch's saved c
 
 **Responses**
 
-| Status | Description                                                                                         | Schema                                                   |
-| ------ | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| 200    | Retry/resume triggered.                                                                             | [`ApiSuccess`](#standard-success-envelope)&lt;object&gt; |
-| 400    | Validation or request error.                                                                        | [`ApiError`](#standard-error-envelope)                   |
-| 401    | Authentication required or expired.                                                                 | [`ApiError`](#standard-error-envelope)                   |
-| 403    | Access denied by RBAC, ABAC, or tenant policy.                                                      | [`ApiError`](#standard-error-envelope)                   |
-| 404    | Resource not found or hidden by soft-delete policy.                                                 | [`ApiError`](#standard-error-envelope)                   |
-| 409    | Batch is not retryable from its current status, or Idempotency-Key reused with a different request. | [`ApiError`](#standard-error-envelope)                   |
-| 500    | Internal server error without stack trace.                                                          | [`ApiError`](#standard-error-envelope)                   |
+| Status | Description                                                                                                                                                                       | Schema                                                   |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| 200    | Retry/resume triggered.                                                                                                                                                           | [`ApiSuccess`](#standard-success-envelope)&lt;object&gt; |
+| 400    | Validation or request error.                                                                                                                                                      | [`ApiError`](#standard-error-envelope)                   |
+| 401    | Authentication required or expired.                                                                                                                                               | [`ApiError`](#standard-error-envelope)                   |
+| 403    | Access denied by RBAC, ABAC, or tenant policy.                                                                                                                                    | [`ApiError`](#standard-error-envelope)                   |
+| 404    | Resource not found or hidden by soft-delete policy.                                                                                                                               | [`ApiError`](#standard-error-envelope)                   |
+| 409    | Batch is not retryable from its current status, its importKey is no longer registered (owning module disabled after staging), or Idempotency-Key reused with a different request. | [`ApiError`](#standard-error-envelope)                   |
+| 500    | Internal server error without stack trace.                                                                                                                                        | [`ApiError`](#standard-error-envelope)                   |
 
 ### `GET /api/v1/data-exchange/reconciliation/{subjectType}/{subjectId}` — Read reconciliation reports for an import or export subject
 

--- a/docs/awcms-mini/api-reference.md
+++ b/docs/awcms-mini/api-reference.md
@@ -8000,12 +8000,12 @@ Writes ONLY to the caller's own tenant-scoped table (RLS FORCE) -- never the glo
 | 404    | Resource not found or hidden by soft-delete policy. | [`ApiError`](#standard-error-envelope)                   |
 | 500    | Internal server error without stack trace.          | [`ApiError`](#standard-error-envelope)                   |
 
-### `PATCH /api/v1/reference-data/tenant-codes/{id}` — Update a tenant reference code override/extension
+### `PATCH /api/v1/reference-data/tenant-codes/{id}` — Partially update a tenant reference code override/extension
 
 - **operationId**: `referenceDataTenantCodesUpdate`
 - **Security**: bearerAuth + tenantHeader
 
-Requires Idempotency-Key.
+True PATCH semantics -- omitted fields keep their stored value, explicit null clears/resets (see ReferenceDataUpdateTenantCodeRequest). Requires Idempotency-Key.
 
 **Parameters**
 
@@ -8304,12 +8304,12 @@ Writes to the GLOBAL baseline shared by every tenant -- requires Idempotency-Key
 | 404    | Resource not found or hidden by soft-delete policy. | [`ApiError`](#standard-error-envelope)                   |
 | 500    | Internal server error without stack trace.          | [`ApiError`](#standard-error-envelope)                   |
 
-### `PATCH /api/v1/reference-data/value-sets/{key}/codes/{code}` — Update a reference code's mutable attributes
+### `PATCH /api/v1/reference-data/value-sets/{key}/codes/{code}` — Partially update a reference code's mutable attributes
 
 - **operationId**: `referenceDataCodesUpdate`
 - **Security**: bearerAuth + tenantHeader
 
-Writes to the GLOBAL baseline shared by every tenant -- requires Idempotency-Key. Rejected for descriptor-managed codes.
+True PATCH semantics -- omitted fields keep their stored value, explicit null clears/resets (see ReferenceDataUpdateCodeRequest). Writes to the GLOBAL baseline shared by every tenant -- requires Idempotency-Key. Rejected for descriptor-managed codes.
 
 **Parameters**
 
@@ -15269,13 +15269,15 @@ One localized label/description for a reference code (Issue
 
 ### Schema: ReferenceDataUpdateCodeRequest
 
-| Field       | Type                                                        | Required | Nullable | Description |
-| ----------- | ----------------------------------------------------------- | -------- | -------- | ----------- |
-| `labels`    | array of [`ReferenceCodeLabel`](#schema-referencecodelabel) | yes      | no       |             |
-| `sortOrder` | integer                                                     | no       | no       |             |
-| `metadata`  | object                                                      | no       | no       |             |
-| `validFrom` | string (date-time)                                          | no       | no       |             |
-| `validTo`   | string (date-time)                                          | no       | yes      |             |
+Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update.
+
+| Field       | Type                                                        | Required | Nullable | Description                                                                                       |
+| ----------- | ----------------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `labels`    | array of [`ReferenceCodeLabel`](#schema-referencecodelabel) | no       | no       | Replaces ALL stored labels for this code. Omit to keep them; null is rejected.                    |
+| `sortOrder` | integer                                                     | no       | yes      | Omit to keep the stored value; null resets to 0.                                                  |
+| `metadata`  | object                                                      | no       | yes      | Replaces the stored metadata wholesale (not a deep merge). Omit to keep it; null clears it to {}. |
+| `validFrom` | string (date-time)                                          | no       | no       | Omit to keep the stored value; null is rejected.                                                  |
+| `validTo`   | string (date-time)                                          | no       | yes      | Omit to keep the stored value; null clears the end of validity.                                   |
 
 **Example**
 
@@ -15297,13 +15299,15 @@ One localized label/description for a reference code (Issue
 
 ### Schema: ReferenceDataUpdateTenantCodeRequest
 
-| Field       | Type                                                        | Required | Nullable | Description |
-| ----------- | ----------------------------------------------------------- | -------- | -------- | ----------- |
-| `labels`    | array of [`ReferenceCodeLabel`](#schema-referencecodelabel) | yes      | no       |             |
-| `sortOrder` | integer                                                     | no       | no       |             |
-| `metadata`  | object                                                      | no       | no       |             |
-| `validFrom` | string (date-time)                                          | no       | no       |             |
-| `validTo`   | string (date-time)                                          | no       | yes      |             |
+Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update.
+
+| Field       | Type                                                        | Required | Nullable | Description                                                                                       |
+| ----------- | ----------------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `labels`    | array of [`ReferenceCodeLabel`](#schema-referencecodelabel) | no       | no       | Replaces ALL stored labels for this code. Omit to keep them; null is rejected.                    |
+| `sortOrder` | integer                                                     | no       | yes      | Omit to keep the stored value; null resets to 0.                                                  |
+| `metadata`  | object                                                      | no       | yes      | Replaces the stored metadata wholesale (not a deep merge). Omit to keep it; null clears it to {}. |
+| `validFrom` | string (date-time)                                          | no       | no       | Omit to keep the stored value; null is rejected.                                                  |
+| `validTo`   | string (date-time)                                          | no       | yes      | Omit to keep the stored value; null clears the end of validity.                                   |
 
 **Example**
 

--- a/docs/awcms-mini/api-reference.md
+++ b/docs/awcms-mini/api-reference.md
@@ -15269,7 +15269,7 @@ One localized label/description for a reference code (Issue
 
 ### Schema: ReferenceDataUpdateCodeRequest
 
-Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update.
+Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update: it returns the current representation with 200 and is genuinely inert -- updated_at is not bumped and no audit or domain event is emitted. The body itself is required and must be a JSON object; an absent, malformed, non-object (null, array, scalar) body is rejected with 400 VALIDATION_ERROR rather than being treated as {}.
 
 | Field       | Type                                                        | Required | Nullable | Description                                                                                       |
 | ----------- | ----------------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
@@ -15299,7 +15299,7 @@ Partial PATCH body. Every property is optional: a property that is ABSENT from t
 
 ### Schema: ReferenceDataUpdateTenantCodeRequest
 
-Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update.
+Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update: it returns the current representation with 200 and is genuinely inert -- updated_at is not bumped and no audit or domain event is emitted. The body itself is required and must be a JSON object; an absent, malformed, non-object (null, array, scalar) body is rejected with 400 VALIDATION_ERROR rather than being treated as {}.
 
 | Field       | Type                                                        | Required | Nullable | Description                                                                                       |
 | ----------- | ----------------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |

--- a/docs/awcms-mini/branch-protection.md
+++ b/docs/awcms-mini/branch-protection.md
@@ -2,15 +2,35 @@
 
 Issue #685 (epic #679, platform-hardening) acceptance criterion: "Branch
 protection documentation identifies required checks." This document is
-that reference — it does **not** itself configure GitHub, and as of this
-writing `main` has **no branch protection rule at all**
-(`gh api repos/ahliweb/awcms-mini/branches/main/protection` returns
-`404 Branch not protected`). Every check below already runs and reports
-its status on every PR; none of them currently **block** a merge — a PR
-with a failing check can still be merged today. Enabling branch protection
-is a repo-admin, shared-state change (affects every contributor's merge
-flow) and is deliberately left to a maintainer to apply explicitly, not
-done automatically by this doc or by CI itself.
+that reference.
+
+> ## ✅ AKTIF sejak 2026-07-17 (Issue #823, epic #818)
+>
+> `main` **sudah diproteksi**. Sebelumnya tidak sama sekali
+> (`404 Branch not protected`) — CI berjalan tapi **advisory**: PR dengan
+> check merah tetap bisa di-merge, dan itu akar beberapa temuan audit
+> [#818](https://github.com/ahliweb/awcms-mini/issues/818).
+>
+> Konfigurasi terpasang (verifikasi: `gh api repos/ahliweb/awcms-mini/branches/main/protection`):
+>
+> | Setelan                            | Nilai                    | Alasan                                                                                                                                                         |
+> | ---------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+> | Required checks                    | 6 (lihat tabel di bawah) | CI tidak lagi advisory                                                                                                                                         |
+> | `strict`                           | `false`                  | PR tidak dipaksa selalu up-to-date dengan `main` — trade-off sadar agar banyak PR paralel tidak terserialisasi. Pertimbangkan `true` setelah epic #818 selesai |
+> | Approval wajib                     | `0`                      | PR tetap wajib + CI wajib hijau, tapi alur agent masih bisa me-merge PR hijau. Naikkan ke `1` bila ingin review manusia wajib                                  |
+> | `enforce_admins`                   | `false`                  | Menyisakan jalan darurat bila CI rusak total                                                                                                                   |
+> | Force push                         | diblokir                 |                                                                                                                                                                |
+> | Penghapusan branch                 | diblokir                 |                                                                                                                                                                |
+> | `required_conversation_resolution` | `true`                   | Temuan review tidak bisa diabaikan diam-diam                                                                                                                   |
+>
+> **`CodeQL` (yang polos) sengaja TIDAK diwajibkan** — check itu melapor
+> `skipping` pada sebagian run, dan mewajibkannya akan menggantungkan PR
+> selamanya. Yang diwajibkan adalah dua job `Analyze (...)` yang benar-benar
+> berjalan. Ini jebakan nyata: required check yang bisa "skip" = deadlock.
+
+Mengubah proteksi adalah perubahan shared-state (memengaruhi alur merge
+setiap kontributor) — lakukan eksplisit oleh maintainer, jangan otomatis dari
+doc ini atau dari CI.
 
 ## Required status checks (recommended)
 
@@ -34,7 +54,19 @@ list too if the org's GitGuardian integration is expected to stay enabled
 long-term; it is not configured by anything in `.github/workflows/`, so
 it isn't itemized above with the rest.
 
-## Applying this (maintainer action, not automated)
+## Mengubah proteksi (sudah diterapkan — bagian ini untuk MENGUBAH, bukan memasang)
+
+> Perintah & anjuran di bawah ditulis **sebelum** proteksi aktif dan
+> mencerminkan usulan awal, bukan kondisi terpasang. Yang benar-benar aktif
+> ada di kotak ✅ di bagian atas. **Dua nilai sengaja berbeda dari contoh di
+> bawah**: `strict=false` (bukan `true`) agar PR paralel tidak terserialisasi,
+> dan `enforce_admins=false` (bukan `true`) untuk menyisakan jalan darurat.
+> Contoh di bawah juga memakai `required_pull_request_reviews=null`, sedangkan
+> yang terpasang mewajibkan PR dengan `0` approval.
+>
+> Cara terpasangnya: `gh api -X PUT ... --input <file.json>` (payload JSON
+> penuh) — bentuk `-f key.subkey=value` di bawah rapuh untuk struktur bersarang.
+> **Selalu verifikasi dengan `GET` setelah mengubah.**
 
 Via the GitHub UI: **Settings → Branches → Add branch protection rule**,
 pattern `main`, enable **Require status checks to pass before merging**,

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -145,13 +145,13 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 
 ## Tests
 
-328 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
+330 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 46         |
+| `(root)`      | 47         |
 | `e2e`         | 9          |
-| `integration` | 96         |
+| `integration` | 97         |
 | `modules`     | 5          |
 | `unit`        | 172        |
 

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -146,7 +146,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 
 ## Tests
 
-335 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
+336 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
 
 | Directory     | Test files |
 | ------------- | ---------- |
@@ -154,7 +154,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 | `e2e`         | 9          |
 | `integration` | 97         |
 | `modules`     | 5          |
-| `unit`        | 177        |
+| `unit`        | 178        |
 
 ## Routes / Operations (summary)
 

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -146,7 +146,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 
 ## Tests
 
-334 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
+335 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
 
 | Directory     | Test files |
 | ------------- | ---------- |
@@ -154,7 +154,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 | `e2e`         | 9          |
 | `integration` | 97         |
 | `modules`     | 5          |
-| `unit`        | 176        |
+| `unit`        | 177        |
 
 ## Routes / Operations (summary)
 

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -36,7 +36,7 @@
 
 ## Migrations
 
-76 migration files in `sql/` (`001_awcms_mini_foundation_schema.sql` .. `076_awcms_mini_reference_data_permissions.sql`). Reserved base migration namespace (Issue #740, ADR-0014): `1-899` — a derived repository's own migrations start numbering at `900` or above.
+77 migration files in `sql/` (`001_awcms_mini_foundation_schema.sql` .. `077_awcms_mini_performance_missing_indexes.sql`). Reserved base migration namespace (Issue #740, ADR-0014): `1-899` — a derived repository's own migrations start numbering at `900` or above.
 
 | #   | File                                                                     |
 | --- | ------------------------------------------------------------------------ |
@@ -116,6 +116,7 @@
 | 074 | `074_awcms_mini_integration_hub_permissions.sql`                         |
 | 075 | `075_awcms_mini_reference_data_schema.sql`                               |
 | 076 | `076_awcms_mini_reference_data_permissions.sql`                          |
+| 077 | `077_awcms_mini_performance_missing_indexes.sql`                         |
 
 ## Tables & Row-Level Security
 

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -146,7 +146,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 
 ## Tests
 
-333 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
+334 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
 
 | Directory     | Test files |
 | ------------- | ---------- |
@@ -154,7 +154,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 | `e2e`         | 9          |
 | `integration` | 97         |
 | `modules`     | 5          |
-| `unit`        | 175        |
+| `unit`        | 176        |
 
 ## Routes / Operations (summary)
 

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -146,7 +146,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 
 ## Tests
 
-330 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
+332 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
 
 | Directory     | Test files |
 | ------------- | ---------- |
@@ -154,7 +154,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 | `e2e`         | 9          |
 | `integration` | 97         |
 | `modules`     | 5          |
-| `unit`        | 172        |
+| `unit`        | 174        |
 
 ## Routes / Operations (summary)
 

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -145,7 +145,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 
 ## Tests
 
-328 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
+329 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
 
 | Directory     | Test files |
 | ------------- | ---------- |
@@ -153,7 +153,7 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 | `e2e`         | 9          |
 | `integration` | 96         |
 | `modules`     | 5          |
-| `unit`        | 172        |
+| `unit`        | 173        |
 
 ## Routes / Operations (summary)
 

--- a/docs/awcms-mini/repo-inventory.md
+++ b/docs/awcms-mini/repo-inventory.md
@@ -36,7 +36,7 @@
 
 ## Migrations
 
-76 migration files in `sql/` (`001_awcms_mini_foundation_schema.sql` .. `076_awcms_mini_reference_data_permissions.sql`). Reserved base migration namespace (Issue #740, ADR-0014): `1-899` — a derived repository's own migrations start numbering at `900` or above.
+77 migration files in `sql/` (`001_awcms_mini_foundation_schema.sql` .. `077_awcms_mini_performance_missing_indexes.sql`). Reserved base migration namespace (Issue #740, ADR-0014): `1-899` — a derived repository's own migrations start numbering at `900` or above.
 
 | #   | File                                                                     |
 | --- | ------------------------------------------------------------------------ |
@@ -116,6 +116,7 @@
 | 074 | `074_awcms_mini_integration_hub_permissions.sql`                         |
 | 075 | `075_awcms_mini_reference_data_schema.sql`                               |
 | 076 | `076_awcms_mini_reference_data_permissions.sql`                          |
+| 077 | `077_awcms_mini_performance_missing_indexes.sql`                         |
 
 ## Tables & Row-Level Security
 
@@ -145,15 +146,15 @@ No gap found: every tenant-scoped table has an `ENABLE ROW LEVEL SECURITY` state
 
 ## Tests
 
-329 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
+333 test files under `tests/` (`*.test.ts`, `*.test.mjs`, `*.e2e.ts`).
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 46         |
+| `(root)`      | 47         |
 | `e2e`         | 9          |
-| `integration` | 96         |
+| `integration` | 97         |
 | `modules`     | 5          |
-| `unit`        | 173        |
+| `unit`        | 175        |
 
 ## Routes / Operations (summary)
 

--- a/i18n/messages.pot
+++ b/i18n/messages.pot
@@ -2164,15 +2164,15 @@ msgstr ""
 msgid "admin.data_exchange.exports.title"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:66
+#: src/pages/admin/data-exchange/imports/[id].astro:78
 msgid "admin.data_exchange.imports.action_success"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:223
+#: src/pages/admin/data-exchange/imports/[id].astro:264
 msgid "admin.data_exchange.imports.cancel_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:67
+#: src/pages/admin/data-exchange/imports/[id].astro:79
 msgid "admin.data_exchange.imports.cancel_reason_prompt"
 msgstr ""
 
@@ -2184,7 +2184,7 @@ msgstr ""
 msgid "admin.data_exchange.imports.col_actions"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:243
+#: src/pages/admin/data-exchange/imports/[id].astro:284
 msgid "admin.data_exchange.imports.col_commit_status"
 msgstr ""
 
@@ -2192,19 +2192,19 @@ msgstr ""
 msgid "admin.data_exchange.imports.col_created_at"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:246
+#: src/pages/admin/data-exchange/imports/[id].astro:287
 msgid "admin.data_exchange.imports.col_errors"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:175
+#: src/pages/admin/data-exchange/imports/[id].astro:216
 msgid "admin.data_exchange.imports.col_import_key"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:237
+#: src/pages/admin/data-exchange/imports/[id].astro:278
 msgid "admin.data_exchange.imports.col_natural_key"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:240
+#: src/pages/admin/data-exchange/imports/[id].astro:281
 msgid "admin.data_exchange.imports.col_proposed_action"
 msgstr ""
 
@@ -2212,15 +2212,15 @@ msgstr ""
 msgid "admin.data_exchange.imports.col_rows"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:177
+#: src/pages/admin/data-exchange/imports/[id].astro:218
 msgid "admin.data_exchange.imports.col_status"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:199
+#: src/pages/admin/data-exchange/imports/[id].astro:240
 msgid "admin.data_exchange.imports.commit_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:134
+#: src/pages/admin/data-exchange/imports/[id].astro:175
 msgid "admin.data_exchange.imports.detail_title"
 msgstr ""
 
@@ -2236,47 +2236,47 @@ msgstr ""
 msgid "admin.data_exchange.imports.field_import_key"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:289
+#: src/pages/admin/data-exchange/imports/[id].astro:330
 msgid "admin.data_exchange.imports.matched"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:288
+#: src/pages/admin/data-exchange/imports/[id].astro:329
 msgid "admin.data_exchange.imports.mismatch"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:230
+#: src/pages/admin/data-exchange/imports/[id].astro:271
 msgid "admin.data_exchange.imports.no_rows"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:210
+#: src/pages/admin/data-exchange/imports/[id].astro:251
 msgid "admin.data_exchange.imports.pause_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:228
+#: src/pages/admin/data-exchange/imports/[id].astro:269
 msgid "admin.data_exchange.imports.preview_heading"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:285
+#: src/pages/admin/data-exchange/imports/[id].astro:326
 msgid "admin.data_exchange.imports.processed_count"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:278
+#: src/pages/admin/data-exchange/imports/[id].astro:319
 msgid "admin.data_exchange.imports.reconciliation_heading"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:215
+#: src/pages/admin/data-exchange/imports/[id].astro:256
 msgid "admin.data_exchange.imports.resume_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:205
+#: src/pages/admin/data-exchange/imports/[id].astro:246
 msgid "admin.data_exchange.imports.retry_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:270
+#: src/pages/admin/data-exchange/imports/[id].astro:311
 msgid "admin.data_exchange.imports.showing_rows"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:283
+#: src/pages/admin/data-exchange/imports/[id].astro:324
 msgid "admin.data_exchange.imports.source_count"
 msgstr ""
 
@@ -2292,31 +2292,31 @@ msgstr ""
 msgid "admin.data_exchange.imports.stage_summary"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:187
+#: src/pages/admin/data-exchange/imports/[id].astro:228
 msgid "admin.data_exchange.imports.summary_conflict"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:181
+#: src/pages/admin/data-exchange/imports/[id].astro:222
 msgid "admin.data_exchange.imports.summary_created"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:191
+#: src/pages/admin/data-exchange/imports/[id].astro:232
 msgid "admin.data_exchange.imports.summary_failed"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:189
+#: src/pages/admin/data-exchange/imports/[id].astro:230
 msgid "admin.data_exchange.imports.summary_invalid"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:185
+#: src/pages/admin/data-exchange/imports/[id].astro:226
 msgid "admin.data_exchange.imports.summary_skipped"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:179
+#: src/pages/admin/data-exchange/imports/[id].astro:220
 msgid "admin.data_exchange.imports.summary_totals"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:183
+#: src/pages/admin/data-exchange/imports/[id].astro:224
 msgid "admin.data_exchange.imports.summary_updated"
 msgstr ""
 
@@ -6226,11 +6226,11 @@ msgstr ""
 msgid "common.no"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:160
+#: src/pages/admin/data-exchange/imports/[id].astro:201
 msgid "common.not_found_body"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:159
+#: src/pages/admin/data-exchange/imports/[id].astro:200
 msgid "common.not_found_title"
 msgstr ""
 

--- a/i18n/messages.pot
+++ b/i18n/messages.pot
@@ -2164,15 +2164,15 @@ msgstr ""
 msgid "admin.data_exchange.exports.title"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:58
+#: src/pages/admin/data-exchange/imports/[id].astro:66
 msgid "admin.data_exchange.imports.action_success"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:202
+#: src/pages/admin/data-exchange/imports/[id].astro:223
 msgid "admin.data_exchange.imports.cancel_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:59
+#: src/pages/admin/data-exchange/imports/[id].astro:67
 msgid "admin.data_exchange.imports.cancel_reason_prompt"
 msgstr ""
 
@@ -2184,7 +2184,7 @@ msgstr ""
 msgid "admin.data_exchange.imports.col_actions"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:222
+#: src/pages/admin/data-exchange/imports/[id].astro:243
 msgid "admin.data_exchange.imports.col_commit_status"
 msgstr ""
 
@@ -2192,19 +2192,19 @@ msgstr ""
 msgid "admin.data_exchange.imports.col_created_at"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:225
+#: src/pages/admin/data-exchange/imports/[id].astro:246
 msgid "admin.data_exchange.imports.col_errors"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:154
+#: src/pages/admin/data-exchange/imports/[id].astro:175
 msgid "admin.data_exchange.imports.col_import_key"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:216
+#: src/pages/admin/data-exchange/imports/[id].astro:237
 msgid "admin.data_exchange.imports.col_natural_key"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:219
+#: src/pages/admin/data-exchange/imports/[id].astro:240
 msgid "admin.data_exchange.imports.col_proposed_action"
 msgstr ""
 
@@ -2212,15 +2212,15 @@ msgstr ""
 msgid "admin.data_exchange.imports.col_rows"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:156
+#: src/pages/admin/data-exchange/imports/[id].astro:177
 msgid "admin.data_exchange.imports.col_status"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:178
+#: src/pages/admin/data-exchange/imports/[id].astro:199
 msgid "admin.data_exchange.imports.commit_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:113
+#: src/pages/admin/data-exchange/imports/[id].astro:134
 msgid "admin.data_exchange.imports.detail_title"
 msgstr ""
 
@@ -2236,47 +2236,47 @@ msgstr ""
 msgid "admin.data_exchange.imports.field_import_key"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:268
+#: src/pages/admin/data-exchange/imports/[id].astro:289
 msgid "admin.data_exchange.imports.matched"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:267
+#: src/pages/admin/data-exchange/imports/[id].astro:288
 msgid "admin.data_exchange.imports.mismatch"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:209
+#: src/pages/admin/data-exchange/imports/[id].astro:230
 msgid "admin.data_exchange.imports.no_rows"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:189
+#: src/pages/admin/data-exchange/imports/[id].astro:210
 msgid "admin.data_exchange.imports.pause_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:207
+#: src/pages/admin/data-exchange/imports/[id].astro:228
 msgid "admin.data_exchange.imports.preview_heading"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:264
+#: src/pages/admin/data-exchange/imports/[id].astro:285
 msgid "admin.data_exchange.imports.processed_count"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:257
+#: src/pages/admin/data-exchange/imports/[id].astro:278
 msgid "admin.data_exchange.imports.reconciliation_heading"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:194
+#: src/pages/admin/data-exchange/imports/[id].astro:215
 msgid "admin.data_exchange.imports.resume_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:184
+#: src/pages/admin/data-exchange/imports/[id].astro:205
 msgid "admin.data_exchange.imports.retry_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:249
+#: src/pages/admin/data-exchange/imports/[id].astro:270
 msgid "admin.data_exchange.imports.showing_rows"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:262
+#: src/pages/admin/data-exchange/imports/[id].astro:283
 msgid "admin.data_exchange.imports.source_count"
 msgstr ""
 
@@ -2292,31 +2292,31 @@ msgstr ""
 msgid "admin.data_exchange.imports.stage_summary"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:166
+#: src/pages/admin/data-exchange/imports/[id].astro:187
 msgid "admin.data_exchange.imports.summary_conflict"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:160
+#: src/pages/admin/data-exchange/imports/[id].astro:181
 msgid "admin.data_exchange.imports.summary_created"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:170
+#: src/pages/admin/data-exchange/imports/[id].astro:191
 msgid "admin.data_exchange.imports.summary_failed"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:168
+#: src/pages/admin/data-exchange/imports/[id].astro:189
 msgid "admin.data_exchange.imports.summary_invalid"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:164
+#: src/pages/admin/data-exchange/imports/[id].astro:185
 msgid "admin.data_exchange.imports.summary_skipped"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:158
+#: src/pages/admin/data-exchange/imports/[id].astro:179
 msgid "admin.data_exchange.imports.summary_totals"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:162
+#: src/pages/admin/data-exchange/imports/[id].astro:183
 msgid "admin.data_exchange.imports.summary_updated"
 msgstr ""
 
@@ -3449,7 +3449,7 @@ msgstr ""
 msgid "admin.modules.filter_all"
 msgstr ""
 
-#: src/pages/admin/modules.astro:143
+#: src/pages/admin/modules.astro:144
 msgid "admin.modules.filter_health_label"
 msgstr ""
 
@@ -6226,11 +6226,11 @@ msgstr ""
 msgid "common.no"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:139
+#: src/pages/admin/data-exchange/imports/[id].astro:160
 msgid "common.not_found_body"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:138
+#: src/pages/admin/data-exchange/imports/[id].astro:159
 msgid "common.not_found_title"
 msgstr ""
 

--- a/i18n/messages.pot
+++ b/i18n/messages.pot
@@ -2164,15 +2164,15 @@ msgstr ""
 msgid "admin.data_exchange.exports.title"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:78
+#: src/pages/admin/data-exchange/imports/[id].astro:79
 msgid "admin.data_exchange.imports.action_success"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:264
+#: src/pages/admin/data-exchange/imports/[id].astro:296
 msgid "admin.data_exchange.imports.cancel_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:79
+#: src/pages/admin/data-exchange/imports/[id].astro:80
 msgid "admin.data_exchange.imports.cancel_reason_prompt"
 msgstr ""
 
@@ -2184,7 +2184,7 @@ msgstr ""
 msgid "admin.data_exchange.imports.col_actions"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:284
+#: src/pages/admin/data-exchange/imports/[id].astro:316
 msgid "admin.data_exchange.imports.col_commit_status"
 msgstr ""
 
@@ -2192,19 +2192,19 @@ msgstr ""
 msgid "admin.data_exchange.imports.col_created_at"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:287
+#: src/pages/admin/data-exchange/imports/[id].astro:319
 msgid "admin.data_exchange.imports.col_errors"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:216
+#: src/pages/admin/data-exchange/imports/[id].astro:248
 msgid "admin.data_exchange.imports.col_import_key"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:278
+#: src/pages/admin/data-exchange/imports/[id].astro:310
 msgid "admin.data_exchange.imports.col_natural_key"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:281
+#: src/pages/admin/data-exchange/imports/[id].astro:313
 msgid "admin.data_exchange.imports.col_proposed_action"
 msgstr ""
 
@@ -2212,15 +2212,15 @@ msgstr ""
 msgid "admin.data_exchange.imports.col_rows"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:218
+#: src/pages/admin/data-exchange/imports/[id].astro:250
 msgid "admin.data_exchange.imports.col_status"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:240
+#: src/pages/admin/data-exchange/imports/[id].astro:272
 msgid "admin.data_exchange.imports.commit_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:175
+#: src/pages/admin/data-exchange/imports/[id].astro:207
 msgid "admin.data_exchange.imports.detail_title"
 msgstr ""
 
@@ -2236,47 +2236,47 @@ msgstr ""
 msgid "admin.data_exchange.imports.field_import_key"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:330
+#: src/pages/admin/data-exchange/imports/[id].astro:362
 msgid "admin.data_exchange.imports.matched"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:329
+#: src/pages/admin/data-exchange/imports/[id].astro:361
 msgid "admin.data_exchange.imports.mismatch"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:271
+#: src/pages/admin/data-exchange/imports/[id].astro:303
 msgid "admin.data_exchange.imports.no_rows"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:251
+#: src/pages/admin/data-exchange/imports/[id].astro:283
 msgid "admin.data_exchange.imports.pause_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:269
+#: src/pages/admin/data-exchange/imports/[id].astro:301
 msgid "admin.data_exchange.imports.preview_heading"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:326
+#: src/pages/admin/data-exchange/imports/[id].astro:358
 msgid "admin.data_exchange.imports.processed_count"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:319
+#: src/pages/admin/data-exchange/imports/[id].astro:351
 msgid "admin.data_exchange.imports.reconciliation_heading"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:256
+#: src/pages/admin/data-exchange/imports/[id].astro:288
 msgid "admin.data_exchange.imports.resume_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:246
+#: src/pages/admin/data-exchange/imports/[id].astro:278
 msgid "admin.data_exchange.imports.retry_button"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:311
+#: src/pages/admin/data-exchange/imports/[id].astro:343
 msgid "admin.data_exchange.imports.showing_rows"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:324
+#: src/pages/admin/data-exchange/imports/[id].astro:356
 msgid "admin.data_exchange.imports.source_count"
 msgstr ""
 
@@ -2292,31 +2292,31 @@ msgstr ""
 msgid "admin.data_exchange.imports.stage_summary"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:228
+#: src/pages/admin/data-exchange/imports/[id].astro:260
 msgid "admin.data_exchange.imports.summary_conflict"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:222
+#: src/pages/admin/data-exchange/imports/[id].astro:254
 msgid "admin.data_exchange.imports.summary_created"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:232
+#: src/pages/admin/data-exchange/imports/[id].astro:264
 msgid "admin.data_exchange.imports.summary_failed"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:230
+#: src/pages/admin/data-exchange/imports/[id].astro:262
 msgid "admin.data_exchange.imports.summary_invalid"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:226
+#: src/pages/admin/data-exchange/imports/[id].astro:258
 msgid "admin.data_exchange.imports.summary_skipped"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:220
+#: src/pages/admin/data-exchange/imports/[id].astro:252
 msgid "admin.data_exchange.imports.summary_totals"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:224
+#: src/pages/admin/data-exchange/imports/[id].astro:256
 msgid "admin.data_exchange.imports.summary_updated"
 msgstr ""
 
@@ -6226,11 +6226,11 @@ msgstr ""
 msgid "common.no"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:201
+#: src/pages/admin/data-exchange/imports/[id].astro:233
 msgid "common.not_found_body"
 msgstr ""
 
-#: src/pages/admin/data-exchange/imports/[id].astro:200
+#: src/pages/admin/data-exchange/imports/[id].astro:232
 msgid "common.not_found_title"
 msgstr ""
 

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -23394,6 +23394,7 @@ components:
         - limits
         - adapterRegistryKey
         - description
+        - sensitiveFields
       additionalProperties: false
       properties:
         key:

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -4510,7 +4510,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Export job is not completed.
+          description: Export job is not completed, or its exportKey is no longer registered (owning module disabled after the job ran).
           content:
             application/json:
               schema:
@@ -4817,7 +4817,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Batch is not in previewed status, or Idempotency-Key reused with a different request.
+          description: Batch is not in previewed status, its importKey is no longer registered (owning module disabled after staging), or Idempotency-Key reused with a different request.
           content:
             application/json:
               schema:
@@ -4885,7 +4885,7 @@ paths:
       tags:
         - Data Exchange
       summary: Paginated preview of a batch's staged rows
-      description: Zero domain mutation. Sensitive fields are masked unless the caller also holds data_exchange.preview_errors.read.
+      description: Zero domain mutation. Raw staged values are revealed only when the batch's descriptor declares a sensitiveFields policy AND the caller holds the permission THAT descriptor names in sensitiveFields.rawValuePermission -- never a generic data_exchange permission. A descriptor declaring no policy is masked entirely (default-deny), and a batch whose importKey no longer resolves (its owning module was disabled after staging) is refused with 409.
       operationId: dataExchangeImportsPreview
       security:
         - bearerAuth: []
@@ -4911,9 +4911,11 @@ paths:
         - name: offset
           in: query
           required: false
+          description: Clamped to the maximum below, which equals the hard cap on rows per batch -- no batch can hold a row beyond it. The response echoes the effective (clamped) offset.
           schema:
             type: integer
             minimum: 0
+            maximum: 50000
         - name: limit
           in: query
           required: false
@@ -4986,6 +4988,12 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: The batch's importKey is no longer registered -- its owning module was disabled or removed after the batch was staged.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/data-exchange/imports/{id}/resume:
@@ -5093,7 +5101,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Batch is not retryable from its current status, or Idempotency-Key reused with a different request.
+          description: Batch is not retryable from its current status, its importKey is no longer registered (owning module disabled after staging), or Idempotency-Key reused with a different request.
           content:
             application/json:
               schema:

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -15166,8 +15166,8 @@ paths:
     patch:
       tags:
         - Reference Data
-      summary: Update a tenant reference code override/extension
-      description: Requires Idempotency-Key.
+      summary: Partially update a tenant reference code override/extension
+      description: True PATCH semantics -- omitted fields keep their stored value, explicit null clears/resets (see ReferenceDataUpdateTenantCodeRequest). Requires Idempotency-Key.
       operationId: referenceDataTenantCodesUpdate
       security:
         - bearerAuth: []
@@ -15792,8 +15792,8 @@ paths:
     patch:
       tags:
         - Reference Data
-      summary: Update a reference code's mutable attributes
-      description: Writes to the GLOBAL baseline shared by every tenant -- requires Idempotency-Key. Rejected for descriptor-managed codes.
+      summary: Partially update a reference code's mutable attributes
+      description: True PATCH semantics -- omitted fields keep their stored value, explicit null clears/resets (see ReferenceDataUpdateCodeRequest). Writes to the GLOBAL baseline shared by every tenant -- requires Idempotency-Key. Rejected for descriptor-managed codes.
       operationId: referenceDataCodesUpdate
       security:
         - bearerAuth: []
@@ -28206,50 +28206,60 @@ components:
           description: Explicit opt-in to REPLACE (not update) an existing code's identity. Rejected by commit when the target code is already referenced by tenant data.
     ReferenceDataUpdateCodeRequest:
       type: object
-      required:
-        - labels
       additionalProperties: false
+      description: "Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update."
       properties:
         labels:
           type: array
           minItems: 1
+          description: Replaces ALL stored labels for this code. Omit to keep them; null is rejected.
           items:
             $ref: "#/components/schemas/ReferenceCodeLabel"
         sortOrder:
           type: integer
-          default: 0
+          nullable: true
+          description: Omit to keep the stored value; null resets to 0.
         metadata:
           type: object
+          nullable: true
+          description: Replaces the stored metadata wholesale (not a deep merge). Omit to keep it; null clears it to {}.
         validFrom:
           type: string
           format: date-time
+          description: Omit to keep the stored value; null is rejected.
         validTo:
           type: string
           format: date-time
           nullable: true
+          description: Omit to keep the stored value; null clears the end of validity.
     ReferenceDataUpdateTenantCodeRequest:
       type: object
-      required:
-        - labels
       additionalProperties: false
+      description: "Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update."
       properties:
         labels:
           type: array
           minItems: 1
+          description: Replaces ALL stored labels for this code. Omit to keep them; null is rejected.
           items:
             $ref: "#/components/schemas/ReferenceCodeLabel"
         sortOrder:
           type: integer
-          default: 0
+          nullable: true
+          description: Omit to keep the stored value; null resets to 0.
         metadata:
           type: object
+          nullable: true
+          description: Replaces the stored metadata wholesale (not a deep merge). Omit to keep it; null clears it to {}.
         validFrom:
           type: string
           format: date-time
+          description: Omit to keep the stored value; null is rejected.
         validTo:
           type: string
           format: date-time
           nullable: true
+          description: Omit to keep the stored value; null clears the end of validity.
     ReferenceDataUpdateValueSetRequest:
       type: object
       required:

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -28215,7 +28215,7 @@ components:
     ReferenceDataUpdateCodeRequest:
       type: object
       additionalProperties: false
-      description: "Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update."
+      description: "Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update: it returns the current representation with 200 and is genuinely inert -- updated_at is not bumped and no audit or domain event is emitted. The body itself is required and must be a JSON object; an absent, malformed, non-object (null, array, scalar) body is rejected with 400 VALIDATION_ERROR rather than being treated as {}."
       properties:
         labels:
           type: array
@@ -28243,7 +28243,7 @@ components:
     ReferenceDataUpdateTenantCodeRequest:
       type: object
       additionalProperties: false
-      description: "Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update."
+      description: "Partial PATCH body. Every property is optional: a property that is ABSENT from the body leaves the stored value untouched. A property sent as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {}, validTo -> null). labels and validFrom reject null -- at least one label is always required and valid_from is NOT NULL -- so omit them instead of nulling them. Sending {} is a valid no-op update: it returns the current representation with 200 and is genuinely inert -- updated_at is not bumped and no audit or domain event is emitted. The body itself is required and must be a JSON object; an absent, malformed, non-object (null, array, scalar) body is rejected with 400 VALIDATION_ERROR rather than being treated as {}."
       properties:
         labels:
           type: array

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -23445,6 +23445,9 @@ components:
                 type: string
             rawValuePermission:
               type: string
+            naturalKeyField:
+              type: string
+              description: The parsed-row field name the owning module's adapter derives a staged row's naturalKey from. When this name also appears in fieldNames, naturalKey is masked alongside fields -- masking previously assumed naturalKey was never sensitive, but the dedup key IS commonly the sensitive identifier (an email or a national ID). Declared per descriptor; the default data_exchange.reference_items descriptor sets it to "code".
         description:
           type: string
     DataExchangeExportJob:

--- a/openapi/modules/data-exchange.openapi.yaml
+++ b/openapi/modules/data-exchange.openapi.yaml
@@ -1280,5 +1280,15 @@ components:
                 type: string
             rawValuePermission:
               type: string
+            naturalKeyField:
+              type: string
+              description: >-
+                The parsed-row field name the owning module's adapter derives a
+                staged row's naturalKey from. When this name also appears in
+                fieldNames, naturalKey is masked alongside fields -- masking
+                previously assumed naturalKey was never sensitive, but the dedup
+                key IS commonly the sensitive identifier (an email or a national
+                ID). Declared per descriptor; the default
+                data_exchange.reference_items descriptor sets it to "code".
         description:
           type: string

--- a/openapi/modules/data-exchange.openapi.yaml
+++ b/openapi/modules/data-exchange.openapi.yaml
@@ -222,8 +222,13 @@ paths:
       tags: [Data Exchange]
       summary: Paginated preview of a batch's staged rows
       description: >-
-        Zero domain mutation. Sensitive fields are masked unless the caller
-        also holds data_exchange.preview_errors.read.
+        Zero domain mutation. Raw staged values are revealed only when the
+        batch's descriptor declares a sensitiveFields policy AND the caller
+        holds the permission THAT descriptor names in
+        sensitiveFields.rawValuePermission -- never a generic data_exchange
+        permission. A descriptor declaring no policy is masked entirely
+        (default-deny), and a batch whose importKey no longer resolves (its
+        owning module was disabled after staging) is refused with 409.
       operationId: dataExchangeImportsPreview
       security:
         - bearerAuth: []
@@ -244,9 +249,14 @@ paths:
         - name: offset
           in: query
           required: false
+          description: >-
+            Clamped to the maximum below, which equals the hard cap on rows
+            per batch -- no batch can hold a row beyond it. The response
+            echoes the effective (clamped) offset.
           schema:
             type: integer
             minimum: 0
+            maximum: 50000
         - name: limit
           in: query
           required: false
@@ -315,6 +325,14 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          description: >-
+            The batch's importKey is no longer registered -- its owning
+            module was disabled or removed after the batch was staged.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
         "500":
           $ref: "#/components/responses/InternalError"
   /api/v1/data-exchange/imports/{id}/commit:
@@ -363,7 +381,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Batch is not in previewed status, or Idempotency-Key reused with a different request.
+          description: >-
+            Batch is not in previewed status, its importKey is no longer
+            registered (owning module disabled after staging), or
+            Idempotency-Key reused with a different request.
           content:
             application/json:
               schema:
@@ -482,7 +503,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Batch is not retryable from its current status, or Idempotency-Key reused with a different request.
+          description: >-
+            Batch is not retryable from its current status, its importKey is
+            no longer registered (owning module disabled after staging), or
+            Idempotency-Key reused with a different request.
           content:
             application/json:
               schema:
@@ -781,7 +805,9 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: Export job is not completed.
+          description: >-
+            Export job is not completed, or its exportKey is no longer
+            registered (owning module disabled after the job ran).
           content:
             application/json:
               schema:

--- a/openapi/modules/data-exchange.openapi.yaml
+++ b/openapi/modules/data-exchange.openapi.yaml
@@ -1238,6 +1238,14 @@ components:
         - limits
         - adapterRegistryKey
         - description
+        # Mandatory since Issue #820 Cacat 1: an ABSENT policy used to make the
+        # preview route return every staged value raw with no raw-value
+        # permission check, so forgetting to declare it OPENED the data. The
+        # registry now rejects a descriptor that omits it -- a module must say
+        # `{ fieldNames: [] }` affirmatively rather than say nothing -- and the
+        # published contract has to agree, or generated clients keep treating
+        # the masking policy as optional.
+        - sensitiveFields
       additionalProperties: false
       properties:
         key:

--- a/openapi/modules/reference-data.openapi.yaml
+++ b/openapi/modules/reference-data.openapi.yaml
@@ -511,8 +511,12 @@ paths:
     patch:
       tags:
         - Reference Data
-      summary: Update a reference code's mutable attributes
-      description: Writes to the GLOBAL baseline shared by every tenant -- requires Idempotency-Key. Rejected for descriptor-managed codes.
+      summary: Partially update a reference code's mutable attributes
+      description: >-
+        True PATCH semantics -- omitted fields keep their stored value, explicit
+        null clears/resets (see ReferenceDataUpdateCodeRequest). Writes to the
+        GLOBAL baseline shared by every tenant -- requires Idempotency-Key.
+        Rejected for descriptor-managed codes.
       operationId: referenceDataCodesUpdate
       security:
         - bearerAuth: []
@@ -1171,8 +1175,11 @@ paths:
     patch:
       tags:
         - Reference Data
-      summary: Update a tenant reference code override/extension
-      description: Requires Idempotency-Key.
+      summary: Partially update a tenant reference code override/extension
+      description: >-
+        True PATCH semantics -- omitted fields keep their stored value, explicit
+        null clears/resets (see ReferenceDataUpdateTenantCodeRequest). Requires
+        Idempotency-Key.
       operationId: referenceDataTenantCodesUpdate
       security:
         - bearerAuth: []
@@ -1761,27 +1768,38 @@ components:
           nullable: true
     ReferenceDataUpdateCodeRequest:
       type: object
-      required:
-        - labels
       additionalProperties: false
+      description: >-
+        Partial PATCH body. Every property is optional: a property that is
+        ABSENT from the body leaves the stored value untouched. A property sent
+        as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {},
+        validTo -> null). labels and validFrom reject null -- at least one label
+        is always required and valid_from is NOT NULL -- so omit them instead of
+        nulling them. Sending {} is a valid no-op update.
       properties:
         labels:
           type: array
           minItems: 1
+          description: Replaces ALL stored labels for this code. Omit to keep them; null is rejected.
           items:
             $ref: "#/components/schemas/ReferenceCodeLabel"
         sortOrder:
           type: integer
-          default: 0
+          nullable: true
+          description: Omit to keep the stored value; null resets to 0.
         metadata:
           type: object
+          nullable: true
+          description: Replaces the stored metadata wholesale (not a deep merge). Omit to keep it; null clears it to {}.
         validFrom:
           type: string
           format: date-time
+          description: Omit to keep the stored value; null is rejected.
         validTo:
           type: string
           format: date-time
           nullable: true
+          description: Omit to keep the stored value; null clears the end of validity.
     ReferenceDataCreateTenantCodeRequest:
       type: object
       required:
@@ -1821,27 +1839,38 @@ components:
           nullable: true
     ReferenceDataUpdateTenantCodeRequest:
       type: object
-      required:
-        - labels
       additionalProperties: false
+      description: >-
+        Partial PATCH body. Every property is optional: a property that is
+        ABSENT from the body leaves the stored value untouched. A property sent
+        as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {},
+        validTo -> null). labels and validFrom reject null -- at least one label
+        is always required and valid_from is NOT NULL -- so omit them instead of
+        nulling them. Sending {} is a valid no-op update.
       properties:
         labels:
           type: array
           minItems: 1
+          description: Replaces ALL stored labels for this code. Omit to keep them; null is rejected.
           items:
             $ref: "#/components/schemas/ReferenceCodeLabel"
         sortOrder:
           type: integer
-          default: 0
+          nullable: true
+          description: Omit to keep the stored value; null resets to 0.
         metadata:
           type: object
+          nullable: true
+          description: Replaces the stored metadata wholesale (not a deep merge). Omit to keep it; null clears it to {}.
         validFrom:
           type: string
           format: date-time
+          description: Omit to keep the stored value; null is rejected.
         validTo:
           type: string
           format: date-time
           nullable: true
+          description: Omit to keep the stored value; null clears the end of validity.
     ReferenceDataImportPayloadCode:
       type: object
       required:

--- a/openapi/modules/reference-data.openapi.yaml
+++ b/openapi/modules/reference-data.openapi.yaml
@@ -1775,7 +1775,12 @@ components:
         as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {},
         validTo -> null). labels and validFrom reject null -- at least one label
         is always required and valid_from is NOT NULL -- so omit them instead of
-        nulling them. Sending {} is a valid no-op update.
+        nulling them. Sending {} is a valid no-op update: it returns the current
+        representation with 200 and is genuinely inert -- updated_at is not
+        bumped and no audit or domain event is emitted. The body itself is
+        required and must be a JSON object; an absent, malformed, non-object
+        (null, array, scalar) body is rejected with 400 VALIDATION_ERROR rather
+        than being treated as {}.
       properties:
         labels:
           type: array
@@ -1846,7 +1851,12 @@ components:
         as explicit null CLEARS/resets it (sortOrder -> 0, metadata -> {},
         validTo -> null). labels and validFrom reject null -- at least one label
         is always required and valid_from is NOT NULL -- so omit them instead of
-        nulling them. Sending {} is a valid no-op update.
+        nulling them. Sending {} is a valid no-op update: it returns the current
+        representation with 200 and is genuinely inert -- updated_at is not
+        bumped and no audit or domain event is emitted. The body itself is
+        required and must be a JSON object; an absent, malformed, non-object
+        (null, array, scalar) body is rejected with 400 VALIDATION_ERROR rather
+        than being treated as {}.
       properties:
         labels:
           type: array

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -179,6 +179,7 @@
  * sync.
  */
 import { checkSyncHmacSecretNotDefault } from "./security-readiness";
+import { findConfigVarEntry } from "../src/lib/config/registry";
 import {
   EMAIL_MAILKETING_REQUIRED_WHEN_SELECTED,
   EMAIL_REQUIRED_WHEN_ENABLED,
@@ -398,6 +399,51 @@ export function checkRequiredVars(
       detail: `${name} is required but missing or empty.`
     };
   });
+}
+
+/**
+ * `AUTH_JWT_SECRET` keys the audit-log `ipHash` HMAC
+ * (`src/lib/security/client-fingerprint.ts`), so leaving it at the
+ * placeholder `.env.example` ships makes that HMAC's key public knowledge —
+ * every persisted `ipHash` becomes reversible by anyone who can read this
+ * repo. `checkRequiredVars` only proves the variable is non-empty, and the
+ * placeholder is non-empty, so it sails straight through: this is the same
+ * gap `checkSyncHmacSecretNotDefault` closes for the sync secret, applied to
+ * the one other secret whose default is shipped in `.env.example`.
+ *
+ * The placeholder is read from the registry entry's own `default` rather
+ * than re-typed here, so it cannot drift from `.env.example`
+ * (`config:docs:check` already pins those two to each other).
+ */
+export function checkAuthJwtSecretNotDefault(
+  env: NodeJS.ProcessEnv = process.env
+): EnvCheckResult {
+  const name = "AUTH_JWT_SECRET is not left at its documented placeholder";
+  const placeholder = findConfigVarEntry("AUTH_JWT_SECRET")?.default;
+  const secret = env.AUTH_JWT_SECRET;
+
+  if (!isSet(secret)) {
+    // `checkRequiredVars` already reports the unset case; don't double-fail.
+    return {
+      name,
+      status: "pass",
+      detail: "AUTH_JWT_SECRET is unset — reported by the required-vars check."
+    };
+  }
+
+  if (placeholder !== undefined && secret === placeholder) {
+    return {
+      name,
+      status: "fail",
+      detail: `AUTH_JWT_SECRET is still the documented placeholder ("${placeholder}"). It keys the audit ipHash HMAC — set a high-entropy secret.`
+    };
+  }
+
+  return {
+    name,
+    status: "pass",
+    detail: "AUTH_JWT_SECRET has been changed from its documented placeholder."
+  };
 }
 
 export function checkSyncConfig(
@@ -1491,6 +1537,7 @@ export function runEnvValidation(
   return [
     ...checkRequiredVars(env),
     checkAppEnvValue(env),
+    checkAuthJwtSecretNotDefault(env),
     checkSyncConfig(env),
     ...checkR2Config(env),
     ...checkEmailConfig(env),

--- a/sql/077_awcms_mini_performance_missing_indexes.sql
+++ b/sql/077_awcms_mini_performance_missing_indexes.sql
@@ -1,0 +1,118 @@
+-- Issue #830 (epic #818 post-audit hardening) — Tier A missing indexes.
+-- Pure DDL: no table/column/constraint/RLS change, no application code
+-- change. Every index below is additive and `IF NOT EXISTS`, so this
+-- migration is safe to apply to an already-populated database.
+--
+-- Two distinct rationales are mixed here; they are kept in one migration
+-- because they share a single motivation (an index that should have
+-- existed since the table was created) and none of them is hot enough on
+-- its own to justify its own migration number:
+--
+--   (1) ORDER BY / predicate support for a real query in this repo —
+--       verified with EXPLAIN (ANALYZE) against a 60k-row seed, not
+--       assumed. See the per-index comments below.
+--   (2) FK-check support: PostgreSQL does NOT auto-create an index on a
+--       REFERENCING column. Without one, every DELETE/UPDATE of a
+--       referenced parent row forces a full seq scan of the child table
+--       to prove no child still points at it. The four columns in §3 are
+--       FK columns with no covering index at all.
+--
+-- The three pure-FK-check indexes in §3 are deliberately NOT partial on
+-- `IS NOT NULL`, unlike the read-path indexes in §1/§2. A referential-
+-- integrity check is planned internally by PostgreSQL, not from this
+-- repo's own SQL, so it is not worth betting the entire point of the
+-- index on the planner proving that `col = $1` implies a partial index's
+-- `col IS NOT NULL` predicate. NULL btree entries are cheap; the seq scan
+-- this index exists to prevent is not.
+--
+-- Deliberately NOT included: the ~57 other FK columns that are already
+-- covered as the NON-leading column of a `(tenant_id, x)` index. Those
+-- are fine and must stay untouched — every query in this repo filters
+-- `tenant_id` explicitly (doc 16 §tenant-scoped access), so the composite
+-- already serves them, and an extra single-column index would be pure
+-- write amplification with no read benefit.
+
+-- ---------------------------------------------------------------------
+-- 1. Blog admin list: ORDER BY updated_at DESC
+-- ---------------------------------------------------------------------
+-- `blog-post-directory.ts` (listBlogPostsForAdmin) and
+-- `blog-page-directory.ts` (listBlogPagesForAdmin) both end in
+-- `... WHERE tenant_id = $1 AND deleted_at IS NULL ORDER BY updated_at
+-- DESC LIMIT $n OFFSET $m`. Migration 026 created neither table with any
+-- `updated_at` index, so EVERY admin blog list page was a Seq Scan over
+-- the tenant's entire post/page set followed by a top-N heapsort.
+--
+-- The index is partial on `deleted_at IS NULL` (matching the query's own
+-- constant predicate) so that soft-deleted rows cost nothing to keep and
+-- the index stays proportional to the live working set — the same shape
+-- as `awcms_mini_blog_posts_slug_dedup` already uses on these tables.
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_posts_tenant_updated_idx
+  ON awcms_mini_blog_posts (tenant_id, updated_at DESC)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_pages_tenant_updated_idx
+  ON awcms_mini_blog_pages (tenant_id, updated_at DESC)
+  WHERE deleted_at IS NULL;
+
+-- ---------------------------------------------------------------------
+-- 2. Scheduled-publish job: WHERE status = 'scheduled' AND scheduled_at <= now()
+-- ---------------------------------------------------------------------
+-- `blog-scheduled-publish.ts` (publishDueScheduledPosts) runs
+-- `WHERE tenant_id = $1 AND status = 'scheduled' AND scheduled_at IS NOT
+-- NULL AND scheduled_at <= $2 AND deleted_at IS NULL FOR UPDATE` on a
+-- timer, per tenant.
+--
+-- NOTE (corrects issue #830's premise): the existing
+-- `(tenant_id, status, published_at DESC)` index is NOT useless here —
+-- EXPLAIN confirms it is already picked as a Bitmap Index Scan on its two
+-- leading columns. What it cannot do is apply the `scheduled_at <= now()`
+-- bound, so it reads the heap for EVERY scheduled row of the tenant and
+-- discards the not-yet-due ones. The partial index below carries
+-- `scheduled_at` as an index column, so the time bound becomes an Index
+-- Cond and the job touches only genuinely-due rows.
+--
+-- Partial on the job's own constant predicates (`status = 'scheduled'`,
+-- `deleted_at IS NULL`): 'scheduled' is a transient state a post leaves
+-- as soon as it publishes, so this index stays tiny — a rounding error
+-- next to the full table — while `published`/`draft` rows, which are the
+-- overwhelming majority and are never read by this job, cost nothing.
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_posts_scheduled_due_idx
+  ON awcms_mini_blog_posts (tenant_id, scheduled_at)
+  WHERE status = 'scheduled' AND deleted_at IS NULL;
+
+-- ---------------------------------------------------------------------
+-- 3. FK columns with no covering index at all
+-- ---------------------------------------------------------------------
+-- `awcms_mini_abac_decision_logs.tenant_user_id` -> awcms_mini_tenant_users
+-- (migration 005). This is the fastest-growing table in the base: one
+-- INSERT per ABAC decision, allow AND deny alike. Its only index is
+-- `(tenant_id, created_at DESC)`, which cannot serve a FK check on
+-- `tenant_user_id`, so revoking a tenant user's access (a DELETE of the
+-- parent `awcms_mini_tenant_users` row) seq-scans the entire decision log.
+CREATE INDEX IF NOT EXISTS awcms_mini_abac_decision_logs_tenant_user_idx
+  ON awcms_mini_abac_decision_logs (tenant_user_id);
+
+-- `awcms_mini_visitor_sessions.identity_id` -> awcms_mini_identities
+-- (migration 039). High-volume table; its sibling `awcms_mini_visit_events`
+-- already has `(identity_id, occurred_at DESC)` from the same migration —
+-- the sessions table was simply missed.
+CREATE INDEX IF NOT EXISTS awcms_mini_visitor_sessions_identity_idx
+  ON awcms_mini_visitor_sessions (identity_id);
+
+-- `awcms_mini_sync_outbox.node_id` -> awcms_mini_sync_nodes (migration 007).
+-- The directly adjacent `awcms_mini_sync_inbox` in the SAME migration has
+-- `awcms_mini_sync_inbox_tenant_node_idx`; the outbox never got the
+-- equivalent. Node de-registration is the parent DELETE this protects.
+CREATE INDEX IF NOT EXISTS awcms_mini_sync_outbox_node_idx
+  ON awcms_mini_sync_outbox (node_id);
+
+-- `awcms_mini_blog_ads.tenant_id` -> awcms_mini_tenants (migration 029).
+-- Unlike the three above, this one is read-path relevant, not just
+-- FK-check relevant: `ads-directory.ts`'s getAd/listAds/updateAd all
+-- filter `tenant_id = $1`, and the RLS policy predicate is `tenant_id`
+-- too — yet the table has no index whatsoever beyond its PK. Ordered by
+-- `created_at DESC` to match listAds' own ORDER BY, and partial on
+-- `deleted_at IS NULL` to match its soft-delete filter.
+CREATE INDEX IF NOT EXISTS awcms_mini_blog_ads_tenant_created_idx
+  ON awcms_mini_blog_ads (tenant_id, created_at DESC)
+  WHERE deleted_at IS NULL;

--- a/src/lib/config/registry.ts
+++ b/src/lib/config/registry.ts
@@ -495,14 +495,8 @@ export const CONFIG_REGISTRY: readonly ConfigVarEntry[] = [
     profiles: ALL_PROFILES,
     default: "change-me-in-production",
     description:
-      "Documented as the session-token signing secret, still enforced non-empty at boot for backward compatibility.",
-    validatorGroup: "checkRequiredVars",
-    deprecated: {
-      since: "0.24.0",
-      removalVersion: "1.0.0",
-      guidance:
-        "Verified dead (Issue #689, matches the issue's own evidence): sessions are OPAQUE tokens, not JWT — src/modules/identity-access/README.md states `awcms_mini_sessions` stores only `token_hash` (raw token sent once at login). `grep -rn AUTH_JWT_SECRET src` outside scripts/validate-env.ts/tests finds zero consumers; the only real JWT verification in this repo (src/lib/auth/jwt-verify.ts, RS256 for Google/generic-OIDC ID tokens) verifies signatures against provider-published JWKS via WebCrypto — it never signs anything with this secret, and never reads it. This env var has zero runtime effect. Still required at boot for this release only to avoid a same-release behavior change; a future major version drops the boot-time requirement and then the variable itself. Nothing to migrate to — session tokens are generated with cryptographically random bytes, not derived from a shared secret."
-    }
+      "HMAC key for the audit-log client-IP pseudonym (`ipHash`) written by the auth routes — src/lib/security/client-fingerprint.ts. Despite its name it does NOT sign session tokens: sessions are opaque random tokens (`awcms_mini_sessions.token_hash`) and src/lib/auth/jwt-verify.ts verifies provider ID tokens with RS256 against published JWKS, never with this secret. Must be a high-entropy value and must NOT be left at the documented placeholder: the audit `ipHash` is only as unguessable as this key (an unkeyed digest over the 2^32 IPv4 space is reversible in seconds). Rotating it breaks `ipHash` correlation across the rotation boundary — audit rows before and after no longer group by source.",
+    validatorGroup: "checkRequiredVars + checkAuthJwtSecretNotDefault"
   },
   {
     name: "AUTH_SESSION_TTL_MIN",

--- a/src/lib/security/client-fingerprint.ts
+++ b/src/lib/security/client-fingerprint.ts
@@ -1,5 +1,7 @@
 import { createHmac } from "node:crypto";
 
+import { findConfigVarEntry } from "../config/registry";
+
 /**
  * Issue #821 — audit attributes for authentication events need to answer
  * "which source is this?" (brute-force / credential-stuffing forensics)
@@ -44,10 +46,22 @@ const IP_HASH_PREFIX = "hmac-sha256:";
  * persisted `ipHash` would become trivially reversible, silently, with no
  * error anywhere. A hard failure inside the auth path is strictly preferable
  * to an auth trail that quietly becomes a log of plaintext addresses.
- * `scripts/validate-env.ts` (`checkRequiredVars` +
- * `checkAuthJwtSecretNotDefault`) rejects both an unset value and the
- * documented placeholder at boot, so a correctly validated deployment never
- * reaches this throw.
+ *
+ * The documented placeholder is rejected HERE, not only by
+ * `scripts/validate-env.ts`'s `checkAuthJwtSecretNotDefault`. That validator
+ * is correct and wired into `runEnvValidation`, but nothing forces it to run:
+ * `bun run dev` and `bun run start` invoke the server directly, never
+ * `config:validate`. A deployment copied from `.env.example` therefore boots
+ * happily with `AUTH_JWT_SECRET` still set to a value published in a PUBLIC
+ * repo — keying this HMAC with public knowledge and making every persisted
+ * `ipHash` reversible, which is the one property the whole pseudonym exists
+ * to provide. A check that only runs when an operator remembers to run it is
+ * not a control; this one cannot be bypassed by any entry path.
+ * (Review finding, PR #839.)
+ *
+ * The placeholder is read from the registry entry's own `default` rather than
+ * re-typed here, exactly as `checkAuthJwtSecretNotDefault` does, so the two
+ * cannot drift from each other or from `.env.example`.
  *
  * Read per call, not cached at module load, so a test (or a rotated secret)
  * that changes `process.env.AUTH_JWT_SECRET` takes effect immediately.
@@ -58,6 +72,13 @@ function resolveIpHashKey(): string {
   if (key === undefined || key.length === 0) {
     throw new Error(
       "AUTH_JWT_SECRET is required: it keys the audit `ipHash` HMAC (src/lib/security/client-fingerprint.ts). Refusing to fall back to an unkeyed digest, which would make every persisted ipHash reversible."
+    );
+  }
+
+  const placeholder = findConfigVarEntry("AUTH_JWT_SECRET")?.default;
+  if (placeholder !== undefined && key === placeholder) {
+    throw new Error(
+      "AUTH_JWT_SECRET is still the documented .env.example placeholder: it keys the audit `ipHash` HMAC (src/lib/security/client-fingerprint.ts), and that placeholder is published in a public repo. Refusing to key the pseudonym with public knowledge, which would make every persisted ipHash reversible. Set a high-entropy secret, then re-run `bun run config:validate`."
     );
   }
 

--- a/src/lib/security/client-fingerprint.ts
+++ b/src/lib/security/client-fingerprint.ts
@@ -1,0 +1,80 @@
+import { createHmac } from "node:crypto";
+
+/**
+ * Issue #821 — audit attributes for authentication events need to answer
+ * "which source is this?" (brute-force / credential-stuffing forensics)
+ * without persisting a raw client IP.
+ *
+ * A raw IP cannot go into audit `attributes`: `src/modules/_shared/redaction.ts`
+ * deliberately treats `ip`/`ipAddress`/`clientIp`/`remoteAddr`/`x-forwarded-for`
+ * as sensitive (Issue #687) and would replace the value with `"[REDACTED]"`
+ * anyway — an unusable, permanently blank column. Renaming the key to dodge
+ * that redaction would be a security regression, not a fix.
+ *
+ * A *keyed* hash resolves both requirements at once: the stored value is
+ * stable, so an operator can group audit rows by source ("40 `login_failed`
+ * rows, same `ipHash`, 40 different accounts" — the exact signal the audit
+ * exists for), while the address itself is not recoverable from the audit
+ * trail.
+ *
+ * Keyed (HMAC) rather than a plain digest on purpose: the IPv4 space is only
+ * 2^32, so an unsalted `sha256(ip)` is exhaustively reversible in seconds and
+ * would be pseudonymization in name only.
+ */
+const IP_HASH_PREFIX = "hmac-sha256:";
+
+/**
+ * Reuses `AUTH_JWT_SECRET` (already a *required* env var — see
+ * `scripts/validate-env.ts`'s required list) rather than introducing another
+ * secret to provision, rotate, and validate for a purely internal
+ * pseudonymization key.
+ *
+ * Falls back to an empty key when unset so that unit tests and local
+ * throwaway runs still produce a stable, well-formed value instead of
+ * throwing inside an auth path. That degrades the hash to an effectively
+ * unsalted digest, which is acceptable *only* because `validate-env` refuses
+ * to start any real deployment without `AUTH_JWT_SECRET` — never rely on this
+ * fallback in production.
+ *
+ * Read per call, not cached at module load, so a test (or a rotated secret)
+ * that changes `process.env.AUTH_JWT_SECRET` takes effect immediately.
+ */
+function resolveIpHashKey(): string {
+  return process.env.AUTH_JWT_SECRET ?? "";
+}
+
+/**
+ * Stable, non-reversible pseudonym for a client IP, safe to persist in audit
+ * `attributes` under the key `ipHash` (which no redaction rule matches — it
+ * normalizes to `iphash`, which is neither an entry of the exact-match IP
+ * synonym allowlist nor a substring of any redaction key).
+ */
+export function hashClientIp(ip: string): string {
+  return (
+    IP_HASH_PREFIX +
+    createHmac("sha256", resolveIpHashKey()).update(ip).digest("hex")
+  );
+}
+
+/**
+ * Upper bound on the persisted `User-Agent`. The header is fully
+ * attacker-controlled and unbounded in practice, so it is truncated before it
+ * ever reaches a `jsonb` column — an audit row must never become an
+ * attacker-sized write amplifier on a public, unauthenticated endpoint.
+ */
+const MAX_USER_AGENT_LENGTH = 256;
+
+/**
+ * The request's `User-Agent`, truncated, or `undefined` when absent/blank so
+ * the key is simply omitted from audit attributes rather than stored as an
+ * empty string.
+ */
+export function summarizeUserAgent(request: Request): string | undefined {
+  const userAgent = request.headers.get("user-agent")?.trim();
+
+  if (!userAgent) {
+    return undefined;
+  }
+
+  return userAgent.slice(0, MAX_USER_AGENT_LENGTH);
+}

--- a/src/lib/security/client-fingerprint.ts
+++ b/src/lib/security/client-fingerprint.ts
@@ -27,20 +27,41 @@ const IP_HASH_PREFIX = "hmac-sha256:";
  * Reuses `AUTH_JWT_SECRET` (already a *required* env var — see
  * `scripts/validate-env.ts`'s required list) rather than introducing another
  * secret to provision, rotate, and validate for a purely internal
- * pseudonymization key.
+ * pseudonymization key. Key separation would be sound in the abstract, but
+ * there is nothing here to separate FROM: `AUTH_JWT_SECRET` signs nothing
+ * (sessions are opaque random tokens; `src/lib/auth/jwt-verify.ts` verifies
+ * provider ID tokens with RS256 against published JWKS), so no
+ * cross-protocol reuse exists — and a brand-new required secret would break
+ * every already-provisioned deployment for no security gain.
  *
- * Falls back to an empty key when unset so that unit tests and local
- * throwaway runs still produce a stable, well-formed value instead of
- * throwing inside an auth path. That degrades the hash to an effectively
- * unsalted digest, which is acceptable *only* because `validate-env` refuses
- * to start any real deployment without `AUTH_JWT_SECRET` — never rely on this
- * fallback in production.
+ * Because this IS now that variable's only consumer, its `deprecated` +
+ * `removalVersion: "1.0.0"` marking in `src/lib/config/registry.ts` was
+ * lifted (PR #839 security review): a variable scheduled for removal must
+ * never be load-bearing for a security control.
+ *
+ * Throws rather than falling back to an empty key. An empty key degrades
+ * this HMAC to a bare `sha256(ip)` — and the IPv4 space is 2^32, so every
+ * persisted `ipHash` would become trivially reversible, silently, with no
+ * error anywhere. A hard failure inside the auth path is strictly preferable
+ * to an auth trail that quietly becomes a log of plaintext addresses.
+ * `scripts/validate-env.ts` (`checkRequiredVars` +
+ * `checkAuthJwtSecretNotDefault`) rejects both an unset value and the
+ * documented placeholder at boot, so a correctly validated deployment never
+ * reaches this throw.
  *
  * Read per call, not cached at module load, so a test (or a rotated secret)
  * that changes `process.env.AUTH_JWT_SECRET` takes effect immediately.
  */
 function resolveIpHashKey(): string {
-  return process.env.AUTH_JWT_SECRET ?? "";
+  const key = process.env.AUTH_JWT_SECRET;
+
+  if (key === undefined || key.length === 0) {
+    throw new Error(
+      "AUTH_JWT_SECRET is required: it keys the audit `ipHash` HMAC (src/lib/security/client-fingerprint.ts). Refusing to fall back to an unkeyed digest, which would make every persisted ipHash reversible."
+    );
+  }
+
+  return key;
 }
 
 /**

--- a/src/lib/security/request-body-limit.ts
+++ b/src/lib/security/request-body-limit.ts
@@ -173,6 +173,67 @@ export async function readJsonBody<T = unknown>(
   }
 }
 
+/**
+ * Result of {@link readJsonObjectBody}. `ok: false` carries `reason` so the
+ * handler can say which of the rejected shapes arrived instead of a generic
+ * "invalid body".
+ */
+export type InvalidJsonObjectBodyReason = "absent" | "malformed" | "not_object";
+
+export type JsonObjectBodyResult =
+  | { tooLarge: true; limitBytes: number }
+  | { tooLarge: false; ok: true; value: Record<string, unknown> }
+  | { tooLarge: false; ok: false; reason: InvalidJsonObjectBodyReason };
+
+/**
+ * `readJsonBody` collapses "absent body", "malformed JSON" and "the literal
+ * `null`" into the same `value: null`, and passes a well-formed array/number/
+ * string straight through. Handlers that require a JSON *object* cannot tell
+ * those apart, so they reach for `bodyRead.value ?? {}` — which silently turns
+ * an empty, malformed, or non-object body into a valid empty request. For a
+ * PATCH whose empty body is a legitimate no-op that is not a harmless default:
+ * garbage passes authorization and idempotency and lands as a real write.
+ *
+ * Use this instead whenever the endpoint's request body is a required JSON
+ * object. `{}` is returned as `ok: true` — an empty *object* is a real body,
+ * distinct from no body at all.
+ */
+export async function readJsonObjectBody(
+  request: Request,
+  tier: BodySizeTier = "default"
+): Promise<JsonObjectBodyResult> {
+  const limitBytes = resolveLimitBytes(tier);
+  const textResult = await readCappedText(request, limitBytes);
+
+  if (textResult.tooLarge) {
+    return { tooLarge: true, limitBytes };
+  }
+
+  if (textResult.text.trim().length === 0) {
+    return { tooLarge: false, ok: false, reason: "absent" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(textResult.text);
+  } catch {
+    return { tooLarge: false, ok: false, reason: "malformed" };
+  }
+
+  // `typeof null === "object"`, and arrays are objects too — both must be
+  // rejected here rather than reaching a field-by-field patch parser, which
+  // would find no known keys on them and report a clean empty patch.
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { tooLarge: false, ok: false, reason: "not_object" };
+  }
+
+  return {
+    tooLarge: false,
+    ok: true,
+    value: parsed as Record<string, unknown>
+  };
+}
+
 /** Drop-in replacement for `await request.text()`, capped at `tier`'s limit. */
 export async function readTextBody(
   request: Request,
@@ -247,6 +308,31 @@ export function bodyTooLargeResponse(limitBytes: number): Response {
     {},
     undefined,
     { connection: "close" }
+  );
+}
+
+const INVALID_JSON_OBJECT_BODY_MESSAGE: Record<
+  InvalidJsonObjectBodyReason,
+  string
+> = {
+  absent: "A JSON object request body is required; none was sent.",
+  malformed: "Request body is not valid JSON.",
+  not_object:
+    "Request body must be a JSON object. Send {} for a no-op; null, arrays and scalars are not accepted."
+};
+
+/**
+ * Maps a {@link readJsonObjectBody} rejection to the `400` the endpoint's
+ * required-object request body implies. Kept next to the reader so a new
+ * `reason` cannot be added without the compiler demanding a message for it.
+ */
+export function invalidJsonObjectBodyResponse(
+  reason: InvalidJsonObjectBodyReason
+): Response {
+  return fail(
+    400,
+    "VALIDATION_ERROR",
+    INVALID_JSON_OBJECT_BODY_MESSAGE[reason]
   );
 }
 

--- a/src/modules/_shared/module-contract.ts
+++ b/src/modules/_shared/module-contract.ts
@@ -398,11 +398,30 @@ export type ExchangeDirection = "import" | "export" | "both";
 
 export type ExchangeFormat = "csv" | "json";
 
+/**
+ * A descriptor's sensitive-value policy (Issue #752; hardened by Issue
+ * #820). REQUIRED on every descriptor — declaring it is an affirmative act
+ * by the owning module, never an omission the base silently interprets in
+ * the caller's favour:
+ *
+ * - `fieldNames: []` means "this descriptor has deliberately reasoned about
+ *   its fields and none of them are sensitive" — preview returns raw values.
+ * - A non-empty `fieldNames` masks exactly those fields unless the caller
+ *   holds THIS descriptor's own `rawValuePermission` (never a generic
+ *   `data_exchange.*` permission — see `preview.ts`).
+ * - A descriptor with NO policy at all (only reachable if it bypassed the
+ *   registry gate in `data-exchange/domain/exchange-registry.ts`) is masked
+ *   ENTIRELY at preview time, and no permission can unmask it. Default-deny:
+ *   an undeclared field is an unknown field, and an unknown field is
+ *   treated as sensitive.
+ */
 export type ExchangeSensitiveFieldPolicy = {
-  /** Field names (as they appear in the parsed row, not a column name) that must never appear unmasked in a preview/error artifact without the caller holding the descriptor's `rawValuePermission`. */
+  /** Field names (as they appear in the parsed row, not a column name) that must never appear unmasked in a preview/error artifact without the caller holding the descriptor's `rawValuePermission`. Declare `[]` to state explicitly that no field is sensitive. */
   fieldNames: readonly string[];
-  /** Permission key (module.activity.action format) required to view unmasked values for the fields above — required when `fieldNames` is non-empty. */
+  /** Permission key (module.activity.action format) required to view unmasked values for the fields above — required when `fieldNames` is non-empty, and the ONLY permission that unmasks them (Issue #820: previously this field was validated but never enforced, and the route hardcoded the far broader `data_exchange.preview_errors.read` instead). */
   rawValuePermission?: string;
+  /** The parsed-row field name the owning module's adapter derives a staged row's `naturalKey` from (e.g. `"code"` for `reference_items`, but plausibly `"email"`/`"nik"` for a profile import — the dedup key IS commonly the sensitive identifier). When this name also appears in `fieldNames`, `naturalKey` is masked alongside `fields` (Issue #820 Cacat 4: masking previously ASSUMED `naturalKey` was non-sensitive). */
+  naturalKeyField?: string;
 };
 
 export type ExchangeLimits = {
@@ -426,7 +445,8 @@ export type ExchangeDescriptor = {
   adapterRegistryKey: string;
   /** Permission key (module.activity.action) required to stage/preview/commit against this descriptor, beyond the generic `data_exchange.imports.*`/`data_exchange.exports.*` gate — e.g. an owning module may require its OWN write permission (`reference_data.items.create`) in addition. `undefined` means no additional permission beyond the generic gate. */
   requiredPermission?: string;
-  sensitiveFields?: ExchangeSensitiveFieldPolicy;
+  /** REQUIRED (Issue #820) — declare `{ fieldNames: [] }` to state explicitly that no field is sensitive. Omitting it used to mean "return every staged value raw, with no permission check at all"; it is now rejected by the registry gate, and masked entirely at preview time if it somehow reaches the route. */
+  sensitiveFields: ExchangeSensitiveFieldPolicy;
   description: string;
 };
 

--- a/src/modules/_shared/offset-pagination.ts
+++ b/src/modules/_shared/offset-pagination.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared bounds for `?page=`/`OFFSET` (page-number) pagination (Issue #819).
+ *
+ * Keyset pagination (`keyset-pagination.ts`) is the preferred shape for list
+ * endpoints, but a few surfaces genuinely need a page *number* (public blog
+ * archives with `?page=2` links that must stay stable/bookmarkable, admin
+ * lists with a total count). Those compute `OFFSET (page - 1) * pageSize`,
+ * which makes an unbounded `page` two distinct hazards:
+ *
+ *   - `?page=1e8` → `OFFSET 1e9`. Postgres still scans and discards a
+ *     billion rows, holding a pool connection for the duration. On a route
+ *     that is public and unauthenticated, one GET per connection exhausts
+ *     the pool.
+ *   - `?page=abc` → `Number("abc")` → `NaN` → `OFFSET NaN` → 500.
+ *
+ * So every page number crossing into a query must go through
+ * `boundedPageNumber`, which clamps *both* ends and rejects non-finite and
+ * fractional input. Junk is normalised to page 1 rather than surfaced as an
+ * error: these are HTML archive routes where a bad `?page=` should render
+ * the first page, not a 500 (and not a 400 that crawlers would index).
+ */
+
+/**
+ * Upper bound on `?page=`. Deep offsets past this are not meaningful for the
+ * surfaces here (a public blog archive at page 10,000 with the default page
+ * size is already 100,000 posts deep), and allowing them only buys an
+ * attacker a longer scan.
+ */
+export const MAX_PAGE_NUMBER = 10_000;
+
+/**
+ * Clamp a client-supplied page number into `[1, maxPage]`.
+ *
+ * Returns 1 for `undefined`, `NaN`, and `±Infinity` — `Math.max(NaN, 1)` is
+ * `NaN`, so a bare `Math.max` guard passes junk straight through to `OFFSET`.
+ * Fractional input is truncated (`OFFSET 1.5` is a Postgres error).
+ */
+export function boundedPageNumber(
+  page: number | undefined,
+  maxPage: number = MAX_PAGE_NUMBER
+): number {
+  if (page === undefined || !Number.isFinite(page)) {
+    return 1;
+  }
+
+  return Math.min(Math.max(Math.trunc(page), 1), maxPage);
+}
+
+/**
+ * Clamp a client-supplied page size into `[1, maxPageSize]`, falling back to
+ * `defaultPageSize` for absent or non-finite input. Same `NaN` reasoning as
+ * `boundedPageNumber`.
+ */
+export function boundedPageSize(
+  pageSize: number | undefined,
+  defaultPageSize: number,
+  maxPageSize: number
+): number {
+  if (pageSize === undefined || !Number.isFinite(pageSize)) {
+    return defaultPageSize;
+  }
+
+  return Math.min(Math.max(Math.trunc(pageSize), 1), maxPageSize);
+}
+
+/**
+ * Parse a raw `?page=` query-string value into a bounded page number.
+ *
+ * Routes should use this rather than `Number(param)` directly: the parsed
+ * value is typically reused for rendering (pagination nav links, "page N of"
+ * labels), so it must be the *same* clamped number the query used — otherwise
+ * `?page=abc` renders `NaN` into next/prev links even once the query itself
+ * is safe.
+ */
+export function parsePageParam(
+  rawPage: string | null | undefined,
+  maxPage: number = MAX_PAGE_NUMBER
+): number {
+  if (rawPage === null || rawPage === undefined || rawPage.trim() === "") {
+    return 1;
+  }
+
+  return boundedPageNumber(Number(rawPage), maxPage);
+}

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -239,6 +239,8 @@ Setiap route handler dibungkus `try/catch` di level teratas: error asli di-log l
 
 Index dan arsip kategori/tag pakai `?page=` (1-indexed) + `LIMIT`/`OFFSET` sederhana, bukan keyset — ini halaman publik yang dibaca pengunjung manusia (ekspektasi UX "halaman 1, 2, 3", bukan cursor buram), beda dari admin search (Issue #539) yang keyset-paginated. `pageSize` diambil dari `awcms_mini_blog_settings.posts_per_page` (Issue #537, default 10) lewat `fetchPublicBlogSettings`. RSS/sitemap tidak dipaginasi sama sekali — flat, dibatasi 50 post terbaru (`FEED_ITEM_LIMIT`), karena konsumennya mesin (feed reader/crawler), bukan pengunjung yang mengklik "next".
 
+`?page=` di-normalisasi lewat `parsePageParam`/`boundedPageNumber` (`src/modules/_shared/offset-pagination.ts`, Issue #819) — **bukan** `Number(param)` langsung. Route ini publik tanpa auth, jadi `page` wajib terklamp di kedua ujung: `?page=1e8` dulu jadi `OFFSET 1e9` (Postgres tetap memindai lalu membuang satu miliar baris sambil menahan satu koneksi pool — DoS satu-request), dan `?page=abc` jadi `OFFSET NaN` → 500. Sekarang nilai non-numerik/`NaN`/`±Infinity`/negatif jatuh ke halaman 1, pecahan di-truncate, dan batas atas `MAX_PAGE_NUMBER` = 10.000. Junk dinormalisasi ke halaman 1, bukan 400: ini route arsip HTML — `?page=` rusak harus merender halaman pertama, bukan error yang ikut terindeks crawler. Nilai terklamp itu juga yang dipakai untuk merender nav pagination, supaya `?page=abc` tidak pernah menghasilkan link `NaN`. Daftar admin (`listBlogPostsForAdmin`/`listBlogPagesForAdmin`) memakai helper yang sama.
+
 ## Public routes `/news` (Issue #560, epic #555)
 
 `src/pages/news/` — tenant-code-free counterpart of `/blog/{tenantCode}`

--- a/src/modules/blog-content/application/blog-page-directory.ts
+++ b/src/modules/blog-content/application/blog-page-directory.ts
@@ -7,6 +7,10 @@ import type {
   UpdateBlogPageInput
 } from "../domain/blog-page-validation";
 import type { PageType } from "../domain/page-type";
+import {
+  boundedPageNumber,
+  boundedPageSize
+} from "../../_shared/offset-pagination";
 
 /**
  * Read/write query module for `awcms_mini_blog_pages` (Issue #539) — same
@@ -283,11 +287,12 @@ export async function listBlogPagesForAdmin(
   tenantId: string,
   filter: ListBlogPagesForAdminFilter = {}
 ): Promise<ListBlogPagesForAdminResult> {
-  const pageSize = Math.min(
-    Math.max(filter.pageSize ?? DEFAULT_ADMIN_LIST_PAGE_SIZE, 1),
+  const pageSize = boundedPageSize(
+    filter.pageSize,
+    DEFAULT_ADMIN_LIST_PAGE_SIZE,
     MAX_ADMIN_LIST_PAGE_SIZE
   );
-  const page = Math.max(filter.page ?? 1, 1);
+  const page = boundedPageNumber(filter.page);
   const offset = (page - 1) * pageSize;
   const search = filter.search?.trim() || null;
   const status = filter.status ?? null;

--- a/src/modules/blog-content/application/blog-post-directory.ts
+++ b/src/modules/blog-content/application/blog-post-directory.ts
@@ -6,6 +6,10 @@ import type {
   CreateBlogPostInput,
   UpdateBlogPostInput
 } from "../domain/blog-post-validation";
+import {
+  boundedPageNumber,
+  boundedPageSize
+} from "../../_shared/offset-pagination";
 
 /**
  * Read/write query module for `awcms_mini_blog_posts` (Issue #537 scaffolded
@@ -225,8 +229,9 @@ export async function listBlogPosts(
   tenantId: string,
   filter: ListBlogPostsFilter = {}
 ): Promise<BlogPostSummary[]> {
-  const limit = Math.min(
-    Math.max(filter.limit ?? DEFAULT_LIST_LIMIT, 1),
+  const limit = boundedPageSize(
+    filter.limit,
+    DEFAULT_LIST_LIMIT,
     MAX_LIST_LIMIT
   );
 
@@ -430,11 +435,12 @@ export async function listBlogPostsForAdmin(
   tenantId: string,
   filter: ListBlogPostsForAdminFilter = {}
 ): Promise<ListBlogPostsForAdminResult> {
-  const pageSize = Math.min(
-    Math.max(filter.pageSize ?? DEFAULT_ADMIN_LIST_PAGE_SIZE, 1),
+  const pageSize = boundedPageSize(
+    filter.pageSize,
+    DEFAULT_ADMIN_LIST_PAGE_SIZE,
     MAX_ADMIN_LIST_PAGE_SIZE
   );
-  const page = Math.max(filter.page ?? 1, 1);
+  const page = boundedPageNumber(filter.page);
   const offset = (page - 1) * pageSize;
   const search = filter.search?.trim() || null;
   const status = filter.status ?? null;

--- a/src/modules/blog-content/application/public-blog-directory.ts
+++ b/src/modules/blog-content/application/public-blog-directory.ts
@@ -20,6 +20,10 @@
  *   which is never publicly reachable at all).
  */
 import type { BlogContentVisibility } from "../domain/post-status";
+import {
+  boundedPageNumber,
+  boundedPageSize as sharedBoundedPageSize
+} from "../../_shared/offset-pagination";
 export type PublicBlogPostDetail = {
   id: string;
   title: string;
@@ -145,11 +149,16 @@ const DEFAULT_PAGE_SIZE = 10;
 const MAX_PAGE_SIZE = 50;
 
 function boundedPageSize(pageSize: number | undefined): number {
-  return Math.min(Math.max(pageSize ?? DEFAULT_PAGE_SIZE, 1), MAX_PAGE_SIZE);
+  return sharedBoundedPageSize(pageSize, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
 }
 
+/**
+ * Clamped at both ends via the shared helper (Issue #819) — these routes are
+ * public and unauthenticated, so an unbounded `page` was a one-request
+ * deep-offset scan (`?page=1e8` → `OFFSET 1e9`) and `NaN` was a 500.
+ */
 function boundedPage(page: number | undefined): number {
-  return Math.max(page ?? 1, 1);
+  return boundedPageNumber(page);
 }
 
 /** Standard `?page=` (1-indexed) pagination — fetches `pageSize + 1` rows to derive `hasNextPage` without a separate `COUNT(*)` query, same "one extra row" trick used for cursor pagination elsewhere in this repo. */

--- a/src/modules/data-exchange/README.md
+++ b/src/modules/data-exchange/README.md
@@ -35,7 +35,7 @@ POST /imports (multipart/form-data)         -> stage (checksum, size bound, Idem
 runImportValidatePass  -- bounded passes, staged -> validating -> previewed
   |  (parses CSV/JSON with row/field bounds + formula-injection neutralization)
   v
-GET /imports/{id}/preview                   -- zero-mutation, masked unless preview_errors.read
+GET /imports/{id}/preview                   -- zero-mutation, masked per descriptor's sensitiveFields
   |
 POST /imports/{id}/commit                   -- previewed -> committing (trigger only, Idempotency-Key)
   |
@@ -104,9 +104,34 @@ neutralization at serialization) -> `completed` -> `GET /exports/{id}/download`.
 - **Idempotency-Key** required on every mutating endpoint: stage-upload,
   commit, cancel, retry, pause, resume (imports); create, cancel
   (exports).
-- **Preview/error artifact masking**: `data_exchange.preview_errors.read`
-  is a separate permission from `data_exchange.imports.read` — raw invalid
-  row values are masked by default.
+- **Preview raw-value masking is default-deny and descriptor-driven**
+  (hardened by Issue #820): a descriptor MUST declare `sensitiveFields`
+  (the registry gate rejects one that does not) — declare
+  `{ fieldNames: [] }` to state affirmatively that nothing is sensitive.
+  Fields named in `fieldNames` are unmasked ONLY for a caller holding the
+  permission that same descriptor names in `sensitiveFields.rawValuePermission`
+  — its own, narrow permission, never a generic `data_exchange.*` one. A
+  descriptor with no policy at all is masked entirely and no permission
+  unmasks it. `naturalKey` is masked too when `sensitiveFields.naturalKeyField`
+  names a field that is itself sensitive (a profile import's dedup key is
+  typically the email/NIK — masking the `fields` copy while echoing the
+  same value back as `naturalKey` would mask nothing).
+  Before #820 all of this was inverted: omitting `sensitiveFields` returned
+  every staged value raw with no check at all, `rawValuePermission` was
+  validated at registration but enforced nowhere, and the route gated on a
+  hardcoded, far broader `data_exchange.preview_errors.read` instead.
+- **An unresolvable descriptor fails closed** (Issue #820): if a batch's
+  `importKey`/`exportKey` stops resolving because its owning module was
+  disabled or removed via `module_management` after staging, preview/commit/
+  retry/download answer `409 INVALID_STATE` rather than proceeding. A batch
+  must never become MORE accessible than while its module was running —
+  which is what passing a `null` descriptor to the descriptor gate used to
+  cause. `authorizeExchangeDescriptorPermission` no longer accepts `null`
+  at all, so each route must decide explicitly.
+- **Preview pagination is bounded on both ends** (Issue #831): `limit` is
+  capped at `PREVIEW_PAGE_SIZE_MAX`, and `offset` at `PREVIEW_OFFSET_MAX`
+  (= `MAX_EXCHANGE_ROW_COUNT`, so it can hide no reachable row). A single
+  large CSV fills `staged_rows` to deep-offset volume in one shot.
 - **Export downloads**: `data_exchange.export_downloads.read` is a
   separate, more sensitive permission from `data_exchange.exports.read`,
   and every download writes its own `recordAuditEvent` entry (distinct

--- a/src/modules/data-exchange/application/descriptor-authorization.ts
+++ b/src/modules/data-exchange/application/descriptor-authorization.ts
@@ -30,34 +30,28 @@ export type DescriptorPermissionCheck =
   { allowed: true } | { allowed: false; denied: Response };
 
 /**
- * `descriptor` may be `null` (an unresolvable importKey/exportKey) — the
- * caller is expected to have already handled that as its own 404 before
- * reaching a data mutation; passing `null` here is treated as "nothing
- * additional to check" so callers can resolve-then-check in either order
- * without this function throwing.
+ * Authorizes one descriptor-declared permission key (`module.activity.
+ * action`) against the caller. A malformed key fails CLOSED (500), never
+ * open — a declaration the base cannot parse is never silently downgraded
+ * to "no requirement". Shared by `requiredPermission` (the descriptor-level
+ * gate below) and `sensitiveFields.rawValuePermission` (the raw-value gate
+ * in `imports/[id]/preview.ts`), so both enforce the SAME semantics from
+ * one place (Issue #820 Cacat 2: `rawValuePermission` had zero enforcement
+ * sites and the route hardcoded a broader permission instead).
  */
-export async function authorizeExchangeDescriptorPermission(
+export async function authorizeDescriptorPermissionKey(
   tx: Bun.SQL,
   tenantId: string,
   tokenHash: string,
   now: Date,
-  descriptor: ExchangeDescriptor | null
+  permissionKey: string,
+  malformedMessage: string
 ): Promise<DescriptorPermissionCheck> {
-  if (!descriptor || !descriptor.requiredPermission) {
-    return { allowed: true };
-  }
-
-  const parts = descriptor.requiredPermission.split(".");
+  const parts = permissionKey.split(".");
   if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
-    // A malformed descriptor-declared permission fails CLOSED, never open
-    // — never silently treated as "no extra requirement".
     return {
       allowed: false,
-      denied: fail(
-        500,
-        "INTERNAL_ERROR",
-        "Exchange descriptor's requiredPermission is malformed."
-      )
+      denied: fail(500, "INTERNAL_ERROR", malformedMessage)
     };
   }
 
@@ -74,4 +68,43 @@ export async function authorizeExchangeDescriptorPermission(
   }
 
   return { allowed: true };
+}
+
+/**
+ * `descriptor` is deliberately NON-nullable (Issue #820 Cacat 3). It used
+ * to accept `null` — an importKey/exportKey resolving to nothing, which
+ * happens when the owning module is disabled/removed via `module_management`
+ * AFTER a batch was staged — and treat it as "nothing additional to check",
+ * returning `{ allowed: true }`. That directly contradicted this file's own
+ * fail-closed contract: an unregistered key skipped the descriptor gate
+ * entirely, so a batch became MORE open once its owning module was switched
+ * off.
+ *
+ * Fail-open is now unrepresentable rather than merely discouraged: every
+ * caller must decide what an unresolvable descriptor means for ITS route
+ * before it can call this at all (`imports`/`exports` create and `imports`
+ * retry answer 404 for an unknown key/batch; `imports/[id]/preview` denies
+ * — see each call site). `requiredPermission === undefined` — a resolvable
+ * descriptor that genuinely declares no extra requirement — remains a
+ * legitimate allow, and is now a strictly separate, unrelated branch.
+ */
+export async function authorizeExchangeDescriptorPermission(
+  tx: Bun.SQL,
+  tenantId: string,
+  tokenHash: string,
+  now: Date,
+  descriptor: ExchangeDescriptor
+): Promise<DescriptorPermissionCheck> {
+  if (!descriptor.requiredPermission) {
+    return { allowed: true };
+  }
+
+  return authorizeDescriptorPermissionKey(
+    tx,
+    tenantId,
+    tokenHash,
+    now,
+    descriptor.requiredPermission,
+    "Exchange descriptor's requiredPermission is malformed."
+  );
 }

--- a/src/modules/data-exchange/application/descriptor-authorization.ts
+++ b/src/modules/data-exchange/application/descriptor-authorization.ts
@@ -30,6 +30,45 @@ export type DescriptorPermissionCheck =
   { allowed: true } | { allowed: false; denied: Response };
 
 /**
+ * The same decision as `authorizeDescriptorPermissionKey` below, expressed
+ * against an already-resolved permission set instead of a transaction +
+ * token hash — for the SSR admin screens, whose `Astro.locals.ssrContext`
+ * carries the caller's granted permission keys (`src/lib/auth/ssr-session.ts`
+ * builds it with the very same `fetchGrantedPermissionKeys` the bearer-token
+ * guard uses) and which have no bearer token to authorize with.
+ *
+ * It exists because `src/pages/admin/data-exchange/imports/[id].astro` does
+ * NOT go through the preview route — it queries and projects staged rows
+ * itself (see that page's own note) — and so needs its own call site for the
+ * descriptor gate. PR #839's security review found the page had replicated
+ * the raw-value decision but never made the `requiredPermission` one at all:
+ * a descriptor requiring, say, `hr.payroll.read` was enforced by all six API
+ * routes and by nothing in the UI, so a holder of the generic
+ * `data_exchange.imports.read` could read the owning module's staged content
+ * (natural keys, validation errors, reconciliation) straight off the page.
+ *
+ * Fails closed identically to the route path: a malformed key is `false`,
+ * never "no requirement". `undefined` — a descriptor genuinely declaring no
+ * extra requirement — is a legitimate allow, exactly as in
+ * `authorizeExchangeDescriptorPermission`.
+ */
+export function isDescriptorPermissionGranted(
+  permissions: ReadonlySet<string>,
+  permissionKey: string | undefined
+): boolean {
+  if (permissionKey === undefined) {
+    return true;
+  }
+
+  const parts = permissionKey.split(".");
+  if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+    return false;
+  }
+
+  return permissions.has(permissionKey);
+}
+
+/**
  * Authorizes one descriptor-declared permission key (`module.activity.
  * action`) against the caller. A malformed key fails CLOSED (500), never
  * open — a declaration the base cannot parse is never silently downgraded

--- a/src/modules/data-exchange/application/descriptor-authorization.ts
+++ b/src/modules/data-exchange/application/descriptor-authorization.ts
@@ -23,6 +23,7 @@
  */
 import { fail } from "../../_shared/api-response";
 import { authorizeInTransaction } from "../../identity-access/application/access-guard";
+import { resolveModuleEnabled } from "../../identity-access/application/auth-context";
 import type { AccessAction } from "../../identity-access/domain/access-control";
 import type { ExchangeDescriptor } from "../../_shared/module-contract";
 
@@ -30,38 +31,65 @@ export type DescriptorPermissionCheck =
   { allowed: true } | { allowed: false; denied: Response };
 
 /**
- * The same decision as `authorizeDescriptorPermissionKey` below, expressed
- * against an already-resolved permission set instead of a transaction +
- * token hash — for the SSR admin screens, whose `Astro.locals.ssrContext`
- * carries the caller's granted permission keys (`src/lib/auth/ssr-session.ts`
- * builds it with the very same `fetchGrantedPermissionKeys` the bearer-token
- * guard uses) and which have no bearer token to authorize with.
+ * The same decision as `authorizeDescriptorPermissionKey` below, for a caller
+ * that has an already-resolved permission set instead of a bearer token — the
+ * SSR admin screens, whose `Astro.locals.ssrContext` carries the caller's
+ * granted permission keys (`src/lib/auth/ssr-session.ts` builds it with the
+ * very same `fetchGrantedPermissionKeys` the bearer-token guard uses) and
+ * which have no token to authorize with.
  *
  * It exists because `src/pages/admin/data-exchange/imports/[id].astro` does
  * NOT go through the preview route — it queries and projects staged rows
  * itself (see that page's own note) — and so needs its own call site for the
- * descriptor gate. PR #839's security review found the page had replicated
+ * descriptor gates. PR #839's security review found the page had replicated
  * the raw-value decision but never made the `requiredPermission` one at all:
  * a descriptor requiring, say, `hr.payroll.read` was enforced by all six API
  * routes and by nothing in the UI, so a holder of the generic
  * `data_exchange.imports.read` could read the owning module's staged content
  * (natural keys, validation errors, reconciliation) straight off the page.
  *
+ * Takes `tx`/`tenantId` and resolves tenant module state ITSELF rather than
+ * accepting a plain permission set, because a permission set is NOT the whole
+ * route decision and reviewing it as if it were is what went wrong the first
+ * time. `authorizeInTransaction` denies `403 MODULE_DISABLED` on
+ * `resolveModuleEnabled` BEFORE it ever evaluates RBAC, and
+ * `fetchGrantedPermissionKeys` does not filter disabled modules out of its
+ * result — so a subject keeps every permission key of a module that has been
+ * switched off for their tenant. Checking only `permissions.has(key)` made
+ * the SSR page LOOSER than the API on that axis: with the owning module
+ * disabled, preview/commit answered 403 while the page still rendered the
+ * staged rows. Same parity failure as the original finding, different axis;
+ * the module check is therefore inside this function, where neither caller
+ * can forget it, and in the same order as the route (module, then RBAC).
+ *
  * Fails closed identically to the route path: a malformed key is `false`,
  * never "no requirement". `undefined` — a descriptor genuinely declaring no
  * extra requirement — is a legitimate allow, exactly as in
- * `authorizeExchangeDescriptorPermission`.
+ * `authorizeExchangeDescriptorPermission` (there is no module to resolve for
+ * a requirement that was never declared; the page's generic
+ * `data_exchange.*` gate is a separate matter — see this file's footer note).
  */
-export function isDescriptorPermissionGranted(
+export async function isDescriptorPermissionGranted(
+  tx: Bun.SQL,
+  tenantId: string,
   permissions: ReadonlySet<string>,
   permissionKey: string | undefined
-): boolean {
+): Promise<boolean> {
   if (permissionKey === undefined) {
     return true;
   }
 
   const parts = permissionKey.split(".");
   if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+    return false;
+  }
+
+  const [moduleKey] = parts as [string, string, string];
+
+  // Module state first, exactly as `authorizeInTransaction` orders it: a
+  // permission key belonging to a module this tenant has disabled grants
+  // nothing, however the key itself was obtained.
+  if (!(await resolveModuleEnabled(tx, tenantId, moduleKey))) {
     return false;
   }
 

--- a/src/modules/data-exchange/application/staged-row-directory.ts
+++ b/src/modules/data-exchange/application/staged-row-directory.ts
@@ -129,6 +129,17 @@ const REDACTED_VALUE = "[REDACTED]";
  * round for the very adapters this base exists to host: a profile import's
  * dedup key IS the email/NIK. Masking the `fields` copy while echoing the
  * same value back as `naturalKey` would have masked nothing at all.
+ *
+ * `validationWarnings` and `commitError` are dropped for that same reason
+ * (PR #839 security review). Both are FREE TEXT produced by the owning
+ * module's adapter — a warning like `"email x@y.com is already registered"`,
+ * or an `outcome.reason` quoting the offending value — so both are channels
+ * the masked value comes straight back through. `maskAllFields` already
+ * dropped `validationWarnings` on exactly this reasoning ("a warning is free
+ * text an adapter may have interpolated a raw value into"); that reasoning
+ * was always equally true here, and `commitError` was kept on BOTH paths.
+ * `validationErrors` stay: they carry a field name plus a fixed message, not
+ * a value.
  */
 export function maskSensitiveFields(
   row: StagedRowRow,
@@ -155,7 +166,9 @@ export function maskSensitiveFields(
     naturalKey:
       naturalKeyIsSensitive && row.naturalKey !== null
         ? REDACTED_VALUE
-        : row.naturalKey
+        : row.naturalKey,
+    validationWarnings: row.validationWarnings === null ? null : [],
+    commitError: row.commitError === null ? null : REDACTED_VALUE
   };
 }
 
@@ -171,8 +184,12 @@ export function maskSensitiveFields(
  * some other path).
  *
  * `validationErrors` are kept — they carry a field name and a message, not
- * a value — but `validationWarnings` are dropped, since a warning is free
- * text an adapter may have interpolated a raw value into.
+ * a value — but `validationWarnings` and `commitError` are dropped, since
+ * both are free text an adapter may have interpolated a raw value into
+ * (`commitError` is the adapter's own `outcome.reason`). `commitError`
+ * becomes the redaction marker rather than `null` so the row still reports
+ * THAT it failed, just not with what value (PR #839 security review: it was
+ * previously passed through verbatim even on this default-deny path).
  */
 export function maskAllFields(row: StagedRowRow): StagedRowRow {
   const maskedFields: Record<string, unknown> = {};
@@ -184,6 +201,7 @@ export function maskAllFields(row: StagedRowRow): StagedRowRow {
     ...row,
     fields: maskedFields,
     naturalKey: row.naturalKey === null ? null : REDACTED_VALUE,
-    validationWarnings: row.validationWarnings === null ? null : []
+    validationWarnings: row.validationWarnings === null ? null : [],
+    commitError: row.commitError === null ? null : REDACTED_VALUE
   };
 }

--- a/src/modules/data-exchange/application/staged-row-directory.ts
+++ b/src/modules/data-exchange/application/staged-row-directory.ts
@@ -5,6 +5,7 @@
  * read-only, consumed by the interactive `GET .../imports/{id}/preview`
  * endpoint.
  */
+import { MAX_EXCHANGE_ROW_COUNT } from "../domain/exchange-registry";
 
 export type StagedRowRow = {
   id: string;
@@ -56,6 +57,21 @@ function toRow(row: StagedRowDbRow): StagedRowRow {
 export const PREVIEW_PAGE_SIZE_DEFAULT = 50;
 export const PREVIEW_PAGE_SIZE_MAX = 200;
 
+/**
+ * Hard ceiling on the preview's `OFFSET` (Issue #831). `limit` was already
+ * clamped one line below its parse site in the route, but `offset` was only
+ * checked `>= 0` — `?offset=5000000` reached Postgres verbatim, forcing it
+ * to walk and discard five million `staged_rows` per request. This table is
+ * unlike the base's log-shaped tables: a single 100k-row CSV import fills it
+ * to deep-offset volume in one shot, so the ceiling is not theoretical.
+ *
+ * Derived from `MAX_EXCHANGE_ROW_COUNT` — the registry gate caps every
+ * descriptor's `limits.maxRowCount` at that value, so no batch can hold a
+ * row at this offset in the first place. The ceiling therefore hides no
+ * reachable row, and stays correct if that cap is ever raised.
+ */
+export const PREVIEW_OFFSET_MAX = MAX_EXCHANGE_ROW_COUNT;
+
 export type ListStagedRowsFilter = {
   proposedAction?: StagedRowRow["proposedAction"];
   offset: number;
@@ -102,26 +118,72 @@ export async function countStagedRows(
 const REDACTED_VALUE = "[REDACTED]";
 
 /**
- * Masks any field named in `sensitiveFieldNames` — Issue #752 security
- * requirement: "Preview/error artifacts minimize and mask PII; raw
- * invalid values require explicit permission". Applied to a row's
- * `fields` only (never to `naturalKey`, which is assumed non-sensitive —
- * it is also displayed as the row's identity in every preview list).
+ * Masks any field named in `policy.fieldNames` — Issue #752 security
+ * requirement: "Preview/error artifacts minimize and mask PII; raw invalid
+ * values require explicit permission".
+ *
+ * `naturalKey` is masked too when `policy.naturalKeyField` names a field
+ * that is itself sensitive (Issue #820 Cacat 4). This function previously
+ * masked `fields` only, on the stated ASSUMPTION that `naturalKey` was
+ * non-sensitive — an assumption, never an invariant, and the wrong way
+ * round for the very adapters this base exists to host: a profile import's
+ * dedup key IS the email/NIK. Masking the `fields` copy while echoing the
+ * same value back as `naturalKey` would have masked nothing at all.
  */
 export function maskSensitiveFields(
   row: StagedRowRow,
-  sensitiveFieldNames: readonly string[]
+  policy: { fieldNames: readonly string[]; naturalKeyField?: string }
 ): StagedRowRow {
-  if (sensitiveFieldNames.length === 0) {
+  if (policy.fieldNames.length === 0) {
     return row;
   }
 
   const maskedFields: Record<string, unknown> = { ...row.fields };
-  for (const fieldName of sensitiveFieldNames) {
+  for (const fieldName of policy.fieldNames) {
     if (fieldName in maskedFields) {
       maskedFields[fieldName] = REDACTED_VALUE;
     }
   }
 
-  return { ...row, fields: maskedFields };
+  const naturalKeyIsSensitive =
+    policy.naturalKeyField !== undefined &&
+    policy.fieldNames.includes(policy.naturalKeyField);
+
+  return {
+    ...row,
+    fields: maskedFields,
+    naturalKey:
+      naturalKeyIsSensitive && row.naturalKey !== null
+        ? REDACTED_VALUE
+        : row.naturalKey
+  };
+}
+
+/**
+ * Default-deny projection (Issue #820 Cacat 1): redacts EVERY field value
+ * plus `naturalKey`, keeping only the row's non-content metadata (row
+ * number, proposed action, commit status). Used when a descriptor declares
+ * no `sensitiveFields` policy at all — the base cannot know which of that
+ * descriptor's fields are safe, and an unknown field is treated as
+ * sensitive, never as safe. No permission unmasks this; the owning module
+ * must declare its policy (the registry gate rejects a descriptor without
+ * one, so this is defence in depth for a descriptor reaching the route by
+ * some other path).
+ *
+ * `validationErrors` are kept — they carry a field name and a message, not
+ * a value — but `validationWarnings` are dropped, since a warning is free
+ * text an adapter may have interpolated a raw value into.
+ */
+export function maskAllFields(row: StagedRowRow): StagedRowRow {
+  const maskedFields: Record<string, unknown> = {};
+  for (const fieldName of Object.keys(row.fields)) {
+    maskedFields[fieldName] = REDACTED_VALUE;
+  }
+
+  return {
+    ...row,
+    fields: maskedFields,
+    naturalKey: row.naturalKey === null ? null : REDACTED_VALUE,
+    validationWarnings: row.validationWarnings === null ? null : []
+  };
 }

--- a/src/modules/data-exchange/domain/exchange-registry.ts
+++ b/src/modules/data-exchange/domain/exchange-registry.ts
@@ -146,13 +146,28 @@ function validateSingleDescriptor(
     }
   }
 
-  if (
-    descriptor.sensitiveFields &&
+  // Issue #820 Cacat 1: `sensitiveFields` used to be optional, and its
+  // absence made the preview route return every staged value RAW with no
+  // raw-value permission check at all — forgetting to declare it OPENED the
+  // data instead of closing it. It is now mandatory: a module must state
+  // `{ fieldNames: [] }` affirmatively rather than say nothing.
+  if (!descriptor.sensitiveFields) {
+    push(
+      "sensitiveFields is required — declare { fieldNames: [] } to state explicitly that no field is sensitive."
+    );
+  } else if (
     descriptor.sensitiveFields.fieldNames.length > 0 &&
     !descriptor.sensitiveFields.rawValuePermission
   ) {
     push(
       "sensitiveFields.rawValuePermission is required whenever sensitiveFields.fieldNames is non-empty."
+    );
+  }
+
+  const naturalKeyField = descriptor.sensitiveFields?.naturalKeyField;
+  if (naturalKeyField !== undefined && naturalKeyField.length === 0) {
+    push(
+      "sensitiveFields.naturalKeyField must be a non-empty parsed-row field name when declared."
     );
   }
 

--- a/src/modules/data-exchange/module.ts
+++ b/src/modules/data-exchange/module.ts
@@ -315,6 +315,11 @@ export const dataExchangeModule = defineModule({
         maxFieldsPerRow: 10
       },
       adapterRegistryKey: "reference_items",
+      // Affirmatively non-sensitive (Issue #820): this fixture's fields are
+      // synthetic code/label/value/status rows carrying no identifier, and
+      // `naturalKey` is its `code`. Declared explicitly rather than omitted
+      // — omission is now a registry-gate error, not a silent "show all".
+      sensitiveFields: { fieldNames: [], naturalKeyField: "code" },
       description:
         "Self-contained reference fixture (generic tenant-scoped code/label/value/status rows, awcms_mini_data_exchange_reference_items) proving the staging/validate/preview/commit/export/reconciliation mechanism end-to-end. Not a real business domain — see this module's README."
     }

--- a/src/modules/module-management/application/health-registry.ts
+++ b/src/modules/module-management/application/health-registry.ts
@@ -21,8 +21,16 @@ import { parseDocument } from "yaml";
 import { log } from "../../../lib/logging/logger";
 import { listModules } from "../..";
 import type { ModuleDescriptor } from "../../_shared/module-contract";
-import { fetchModulePermissionSyncReport } from "./permission-sync";
-import { fetchModuleSettingsView } from "./module-settings";
+import {
+  buildModulePermissionSyncReport,
+  fetchCatalogPermissionsByModule
+} from "./permission-sync";
+import {
+  buildModuleSettingsView,
+  fetchTenantSettingsRowsByModule,
+  type ModuleSettingsRow
+} from "./module-settings";
+import type { CatalogPermission } from "../domain/permission-sync";
 import { fetchModuleJobs } from "./job-registry";
 import { syncModuleDescriptors } from "./descriptor-sync";
 import { validateJobDescriptor } from "../domain/job-registry";
@@ -50,14 +58,39 @@ function findDescriptor(moduleKey: string): ModuleDescriptor | null {
  * (that would be a backwards dependency, `src/` on `scripts/`, and drags
  * in checksum/transaction-control validation this read-only check doesn't
  * need). Just enough to compare "files on disk" vs. "rows already applied".
+ *
+ * Cached for the life of the process on first success, same promise-caching
+ * shape as `readYamlCached` below (Issue #824): `sql/*.sql` is build-time
+ * content that cannot change under a running server, so re-`readdir`-ing it on
+ * every health signal was pure waste. Caching the in-flight promise (not the
+ * resolved value) means concurrent callers join one `readdir` instead of each
+ * starting their own — see `readYamlCached`'s note on why that distinction
+ * matters. Failures are deliberately NOT cached: unlike a missing spec file, a
+ * filesystem error here is plausibly transient and must not pin
+ * `migrations_applied` to `fail` for the rest of the process's life.
  */
-async function listMigrationFileNames(): Promise<string[]> {
-  const migrationsDir = path.resolve(process.cwd(), "sql");
-  const entries = await readdir(migrationsDir, { withFileTypes: true });
+let migrationFileNamesCache: Promise<string[]> | null = null;
 
-  return entries
-    .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
-    .map((entry) => entry.name);
+function listMigrationFileNames(): Promise<string[]> {
+  if (!migrationFileNamesCache) {
+    const pending = (async () => {
+      const migrationsDir = path.resolve(process.cwd(), "sql");
+      const entries = await readdir(migrationsDir, { withFileTypes: true });
+
+      return entries
+        .filter((entry) => entry.isFile() && entry.name.endsWith(".sql"))
+        .map((entry) => entry.name);
+    })();
+
+    migrationFileNamesCache = pending;
+    pending.catch(() => {
+      if (migrationFileNamesCache === pending) {
+        migrationFileNamesCache = null;
+      }
+    });
+  }
+
+  return migrationFileNamesCache;
 }
 
 async function migrationsAppliedSignal(
@@ -95,55 +128,165 @@ async function migrationsAppliedSignal(
   }
 }
 
-async function dbRegistrySyncedSignal(
+/**
+ * Every DB-backed input the generic signals need, fetched ONCE per render
+ * rather than once per module (Issue #824). Before this existed, each of the
+ * 23 registered modules independently ran its own registry lookup, migration
+ * scan, permission-catalog query and settings lookup — ≈92 queries to answer a
+ * single admin screen, growing linearly with every module added, which
+ * saturated the connection pool and made `fetchModuleMatrix` time out under
+ * load. All four inputs are small, whole-table (or whole-tenant) reads at this
+ * scale, so batching them costs nothing and makes the fan-out O(1).
+ *
+ * A `null` map means that batch query itself failed; the signal it feeds then
+ * reports `fail` with the same generic detail string the old per-module
+ * `catch` produced, preserving the "never leak a raw error" guarantee.
+ */
+export type ModuleHealthContext = {
+  /** Module-invariant by construction — `migrationsAppliedSignal` takes no module key, so all modules share one answer. */
+  migrations: ReadinessSignal;
+  registryStatusByKey: Map<string, string> | null;
+  permissionsByModuleKey: Map<string, CatalogPermission[]> | null;
+  settingsRowByModuleKey: Map<string, ModuleSettingsRow> | null;
+};
+
+async function fetchRegistryStatuses(
   tx: Bun.SQL,
-  descriptor: ModuleDescriptor,
   correlationId?: string
-): Promise<ReadinessSignal> {
+): Promise<Map<string, string> | null> {
   try {
     const rows = (await tx`
-      SELECT lifecycle_status FROM awcms_mini_modules WHERE module_key = ${descriptor.key}
-    `) as { lifecycle_status: string }[];
-    const row = rows[0];
+      SELECT module_key, lifecycle_status FROM awcms_mini_modules
+    `) as { module_key: string; lifecycle_status: string }[];
 
-    if (!row) {
-      return {
-        name: "db_registry_synced",
-        status: "fail",
-        detail: "No database registry row yet — run the descriptor sync."
-      };
-    }
-
-    return {
-      name: "db_registry_synced",
-      status: row.lifecycle_status === descriptor.status ? "pass" : "fail",
-      detail:
-        row.lifecycle_status === descriptor.status
-          ? undefined
-          : "Database registry status is stale — run the descriptor sync."
-    };
+    return new Map(rows.map((row) => [row.module_key, row.lifecycle_status]));
   } catch (error) {
     log("error", "health-registry: db_registry_synced check failed", {
-      moduleKey: descriptor.key,
+      moduleKey: "module_management",
       correlationId,
       error: error instanceof Error ? error.message : String(error)
     });
 
+    return null;
+  }
+}
+
+async function fetchPermissionCatalog(
+  tx: Bun.SQL,
+  correlationId?: string
+): Promise<Map<string, CatalogPermission[]> | null> {
+  try {
+    return await fetchCatalogPermissionsByModule(tx);
+  } catch (error) {
+    log("error", "health-registry: permission_catalog_synced check failed", {
+      moduleKey: "module_management",
+      correlationId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+
+    return null;
+  }
+}
+
+async function fetchTenantSettingsRows(
+  tx: Bun.SQL,
+  tenantId: string,
+  correlationId?: string
+): Promise<Map<string, ModuleSettingsRow> | null> {
+  try {
+    return await fetchTenantSettingsRowsByModule(tx, tenantId);
+  } catch (error) {
+    log("error", "health-registry: settings_valid check failed", {
+      moduleKey: "module_management",
+      correlationId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+
+    return null;
+  }
+}
+
+/**
+ * Four queries + one (cached) `readdir` — the whole DB cost of a health render,
+ * no matter how many modules are then resolved against it. Share one context
+ * across every module of a single render; never cache it across requests (the
+ * registry/settings state it snapshots is live data).
+ */
+export async function prepareModuleHealthContext(
+  tx: Bun.SQL,
+  tenantId: string,
+  correlationId?: string
+): Promise<ModuleHealthContext> {
+  const [
+    migrations,
+    registryStatusByKey,
+    permissionsByModuleKey,
+    settingsRowByModuleKey
+  ] = await Promise.all([
+    migrationsAppliedSignal(tx, correlationId),
+    fetchRegistryStatuses(tx, correlationId),
+    fetchPermissionCatalog(tx, correlationId),
+    fetchTenantSettingsRows(tx, tenantId, correlationId)
+  ]);
+
+  return {
+    migrations,
+    registryStatusByKey,
+    permissionsByModuleKey,
+    settingsRowByModuleKey
+  };
+}
+
+function dbRegistrySyncedSignal(
+  descriptor: ModuleDescriptor,
+  context: ModuleHealthContext
+): ReadinessSignal {
+  if (!context.registryStatusByKey) {
     return {
       name: "db_registry_synced",
       status: "fail",
       detail: "Could not query the module registry."
     };
   }
+
+  const lifecycleStatus = context.registryStatusByKey.get(descriptor.key);
+
+  if (lifecycleStatus === undefined) {
+    return {
+      name: "db_registry_synced",
+      status: "fail",
+      detail: "No database registry row yet — run the descriptor sync."
+    };
+  }
+
+  return {
+    name: "db_registry_synced",
+    status: lifecycleStatus === descriptor.status ? "pass" : "fail",
+    detail:
+      lifecycleStatus === descriptor.status
+        ? undefined
+        : "Database registry status is stale — run the descriptor sync."
+  };
 }
 
-async function permissionCatalogSyncedSignal(
-  tx: Bun.SQL,
+function permissionCatalogSyncedSignal(
   moduleKey: string,
+  context: ModuleHealthContext,
   correlationId?: string
-): Promise<ReadinessSignal> {
+): ReadinessSignal {
+  if (!context.permissionsByModuleKey) {
+    return {
+      name: "permission_catalog_synced",
+      status: "fail",
+      detail: "Could not check the permission catalog."
+    };
+  }
+
   try {
-    const report = await fetchModulePermissionSyncReport(tx, moduleKey);
+    const report = buildModulePermissionSyncReport(
+      moduleKey,
+      context.permissionsByModuleKey.get(moduleKey) ?? []
+    );
     const unsynced = (report?.entries ?? []).filter(
       (entry) =>
         entry.status === "missing" || entry.status === "mismatched_description"
@@ -172,14 +315,24 @@ async function permissionCatalogSyncedSignal(
   }
 }
 
-async function settingsValidSignal(
-  tx: Bun.SQL,
-  tenantId: string,
+function settingsValidSignal(
   moduleKey: string,
+  context: ModuleHealthContext,
   correlationId?: string
-): Promise<ReadinessSignal> {
+): ReadinessSignal {
+  if (!context.settingsRowByModuleKey) {
+    return {
+      name: "settings_valid",
+      status: "fail",
+      detail: "Could not resolve effective module settings."
+    };
+  }
+
   try {
-    await fetchModuleSettingsView(tx, tenantId, moduleKey);
+    buildModuleSettingsView(
+      moduleKey,
+      context.settingsRowByModuleKey.get(moduleKey) ?? null
+    );
     return { name: "settings_valid", status: "pass" };
   } catch (error) {
     log("error", "health-registry: settings_valid check failed", {
@@ -215,25 +368,47 @@ function jobsDocumentedSignal(moduleKey: string): ReadinessSignal {
   };
 }
 
-const yamlDocumentCache = new Map<string, unknown>();
+/**
+ * Caches the in-flight PROMISE, not the resolved document — deliberately, and
+ * this is the single biggest win in Issue #824.
+ *
+ * The previous version only populated the cache AFTER its `await`, so every
+ * concurrent caller missed. 22 of the 23 modules declare the very same
+ * `openapi/awcms-mini-public-api.openapi.yaml` (~1 MB), and a health render
+ * resolves them all in one `Promise.all` — so that one file was read and
+ * YAML-parsed 22 times in parallel, ~5.6s of pure CPU, a textbook cache
+ * stampede. Storing the promise synchronously before the first `await` means
+ * the 21 later callers join the first parse instead of starting their own,
+ * which is what actually collapses a cold render from ~5.6s to ~6ms.
+ *
+ * A parse failure resolves (and caches) `null` exactly as before — spec files
+ * are build-time content, so a missing/broken one is a permanent fact, not a
+ * transient error worth retrying per request.
+ */
+const yamlDocumentCache = new Map<string, Promise<unknown | null>>();
 
-async function readYamlCached(relativePath: string): Promise<unknown | null> {
-  if (yamlDocumentCache.has(relativePath)) {
-    return yamlDocumentCache.get(relativePath) ?? null;
+function readYamlCached(relativePath: string): Promise<unknown | null> {
+  const cached = yamlDocumentCache.get(relativePath);
+
+  if (cached) {
+    return cached;
   }
 
-  try {
-    const source = await readFile(
-      path.resolve(process.cwd(), relativePath),
-      "utf8"
-    );
-    const document = parseDocument(source).toJSON();
-    yamlDocumentCache.set(relativePath, document);
-    return document;
-  } catch {
-    yamlDocumentCache.set(relativePath, null);
-    return null;
-  }
+  const pending = (async () => {
+    try {
+      const source = await readFile(
+        path.resolve(process.cwd(), relativePath),
+        "utf8"
+      );
+      return parseDocument(source).toJSON() as unknown;
+    } catch {
+      return null;
+    }
+  })();
+
+  yamlDocumentCache.set(relativePath, pending);
+
+  return pending;
 }
 
 async function openApiDocumentedSignal(
@@ -287,29 +462,35 @@ async function asyncApiDocumentedSignal(
 }
 
 async function computeGenericSignals(
-  tx: Bun.SQL,
-  tenantId: string,
   descriptor: ModuleDescriptor,
+  context: ModuleHealthContext,
   correlationId?: string
 ): Promise<ReadinessSignal[]> {
   return [
     { name: "descriptor_registered", status: "pass" },
-    await dbRegistrySyncedSignal(tx, descriptor, correlationId),
-    await migrationsAppliedSignal(tx, correlationId),
-    await permissionCatalogSyncedSignal(tx, descriptor.key, correlationId),
-    await settingsValidSignal(tx, tenantId, descriptor.key, correlationId),
+    dbRegistrySyncedSignal(descriptor, context),
+    context.migrations,
+    permissionCatalogSyncedSignal(descriptor.key, context, correlationId),
+    settingsValidSignal(descriptor.key, context, correlationId),
     jobsDocumentedSignal(descriptor.key),
     await openApiDocumentedSignal(descriptor),
     await asyncApiDocumentedSignal(descriptor)
   ];
 }
 
-/** `null` means `moduleKey` isn't a registered descriptor — `404`. */
+/**
+ * `null` means `moduleKey` isn't a registered descriptor — `404`.
+ *
+ * Pass `context` when reporting on several modules in one render so they share
+ * a single prefetch; omit it and this builds its own (four queries), which is
+ * exactly what the single-module `GET .../health` endpoint wants.
+ */
 export async function fetchModuleHealthReport(
   tx: Bun.SQL,
   tenantId: string,
   moduleKey: string,
-  correlationId?: string
+  correlationId?: string,
+  context?: ModuleHealthContext
 ): Promise<ModuleHealthReport | null> {
   const descriptor = findDescriptor(moduleKey);
 
@@ -317,10 +498,11 @@ export async function fetchModuleHealthReport(
     return null;
   }
 
+  const resolvedContext =
+    context ?? (await prepareModuleHealthContext(tx, tenantId, correlationId));
   const signals = await computeGenericSignals(
-    tx,
-    tenantId,
     descriptor,
+    resolvedContext,
     correlationId
   );
 
@@ -330,6 +512,38 @@ export async function fetchModuleHealthReport(
     signals,
     generatedAt: new Date().toISOString()
   };
+}
+
+/**
+ * Health for many modules at a flat cost of four queries total (Issue #824) —
+ * the batch entry point every multi-module caller (`fetchModuleMatrix`,
+ * `admin/modules.astro`) should use instead of looping `fetchModuleHealthReport`.
+ * Unregistered keys are simply absent from the returned map.
+ */
+export async function fetchModuleHealthReports(
+  tx: Bun.SQL,
+  tenantId: string,
+  moduleKeys: readonly string[],
+  correlationId?: string
+): Promise<Map<string, ModuleHealthReport>> {
+  const context = await prepareModuleHealthContext(tx, tenantId, correlationId);
+  const reports = new Map<string, ModuleHealthReport>();
+
+  for (const moduleKey of moduleKeys) {
+    const report = await fetchModuleHealthReport(
+      tx,
+      tenantId,
+      moduleKey,
+      correlationId,
+      context
+    );
+
+    if (report) {
+      reports.set(moduleKey, report);
+    }
+  }
+
+  return reports;
 }
 
 /**
@@ -430,10 +644,10 @@ export async function runModuleHealthCheck(
 
   await syncModuleDescriptors(tx);
 
+  const context = await prepareModuleHealthContext(tx, tenantId, correlationId);
   const signals = await computeGenericSignals(
-    tx,
-    tenantId,
     descriptor,
+    context,
     correlationId
   );
   signals.push(await providerHealthCheckSignal(moduleKey, correlationId));

--- a/src/modules/module-management/application/health-registry.ts
+++ b/src/modules/module-management/application/health-registry.ts
@@ -211,23 +211,31 @@ async function fetchTenantSettingsRows(
  * no matter how many modules are then resolved against it. Share one context
  * across every module of a single render; never cache it across requests (the
  * registry/settings state it snapshots is live data).
+ *
+ * Sequential, NOT `Promise.all` — every caller passes a `tx` bound to ONE
+ * connection, and a single Postgres connection serves one query at a time;
+ * issuing these concurrently on it produced a real hang in this repo (see the
+ * note in `reporting/application/projection-reconciliation.ts`, where the stuck
+ * connection went on to break every subsequent test's `resetDatabase()`).
+ * The win here was never concurrency — it is collapsing a per-module fan-out
+ * into four queries total, which sequential awaits keep intact.
  */
 export async function prepareModuleHealthContext(
   tx: Bun.SQL,
   tenantId: string,
   correlationId?: string
 ): Promise<ModuleHealthContext> {
-  const [
-    migrations,
-    registryStatusByKey,
-    permissionsByModuleKey,
-    settingsRowByModuleKey
-  ] = await Promise.all([
-    migrationsAppliedSignal(tx, correlationId),
-    fetchRegistryStatuses(tx, correlationId),
-    fetchPermissionCatalog(tx, correlationId),
-    fetchTenantSettingsRows(tx, tenantId, correlationId)
-  ]);
+  const migrations = await migrationsAppliedSignal(tx, correlationId);
+  const registryStatusByKey = await fetchRegistryStatuses(tx, correlationId);
+  const permissionsByModuleKey = await fetchPermissionCatalog(
+    tx,
+    correlationId
+  );
+  const settingsRowByModuleKey = await fetchTenantSettingsRows(
+    tx,
+    tenantId,
+    correlationId
+  );
 
   return {
     migrations,

--- a/src/modules/module-management/application/module-matrix.ts
+++ b/src/modules/module-management/application/module-matrix.ts
@@ -52,7 +52,10 @@ import {
   fetchTenantModuleEntries,
   type TenantModuleListEntry
 } from "./tenant-module-lifecycle";
-import { fetchModuleHealthReport } from "./health-registry";
+import {
+  prepareModuleHealthContext,
+  fetchModuleHealthReport
+} from "./health-registry";
 import { resolveProtectedModuleKeys } from "../domain/module-presets";
 import {
   evaluateModuleDisable,
@@ -126,6 +129,19 @@ export async function fetchModuleMatrix(
     tenantEntries.map((entry) => [entry.moduleKey, entry])
   );
   const protectedKeys = resolveProtectedModuleKeys(allDescriptors);
+
+  // One prefetch shared by every row below, instead of each row's
+  // `fetchModuleHealthReport` running its own four queries — ≈92 queries per
+  // render at 23 modules, growing with every module added, which saturated the
+  // pool and timed this screen out (Issue #824). Still strictly gated on
+  // `includeHealth`: when health wasn't requested, not a single health query runs.
+  const healthContext = options.includeHealth
+    ? await prepareModuleHealthContext(
+        tx,
+        tenantId,
+        options.correlationId ?? undefined
+      )
+    : null;
 
   function resolveTenantState(moduleKey: string): ModuleTenantState {
     return (
@@ -201,13 +217,14 @@ export async function fetchModuleMatrix(
         }
       }
 
-      const healthStatus = options.includeHealth
+      const healthStatus = healthContext
         ? ((
             await fetchModuleHealthReport(
               tx,
               tenantId,
               entry.moduleKey,
-              options.correlationId ?? undefined
+              options.correlationId ?? undefined,
+              healthContext
             )
           )?.status ?? null)
         : null;

--- a/src/modules/module-management/application/module-settings.ts
+++ b/src/modules/module-management/application/module-settings.ts
@@ -23,7 +23,7 @@ export type ModuleSettingsView = {
   updatedAt: string | null;
 };
 
-type ModuleSettingsRow = {
+export type ModuleSettingsRow = {
   schema_version: number;
   settings: Record<string, unknown>;
   updated_at: Date;
@@ -80,6 +80,35 @@ export async function fetchModuleSettingsView(
   const row = await fetchSettingsRow(tx, tenantId, moduleKey);
 
   return toView(descriptor, row);
+}
+
+/**
+ * The pure half of `fetchModuleSettingsView` — same view, but fed an
+ * already-fetched row instead of running its own query. Pairs with
+ * `fetchTenantSettingsRowsByModule` so a caller resolving MANY modules at once
+ * (`fetchModuleHealthReports`, Issue #824) pays for one query total.
+ */
+export function buildModuleSettingsView(
+  moduleKey: string,
+  row: ModuleSettingsRow | null
+): ModuleSettingsView | null {
+  const descriptor = findDescriptor(moduleKey);
+
+  return descriptor ? toView(descriptor, row) : null;
+}
+
+/** Every module's override for ONE tenant in a single query, keyed by module key (Issue #824). */
+export async function fetchTenantSettingsRowsByModule(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<Map<string, ModuleSettingsRow>> {
+  const rows = (await tx`
+    SELECT module_key, schema_version, settings, updated_at
+    FROM awcms_mini_module_settings
+    WHERE tenant_id = ${tenantId}
+  `) as (ModuleSettingsRow & { module_key: string })[];
+
+  return new Map(rows.map((row) => [row.module_key, row]));
 }
 
 export type UpdateModuleSettingsResult =

--- a/src/modules/module-management/application/permission-sync.ts
+++ b/src/modules/module-management/application/permission-sync.ts
@@ -77,7 +77,23 @@ export async function fetchModulePermissionSyncReport(
   tx: Bun.SQL,
   moduleKey: string
 ): Promise<ModulePermissionSyncReport | null> {
-  const catalogPermissions = await fetchCatalogPermissions(tx, moduleKey);
+  return buildModulePermissionSyncReport(
+    moduleKey,
+    await fetchCatalogPermissions(tx, moduleKey)
+  );
+}
+
+/**
+ * The pure half of `fetchModulePermissionSyncReport` — same comparison, but
+ * fed already-fetched catalog rows instead of running its own query. Exists so
+ * a caller reporting on MANY modules at once (`fetchModuleHealthReports`,
+ * Issue #824) can pay for one catalog query total instead of one per module,
+ * without re-deriving the compare logic.
+ */
+export function buildModulePermissionSyncReport(
+  moduleKey: string,
+  catalogPermissions: CatalogPermission[]
+): ModulePermissionSyncReport | null {
   const descriptorExists = listModules().some((d) => d.key === moduleKey);
 
   if (!descriptorExists && catalogPermissions.length === 0) {
@@ -90,4 +106,23 @@ export async function fetchModulePermissionSyncReport(
   );
 
   return { moduleKey, entries };
+}
+
+/** Whole catalog in ONE query, grouped by module key — the batch feed for `buildModulePermissionSyncReport` (Issue #824). */
+export async function fetchCatalogPermissionsByModule(
+  tx: Bun.SQL
+): Promise<Map<string, CatalogPermission[]>> {
+  const byModule = new Map<string, CatalogPermission[]>();
+
+  for (const permission of await fetchCatalogPermissions(tx)) {
+    const existing = byModule.get(permission.moduleKey);
+
+    if (existing) {
+      existing.push(permission);
+    } else {
+      byModule.set(permission.moduleKey, [permission]);
+    }
+  }
+
+  return byModule;
 }

--- a/src/modules/reference-data/domain/code-patch.ts
+++ b/src/modules/reference-data/domain/code-patch.ts
@@ -1,0 +1,165 @@
+import type {
+  ReferenceCodeLabelInput,
+  ReferenceCodeValidationError
+} from "./code";
+
+/**
+ * Mutable attributes shared by `awcms_mini_reference_codes` and
+ * `awcms_mini_reference_tenant_codes`. This is the full-shape input the
+ * application-layer `update*` functions expect.
+ */
+export type ReferenceCodeMutableFields = {
+  labels: ReferenceCodeLabelInput[];
+  sortOrder: number;
+  metadata: Record<string, unknown>;
+  validFrom: Date;
+  validTo: Date | null;
+};
+
+/**
+ * A `PATCH` body parsed with true partial semantics: a key that is absent from
+ * the request body is absent here too (`undefined`) and must be left untouched
+ * by {@link mergeReferenceCodePatchInput}.
+ */
+export type ReferenceCodePatchInput = {
+  labels?: ReferenceCodeLabelInput[];
+  sortOrder?: number;
+  metadata?: Record<string, unknown>;
+  validFrom?: Date;
+  validTo?: Date | null;
+};
+
+export type ParseReferenceCodePatchResult =
+  | { ok: true; patch: ReferenceCodePatchInput }
+  | { ok: false; errors: ReferenceCodeValidationError[] };
+
+const DEFAULT_SORT_ORDER = 0;
+
+function hasField(body: Record<string, unknown>, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(body, field);
+}
+
+function parseLabels(value: unknown[]): ReferenceCodeLabelInput[] {
+  return value
+    .filter(
+      (entry): entry is Record<string, unknown> =>
+        !!entry && typeof entry === "object"
+    )
+    .map((entry) => ({
+      locale: typeof entry.locale === "string" ? entry.locale : "",
+      label: typeof entry.label === "string" ? entry.label : "",
+      description:
+        typeof entry.description === "string" ? entry.description : null
+    }));
+}
+
+/**
+ * Parse a reference-code `PATCH` body with normative `PATCH` semantics.
+ *
+ * Per field: **absent** = keep the stored value untouched, **`null`** =
+ * clear/reset to the field's empty value (`sortOrder` -> `0`, `metadata` ->
+ * `{}`, `validTo` -> `null`), any other value = replace. `validFrom` is
+ * `NOT NULL` in the schema and `labels` always needs at least one entry, so an
+ * explicit `null` for either is rejected rather than silently defaulted.
+ */
+export function parseReferenceCodePatchInput(
+  body: Record<string, unknown>
+): ParseReferenceCodePatchResult {
+  const patch: ReferenceCodePatchInput = {};
+  const errors: ReferenceCodeValidationError[] = [];
+
+  if (hasField(body, "labels")) {
+    const value = body.labels;
+    if (Array.isArray(value)) {
+      patch.labels = parseLabels(value);
+    } else {
+      errors.push({
+        field: "labels",
+        message:
+          "labels must be a non-empty array of label objects; null is not allowed because at least one label is always required. Omit the field to keep the stored labels."
+      });
+    }
+  }
+
+  if (hasField(body, "sortOrder")) {
+    const value = body.sortOrder;
+    if (value === null) {
+      patch.sortOrder = DEFAULT_SORT_ORDER;
+    } else if (typeof value === "number" && Number.isFinite(value)) {
+      patch.sortOrder = value;
+    } else {
+      errors.push({
+        field: "sortOrder",
+        message:
+          "sortOrder must be a finite number, or null to reset to 0. Omit the field to keep the stored value."
+      });
+    }
+  }
+
+  if (hasField(body, "metadata")) {
+    const value = body.metadata;
+    if (value === null) {
+      patch.metadata = {};
+    } else if (typeof value === "object" && !Array.isArray(value)) {
+      patch.metadata = value as Record<string, unknown>;
+    } else {
+      errors.push({
+        field: "metadata",
+        message:
+          "metadata must be an object, or null to clear it. Omit the field to keep the stored value."
+      });
+    }
+  }
+
+  if (hasField(body, "validFrom")) {
+    const value = body.validFrom;
+    if (typeof value === "string") {
+      patch.validFrom = new Date(value);
+    } else {
+      errors.push({
+        field: "validFrom",
+        message:
+          "validFrom must be an ISO-8601 date string; null is not allowed. Omit the field to keep the stored value."
+      });
+    }
+  }
+
+  if (hasField(body, "validTo")) {
+    const value = body.validTo;
+    if (value === null) {
+      patch.validTo = null;
+    } else if (typeof value === "string") {
+      patch.validTo = new Date(value);
+    } else {
+      errors.push({
+        field: "validTo",
+        message:
+          "validTo must be an ISO-8601 date string, or null to clear it. Omit the field to keep the stored value."
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true, patch };
+}
+
+/**
+ * Apply a parsed partial patch onto the stored record's current mutable
+ * attributes. Fields absent from the patch are carried over verbatim.
+ */
+export function mergeReferenceCodePatchInput(
+  existing: ReferenceCodeMutableFields,
+  patch: ReferenceCodePatchInput
+): ReferenceCodeMutableFields {
+  return {
+    labels: patch.labels === undefined ? existing.labels : patch.labels,
+    sortOrder:
+      patch.sortOrder === undefined ? existing.sortOrder : patch.sortOrder,
+    metadata: patch.metadata === undefined ? existing.metadata : patch.metadata,
+    validFrom:
+      patch.validFrom === undefined ? existing.validFrom : patch.validFrom,
+    validTo: patch.validTo === undefined ? existing.validTo : patch.validTo
+  };
+}

--- a/src/modules/reference-data/domain/code-patch.ts
+++ b/src/modules/reference-data/domain/code-patch.ts
@@ -35,6 +35,20 @@ export type ParseReferenceCodePatchResult =
 
 const DEFAULT_SORT_ORDER = 0;
 
+/**
+ * The complete set this parser understands. Kept beside the per-field blocks
+ * below so adding a field without listing it here makes that field's own tests
+ * fail immediately (it would be rejected as unknown) rather than silently
+ * ignored — the failure mode this set exists to prevent.
+ */
+const KNOWN_PATCH_FIELDS: ReadonlySet<string> = new Set([
+  "labels",
+  "sortOrder",
+  "metadata",
+  "validFrom",
+  "validTo"
+]);
+
 function hasField(body: Record<string, unknown>, field: string): boolean {
   return Object.prototype.hasOwnProperty.call(body, field);
 }
@@ -67,6 +81,24 @@ export function parseReferenceCodePatchInput(
 ): ParseReferenceCodePatchResult {
   const patch: ReferenceCodePatchInput = {};
   const errors: ReferenceCodeValidationError[] = [];
+
+  // Both PATCH schemas are `additionalProperties: false`, so an unknown key is
+  // a 400 by contract — but this parser reads known keys and ignores the rest,
+  // which turned a client typo (`validUntil` for `validTo`) into an empty
+  // patch. Combined with the empty-patch no-op branch the routes now take,
+  // that typo would answer 200 and change nothing: the request LOOKS accepted
+  // while doing nothing at all, which is worse than either rejecting it or
+  // applying it. Rejecting unknown keys here keeps the parser honest to the
+  // published contract. (Review finding, PR #839.)
+  const unknownFields = Object.keys(body).filter(
+    (key) => !KNOWN_PATCH_FIELDS.has(key)
+  );
+  for (const field of unknownFields) {
+    errors.push({
+      field,
+      message: `Unknown field "${field}". Allowed fields: ${[...KNOWN_PATCH_FIELDS].join(", ")}. Omit a field to keep its stored value.`
+    });
+  }
 
   if (hasField(body, "labels")) {
     const value = body.labels;

--- a/src/pages/admin/data-exchange/imports/[id].astro
+++ b/src/pages/admin/data-exchange/imports/[id].astro
@@ -17,7 +17,9 @@ import {
 import {
   countStagedRows,
   listStagedRows,
-  maskSensitiveFields
+  maskAllFields,
+  maskSensitiveFields,
+  type StagedRowRow
 } from "../../../../modules/data-exchange/application/staged-row-directory";
 import { listReconciliationReports } from "../../../../modules/data-exchange/application/reconciliation-service";
 import { createTranslator } from "../../../../lib/i18n/translate";
@@ -50,9 +52,15 @@ const CAN_RETRY = context.permissions.has(
 const CAN_MANAGE = context.permissions.has(
   permissionKey("data_exchange", "imports", "manage")
 );
-const CAN_SEE_RAW = context.permissions.has(
-  permissionKey("data_exchange", "preview_errors", "read")
-);
+// Issue #820: this screen does NOT go through
+// `GET /api/v1/data-exchange/imports/{id}/preview` — it queries and projects
+// staged rows itself, and so had its own independent copy of every defect
+// that issue fixes in the route (default-allow on an undeclared policy, a
+// hardcoded `data_exchange.preview_errors.read` in place of the
+// descriptor's own `rawValuePermission`, and no handling of a descriptor
+// that stopped resolving). The raw-value decision is made below, from the
+// descriptor, exactly as the route makes it — there is deliberately no
+// page-level `CAN_SEE_RAW` constant to drift from it again.
 
 const clientStrings = {
   actionSuccess: t("admin.data_exchange.imports.action_success"),
@@ -76,18 +84,31 @@ if (CAN_READ && batchId) {
       if (!batch) return;
 
       const descriptor = resolveImportDescriptor(batch.importKey);
-      const sensitiveFieldNames = descriptor?.sensitiveFields?.fieldNames ?? [];
+      const policy = descriptor?.sensitiveFields;
+
+      // Default-deny, same as the route: an unresolvable descriptor (owning
+      // module disabled after staging) and a descriptor declaring no policy
+      // both mask everything — including `naturalKey`, which is the only
+      // staged VALUE this table actually renders.
+      let project: (row: StagedRowRow) => StagedRowRow = maskAllFields;
+      if (policy) {
+        // The descriptor's OWN permission, never a generic data_exchange one.
+        // `rawValuePermission` is a `module.activity.action` key — the exact
+        // format `context.permissions` holds.
+        const canSeeRaw =
+          policy.fieldNames.length === 0 ||
+          (policy.rawValuePermission !== undefined &&
+            context.permissions.has(policy.rawValuePermission));
+        project = canSeeRaw
+          ? (row) => row
+          : (row) => maskSensitiveFields(row, policy);
+      }
 
       const fetchedRows = await listStagedRows(tx, context.tenantId, batchId, {
         offset: 0,
         limit: 50
       });
-      rows =
-        sensitiveFieldNames.length === 0 || CAN_SEE_RAW
-          ? fetchedRows
-          : fetchedRows.map((row) =>
-              maskSensitiveFields(row, sensitiveFieldNames)
-            );
+      rows = fetchedRows.map(project);
       totalRows = await countStagedRows(tx, context.tenantId, batchId);
       reconciliation = await listReconciliationReports(
         tx,

--- a/src/pages/admin/data-exchange/imports/[id].astro
+++ b/src/pages/admin/data-exchange/imports/[id].astro
@@ -22,6 +22,7 @@ import {
   type StagedRowRow
 } from "../../../../modules/data-exchange/application/staged-row-directory";
 import { isDescriptorPermissionGranted } from "../../../../modules/data-exchange/application/descriptor-authorization";
+import { resolveModuleEnabled } from "../../../../modules/identity-access/application/auth-context";
 import { listReconciliationReports } from "../../../../modules/data-exchange/application/reconciliation-service";
 import { createTranslator } from "../../../../lib/i18n/translate";
 import { logAdminPageError } from "../../../../lib/logging/error-log";
@@ -96,6 +97,21 @@ if (CAN_READ && batchId) {
       batch = await getImportBatchById(tx, context.tenantId, batchId);
       if (!batch) return;
 
+      // `context.permissions` is NOT the whole gate the API applies:
+      // `authorizeInTransaction` denies `403 MODULE_DISABLED` before it ever
+      // looks at RBAC, and `fetchGrantedPermissionKeys` (which builds the SSR
+      // permission set) never filters disabled modules out. So the `CAN_*`
+      // constants above are all still true for a tenant that has switched
+      // `data_exchange` off — the page would render staged rows while every
+      // route answered 403 (PR #839 security review, second parity finding).
+      if (
+        !(await resolveModuleEnabled(tx, context.tenantId, "data_exchange"))
+      ) {
+        descriptorDenied = true;
+        batch = null;
+        return;
+      }
+
       const descriptor = resolveImportDescriptor(batch.importKey);
 
       // An unresolvable descriptor (owning module disabled/removed via
@@ -113,13 +129,21 @@ if (CAN_READ && batchId) {
 
       // The OWNING module's own permission, on top of the generic
       // `data_exchange.imports.read` gate above — the same check the six API
-      // routes make with `authorizeExchangeDescriptorPermission` (a
-      // malformed key fails closed there and here).
+      // routes make with `authorizeExchangeDescriptorPermission` (a malformed
+      // key, and a key whose module this tenant disabled, both fail closed
+      // there and here).
+      //
+      // MUST stay awaited: this returns a Promise, and an un-awaited Promise
+      // is truthy, so a dropped `await` here inverts the gate into a silent
+      // fail-OPEN. `tsc` does not check `.astro`, so nothing but this comment
+      // and the integration test guards that.
       if (
-        !isDescriptorPermissionGranted(
+        !(await isDescriptorPermissionGranted(
+          tx,
+          context.tenantId,
           context.permissions,
           descriptor.requiredPermission
-        )
+        ))
       ) {
         descriptorDenied = true;
         batch = null;
@@ -134,12 +158,20 @@ if (CAN_READ && batchId) {
       let project: (row: StagedRowRow) => StagedRowRow = maskAllFields;
       if (policy) {
         // The descriptor's OWN permission, never a generic data_exchange one.
-        // `rawValuePermission` is a `module.activity.action` key — the exact
-        // format `context.permissions` holds.
+        // Goes through the same helper as `requiredPermission` above rather
+        // than reading `context.permissions` directly: the route's raw-value
+        // gate is `authorizeDescriptorPermissionKey`, which resolves module
+        // state too, so a bare `permissions.has()` here would unmask values
+        // the route masks once the declaring module is disabled.
         const canSeeRaw =
           policy.fieldNames.length === 0 ||
           (policy.rawValuePermission !== undefined &&
-            context.permissions.has(policy.rawValuePermission));
+            (await isDescriptorPermissionGranted(
+              tx,
+              context.tenantId,
+              context.permissions,
+              policy.rawValuePermission
+            )));
         project = canSeeRaw
           ? (row) => row
           : (row) => maskSensitiveFields(row, policy);

--- a/src/pages/admin/data-exchange/imports/[id].astro
+++ b/src/pages/admin/data-exchange/imports/[id].astro
@@ -21,6 +21,7 @@ import {
   maskSensitiveFields,
   type StagedRowRow
 } from "../../../../modules/data-exchange/application/staged-row-directory";
+import { isDescriptorPermissionGranted } from "../../../../modules/data-exchange/application/descriptor-authorization";
 import { listReconciliationReports } from "../../../../modules/data-exchange/application/reconciliation-service";
 import { createTranslator } from "../../../../lib/i18n/translate";
 import { logAdminPageError } from "../../../../lib/logging/error-log";
@@ -58,9 +59,20 @@ const CAN_MANAGE = context.permissions.has(
 // that issue fixes in the route (default-allow on an undeclared policy, a
 // hardcoded `data_exchange.preview_errors.read` in place of the
 // descriptor's own `rawValuePermission`, and no handling of a descriptor
-// that stopped resolving). The raw-value decision is made below, from the
-// descriptor, exactly as the route makes it — there is deliberately no
-// page-level `CAN_SEE_RAW` constant to drift from it again.
+// that stopped resolving). BOTH descriptor-level decisions are made below,
+// from the descriptor, exactly as the route makes them — there is
+// deliberately no page-level `CAN_SEE_RAW` constant to drift from them
+// again.
+//
+// PR #839's security review found the first pass here made only the
+// raw-value decision and skipped the descriptor's `requiredPermission`
+// gate entirely — the OWNING module's own permission, which all six API
+// routes enforce via `authorizeExchangeDescriptorPermission`. A descriptor
+// declaring `requiredPermission: "hr.payroll.read"` was therefore enforced
+// everywhere except here, letting a holder of the generic
+// `data_exchange.imports.read` read that module's staged content off this
+// page. Both gates now run below, sharing the route's semantics via
+// `isDescriptorPermissionGranted`.
 
 const clientStrings = {
   actionSuccess: t("admin.data_exchange.imports.action_success"),
@@ -76,6 +88,7 @@ let totalRows = 0;
 let reconciliation: Awaited<ReturnType<typeof listReconciliationReports>> = [];
 let loadError = false;
 let notFound = false;
+let descriptorDenied = false;
 
 if (CAN_READ && batchId) {
   try {
@@ -84,12 +97,40 @@ if (CAN_READ && batchId) {
       if (!batch) return;
 
       const descriptor = resolveImportDescriptor(batch.importKey);
-      const policy = descriptor?.sensitiveFields;
 
-      // Default-deny, same as the route: an unresolvable descriptor (owning
-      // module disabled after staging) and a descriptor declaring no policy
-      // both mask everything — including `naturalKey`, which is the only
-      // staged VALUE this table actually renders.
+      // An unresolvable descriptor (owning module disabled/removed via
+      // `module_management` after staging) DENIES — it does not fall back to
+      // `maskAllFields`. Nothing left in the registry can say who may read
+      // this batch, so masking the values while still rendering the batch's
+      // metadata would leave it strictly more exposed than while its module
+      // ran. The preview route answers 409 for exactly this state; this page
+      // renders the denied notice.
+      if (!descriptor) {
+        descriptorDenied = true;
+        batch = null;
+        return;
+      }
+
+      // The OWNING module's own permission, on top of the generic
+      // `data_exchange.imports.read` gate above — the same check the six API
+      // routes make with `authorizeExchangeDescriptorPermission` (a
+      // malformed key fails closed there and here).
+      if (
+        !isDescriptorPermissionGranted(
+          context.permissions,
+          descriptor.requiredPermission
+        )
+      ) {
+        descriptorDenied = true;
+        batch = null;
+        return;
+      }
+
+      const policy = descriptor.sensitiveFields;
+
+      // Default-deny, same as the route: a descriptor declaring no policy
+      // masks everything — including `naturalKey`, which is the only staged
+      // VALUE this table actually renders.
       let project: (row: StagedRowRow) => StagedRowRow = maskAllFields;
       if (policy) {
         // The descriptor's OWN permission, never a generic data_exchange one.
@@ -117,7 +158,7 @@ if (CAN_READ && batchId) {
         batchId
       );
     });
-    if (!batch) notFound = true;
+    if (!batch && !descriptorDenied) notFound = true;
   } catch (error) {
     logAdminPageError(
       "admin/data-exchange/imports/[id].astro: failed to load batch",
@@ -133,7 +174,7 @@ if (CAN_READ && batchId) {
 
 <AdminLayout title={t("admin.data_exchange.imports.detail_title")}>
   {
-    !CAN_READ && (
+    (!CAN_READ || descriptorDenied) && (
       <StateNotice
         kind="denied"
         title={t("admin.data_exchange.access_denied_title")}

--- a/src/pages/admin/modules.astro
+++ b/src/pages/admin/modules.astro
@@ -20,7 +20,7 @@ import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { fetchModuleCatalog } from "../../modules/module-management/application/module-catalog";
-import { fetchModuleHealthReport } from "../../modules/module-management/application/health-registry";
+import { fetchModuleHealthReports } from "../../modules/module-management/application/health-registry";
 import { createTranslator } from "../../lib/i18n/translate";
 import { logAdminPageError } from "../../lib/logging/error-log";
 
@@ -60,19 +60,20 @@ if (CAN_READ_MODULES) {
           return catalog.map((entry) => ({ ...entry, healthStatus: null }));
         }
 
-        const withHealth = await Promise.all(
-          catalog.map(async (entry) => {
-            const report = await fetchModuleHealthReport(
-              tx,
-              context.tenantId,
-              entry.moduleKey,
-              Astro.locals.correlationId
-            );
-            return { ...entry, healthStatus: report?.status ?? null };
-          })
+        // One batched prefetch for the whole catalog — see Issue #824 for why
+        // a per-module `fetchModuleHealthReport` loop here was a pool-saturating
+        // O(modules) fan-out.
+        const reports = await fetchModuleHealthReports(
+          tx,
+          context.tenantId,
+          catalog.map((entry) => entry.moduleKey),
+          Astro.locals.correlationId
         );
 
-        return withHealth;
+        return catalog.map((entry) => ({
+          ...entry,
+          healthStatus: reports.get(entry.moduleKey)?.status ?? null
+        }));
       }
     );
   } catch (error) {

--- a/src/pages/api/v1/auth/login.ts
+++ b/src/pages/api/v1/auth/login.ts
@@ -138,12 +138,32 @@ async function recordLoginFailure(
   tx: Bun.SQL,
   input: {
     tenantId: string;
+    tenantExists: boolean;
     identityId?: string;
     reason: LoginAuditFailureReason;
     audit: LoginAuditContext;
     correlationId?: string;
   }
 ): Promise<void> {
+  // `awcms_mini_audit_events.tenant_id` is `NOT NULL REFERENCES
+  // awcms_mini_tenants (id)`, so there is no tenant-scoped audit row to write
+  // for a tenant that does not exist — attempting it violates the FK, aborts
+  // the transaction, and turns this endpoint's intended 403 into a 500. A
+  // well-formed but unknown tenant header is reachable by any unauthenticated
+  // caller, so that would be a trivial way to force 500s.
+  //
+  // The attempt is not lost: it goes to the structured log instead, which is
+  // not tenant-scoped. Nothing tenant-scoped can be recorded here by
+  // definition — there is no tenant.
+  if (!input.tenantExists) {
+    log("warning", "identity_access.login_failed.unknown_tenant", {
+      reason: input.reason,
+      correlationId: input.correlationId,
+      ...input.audit
+    });
+    return;
+  }
+
   await recordAuditEvent(tx, {
     tenantId: input.tenantId,
     moduleKey: "identity_access",
@@ -189,8 +209,15 @@ async function recordLoginFailureOutOfBand(
 ): Promise<void> {
   try {
     await withTenant(sql, input.tenantId, async (tx) => {
+      // Re-checked here rather than threaded in: this runs after the login
+      // transaction unwound, so nothing it computed can be trusted to still
+      // hold. Without it an unknown-tenant header would trip the audit table's
+      // tenant FK and this recovery write would fail for the wrong reason.
+      const rows =
+        await tx`SELECT 1 FROM awcms_mini_tenants WHERE id = ${input.tenantId}`;
       await recordLoginFailure(tx, {
         tenantId: input.tenantId,
+        tenantExists: rows.length > 0,
         reason: "internal_error",
         audit: input.audit,
         correlationId: input.correlationId
@@ -366,6 +393,7 @@ export const POST: APIRoute = async ({
       // before it commits.
       await recordLoginFailure(tx, {
         tenantId,
+        tenantExists: tenantRows.length > 0,
         identityId: identityRow?.id,
         reason: result.reason,
         audit: auditContext,

--- a/src/pages/api/v1/auth/login.ts
+++ b/src/pages/api/v1/auth/login.ts
@@ -119,8 +119,20 @@ type LoginAuditFailureReason = LoginDenyReason | "internal_error";
  * the trail of the one field that answers "which account is being attacked?",
  * defeating the purpose of auditing failures at all. The enumeration
  * guarantee this issue asks for is about what an *unauthenticated caller* can
- * infer, and that is unaffected: the HTTP responses below are byte-identical
- * regardless of whether the identity exists.
+ * infer, and setting `resourceId` here does not affect that either way: the
+ * audit row is never part of a response.
+ *
+ * That is deliberately NOT a claim that the responses below are
+ * indistinguishable — they are not, and this comment used to say they were
+ * (PR #839 security review). Two branches, both reachable only once the
+ * identity has resolved, are observably different from the
+ * `"Invalid login identifier or password."` 401 an unknown identifier gets:
+ * `locked` answers 401 with `"Account is temporarily locked."`, and
+ * `password_login_disabled` answers 403. An unauthenticated caller can
+ * therefore still infer that a given identifier exists. That oracle predates
+ * this change and is tracked separately in Issue #840 (the `fail()` calls it
+ * concerns are deliberately untouched here); do not read this comment as
+ * evidence it is closed.
  */
 async function recordLoginFailure(
   tx: Bun.SQL,

--- a/src/pages/api/v1/auth/login.ts
+++ b/src/pages/api/v1/auth/login.ts
@@ -30,8 +30,14 @@ import {
   findActiveMfaFactor
 } from "../../../../modules/identity-access/application/mfa";
 import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  hashClientIp,
+  summarizeUserAgent
+} from "../../../../lib/security/client-fingerprint";
+import { log } from "../../../../lib/logging/logger";
 import { isSsoRequired } from "../../../../lib/auth/sso-config";
 import { isPasswordLoginDisabledForIdentity } from "../../../../modules/identity-access/application/tenant-auth-policy";
+import type { LoginDenyReason } from "../../../../modules/identity-access/domain/login-policy";
 
 const MAX_FAILED_ATTEMPTS = Number(process.env.AUTH_LOGIN_MAX_ATTEMPTS ?? 5);
 const LOCKOUT_MINUTES = 15;
@@ -61,6 +67,131 @@ type LoginBody = {
   password?: unknown;
   turnstileToken?: unknown;
 };
+
+/**
+ * Issue #821 — source attribution shared by the `login_succeeded` and
+ * `login_failed` audit rows below.
+ *
+ * `loginIdentifier` is deliberately NOT part of this: it is typically an
+ * email address (PII, and one that `redactSensitiveAttributes` would *not*
+ * catch under that key name), and persisting the attacker-supplied string on
+ * a failed attempt is exactly the user-enumeration leak this issue asks to
+ * avoid. `password` is likewise never referenced here — the only inputs that
+ * reach an audit attribute are the source fingerprint and the policy's own
+ * deny reason.
+ */
+type LoginAuditContext = {
+  ipHash: string;
+  userAgent?: string;
+};
+
+function buildLoginAuditContext(
+  request: Request,
+  clientIp: string
+): LoginAuditContext {
+  return {
+    ipHash: hashClientIp(clientIp),
+    userAgent: summarizeUserAgent(request)
+  };
+}
+
+/**
+ * Every `evaluateLoginAttempt` deny reason, plus `"internal_error"` for the
+ * one failure the policy layer cannot describe: the login transaction threw
+ * and was rolled back (see `recordLoginFailureOutOfBand`).
+ */
+type LoginAuditFailureReason = LoginDenyReason | "internal_error";
+
+/**
+ * Records one `login_failed` audit row.
+ *
+ * `reason` is the `evaluateLoginAttempt` deny reason verbatim, which is
+ * already collapsed at the policy layer: an unknown `loginIdentifier`, a
+ * wrong password, an inactive identity, and an inactive tenant-user all
+ * return the single reason `"invalid_credentials"` (see
+ * `login-policy.ts`) — so the reason alone never distinguishes "this account
+ * does not exist" from "this account exists and the password was wrong".
+ *
+ * `resourceId` IS set when the identity resolved, and that is intentional:
+ * `awcms_mini_audit_events` is tenant-scoped and RLS-protected, readable only
+ * by operators who can already read `awcms_mini_identities` directly, so it
+ * discloses nothing they don't already hold — while omitting it would strip
+ * the trail of the one field that answers "which account is being attacked?",
+ * defeating the purpose of auditing failures at all. The enumeration
+ * guarantee this issue asks for is about what an *unauthenticated caller* can
+ * infer, and that is unaffected: the HTTP responses below are byte-identical
+ * regardless of whether the identity exists.
+ */
+async function recordLoginFailure(
+  tx: Bun.SQL,
+  input: {
+    tenantId: string;
+    identityId?: string;
+    reason: LoginAuditFailureReason;
+    audit: LoginAuditContext;
+    correlationId?: string;
+  }
+): Promise<void> {
+  await recordAuditEvent(tx, {
+    tenantId: input.tenantId,
+    moduleKey: "identity_access",
+    action: "login_failed",
+    resourceType: "identity",
+    resourceId: input.identityId,
+    severity: "warning",
+    message: `Password sign-in failed: ${input.reason}.`,
+    attributes: {
+      method: "password",
+      reason: input.reason,
+      ...input.audit
+    },
+    correlationId: input.correlationId
+  });
+}
+
+/**
+ * Issue #821 — records `login_failed` in a FRESH transaction, for the case
+ * where the login transaction itself threw and was rolled back, taking any
+ * audit row written inside it along with it.
+ *
+ * Reached only on an exception, never on an ordinary authentication denial
+ * (those `return` and commit with `recordLoginFailure` above), so this never
+ * doubles the connection cost of a brute-force attempt against this public,
+ * unauthenticated endpoint — which is exactly why the normal deny path is not
+ * routed through here as well.
+ *
+ * Strictly best-effort: whatever unwound the login transaction was very
+ * plausibly the database itself, in which case this write cannot succeed
+ * either. Its own failure is swallowed and logged so it can never mask the
+ * original error, which is rethrown by the caller. The raw exception is never
+ * handed to `log()` — see doc 20 §Issue #687: an exception message is
+ * unkeyed free text that key-based redaction cannot clean.
+ */
+async function recordLoginFailureOutOfBand(
+  sql: Bun.SQL,
+  input: {
+    tenantId: string;
+    audit: LoginAuditContext;
+    correlationId?: string;
+  }
+): Promise<void> {
+  try {
+    await withTenant(sql, input.tenantId, async (tx) => {
+      await recordLoginFailure(tx, {
+        tenantId: input.tenantId,
+        reason: "internal_error",
+        audit: input.audit,
+        correlationId: input.correlationId
+      });
+    });
+  } catch {
+    log("warning", "auth.login.audit_write_failed", {
+      moduleKey: "identity_access",
+      tenantId: input.tenantId,
+      correlationId: input.correlationId
+    });
+  }
+}
 
 export const POST: APIRoute = async ({
   request,
@@ -138,6 +269,7 @@ export const POST: APIRoute = async ({
   const password = body.password;
   const sql = getDatabaseClient();
   const now = new Date();
+  const auditContext = buildLoginAuditContext(request, clientIp);
 
   return withTenant(sql, tenantId, async (tx) => {
     const tenantRows =
@@ -212,6 +344,22 @@ export const POST: APIRoute = async ({
         `;
       }
 
+      // Written inside the same transaction as the `failed_login_count`
+      // UPDATE above, and therefore committed with it: every deny path below
+      // `return`s a response rather than throwing, so this transaction always
+      // reaches COMMIT (the lockout counter's durability across the exact same
+      // boundary is what the account-lockout feature has always depended on).
+      // The out-of-band recorder in the `catch` at the bottom of this handler
+      // covers the remaining case — an exception unwinding this transaction
+      // before it commits.
+      await recordLoginFailure(tx, {
+        tenantId,
+        identityId: identityRow?.id,
+        reason: result.reason,
+        audit: auditContext,
+        correlationId: locals.correlationId
+      });
+
       if (result.reason === "tenant_inactive") {
         return fail(403, "ACCESS_DENIED", "Tenant is not active.");
       }
@@ -271,6 +419,7 @@ export const POST: APIRoute = async ({
           resourceId: identityRow!.id,
           severity: "info",
           message: "Password verified; MFA challenge issued.",
+          attributes: { method: "password", ...auditContext },
           correlationId: locals.correlationId
         });
 
@@ -302,6 +451,25 @@ export const POST: APIRoute = async ({
       VALUES (${tenantId}, ${identityRow!.id}, ${tokenHash}, ${expiresAt})
     `;
 
+    // Issue #821 — `method: "password"` is unconditional here: this is the
+    // only branch that mints a session directly from a password, and it is
+    // reached only when no MFA challenge was issued above. The MFA and
+    // OIDC/SSO completions mint their sessions in their own routes and audit
+    // themselves (`mfa_challenge_verified`, `google_login_succeeded`,
+    // `sso_login_succeeded`), so this row must never claim those methods.
+    // Neither `token` nor `tokenHash` is referenced in the attributes.
+    await recordAuditEvent(tx, {
+      tenantId,
+      moduleKey: "identity_access",
+      action: "login_succeeded",
+      resourceType: "identity",
+      resourceId: identityRow!.id,
+      severity: "info",
+      message: "Password sign-in succeeded; session created.",
+      attributes: { method: "password", ...auditContext },
+      correlationId: locals.correlationId
+    });
+
     // Additive (Issue 8.1): also set httpOnly + SameSite=Lax cookies so the
     // SSR admin shell (src/layouts/AdminLayout.astro) can authenticate
     // without exposing the raw session token to client-side JavaScript
@@ -319,5 +487,17 @@ export const POST: APIRoute = async ({
     cookies.set(TENANT_COOKIE_NAME, tenantId, cookieOptions);
 
     return ok({ token, expiresAt: expiresAt.toISOString() });
+  }).catch(async (error: unknown) => {
+    // Issue #821 — the login transaction was rolled back, so any `login_failed`
+    // row `recordLoginFailure` wrote inside it is gone. Re-record it on a fresh
+    // transaction, then rethrow untouched: this handler observes the failure
+    // for the audit trail, it does not swallow or reshape it.
+    await recordLoginFailureOutOfBand(sql, {
+      tenantId,
+      audit: auditContext,
+      correlationId: locals.correlationId
+    });
+
+    throw error;
   });
 };

--- a/src/pages/api/v1/auth/mfa/totp/verify.ts
+++ b/src/pages/api/v1/auth/mfa/totp/verify.ts
@@ -15,6 +15,7 @@ import {
   resolveClientIp
 } from "../../../../../../lib/security/rate-limit";
 import { verifyMfaChallenge } from "../../../../../../modules/identity-access/application/mfa";
+import { log } from "../../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
 import {
   hashClientIp,
@@ -128,6 +129,29 @@ export const POST: APIRoute = async ({
       // resolve to an identity (`verifyMfaChallenge` returns none on the `!ok`
       // path), and the token itself must never be persisted. `result.code` is
       // a fixed enum, not caller-controlled text.
+      // `awcms_mini_audit_events.tenant_id` is `NOT NULL REFERENCES
+      // awcms_mini_tenants (id)`. A well-formed but unknown tenant header
+      // reaches here, and writing this row for a tenant that does not exist
+      // violates that FK, aborts the transaction, and replaces the intended
+      // 401 with a 500. There is no tenant-scoped audit trail to write for a
+      // tenant that does not exist; the structured log (not tenant-scoped)
+      // keeps the attempt visible.
+      const tenantRows =
+        await tx`SELECT 1 FROM awcms_mini_tenants WHERE id = ${tenantId}`;
+      if (tenantRows.length === 0) {
+        log("warning", "identity_access.mfa_challenge_failed.unknown_tenant", {
+          moduleKey: "identity_access",
+          reason: result.code
+        });
+        return fail(
+          status,
+          result.code,
+          result.code === "MFA_MISCONFIGURED"
+            ? "Multi-factor authentication is misconfigured on this server."
+            : "This MFA challenge is invalid, expired, or already used."
+        );
+      }
+
       await recordAuditEvent(tx, {
         tenantId,
         moduleKey: "identity_access",

--- a/src/pages/api/v1/auth/mfa/totp/verify.ts
+++ b/src/pages/api/v1/auth/mfa/totp/verify.ts
@@ -16,6 +16,10 @@ import {
 } from "../../../../../../lib/security/rate-limit";
 import { verifyMfaChallenge } from "../../../../../../modules/identity-access/application/mfa";
 import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  hashClientIp,
+  summarizeUserAgent
+} from "../../../../../../lib/security/client-fingerprint";
 
 const SESSION_TTL_MIN = Number(process.env.AUTH_SESSION_TTL_MIN ?? 120);
 const RATE_LIMIT_MAX_ATTEMPTS = Number(
@@ -115,6 +119,30 @@ export const POST: APIRoute = async ({
     if (!result.ok) {
       const status = result.code === "MFA_MISCONFIGURED" ? 500 : 401;
 
+      // Issue #821 — the second factor is the last gate in front of a session
+      // for a caller who already proved the password, so a failure here is a
+      // higher-signal brute-force indicator than a plain `login_failed`, yet
+      // it was the one auth outcome in this file left untraced.
+      //
+      // No `resourceId`: an invalid/expired/replayed challenge token does not
+      // resolve to an identity (`verifyMfaChallenge` returns none on the `!ok`
+      // path), and the token itself must never be persisted. `result.code` is
+      // a fixed enum, not caller-controlled text.
+      await recordAuditEvent(tx, {
+        tenantId,
+        moduleKey: "identity_access",
+        action: "mfa_challenge_failed",
+        resourceType: "identity",
+        severity: "warning",
+        message: `MFA challenge verification failed: ${result.code}.`,
+        attributes: {
+          reason: result.code,
+          ipHash: hashClientIp(clientIp),
+          userAgent: summarizeUserAgent(request)
+        },
+        correlationId: locals.correlationId
+      });
+
       return fail(
         status,
         result.code,
@@ -148,6 +176,14 @@ export const POST: APIRoute = async ({
       resourceId: identityId,
       severity: "info",
       message: "MFA challenge verified; session created.",
+      // Same source fingerprint as the `login_failed`/`mfa_challenge_failed`
+      // rows, so an operator can follow one source across the whole two-step
+      // sign-in rather than only across its failures (Issue #821).
+      attributes: {
+        method: "mfa",
+        ipHash: hashClientIp(clientIp),
+        userAgent: summarizeUserAgent(request)
+      },
       correlationId: locals.correlationId
     });
 

--- a/src/pages/api/v1/data-exchange/exports/[id]/download.ts
+++ b/src/pages/api/v1/data-exchange/exports/[id]/download.ts
@@ -75,12 +75,26 @@ export const GET: APIRoute = async ({ request, cookies, params, locals }) => {
     // able to bypass an owning module's own `requiredPermission` gate
     // (e.g. a future payroll/HR export descriptor) just because this route
     // forgot to check it.
+    //
+    // Issue #820 Cacat 3: passing an unresolvable descriptor as `null` used
+    // to skip that gate entirely — so disabling the owning module made its
+    // already-materialized export file MORE downloadable, not less. Of
+    // every call site this one matters most: it serves raw file content.
+    const downloadDescriptor = resolveExportDescriptor(job.exportKey);
+    if (!downloadDescriptor) {
+      return fail(
+        409,
+        "INVALID_STATE",
+        `Export job cannot be downloaded: exportKey "${job.exportKey}" is no longer registered — its owning module may be disabled.`
+      );
+    }
+
     const descriptorPermCheck = await authorizeExchangeDescriptorPermission(
       tx,
       tenantId,
       tokenHash,
       now,
-      resolveExportDescriptor(job.exportKey)
+      downloadDescriptor
     );
     if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
 

--- a/src/pages/api/v1/data-exchange/exports/index.ts
+++ b/src/pages/api/v1/data-exchange/exports/index.ts
@@ -150,14 +150,21 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     );
     if (!auth.allowed) return auth.denied;
 
-    const descriptorPermCheck = await authorizeExchangeDescriptorPermission(
-      tx,
-      tenantId,
-      tokenHash,
-      now,
-      resolveExportDescriptor(exportKey)
-    );
-    if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
+    // An unknown exportKey answers 404 further below (`Unknown exportKey`)
+    // — this route's own handling of an unresolvable descriptor, which
+    // `authorizeExchangeDescriptorPermission` no longer accepts as an
+    // implicit allow (Issue #820 Cacat 3).
+    const createDescriptor = resolveExportDescriptor(exportKey);
+    if (createDescriptor) {
+      const descriptorPermCheck = await authorizeExchangeDescriptorPermission(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        createDescriptor
+      );
+      if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
+    }
 
     const existingIdempotency = await findIdempotencyRecord(
       tx,

--- a/src/pages/api/v1/data-exchange/imports/[id]/commit.ts
+++ b/src/pages/api/v1/data-exchange/imports/[id]/commit.ts
@@ -76,14 +76,29 @@ export const POST: APIRoute = async ({ request, cookies, params, locals }) => {
     if (!auth.allowed) return auth.denied;
 
     const existingBatch = await getImportBatchById(tx, tenantId, batchId);
-    const descriptorPermCheck = await authorizeExchangeDescriptorPermission(
-      tx,
-      tenantId,
-      tokenHash,
-      now,
-      existingBatch ? resolveImportDescriptor(existingBatch.importKey) : null
-    );
-    if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
+    // A missing batch answers 404 further below. An EXISTING batch whose
+    // importKey no longer resolves is the module-disabled-after-staging
+    // case (Issue #820 Cacat 3): committing WRITES through the owning
+    // module's adapter, so an unresolvable descriptor must fail CLOSED
+    // rather than skip the descriptor gate the way passing `null` used to.
+    if (existingBatch) {
+      const commitDescriptor = resolveImportDescriptor(existingBatch.importKey);
+      if (!commitDescriptor) {
+        return fail(
+          409,
+          "INVALID_STATE",
+          `Import batch cannot be committed: importKey "${existingBatch.importKey}" is no longer registered — its owning module may be disabled.`
+        );
+      }
+      const descriptorPermCheck = await authorizeExchangeDescriptorPermission(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        commitDescriptor
+      );
+      if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
+    }
 
     const existingIdempotency = await findIdempotencyRecord(
       tx,

--- a/src/pages/api/v1/data-exchange/imports/[id]/commit.ts
+++ b/src/pages/api/v1/data-exchange/imports/[id]/commit.ts
@@ -75,6 +75,36 @@ export const POST: APIRoute = async ({ request, cookies, params, locals }) => {
     );
     if (!auth.allowed) return auth.denied;
 
+    // Replay BEFORE the descriptor-state checks below, not after. A replay
+    // runs no adapter and writes nothing — it hands back an outcome already
+    // recorded for this exact key+hash, under the full gate set as it stood
+    // at the time. The descriptor checks exist to guard the WRITE, so gating
+    // a replay on them prevents nothing and breaks the contract
+    // `_shared/idempotency.ts` states outright ("same key + same request hash
+    // -> replay the stored response"): a client retrying a commit after its
+    // module was disabled would get a fresh 409 instead of the response it
+    // already earned, and the same key+hash would answer differently over
+    // time — the one thing idempotency exists to prevent. (Review finding,
+    // PR #839.)
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
     const existingBatch = await getImportBatchById(tx, tenantId, batchId);
     // A missing batch answers 404 further below. An EXISTING batch whose
     // importKey no longer resolves is the module-disabled-after-staging
@@ -98,25 +128,6 @@ export const POST: APIRoute = async ({ request, cookies, params, locals }) => {
         commitDescriptor
       );
       if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
-    }
-
-    const existingIdempotency = await findIdempotencyRecord(
-      tx,
-      tenantId,
-      IDEMPOTENCY_SCOPE,
-      idempotencyKey
-    );
-    if (existingIdempotency) {
-      if (existingIdempotency.requestHash !== requestHash) {
-        return fail(
-          409,
-          "IDEMPOTENCY_CONFLICT",
-          "Idempotency-Key was already used with a different request."
-        );
-      }
-      return jsonResponse(existingIdempotency.responseBody, {
-        status: existingIdempotency.responseStatus
-      });
     }
 
     const result = await requestImportCommit(

--- a/src/pages/api/v1/data-exchange/imports/[id]/preview.ts
+++ b/src/pages/api/v1/data-exchange/imports/[id]/preview.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from "astro";
 
 import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import type { ExchangeSensitiveFieldPolicy } from "../../../../../../modules/_shared/module-contract";
 import { getDatabaseClient } from "../../../../../../lib/database/client";
 import { withTenant } from "../../../../../../lib/database/tenant-context";
 import {
@@ -12,11 +13,16 @@ import {
   getImportBatchById,
   resolveImportDescriptor
 } from "../../../../../../modules/data-exchange/application/import-batch-directory";
-import { authorizeExchangeDescriptorPermission } from "../../../../../../modules/data-exchange/application/descriptor-authorization";
+import {
+  authorizeDescriptorPermissionKey,
+  authorizeExchangeDescriptorPermission
+} from "../../../../../../modules/data-exchange/application/descriptor-authorization";
 import {
   countStagedRows,
   listStagedRows,
+  maskAllFields,
   maskSensitiveFields,
+  PREVIEW_OFFSET_MAX,
   PREVIEW_PAGE_SIZE_DEFAULT,
   PREVIEW_PAGE_SIZE_MAX,
   type StagedRowRow
@@ -25,11 +31,6 @@ import {
 const READ_GUARD = {
   moduleKey: "data_exchange",
   activityCode: "imports",
-  action: "read" as const
-};
-const RAW_VALUE_GUARD = {
-  moduleKey: "data_exchange",
-  activityCode: "preview_errors",
   action: "read" as const
 };
 
@@ -44,10 +45,20 @@ const VALID_PROPOSED_ACTIONS = new Set([
 /**
  * `GET /api/v1/data-exchange/imports/{id}/preview?proposedAction=&offset=&limit=`
  * (Issue #752) — paginated preview of staged rows, zero domain mutation.
- * Sensitive fields (per the descriptor's `sensitiveFields`) are masked
- * unless the caller ALSO holds `data_exchange.preview_errors.read` (Issue
- * #752 security requirement: raw invalid values require explicit
- * permission).
+ *
+ * Raw staged values are revealed only when the batch's descriptor says so,
+ * and only to a caller holding the permission THAT DESCRIPTOR names (Issue
+ * #820, three composing defects — each fixed alone still left the hole):
+ *
+ * 1. An undeclared `sensitiveFields` policy masks everything (default-deny)
+ *    instead of revealing everything (the old default-allow).
+ * 2. The raw-value gate is `sensitiveFields.rawValuePermission`, the
+ *    descriptor's OWN narrow permission — not the far broader hardcoded
+ *    `data_exchange.preview_errors.read` this route used to check, which
+ *    ignored the descriptor's declaration entirely.
+ * 3. An unresolvable descriptor (owning module disabled after staging) is
+ *    denied, not waved through — a batch must never get MORE open because
+ *    its module was switched off.
  */
 export const GET: APIRoute = async ({ request, cookies, params, url }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
@@ -68,9 +79,12 @@ export const GET: APIRoute = async ({ request, cookies, params, url }) => {
   const limitParam = Number(
     url.searchParams.get("limit") ?? String(PREVIEW_PAGE_SIZE_DEFAULT)
   );
+  // Issue #831: `offset` had a floor but no ceiling, one line above a
+  // `limit` that was already clamped correctly — `?offset=5000000` reached
+  // Postgres verbatim as a deep scan.
   const offset =
     Number.isFinite(offsetParam) && offsetParam >= 0
-      ? Math.floor(offsetParam)
+      ? Math.min(Math.floor(offsetParam), PREVIEW_OFFSET_MAX)
       : 0;
   const limit =
     Number.isFinite(limitParam) && limitParam > 0
@@ -95,6 +109,20 @@ export const GET: APIRoute = async ({ request, cookies, params, url }) => {
     if (!batch) return fail(404, "NOT_FOUND", "Import batch not found.");
 
     const descriptor = resolveImportDescriptor(batch.importKey);
+    if (!descriptor) {
+      // The batch outlived its descriptor — the owning module was disabled
+      // or removed via `module_management` after staging. Its rows are the
+      // owning module's data, and nothing left in the registry can say who
+      // may read them raw or which of its fields are sensitive, so this
+      // fails closed (Issue #820 Cacat 3: previously BOTH the descriptor
+      // gate and the sensitive-field policy silently evaporated here,
+      // leaving the batch strictly more exposed than while its module ran).
+      return fail(
+        409,
+        "INVALID_STATE",
+        `Import batch cannot be previewed: importKey "${batch.importKey}" is no longer registered — its owning module may be disabled.`
+      );
+    }
 
     const descriptorPermCheck = await authorizeExchangeDescriptorPermission(
       tx,
@@ -105,18 +133,49 @@ export const GET: APIRoute = async ({ request, cookies, params, url }) => {
     );
     if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
 
-    const sensitiveFieldNames = descriptor?.sensitiveFields?.fieldNames ?? [];
+    const policy = descriptor.sensitiveFields as
+      ExchangeSensitiveFieldPolicy | undefined;
 
-    let canSeeRawValues = sensitiveFieldNames.length === 0;
-    if (!canSeeRawValues) {
-      const rawValueAuth = await authorizeInTransaction(
-        tx,
-        tenantId,
-        tokenHash,
-        now,
-        RAW_VALUE_GUARD
-      );
-      canSeeRawValues = rawValueAuth.allowed;
+    // Default-deny (Issue #820 Cacat 1): the projection STARTS fully masked
+    // and is only relaxed by an explicit declaration. A descriptor with no
+    // policy at all reveals nothing and no permission unmasks it — omitting
+    // the declaration must never be the permissive branch, which is exactly
+    // what `canSeeRawValues = fieldNames.length === 0` used to make it. The
+    // registry gate now rejects such a descriptor outright; this is defence
+    // in depth for one reaching the route by any other path.
+    let project: (row: StagedRowRow) => StagedRowRow = maskAllFields;
+
+    if (policy) {
+      // The descriptor's OWN permission decides (Issue #820 Cacat 2) —
+      // `rawValuePermission` was validated at registration but enforced
+      // nowhere, while this route checked a hardcoded, far broader
+      // `data_exchange.preview_errors.read` instead, silently ignoring a
+      // descriptor that named something narrow (e.g.
+      // `profile_identity.identifiers.reveal_raw`).
+      let canSeeRawValues = policy.fieldNames.length === 0;
+
+      if (!canSeeRawValues && policy.rawValuePermission) {
+        const rawValueAuth = await authorizeDescriptorPermissionKey(
+          tx,
+          tenantId,
+          tokenHash,
+          now,
+          policy.rawValuePermission,
+          "Exchange descriptor's sensitiveFields.rawValuePermission is malformed."
+        );
+        // A malformed key fails CLOSED loudly (500), never as a quiet mask.
+        if (!rawValueAuth.allowed && rawValueAuth.denied.status === 500) {
+          return rawValueAuth.denied;
+        }
+        canSeeRawValues = rawValueAuth.allowed;
+      }
+      // `fieldNames` non-empty with no `rawValuePermission` is rejected at
+      // registration; if it ever reached here, "no permission named" means
+      // nobody holds it — `canSeeRawValues` stays false.
+
+      project = canSeeRawValues
+        ? (row) => row
+        : (row) => maskSensitiveFields(row, policy);
     }
 
     const proposedAction =
@@ -128,9 +187,7 @@ export const GET: APIRoute = async ({ request, cookies, params, url }) => {
       countStagedRows(tx, tenantId, batchId, proposedAction)
     ]);
 
-    const projectedRows = canSeeRawValues
-      ? rows
-      : rows.map((row) => maskSensitiveFields(row, sensitiveFieldNames));
+    const projectedRows = rows.map(project);
 
     return ok({
       rows: projectedRows,

--- a/src/pages/api/v1/data-exchange/imports/[id]/retry.ts
+++ b/src/pages/api/v1/data-exchange/imports/[id]/retry.ts
@@ -72,6 +72,31 @@ export const POST: APIRoute = async ({ request, cookies, params, locals }) => {
     );
     if (!auth.allowed) return auth.denied;
 
+    // Replay BEFORE the descriptor-state checks below — same reasoning as
+    // `commit.ts`: a replay re-runs no adapter, so the gates guarding the
+    // write cannot meaningfully gate it, and letting mutable descriptor state
+    // decide a replay breaks `_shared/idempotency.ts`'s stated contract
+    // ("same key + same request hash -> replay the stored response").
+    // (Review finding, PR #839.)
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
     const existingBatch = await getImportBatchById(tx, tenantId, batchId);
     // A missing batch answers 404 further below (via `requestImportRetry`).
     // An EXISTING batch whose importKey no longer resolves, however, is the
@@ -95,25 +120,6 @@ export const POST: APIRoute = async ({ request, cookies, params, locals }) => {
         retryDescriptor
       );
       if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
-    }
-
-    const existingIdempotency = await findIdempotencyRecord(
-      tx,
-      tenantId,
-      IDEMPOTENCY_SCOPE,
-      idempotencyKey
-    );
-    if (existingIdempotency) {
-      if (existingIdempotency.requestHash !== requestHash) {
-        return fail(
-          409,
-          "IDEMPOTENCY_CONFLICT",
-          "Idempotency-Key was already used with a different request."
-        );
-      }
-      return jsonResponse(existingIdempotency.responseBody, {
-        status: existingIdempotency.responseStatus
-      });
     }
 
     const result = await requestImportRetry(

--- a/src/pages/api/v1/data-exchange/imports/[id]/retry.ts
+++ b/src/pages/api/v1/data-exchange/imports/[id]/retry.ts
@@ -73,14 +73,29 @@ export const POST: APIRoute = async ({ request, cookies, params, locals }) => {
     if (!auth.allowed) return auth.denied;
 
     const existingBatch = await getImportBatchById(tx, tenantId, batchId);
-    const descriptorPermCheck = await authorizeExchangeDescriptorPermission(
-      tx,
-      tenantId,
-      tokenHash,
-      now,
-      existingBatch ? resolveImportDescriptor(existingBatch.importKey) : null
-    );
-    if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
+    // A missing batch answers 404 further below (via `requestImportRetry`).
+    // An EXISTING batch whose importKey no longer resolves, however, is the
+    // module-disabled-after-staging case (Issue #820 Cacat 3): retrying
+    // re-runs the owning module's adapter, so it must fail CLOSED here
+    // rather than skip the descriptor gate the way passing `null` used to.
+    if (existingBatch) {
+      const retryDescriptor = resolveImportDescriptor(existingBatch.importKey);
+      if (!retryDescriptor) {
+        return fail(
+          409,
+          "INVALID_STATE",
+          `Import batch cannot be retried: importKey "${existingBatch.importKey}" is no longer registered — its owning module may be disabled.`
+        );
+      }
+      const descriptorPermCheck = await authorizeExchangeDescriptorPermission(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        retryDescriptor
+      );
+      if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
+    }
 
     const existingIdempotency = await findIdempotencyRecord(
       tx,

--- a/src/pages/api/v1/data-exchange/imports/index.ts
+++ b/src/pages/api/v1/data-exchange/imports/index.ts
@@ -171,14 +171,21 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     );
     if (!auth.allowed) return auth.denied;
 
-    const descriptorPermCheck = await authorizeExchangeDescriptorPermission(
-      tx,
-      tenantId,
-      tokenHash,
-      now,
-      resolveImportDescriptor(importKey)
-    );
-    if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
+    // An unknown importKey answers 404 further below (`Unknown importKey`)
+    // — this route's own handling of an unresolvable descriptor, which
+    // `authorizeExchangeDescriptorPermission` no longer accepts as an
+    // implicit allow (Issue #820 Cacat 3).
+    const stageDescriptor = resolveImportDescriptor(importKey);
+    if (stageDescriptor) {
+      const descriptorPermCheck = await authorizeExchangeDescriptorPermission(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        stageDescriptor
+      );
+      if (!descriptorPermCheck.allowed) return descriptorPermCheck.denied;
+    }
 
     const existingIdempotency = await findIdempotencyRecord(
       tx,

--- a/src/pages/api/v1/reference-data/tenant-codes/[id].ts
+++ b/src/pages/api/v1/reference-data/tenant-codes/[id].ts
@@ -26,7 +26,10 @@ import {
   fetchTenantReferenceCodeById,
   updateTenantReferenceCode
 } from "../../../../../modules/reference-data/application/tenant-code-directory";
-import type { ReferenceCodeLabelInput } from "../../../../../modules/reference-data/domain/code";
+import {
+  mergeReferenceCodePatchInput,
+  parseReferenceCodePatchInput
+} from "../../../../../modules/reference-data/domain/code-patch";
 
 const UPDATE_IDEMPOTENCY_SCOPE = "reference_data_tenant_code_update";
 const DEPRECATE_IDEMPOTENCY_SCOPE = "reference_data_tenant_code_deprecate";
@@ -46,21 +49,6 @@ const DELETE_GUARD = {
   activityCode: "tenant_codes",
   action: "delete" as const
 };
-
-function parseLabels(value: unknown): ReferenceCodeLabelInput[] {
-  if (!Array.isArray(value)) return [];
-  return value
-    .filter(
-      (entry): entry is Record<string, unknown> =>
-        !!entry && typeof entry === "object"
-    )
-    .map((entry) => ({
-      locale: typeof entry.locale === "string" ? entry.locale : "",
-      label: typeof entry.label === "string" ? entry.label : "",
-      description:
-        typeof entry.description === "string" ? entry.description : null
-    }));
-}
 
 export const GET: APIRoute = async ({ request, cookies, params }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
@@ -91,7 +79,14 @@ export const GET: APIRoute = async ({ request, cookies, params }) => {
   });
 };
 
-/** `PATCH /api/v1/reference-data/tenant-codes/{id}` — update mutable attributes. Requires `Idempotency-Key`. */
+/**
+ * `PATCH /api/v1/reference-data/tenant-codes/{id}` — partial update of mutable
+ * attributes. Requires `Idempotency-Key`.
+ *
+ * True `PATCH` semantics: an omitted field keeps its stored value; an explicit
+ * `null` clears/resets it (`sortOrder` -> `0`, `metadata` -> `{}`, `validTo` ->
+ * `null`). `validFrom` and `labels` reject `null` (both are always required).
+ */
 export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
   if (!tenantId)
@@ -117,19 +112,16 @@ export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
   if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
   const body = bodyRead.value ?? {};
 
-  const input = {
-    labels: parseLabels(body.labels),
-    sortOrder: typeof body.sortOrder === "number" ? body.sortOrder : 0,
-    metadata:
-      body.metadata && typeof body.metadata === "object"
-        ? (body.metadata as Record<string, unknown>)
-        : {},
-    validFrom:
-      typeof body.validFrom === "string"
-        ? new Date(body.validFrom)
-        : new Date(),
-    validTo: typeof body.validTo === "string" ? new Date(body.validTo) : null
-  };
+  const parsed = parseReferenceCodePatchInput(body);
+  if (!parsed.ok) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      parsed.errors
+        .map((error) => `${error.field}: ${error.message}`)
+        .join("; ")
+    );
+  }
 
   const requestHash = computeRequestHash({ ...body, id, action: "update" });
   const sql = getDatabaseClient();
@@ -166,12 +158,15 @@ export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
       });
     }
 
+    const existing = await fetchTenantReferenceCodeById(tx, tenantId, id);
+    if (!existing) return fail(404, "NOT_FOUND", "Tenant code not found.");
+
     const result = await updateTenantReferenceCode(
       tx,
       tenantId,
       auth.context.tenantUserId,
       id,
-      input,
+      mergeReferenceCodePatchInput(existing, parsed.patch),
       correlationId
     );
 

--- a/src/pages/api/v1/reference-data/tenant-codes/[id].ts
+++ b/src/pages/api/v1/reference-data/tenant-codes/[id].ts
@@ -169,7 +169,19 @@ export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
     // no-op stays observably a no-op. Deliberately AFTER authorization and the
     // 404/idempotency-replay checks — an empty patch must not become a way to
     // probe for a code's existence without holding the update permission.
+    //
+    // Every refusal `updateTenantReferenceCode` would have applied has to be
+    // re-applied here, or the endpoint's answer starts depending on how many
+    // fields the caller happened to send. Its UPDATE carries
+    // `AND deprecated_at IS NULL` and reports `not_found` for a deprecated
+    // row, so the empty patch must 404 on one too — otherwise a deprecated
+    // tenant code reads back as a live, editable-looking 200 through this path
+    // alone. (Issue #843 tracks removing this duplication outright.)
     if (Object.keys(parsed.patch).length === 0) {
+      if (existing.deprecatedAt !== null) {
+        return fail(404, "NOT_FOUND", "Tenant code not found.");
+      }
+
       const noopResponse = ok({ tenantCode: existing });
       await saveIdempotencyRecord(
         tx,

--- a/src/pages/api/v1/reference-data/tenant-codes/[id].ts
+++ b/src/pages/api/v1/reference-data/tenant-codes/[id].ts
@@ -14,7 +14,9 @@ import {
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
 import {
   bodyTooLargeResponse,
-  readJsonBody
+  invalidJsonObjectBodyResponse,
+  readJsonBody,
+  readJsonObjectBody
 } from "../../../../../lib/security/request-body-limit";
 import {
   computeRequestHash,
@@ -105,12 +107,10 @@ export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
     );
   }
 
-  const bodyRead = await readJsonBody<Record<string, unknown>>(
-    request,
-    "default"
-  );
+  const bodyRead = await readJsonObjectBody(request, "default");
   if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
-  const body = bodyRead.value ?? {};
+  if (!bodyRead.ok) return invalidJsonObjectBodyResponse(bodyRead.reason);
+  const body = bodyRead.value;
 
   const parsed = parseReferenceCodePatchInput(body);
   if (!parsed.ok) {
@@ -160,6 +160,28 @@ export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
 
     const existing = await fetchTenantReferenceCodeById(tx, tenantId, id);
     if (!existing) return fail(404, "NOT_FOUND", "Tenant code not found.");
+
+    // `{}` is a documented valid no-op (see the OpenAPI request-body note),
+    // but `updateTenantReferenceCode` is unconditional: it would bump
+    // `updated_at`, re-write the translation rows, emit an audit event and
+    // append a `reference-code-updated` domain event for a request that
+    // changes nothing. Answer with the current representation instead, so a
+    // no-op stays observably a no-op. Deliberately AFTER authorization and the
+    // 404/idempotency-replay checks — an empty patch must not become a way to
+    // probe for a code's existence without holding the update permission.
+    if (Object.keys(parsed.patch).length === 0) {
+      const noopResponse = ok({ tenantCode: existing });
+      await saveIdempotencyRecord(
+        tx,
+        tenantId,
+        UPDATE_IDEMPOTENCY_SCOPE,
+        idempotencyKey,
+        requestHash,
+        200,
+        await noopResponse.clone().json()
+      );
+      return noopResponse;
+    }
 
     const result = await updateTenantReferenceCode(
       tx,

--- a/src/pages/api/v1/reference-data/value-sets/[key]/codes/[code].ts
+++ b/src/pages/api/v1/reference-data/value-sets/[key]/codes/[code].ts
@@ -14,7 +14,9 @@ import {
 import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
 import {
   bodyTooLargeResponse,
-  readJsonBody
+  invalidJsonObjectBodyResponse,
+  readJsonBody,
+  readJsonObjectBody
 } from "../../../../../../../lib/security/request-body-limit";
 import {
   computeRequestHash,
@@ -137,12 +139,10 @@ export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
     );
   }
 
-  const bodyRead = await readJsonBody<Record<string, unknown>>(
-    request,
-    "default"
-  );
+  const bodyRead = await readJsonObjectBody(request, "default");
   if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
-  const body = bodyRead.value ?? {};
+  if (!bodyRead.ok) return invalidJsonObjectBodyResponse(bodyRead.reason);
+  const body = bodyRead.value;
 
   const parsed = parseReferenceCodePatchInput(body);
   if (!parsed.ok) {
@@ -196,6 +196,42 @@ export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
       return jsonResponse(existingIdempotency.responseBody, {
         status: existingIdempotency.responseStatus
       });
+    }
+
+    // `{}` is a documented valid no-op (see the OpenAPI request-body note),
+    // but `updateReferenceCode` is unconditional: it would bump `updated_at`,
+    // re-write the translation rows, emit an audit event and append a
+    // `reference-code-updated` domain event for a request that changes
+    // nothing. Answer with the current representation instead, so a no-op
+    // stays observably a no-op. Deliberately AFTER authorization and the
+    // 404/idempotency-replay checks — an empty patch must not become a way to
+    // probe for a code's existence without holding the update permission.
+    //
+    // The `managed_by_descriptor` refusal is re-checked here rather than
+    // skipped: short-circuiting ahead of `updateReferenceCode` would otherwise
+    // turn this module's "descriptor-managed rows are never manually edited"
+    // invariant (issue #750) into a `200` for an empty patch, making the
+    // endpoint's answer depend on how many fields the caller happened to send.
+    if (Object.keys(parsed.patch).length === 0) {
+      if (resolved.code.managedByDescriptor) {
+        return fail(
+          409,
+          "DESCRIPTOR_MANAGED",
+          "This code is managed by a module contribution and cannot be edited manually."
+        );
+      }
+
+      const noopResponse = ok({ code: resolved.code });
+      await saveIdempotencyRecord(
+        tx,
+        tenantId,
+        UPDATE_IDEMPOTENCY_SCOPE,
+        idempotencyKey,
+        requestHash,
+        200,
+        await noopResponse.clone().json()
+      );
+      return noopResponse;
     }
 
     const result = await updateReferenceCode(

--- a/src/pages/api/v1/reference-data/value-sets/[key]/codes/[code].ts
+++ b/src/pages/api/v1/reference-data/value-sets/[key]/codes/[code].ts
@@ -27,7 +27,11 @@ import {
   fetchReferenceCodeByCode,
   updateReferenceCode
 } from "../../../../../../../modules/reference-data/application/code-directory";
-import type { ReferenceCodeLabelInput } from "../../../../../../../modules/reference-data/domain/code";
+import type { ReferenceCodeRow } from "../../../../../../../modules/reference-data/application/code-directory";
+import {
+  mergeReferenceCodePatchInput,
+  parseReferenceCodePatchInput
+} from "../../../../../../../modules/reference-data/domain/code-patch";
 
 const UPDATE_IDEMPOTENCY_SCOPE = "reference_data_code_update";
 const DEPRECATE_IDEMPOTENCY_SCOPE = "reference_data_code_deprecate";
@@ -48,31 +52,16 @@ const DELETE_GUARD = {
   action: "delete" as const
 };
 
-function parseLabels(value: unknown): ReferenceCodeLabelInput[] {
-  if (!Array.isArray(value)) return [];
-  return value
-    .filter(
-      (entry): entry is Record<string, unknown> =>
-        !!entry && typeof entry === "object"
-    )
-    .map((entry) => ({
-      locale: typeof entry.locale === "string" ? entry.locale : "",
-      label: typeof entry.label === "string" ? entry.label : "",
-      description:
-        typeof entry.description === "string" ? entry.description : null
-    }));
-}
-
-async function resolveCodeId(
+async function resolveCode(
   tx: Bun.SQL,
   valueSetKey: string,
   codeString: string
-): Promise<{ valueSetId: string; codeId: string } | null> {
+): Promise<{ valueSetId: string; code: ReferenceCodeRow } | null> {
   const valueSet = await fetchReferenceValueSetByKey(tx, valueSetKey);
   if (!valueSet) return null;
   const code = await fetchReferenceCodeByCode(tx, valueSet.id, codeString);
   if (!code) return null;
-  return { valueSetId: valueSet.id, codeId: code.id };
+  return { valueSetId: valueSet.id, code };
 }
 
 export const GET: APIRoute = async ({ request, cookies, params }) => {
@@ -115,7 +104,14 @@ export const GET: APIRoute = async ({ request, cookies, params }) => {
   });
 };
 
-/** `PATCH /api/v1/reference-data/value-sets/{key}/codes/{code}` — mutable-fields-only update. Requires `Idempotency-Key`. */
+/**
+ * `PATCH /api/v1/reference-data/value-sets/{key}/codes/{code}` — partial update
+ * of mutable fields. Requires `Idempotency-Key`.
+ *
+ * True `PATCH` semantics: an omitted field keeps its stored value; an explicit
+ * `null` clears/resets it (`sortOrder` -> `0`, `metadata` -> `{}`, `validTo` ->
+ * `null`). `validFrom` and `labels` reject `null` (both are always required).
+ */
 export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
   if (!tenantId)
@@ -148,19 +144,16 @@ export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
   if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
   const body = bodyRead.value ?? {};
 
-  const input = {
-    labels: parseLabels(body.labels),
-    sortOrder: typeof body.sortOrder === "number" ? body.sortOrder : 0,
-    metadata:
-      body.metadata && typeof body.metadata === "object"
-        ? (body.metadata as Record<string, unknown>)
-        : {},
-    validFrom:
-      typeof body.validFrom === "string"
-        ? new Date(body.validFrom)
-        : new Date(),
-    validTo: typeof body.validTo === "string" ? new Date(body.validTo) : null
-  };
+  const parsed = parseReferenceCodePatchInput(body);
+  if (!parsed.ok) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      parsed.errors
+        .map((error) => `${error.field}: ${error.message}`)
+        .join("; ")
+    );
+  }
 
   const requestHash = computeRequestHash({
     ...body,
@@ -183,7 +176,7 @@ export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
     );
     if (!auth.allowed) return auth.denied;
 
-    const resolved = await resolveCodeId(tx, key, codeParam);
+    const resolved = await resolveCode(tx, key, codeParam);
     if (!resolved) return fail(404, "NOT_FOUND", "Code not found.");
 
     const existingIdempotency = await findIdempotencyRecord(
@@ -209,8 +202,8 @@ export const PATCH: APIRoute = async ({ request, cookies, params, locals }) => {
       tx,
       tenantId,
       auth.context.tenantUserId,
-      resolved.codeId,
-      input,
+      resolved.code.id,
+      mergeReferenceCodePatchInput(resolved.code, parsed.patch),
       correlationId
     );
 
@@ -312,7 +305,7 @@ export const DELETE: APIRoute = async ({
     );
     if (!auth.allowed) return auth.denied;
 
-    const resolved = await resolveCodeId(tx, key, codeParam);
+    const resolved = await resolveCode(tx, key, codeParam);
     if (!resolved) return fail(404, "NOT_FOUND", "Code not found.");
 
     const existingIdempotency = await findIdempotencyRecord(
@@ -338,7 +331,7 @@ export const DELETE: APIRoute = async ({
       tx,
       tenantId,
       auth.context.tenantUserId,
-      resolved.codeId,
+      resolved.code.id,
       { reason, supersededByCodeId },
       correlationId
     );

--- a/src/pages/blog/[tenantCode]/category/[slug].ts
+++ b/src/pages/blog/[tenantCode]/category/[slug].ts
@@ -9,6 +9,7 @@ import {
   serverErrorHtmlResponse
 } from "../../../../lib/html/error-responses";
 import { log } from "../../../../lib/logging/logger";
+import { parsePageParam } from "../../../../modules/_shared/offset-pagination";
 import {
   fetchPublicTermBySlug,
   listPublicBlogPostsByTermId
@@ -37,8 +38,7 @@ export const GET: APIRoute = async ({ params, url }) => {
       return notFoundHtmlResponse();
     }
 
-    const pageParam = url.searchParams.get("page");
-    const page = pageParam ? Number(pageParam) : 1;
+    const page = parsePageParam(url.searchParams.get("page"));
 
     return await withTenant(sql, tenant.tenantId, async (tx) => {
       if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {

--- a/src/pages/blog/[tenantCode]/index.ts
+++ b/src/pages/blog/[tenantCode]/index.ts
@@ -9,6 +9,7 @@ import {
   serverErrorHtmlResponse
 } from "../../../lib/html/error-responses";
 import { log } from "../../../lib/logging/logger";
+import { parsePageParam } from "../../../modules/_shared/offset-pagination";
 import {
   fetchPublicBlogSettings,
   listPublicBlogPosts
@@ -55,8 +56,7 @@ export const GET: APIRoute = async ({ params, url }) => {
       return notFoundHtmlResponse();
     }
 
-    const pageParam = url.searchParams.get("page");
-    const page = pageParam ? Number(pageParam) : 1;
+    const page = parsePageParam(url.searchParams.get("page"));
 
     return await withTenant(sql, tenant.tenantId, async (tx) => {
       if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {

--- a/src/pages/blog/[tenantCode]/tag/[slug].ts
+++ b/src/pages/blog/[tenantCode]/tag/[slug].ts
@@ -9,6 +9,7 @@ import {
   serverErrorHtmlResponse
 } from "../../../../lib/html/error-responses";
 import { log } from "../../../../lib/logging/logger";
+import { parsePageParam } from "../../../../modules/_shared/offset-pagination";
 import {
   fetchPublicTermBySlug,
   listPublicBlogPostsByTermId
@@ -37,8 +38,7 @@ export const GET: APIRoute = async ({ params, url }) => {
       return notFoundHtmlResponse();
     }
 
-    const pageParam = url.searchParams.get("page");
-    const page = pageParam ? Number(pageParam) : 1;
+    const page = parsePageParam(url.searchParams.get("page"));
 
     return await withTenant(sql, tenant.tenantId, async (tx) => {
       if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {

--- a/src/pages/news/category/[slug].ts
+++ b/src/pages/news/category/[slug].ts
@@ -7,6 +7,7 @@ import {
   serverErrorHtmlResponse
 } from "../../../lib/html/error-responses";
 import { log } from "../../../lib/logging/logger";
+import { parsePageParam } from "../../../modules/_shared/offset-pagination";
 import {
   fetchPublicTermBySlug,
   listPublicBlogPostsByTermId
@@ -33,8 +34,7 @@ export const GET: APIRoute = async ({ params, request, url }) => {
 
   try {
     const sql = getDatabaseClient();
-    const pageParam = url.searchParams.get("page");
-    const page = pageParam ? Number(pageParam) : 1;
+    const page = parsePageParam(url.searchParams.get("page"));
 
     const result = await withNewsTenant(
       sql,

--- a/src/pages/news/index.ts
+++ b/src/pages/news/index.ts
@@ -7,6 +7,7 @@ import {
   serverErrorHtmlResponse
 } from "../../lib/html/error-responses";
 import { log } from "../../lib/logging/logger";
+import { parsePageParam } from "../../modules/_shared/offset-pagination";
 import {
   fetchPublicBlogSettings,
   listPublicBlogPosts
@@ -45,8 +46,7 @@ import { newsMediaPortAdapter } from "../../modules/news-portal/application/news
 export const GET: APIRoute = async ({ request, url }) => {
   try {
     const sql = getDatabaseClient();
-    const pageParam = url.searchParams.get("page");
-    const page = pageParam ? Number(pageParam) : 1;
+    const page = parsePageParam(url.searchParams.get("page"));
 
     const result = await withNewsTenant(
       sql,

--- a/src/pages/news/tag/[slug].ts
+++ b/src/pages/news/tag/[slug].ts
@@ -7,6 +7,7 @@ import {
   serverErrorHtmlResponse
 } from "../../../lib/html/error-responses";
 import { log } from "../../../lib/logging/logger";
+import { parsePageParam } from "../../../modules/_shared/offset-pagination";
 import {
   fetchPublicTermBySlug,
   listPublicBlogPostsByTermId
@@ -32,8 +33,7 @@ export const GET: APIRoute = async ({ params, request, url }) => {
 
   try {
     const sql = getDatabaseClient();
-    const pageParam = url.searchParams.get("page");
-    const page = pageParam ? Number(pageParam) : 1;
+    const page = parsePageParam(url.searchParams.get("page"));
 
     const result = await withNewsTenant(
       sql,

--- a/tests/client-fingerprint.test.ts
+++ b/tests/client-fingerprint.test.ts
@@ -53,6 +53,31 @@ describe("hashClientIp", () => {
   });
 
   /**
+   * PR #839 security review, HIGH 2. This used to be `process.env
+   * .AUTH_JWT_SECRET ?? ""` — with the key removed, the HMAC silently
+   * degrades to a bare `sha256(ip)` over a 2^32 keyspace, i.e. every audit
+   * `ipHash` ever written becomes reversible, with no error anywhere. The
+   * variable was simultaneously marked `deprecated` with `removalVersion:
+   * "1.0.0"`, so that degradation was actually SCHEDULED. Refusing loudly is
+   * the only safe behaviour; the deprecation was lifted in the same change.
+   */
+  test.each([
+    ["unset", undefined],
+    ["empty", ""]
+  ])(
+    "throws rather than degrading to an unkeyed digest (%s)",
+    (_label, value) => {
+      if (value === undefined) {
+        delete process.env.AUTH_JWT_SECRET;
+      } else {
+        process.env.AUTH_JWT_SECRET = value;
+      }
+
+      expect(() => hashClientIp("203.0.113.10")).toThrow(/AUTH_JWT_SECRET/);
+    }
+  );
+
+  /**
    * The whole reason this helper exists: `ip`/`clientIp`/`ipAddress` are
    * redaction keys (Issue #687), so a raw IP under any of those names would be
    * blanked out of the audit trail. `ipHash` must survive the same redactor

--- a/tests/client-fingerprint.test.ts
+++ b/tests/client-fingerprint.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Issue #821 — unit tests for the audit-safe source fingerprint used by the
+ * auth routes' `login_succeeded`/`login_failed`/`mfa_challenge_failed` rows.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  hashClientIp,
+  summarizeUserAgent
+} from "../src/lib/security/client-fingerprint";
+import { redactSensitiveAttributes } from "../src/modules/_shared/redaction";
+
+const SECRET = "unit-test-ip-hash-secret";
+
+describe("hashClientIp", () => {
+  let originalSecret: string | undefined;
+
+  beforeEach(() => {
+    originalSecret = process.env.AUTH_JWT_SECRET;
+    process.env.AUTH_JWT_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.AUTH_JWT_SECRET;
+    } else {
+      process.env.AUTH_JWT_SECRET = originalSecret;
+    }
+  });
+
+  test("is stable for the same address, so audit rows are groupable by source", () => {
+    expect(hashClientIp("203.0.113.10")).toBe(hashClientIp("203.0.113.10"));
+  });
+
+  test("distinguishes different addresses", () => {
+    expect(hashClientIp("203.0.113.10")).not.toBe(hashClientIp("203.0.113.11"));
+  });
+
+  test("never contains the address it hashes", () => {
+    expect(hashClientIp("203.0.113.10")).not.toContain("203.0.113.10");
+    expect(hashClientIp("2001:db8::1")).not.toContain("2001:db8");
+  });
+
+  test("is keyed, not a bare digest — a rotated secret changes the output", () => {
+    const before = hashClientIp("203.0.113.10");
+    process.env.AUTH_JWT_SECRET = "a-different-secret";
+
+    expect(hashClientIp("203.0.113.10")).not.toBe(before);
+  });
+
+  test("emits a labelled, fixed-width sha256 hex value", () => {
+    expect(hashClientIp("203.0.113.10")).toMatch(/^hmac-sha256:[0-9a-f]{64}$/);
+  });
+
+  /**
+   * The whole reason this helper exists: `ip`/`clientIp`/`ipAddress` are
+   * redaction keys (Issue #687), so a raw IP under any of those names would be
+   * blanked out of the audit trail. `ipHash` must survive the same redactor
+   * the audit writer runs — if this ever regresses, every auth audit row
+   * silently loses its source attribution.
+   */
+  test("survives audit redaction under the `ipHash` key", () => {
+    const value = hashClientIp("203.0.113.10");
+    const redacted = redactSensitiveAttributes({ ipHash: value });
+
+    expect(redacted?.ipHash).toBe(value);
+  });
+
+  test("a raw IP under a conventional key would NOT survive — the premise holds", () => {
+    const redacted = redactSensitiveAttributes({ clientIp: "203.0.113.10" });
+
+    expect(redacted?.clientIp).toBe("[REDACTED]");
+  });
+});
+
+describe("summarizeUserAgent", () => {
+  function requestWithUserAgent(userAgent?: string): Request {
+    return new Request("https://example.test/api/v1/auth/login", {
+      headers: userAgent === undefined ? {} : { "user-agent": userAgent }
+    });
+  }
+
+  test("returns the header value when present", () => {
+    expect(summarizeUserAgent(requestWithUserAgent("Mozilla/5.0"))).toBe(
+      "Mozilla/5.0"
+    );
+  });
+
+  test("returns undefined when absent or blank, so the key is omitted", () => {
+    expect(summarizeUserAgent(requestWithUserAgent())).toBeUndefined();
+    expect(summarizeUserAgent(requestWithUserAgent("   "))).toBeUndefined();
+  });
+
+  test("truncates an attacker-sized header before it reaches jsonb", () => {
+    const summarized = summarizeUserAgent(
+      requestWithUserAgent("A".repeat(10_000))
+    );
+
+    expect(summarized).toHaveLength(256);
+  });
+});

--- a/tests/client-fingerprint.test.ts
+++ b/tests/client-fingerprint.test.ts
@@ -8,6 +8,7 @@ import {
   hashClientIp,
   summarizeUserAgent
 } from "../src/lib/security/client-fingerprint";
+import { findConfigVarEntry } from "../src/lib/config/registry";
 import { redactSensitiveAttributes } from "../src/modules/_shared/redaction";
 
 const SECRET = "unit-test-ip-hash-secret";
@@ -76,6 +77,38 @@ describe("hashClientIp", () => {
       expect(() => hashClientIp("203.0.113.10")).toThrow(/AUTH_JWT_SECRET/);
     }
   );
+
+  /**
+   * The placeholder is non-empty, so it sails past the check above — and
+   * `scripts/validate-env.ts`'s `checkAuthJwtSecretNotDefault`, which does
+   * catch it, only runs when someone runs `bun run config:validate`. Neither
+   * `bun run dev` nor `bun run start` does. A deployment copied from
+   * `.env.example` would therefore key this HMAC with a value published in a
+   * public repo, making every persisted `ipHash` reversible. (Review finding,
+   * PR #839.)
+   *
+   * The placeholder is read from the registry rather than typed here, so this
+   * test cannot drift from the value the code rejects or from `.env.example`.
+   */
+  test("throws on the documented .env.example placeholder -- it is non-empty, so the unset/empty guard alone lets it through", () => {
+    const placeholder = findConfigVarEntry("AUTH_JWT_SECRET")?.default;
+
+    // Guard the guard: if the registry ever stops carrying a default, this
+    // test would silently assert nothing.
+    expect(typeof placeholder).toBe("string");
+    expect(placeholder!.length).toBeGreaterThan(0);
+
+    process.env.AUTH_JWT_SECRET = placeholder!;
+
+    expect(() => hashClientIp("203.0.113.10")).toThrow(/placeholder/i);
+  });
+
+  test("a high-entropy secret that merely CONTAINS the placeholder is accepted -- the check is exact-match, not a substring ban", () => {
+    const placeholder = findConfigVarEntry("AUTH_JWT_SECRET")?.default;
+    process.env.AUTH_JWT_SECRET = `${placeholder}-but-actually-rotated-9f3a2b`;
+
+    expect(() => hashClientIp("203.0.113.10")).not.toThrow();
+  });
 
   /**
    * The whole reason this helper exists: `ip`/`clientIp`/`ipAddress` are

--- a/tests/foundation.test.ts
+++ b/tests/foundation.test.ts
@@ -593,7 +593,8 @@ describe("database migration runner helpers", () => {
       "073_awcms_mini_integration_hub_schema.sql",
       "074_awcms_mini_integration_hub_permissions.sql",
       "075_awcms_mini_reference_data_schema.sql",
-      "076_awcms_mini_reference_data_permissions.sql"
+      "076_awcms_mini_reference_data_permissions.sql",
+      "077_awcms_mini_performance_missing_indexes.sql"
     ]);
     for (const migration of migrations) {
       expect(migration.checksum).toMatch(/^sha256:[a-f0-9]{64}$/);

--- a/tests/integration/blog-content-public-routes.integration.test.ts
+++ b/tests/integration/blog-content-public-routes.integration.test.ts
@@ -211,6 +211,41 @@ suite("public blog routes", () => {
     expect(detail.text).toContain("Hello world");
   });
 
+  test("hostile ?page= values never 500 and never reach the query unclamped (Issue #819)", async () => {
+    const owner = await bootstrap();
+    await createAndPublishPost(owner, { slug: "public-post" });
+
+    // `abc`/`Infinity` used to reach `OFFSET NaN` (500); `1e8` used to reach
+    // `OFFSET 1e9` — a deep-offset scan on an unauthenticated route.
+    for (const pageParam of ["abc", "1e8", "-1", "1.5", "Infinity", ""]) {
+      const response = await invokeRaw(publicIndex, {
+        method: "GET",
+        path: `/blog/${owner.tenantCode}?page=${encodeURIComponent(pageParam)}`,
+        params: { tenantCode: owner.tenantCode }
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.text).not.toContain("NaN");
+    }
+
+    // Every hostile value clamps to page 1, which still renders the post.
+    const junk = await invokeRaw(publicIndex, {
+      method: "GET",
+      path: `/blog/${owner.tenantCode}?page=abc`,
+      params: { tenantCode: owner.tenantCode }
+    });
+    expect(junk.text).toContain("public-post");
+
+    // The upper clamp is a real page, not an error: page 10,000 is simply empty.
+    const deep = await invokeRaw(publicIndex, {
+      method: "GET",
+      path: `/blog/${owner.tenantCode}?page=1e8`,
+      params: { tenantCode: owner.tenantCode }
+    });
+    expect(deep.status).toBe(200);
+    expect(deep.text).not.toContain("public-post");
+  });
+
   test("draft post is never publicly visible (index or detail)", async () => {
     const owner = await bootstrap();
     const created = await invoke<{ data: { id: string; slug: string } }>(

--- a/tests/integration/data-exchange.integration.test.ts
+++ b/tests/integration/data-exchange.integration.test.ts
@@ -65,10 +65,14 @@ import { GET as getReconciliation } from "../../src/pages/api/v1/data-exchange/r
 
 import { hashPassword } from "../../src/lib/auth/password";
 import { hashSessionToken } from "../../src/lib/auth/session-token";
+import { fetchGrantedPermissionKeys } from "../../src/modules/identity-access/application/auth-context";
 import { getDatabaseClient } from "../../src/lib/database/client";
 import { withTenant } from "../../src/lib/database/tenant-context";
 import { runDataExchangeWorkerPassForTenant } from "../../src/modules/data-exchange/application/data-exchange-worker";
-import { authorizeExchangeDescriptorPermission } from "../../src/modules/data-exchange/application/descriptor-authorization";
+import {
+  authorizeExchangeDescriptorPermission,
+  isDescriptorPermissionGranted
+} from "../../src/modules/data-exchange/application/descriptor-authorization";
 import { findReferenceItemByCode } from "../../src/modules/data-exchange/application/reference-items-directory";
 import { referenceItemsImportAdapter } from "../../src/modules/data-exchange/application/reference-items-exchange-adapter";
 import {
@@ -1303,6 +1307,109 @@ suite("data_exchange integration", () => {
         )
       );
       expect(allowResult.allowed).toBe(true);
+    });
+
+    /**
+     * PR #839 security review, HIGH 1. `src/pages/admin/data-exchange/
+     * imports/[id].astro` does not go through any of the six routes — it
+     * queries and projects staged rows itself — and made this decision
+     * NOWHERE, so a descriptor's `requiredPermission` was enforced by every
+     * API surface and by nothing in the UI.
+     *
+     * The page cannot reuse `authorizeExchangeDescriptorPermission` (it has
+     * a permission set from `resolveSsrContext`, not a bearer token), so the
+     * risk is that the two gates drift apart again. This pins them TOGETHER
+     * against one real subject and one real database: the SSR decision must
+     * equal the route decision, before and after the grant.
+     */
+    test("the SSR page gate agrees with the route gate for the same real subject", async () => {
+      const owner = await bootstrap();
+      const limited = await bootstrapLimitedUser(owner, [
+        { moduleKey: "data_exchange", activityCode: "imports", action: "read" }
+      ]);
+
+      const syntheticDescriptor: ExchangeDescriptor = {
+        key: "data_exchange.synthetic_test_descriptor",
+        ownerModuleKey: "data_exchange",
+        direction: "both",
+        formats: ["csv"],
+        schemaVersion: "1.0",
+        limits: { maxFileBytes: 1024, maxRowCount: 10, maxFieldsPerRow: 5 },
+        adapterRegistryKey: "reference_items",
+        requiredPermission: "identity_access.user_management.read",
+        // An EMPTY sensitiveFields policy: the exploit shape. The page's
+        // raw-value gate treats this as "nothing sensitive" and renders
+        // values unmasked, so `requiredPermission` is the ONLY thing
+        // standing between this subject and the owning module's data.
+        sensitiveFields: { fieldNames: [] },
+        description:
+          "synthetic descriptor for the SSR-vs-route gate parity test"
+      };
+
+      const appSql = getDatabaseClient();
+      const limitedTokenHash = hashSessionToken(limited.token);
+
+      // The exact permission set `src/lib/auth/ssr-session.ts` puts on
+      // `Astro.locals.ssrContext` — same function, same tenant scope.
+      const ssrPermissions = await withTenant(appSql, owner.tenantId, (tx) =>
+        fetchGrantedPermissionKeys(tx, owner.tenantId, limited.tenantUserId)
+      );
+
+      // The subject really does hold the broad gate the page checks first —
+      // otherwise this test would pass for the wrong reason.
+      expect(ssrPermissions.has("data_exchange.imports.read")).toBe(true);
+
+      expect(
+        isDescriptorPermissionGranted(
+          ssrPermissions,
+          syntheticDescriptor.requiredPermission
+        )
+      ).toBe(false);
+
+      const routeDeny = await withTenant(appSql, owner.tenantId, (tx) =>
+        authorizeExchangeDescriptorPermission(
+          tx,
+          owner.tenantId,
+          limitedTokenHash,
+          new Date(),
+          syntheticDescriptor
+        )
+      );
+      expect(routeDeny.allowed).toBe(false);
+
+      const admin = getAdminSql();
+      await admin`
+        INSERT INTO awcms_mini_role_permissions (tenant_id, role_id, permission_id)
+        SELECT ${owner.tenantId}, r.id, p.id
+        FROM awcms_mini_roles r, awcms_mini_permissions p
+        WHERE r.tenant_id = ${owner.tenantId} AND r.role_code = 'limited'
+          AND p.module_key = 'identity_access' AND p.activity_code = 'user_management' AND p.action = 'read'
+      `;
+
+      const grantedPermissions = await withTenant(
+        appSql,
+        owner.tenantId,
+        (tx) =>
+          fetchGrantedPermissionKeys(tx, owner.tenantId, limited.tenantUserId)
+      );
+
+      expect(
+        isDescriptorPermissionGranted(
+          grantedPermissions,
+          syntheticDescriptor.requiredPermission
+        )
+      ).toBe(true);
+
+      const routeAllow = await withTenant(appSql, owner.tenantId, (tx) =>
+        authorizeExchangeDescriptorPermission(
+          tx,
+          owner.tenantId,
+          limitedTokenHash,
+          new Date(),
+          syntheticDescriptor
+        )
+      );
+      expect(routeAllow.allowed).toBe(true);
     });
 
     // Issue #820 Cacat 3: this test used to pass `null` (an unresolvable

--- a/tests/integration/data-exchange.integration.test.ts
+++ b/tests/integration/data-exchange.integration.test.ts
@@ -66,6 +66,7 @@ import { GET as getReconciliation } from "../../src/pages/api/v1/data-exchange/r
 import { hashPassword } from "../../src/lib/auth/password";
 import { hashSessionToken } from "../../src/lib/auth/session-token";
 import { fetchGrantedPermissionKeys } from "../../src/modules/identity-access/application/auth-context";
+import { syncModuleDescriptors } from "../../src/modules/module-management/application/descriptor-sync";
 import { getDatabaseClient } from "../../src/lib/database/client";
 import { withTenant } from "../../src/lib/database/tenant-context";
 import { runDataExchangeWorkerPassForTenant } from "../../src/modules/data-exchange/application/data-exchange-worker";
@@ -1360,9 +1361,13 @@ suite("data_exchange integration", () => {
       expect(ssrPermissions.has("data_exchange.imports.read")).toBe(true);
 
       expect(
-        isDescriptorPermissionGranted(
-          ssrPermissions,
-          syntheticDescriptor.requiredPermission
+        await withTenant(appSql, owner.tenantId, (tx) =>
+          isDescriptorPermissionGranted(
+            tx,
+            owner.tenantId,
+            ssrPermissions,
+            syntheticDescriptor.requiredPermission
+          )
         )
       ).toBe(false);
 
@@ -1394,9 +1399,13 @@ suite("data_exchange integration", () => {
       );
 
       expect(
-        isDescriptorPermissionGranted(
-          grantedPermissions,
-          syntheticDescriptor.requiredPermission
+        await withTenant(appSql, owner.tenantId, (tx) =>
+          isDescriptorPermissionGranted(
+            tx,
+            owner.tenantId,
+            grantedPermissions,
+            syntheticDescriptor.requiredPermission
+          )
         )
       ).toBe(true);
 
@@ -1410,6 +1419,117 @@ suite("data_exchange integration", () => {
         )
       );
       expect(routeAllow.allowed).toBe(true);
+    });
+
+    /**
+     * PR #839 security review, SECOND parity finding — the axis the test
+     * above could not see.
+     *
+     * That test compares SSR and route on ONE axis (does the caller hold the
+     * key?), so it stayed green while the two gates disagreed on a different
+     * one entirely. `authorizeInTransaction` denies `403 MODULE_DISABLED` via
+     * `resolveModuleEnabled` BEFORE evaluating RBAC, and
+     * `fetchGrantedPermissionKeys` never filters disabled modules out of the
+     * SSR permission set — so with the owning module switched off, every
+     * route refused while the page happily rendered the staged rows.
+     *
+     * The lesson this test encodes: pin the SSR and route decisions together
+     * on every axis the route's guard actually consults, not just the one the
+     * bug of the day happened to be about.
+     */
+    test("the SSR page gate agrees with the route gate when the tenant DISABLES the module", async () => {
+      const owner = await bootstrap();
+      const limited = await bootstrapLimitedUser(owner, [
+        { moduleKey: "data_exchange", activityCode: "imports", action: "read" },
+        {
+          moduleKey: "identity_access",
+          activityCode: "user_management",
+          action: "read"
+        }
+      ]);
+
+      const syntheticDescriptor: ExchangeDescriptor = {
+        key: "data_exchange.synthetic_test_descriptor",
+        ownerModuleKey: "data_exchange",
+        direction: "both",
+        formats: ["csv"],
+        schemaVersion: "1.0",
+        limits: { maxFileBytes: 1024, maxRowCount: 10, maxFieldsPerRow: 5 },
+        adapterRegistryKey: "reference_items",
+        requiredPermission: "identity_access.user_management.read",
+        sensitiveFields: { fieldNames: [] },
+        description:
+          "synthetic descriptor for the SSR-vs-route module-enabled parity test"
+      };
+
+      const appSql = getDatabaseClient();
+      const admin = getAdminSql();
+      const limitedTokenHash = hashSessionToken(limited.token);
+
+      const ssrDecision = () =>
+        withTenant(appSql, owner.tenantId, async (tx) =>
+          isDescriptorPermissionGranted(
+            tx,
+            owner.tenantId,
+            await fetchGrantedPermissionKeys(
+              tx,
+              owner.tenantId,
+              limited.tenantUserId
+            ),
+            syntheticDescriptor.requiredPermission
+          )
+        );
+
+      const routeDecision = () =>
+        withTenant(appSql, owner.tenantId, (tx) =>
+          authorizeExchangeDescriptorPermission(
+            tx,
+            owner.tenantId,
+            limitedTokenHash,
+            new Date(),
+            syntheticDescriptor
+          )
+        );
+
+      // Baseline: module enabled (no row at all — resolveModuleEnabled's
+      // documented "missing row = enabled" default), permission held. BOTH
+      // allow, so a later divergence can only come from the module state.
+      expect(await ssrDecision()).toBe(true);
+      expect((await routeDecision()).allowed).toBe(true);
+
+      // The registry FK requires awcms_mini_modules to be populated first —
+      // this test writes a tenant_modules row directly (bypassing the
+      // enable/disable endpoints, which auto-sync), so it syncs explicitly.
+      // Same reason and same call as module-tenant-lifecycle's own setup.
+      await syncModuleDescriptors(admin);
+
+      // The tenant switches the descriptor's owning module off.
+      await admin`
+        INSERT INTO awcms_mini_tenant_modules (tenant_id, module_key, enabled, disabled_at)
+        VALUES (${owner.tenantId}, 'identity_access', false, now())
+        ON CONFLICT (tenant_id, module_key) DO UPDATE SET enabled = false, disabled_at = now()
+      `;
+
+      // The permission key is STILL granted — this is the mechanism of the
+      // bug, not an incidental detail. Nothing revoked it; the module was
+      // merely disabled, and the SSR permission set cannot tell.
+      const stillGranted = await withTenant(appSql, owner.tenantId, (tx) =>
+        fetchGrantedPermissionKeys(tx, owner.tenantId, limited.tenantUserId)
+      );
+      expect(stillGranted.has("identity_access.user_management.read")).toBe(
+        true
+      );
+
+      // The route denies...
+      const routeAfter = await routeDecision();
+      expect(routeAfter.allowed).toBe(false);
+      if (!routeAfter.allowed) {
+        expect(routeAfter.denied.status).toBe(403);
+      }
+
+      // ...so the SSR page must deny too. THIS is the assertion that fails
+      // against a gate built on `permissions.has()` alone.
+      expect(await ssrDecision()).toBe(false);
     });
 
     // Issue #820 Cacat 3: this test used to pass `null` (an unresolvable

--- a/tests/integration/data-exchange.integration.test.ts
+++ b/tests/integration/data-exchange.integration.test.ts
@@ -53,6 +53,7 @@ import {
 } from "../../src/pages/api/v1/data-exchange/imports/index";
 import { GET as getImportBatchRoute } from "../../src/pages/api/v1/data-exchange/imports/[id]/index";
 import { GET as getPreview } from "../../src/pages/api/v1/data-exchange/imports/[id]/preview";
+import { PREVIEW_OFFSET_MAX } from "../../src/modules/data-exchange/application/staged-row-directory";
 import { POST as commitImport } from "../../src/pages/api/v1/data-exchange/imports/[id]/commit";
 import { POST as cancelImport } from "../../src/pages/api/v1/data-exchange/imports/[id]/cancel";
 import { POST as retryImport } from "../../src/pages/api/v1/data-exchange/imports/[id]/retry";
@@ -1260,6 +1261,7 @@ suite("data_exchange integration", () => {
         limits: { maxFileBytes: 1024, maxRowCount: 10, maxFieldsPerRow: 5 },
         adapterRegistryKey: "reference_items",
         requiredPermission: "identity_access.user_management.read",
+        sensitiveFields: { fieldNames: [] },
         description:
           "synthetic descriptor for requiredPermission enforcement test"
       };
@@ -1303,7 +1305,13 @@ suite("data_exchange integration", () => {
       expect(allowResult.allowed).toBe(true);
     });
 
-    test("a descriptor with no requiredPermission is a no-op (always allowed)", async () => {
+    // Issue #820 Cacat 3: this test used to pass `null` (an unresolvable
+    // descriptor) and assert `allowed: true` — it asserted the fail-open
+    // itself. `null` is no longer representable at this signature; the
+    // genuine no-op case is a RESOLVED descriptor declaring no extra
+    // requirement, which is what this now covers. Each route's own handling
+    // of an unresolvable descriptor is covered by the route tests below.
+    test("a resolved descriptor with no requiredPermission is a no-op (always allowed)", async () => {
       const owner = await bootstrap();
       const noAccess = await bootstrapNoAccessUser(owner);
       const appSql = getDatabaseClient();
@@ -1314,7 +1322,17 @@ suite("data_exchange integration", () => {
           owner.tenantId,
           hashSessionToken(noAccess.token),
           new Date(),
-          null
+          {
+            key: "data_exchange.synthetic_test_descriptor",
+            ownerModuleKey: "data_exchange",
+            direction: "both",
+            formats: ["csv"],
+            schemaVersion: "1.0",
+            limits: { maxFileBytes: 1024, maxRowCount: 10, maxFieldsPerRow: 5 },
+            adapterRegistryKey: "reference_items",
+            sensitiveFields: { fieldNames: [] },
+            description: "synthetic descriptor with no requiredPermission"
+          }
         )
       );
       expect(result.allowed).toBe(true);
@@ -1340,6 +1358,7 @@ suite("data_exchange integration", () => {
             adapterRegistryKey: "reference_items",
             // Only two segments -- not a valid "module.activity.action" key.
             requiredPermission: "not-a-valid-permission-key",
+            sensitiveFields: { fieldNames: [] },
             description:
               "synthetic descriptor with a malformed requiredPermission"
           }
@@ -1495,6 +1514,235 @@ suite("data_exchange integration", () => {
       expect(auditRows.some((row) => row.message.includes("completed"))).toBe(
         true
       );
+    });
+  });
+
+  /**
+   * Issue #820 (raw-value guard) + #831 (offset clamp), both on
+   * `GET .../imports/{id}/preview`.
+   *
+   * These drive the REAL route handler, not the projection helpers in
+   * isolation — the defects being fixed were precisely of the "the helper
+   * is correct, nothing calls it / the route decides something else" class
+   * (cf. #740/#769), which a helper-level test cannot detect.
+   *
+   * `resolveImportDescriptor` re-reads `listModules()` on every request, so
+   * these tests swap the live `reference_items` descriptor's policy for the
+   * duration of one test and restore it afterwards. That keeps the route,
+   * the registry lookup and the permission checks all real, and is the only
+   * way to exercise a sensitive descriptor today: no module in the base
+   * declares one yet (which is exactly why these defects went unnoticed).
+   */
+  describe("preview raw-value guard (Issue #820) and offset clamp (Issue #831)", () => {
+    const referenceDescriptor = dataExchangeModule.dataExchange!.find(
+      (descriptor) => descriptor.key === REFERENCE_ITEMS_KEY
+    )! as {
+      sensitiveFields?: {
+        fieldNames: readonly string[];
+        rawValuePermission?: string;
+        naturalKeyField?: string;
+      };
+    };
+    const originalPolicy = referenceDescriptor.sensitiveFields;
+
+    afterEach(() => {
+      referenceDescriptor.sensitiveFields = originalPolicy;
+    });
+
+    async function stageAndValidate(owner: Bootstrap, idempotencyKey: string) {
+      const stage = await stageCsv(
+        owner,
+        "code,label,value\nwidget-a,Widget A,10\n",
+        idempotencyKey
+      );
+      expect(stage.status).toBe(200);
+      await drainWorker(getWorkerTestSql(), owner.tenantId);
+      return stage.body.data.batch.id as string;
+    }
+
+    test("a descriptor declaring NO sensitiveFields masks every value — omission must not reveal (Cacat 1)", async () => {
+      const owner = await bootstrap();
+      const batchId = await stageAndValidate(owner, "guard-key-1");
+
+      // The pre-#820 default: no policy declared. This used to set
+      // `canSeeRawValues = true` and return every staged value raw, with no
+      // raw-value permission check performed at all.
+      referenceDescriptor.sensitiveFields = undefined;
+
+      // The tenant OWNER — the most privileged caller there is — still sees
+      // nothing raw. No permission unmasks an undeclared policy.
+      const preview = await invoke<{ data: { rows: any[] } }>(getPreview, {
+        method: "GET",
+        path: `/api/v1/data-exchange/imports/${batchId}/preview`,
+        params: { id: batchId },
+        headers: authHeaders(owner)
+      });
+
+      expect(preview.status).toBe(200);
+      const row = preview.body.data.rows[0];
+      expect(Object.keys(row.fields).length).toBeGreaterThan(0);
+      for (const value of Object.values(row.fields)) {
+        expect(value).toBe("[REDACTED]");
+      }
+      expect(row.naturalKey).toBe("[REDACTED]");
+      // Non-content metadata still flows — the preview stays navigable.
+      expect(row.proposedAction).toBe("create");
+      expect(row.rowNumber).toBe(1);
+    });
+
+    test("the DESCRIPTOR's own rawValuePermission gates raw values — the broader data_exchange.preview_errors.read does not (Cacat 2)", async () => {
+      const owner = await bootstrap();
+      const batchId = await stageAndValidate(owner, "guard-key-2");
+
+      // A descriptor declaring a NARROW permission of its own, exactly as
+      // the contract has always promised it could.
+      referenceDescriptor.sensitiveFields = {
+        fieldNames: ["label", "code"],
+        rawValuePermission: "identity_access.user_management.read",
+        naturalKeyField: "code"
+      };
+
+      // A caller holding the BROAD, generic raw-value permission the route
+      // used to hardcode — and nothing the descriptor actually asked for.
+      // Pre-#820 this caller saw NIK/NPWP-equivalents in the clear.
+      const broad = await bootstrapLimitedUser(owner, [
+        { moduleKey: "data_exchange", activityCode: "imports", action: "read" },
+        {
+          moduleKey: "data_exchange",
+          activityCode: "preview_errors",
+          action: "read"
+        }
+      ]);
+
+      const denied = await invoke<{ data: { rows: any[] } }>(getPreview, {
+        method: "GET",
+        path: `/api/v1/data-exchange/imports/${batchId}/preview`,
+        params: { id: batchId },
+        headers: authHeaders(broad)
+      });
+
+      expect(denied.status).toBe(200);
+      const maskedRow = denied.body.data.rows[0];
+      expect(maskedRow.fields.label).toBe("[REDACTED]");
+      expect(maskedRow.fields.code).toBe("[REDACTED]");
+      // Cacat 4: naturalKey IS the sensitive `code` here — masking `fields`
+      // while echoing the same value back as `naturalKey` masks nothing.
+      expect(maskedRow.naturalKey).toBe("[REDACTED]");
+      // A field outside the policy is untouched (the adapter normalizes
+      // `value` to a number, so this is the stored shape, unmasked).
+      expect(maskedRow.fields.value).toBe(10);
+
+      // The descriptor's OWN permission — and only it — reveals the values.
+      const admin = getAdminSql();
+      await admin`
+        INSERT INTO awcms_mini_role_permissions (tenant_id, role_id, permission_id)
+        SELECT ${owner.tenantId}, r.id, p.id
+        FROM awcms_mini_roles r, awcms_mini_permissions p
+        WHERE r.tenant_id = ${owner.tenantId} AND r.role_code = 'limited'
+          AND p.module_key = 'identity_access' AND p.activity_code = 'user_management' AND p.action = 'read'
+      `;
+
+      const allowed = await invoke<{ data: { rows: any[] } }>(getPreview, {
+        method: "GET",
+        path: `/api/v1/data-exchange/imports/${batchId}/preview`,
+        params: { id: batchId },
+        headers: authHeaders(broad)
+      });
+
+      expect(allowed.status).toBe(200);
+      expect(allowed.body.data.rows[0].fields.label).toBe("Widget A");
+      expect(allowed.body.data.rows[0].naturalKey).toBe("widget-a");
+    });
+
+    test("naturalKey stays visible when it is NOT declared sensitive (masking is not blanket)", async () => {
+      const owner = await bootstrap();
+      const batchId = await stageAndValidate(owner, "guard-key-3");
+
+      referenceDescriptor.sensitiveFields = {
+        fieldNames: ["label"],
+        rawValuePermission: "identity_access.user_management.read",
+        naturalKeyField: "code"
+      };
+
+      const limited = await bootstrapLimitedUser(owner, [
+        { moduleKey: "data_exchange", activityCode: "imports", action: "read" }
+      ]);
+
+      const preview = await invoke<{ data: { rows: any[] } }>(getPreview, {
+        method: "GET",
+        path: `/api/v1/data-exchange/imports/${batchId}/preview`,
+        params: { id: batchId },
+        headers: authHeaders(limited)
+      });
+
+      expect(preview.status).toBe(200);
+      expect(preview.body.data.rows[0].fields.label).toBe("[REDACTED]");
+      // `code` is the naturalKey but is not in `fieldNames` — it is the
+      // row's identity in the preview list and stays readable.
+      expect(preview.body.data.rows[0].naturalKey).toBe("widget-a");
+    });
+
+    test("a batch whose importKey is no longer registered is DENIED, not opened (Cacat 3)", async () => {
+      const owner = await bootstrap();
+      const batchId = await stageAndValidate(owner, "guard-key-4");
+
+      // Simulates the owning module being disabled/removed via
+      // `module_management` AFTER the batch was staged: the key stops
+      // resolving. Pre-#820 this made the batch MORE readable than while
+      // its module ran — the descriptor gate returned `allowed: true` for a
+      // null descriptor AND the (now absent) sensitiveFields defaulted to
+      // "nothing is sensitive", so every value came back raw.
+      const admin = getAdminSql();
+      await admin`
+        UPDATE awcms_mini_data_exchange_import_batches
+        SET import_key = 'data_exchange.retired_descriptor'
+        WHERE tenant_id = ${owner.tenantId} AND id = ${batchId}
+      `;
+
+      const preview = await invoke<{ data?: { rows: any[] }; error?: any }>(
+        getPreview,
+        {
+          method: "GET",
+          path: `/api/v1/data-exchange/imports/${batchId}/preview`,
+          params: { id: batchId },
+          headers: authHeaders(owner)
+        }
+      );
+
+      expect(preview.status).toBe(409);
+      expect(preview.body.data).toBeUndefined();
+    });
+
+    test("a deep offset is clamped instead of reaching Postgres verbatim (Issue #831)", async () => {
+      const owner = await bootstrap();
+      const batchId = await stageAndValidate(owner, "guard-key-5");
+
+      const preview = await invoke<{
+        data: { rows: any[]; offset: number; limit: number };
+      }>(getPreview, {
+        method: "GET",
+        path: `/api/v1/data-exchange/imports/${batchId}/preview?offset=5000000`,
+        params: { id: batchId },
+        headers: authHeaders(owner)
+      });
+
+      expect(preview.status).toBe(200);
+      // The echoed offset proves the clamp happened BEFORE the query: an
+      // unclamped 5_000_000 would have been sent to Postgres as an OFFSET
+      // to walk and discard. The ceiling equals the registry's hard cap on
+      // rows per batch, so it can never hide a reachable row.
+      expect(preview.body.data.offset).toBe(PREVIEW_OFFSET_MAX);
+      expect(preview.body.data.offset).toBeLessThan(5_000_000);
+      expect(preview.body.data.rows).toEqual([]);
+
+      // A legitimate in-range offset is untouched.
+      const inRange = await invoke<{ data: { offset: number } }>(getPreview, {
+        method: "GET",
+        path: `/api/v1/data-exchange/imports/${batchId}/preview?offset=0`,
+        params: { id: batchId },
+        headers: authHeaders(owner)
+      });
+      expect(inRange.body.data.offset).toBe(0);
     });
   });
 });

--- a/tests/integration/data-exchange.integration.test.ts
+++ b/tests/integration/data-exchange.integration.test.ts
@@ -1940,6 +1940,76 @@ suite("data_exchange integration", () => {
       expect(preview.body.data).toBeUndefined();
     });
 
+    /**
+     * The Cacat 3 fail-closed branch above must not swallow an idempotent
+     * REPLAY. `_shared/idempotency.ts` states the contract outright ("same key
+     * + same request hash -> replay the stored response"), and a replay runs
+     * no adapter — so gating it on the descriptor's CURRENT state prevents
+     * nothing while making one key+hash answer differently over time, which is
+     * the one thing idempotency exists to prevent. (Review finding, PR #839.)
+     */
+    test("REGRESSION (PR #839): a commit retried with the SAME Idempotency-Key after the module is disabled REPLAYS the stored response instead of the fail-closed 409", async () => {
+      const owner = await bootstrap();
+      const batchId = await stageAndValidate(owner, "replay-key-1");
+
+      const commitKey = "replay-commit-key-1";
+      const firstCommit = await invoke<{ data: unknown }>(commitImport, {
+        method: "POST",
+        path: `/api/v1/data-exchange/imports/${batchId}/commit`,
+        params: { id: batchId },
+        headers: authHeaders(owner, commitKey)
+      });
+      expect(firstCommit.status).toBe(200);
+
+      // The module is disabled AFTER the commit already succeeded.
+      const admin = getAdminSql();
+      await admin`
+        UPDATE awcms_mini_data_exchange_import_batches
+        SET import_key = 'data_exchange.retired_descriptor'
+        WHERE tenant_id = ${owner.tenantId} AND id = ${batchId}
+      `;
+
+      // Same key, same request hash -> the stored response, verbatim.
+      const replay = await invoke<{ data: unknown }>(commitImport, {
+        method: "POST",
+        path: `/api/v1/data-exchange/imports/${batchId}/commit`,
+        params: { id: batchId },
+        headers: authHeaders(owner, commitKey)
+      });
+
+      expect(replay.status).toBe(firstCommit.status);
+      expect(replay.body).toEqual(firstCommit.body);
+    });
+
+    test("REGRESSION (PR #839): the Cacat 3 fail-closed 409 still fires for a FRESH key on a disabled module -- the replay reorder must not have disabled the gate itself", async () => {
+      const owner = await bootstrap();
+      const batchId = await stageAndValidate(owner, "replay-key-2");
+
+      const admin = getAdminSql();
+      await admin`
+        UPDATE awcms_mini_data_exchange_import_batches
+        SET import_key = 'data_exchange.retired_descriptor'
+        WHERE tenant_id = ${owner.tenantId} AND id = ${batchId}
+      `;
+
+      // A key with no stored record cannot replay, so it must reach the
+      // descriptor gate and be refused. Without this half, deleting the gate
+      // outright would still pass the replay test above.
+      const fresh = await invoke<{ data?: unknown; error?: { code: string } }>(
+        commitImport,
+        {
+          method: "POST",
+          path: `/api/v1/data-exchange/imports/${batchId}/commit`,
+          params: { id: batchId },
+          headers: authHeaders(owner, "replay-fresh-key-1")
+        }
+      );
+
+      expect(fresh.status).toBe(409);
+      expect(fresh.body.error?.code).toBe("INVALID_STATE");
+      expect(fresh.body.data).toBeUndefined();
+    });
+
     test("a deep offset is clamped instead of reaching Postgres verbatim (Issue #831)", async () => {
       const owner = await bootstrap();
       const batchId = await stageAndValidate(owner, "guard-key-5");

--- a/tests/integration/harness.ts
+++ b/tests/integration/harness.ts
@@ -34,6 +34,19 @@ import {
 // Captured at module load, before provisionAppRole() repoints DATABASE_URL.
 const ADMIN_DATABASE_URL = process.env.DATABASE_URL ?? "";
 
+/**
+ * `AUTH_JWT_SECRET` keys the audit-log `ipHash` HMAC
+ * (`src/lib/security/client-fingerprint.ts`), and since PR #839 the auth
+ * routes REFUSE to run without it rather than silently degrading to an
+ * unkeyed, reversible digest. It is a real deployment secret, and these tests
+ * are a deployment: supply a fixture value here rather than let the login
+ * route throw. Only defaulted, never overridden, so a run that sets its own
+ * secret keeps it.
+ */
+if (!process.env.AUTH_JWT_SECRET) {
+  process.env.AUTH_JWT_SECRET = "integration-test-ip-hash-secret";
+}
+
 // Non-secret fixture password for the least-privilege app role in tests.
 const APP_ROLE_TEST_PASSWORD = "integration_app_role_password";
 // Issue #683 (epic #679): fixture passwords for the two new least-privilege

--- a/tests/integration/login-audit.integration.test.ts
+++ b/tests/integration/login-audit.integration.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Issue #821 — `POST /api/v1/auth/login` imported `recordAuditEvent` but only
+ * ever called it for `mfa_challenge_issued`: neither a successful nor a failed
+ * password sign-in produced an audit row, leaving zero trail of
+ * brute-force/credential-stuffing against the repo's most attacked endpoint
+ * (doc 01 §"Base-ready boundary" requires "Audit log high-risk tersedia";
+ * skill `awcms-mini-audit-log` lists login as the first high-risk action).
+ *
+ * These tests assert the row COUNT, not just presence — a double-write is as
+ * much a defect as a missing write for an audit trail people reason about by
+ * counting attempts.
+ *
+ * Skipped entirely unless DATABASE_URL is set — see tests/integration/harness.ts.
+ */
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  applyMigrations,
+  createCookieJar,
+  getAdminSql,
+  integrationEnabled,
+  invoke,
+  provisionAppRole,
+  resetDatabase
+} from "./harness";
+
+import { POST as setupInitialize } from "../../src/pages/api/v1/setup/initialize";
+import { POST as authLogin } from "../../src/pages/api/v1/auth/login";
+import { resetRateLimitStoreForTests } from "../../src/lib/security/rate-limit";
+
+const OWNER_LOGIN = "audit-owner@example.com";
+const OWNER_PASSWORD = "integration-test-owner-password";
+const SOURCE_IP = "203.0.113.41";
+const USER_AGENT = "AWCMS-Mini-Integration/1.0";
+const CORRELATION_ID = "corr-login-audit-1";
+
+type AuditRow = {
+  action: string;
+  resource_id: string | null;
+  severity: string;
+  message: string;
+  attributes: Record<string, unknown> | null;
+  correlation_id: string | null;
+};
+
+async function bootstrapTenant(tenantCode: string): Promise<{
+  tenantId: string;
+  ownerIdentityId: string;
+}> {
+  const setup = await invoke<{
+    data: { tenantId: string; ownerIdentityId: string };
+  }>(setupInitialize, {
+    method: "POST",
+    path: "/api/v1/setup/initialize",
+    headers: { "content-type": "application/json" },
+    body: {
+      tenantName: `Tenant ${tenantCode}`,
+      tenantCode,
+      officeCode: "hq",
+      officeName: "Head Office",
+      ownerLoginIdentifier: OWNER_LOGIN,
+      ownerPassword: OWNER_PASSWORD,
+      ownerDisplayName: "Owner"
+    }
+  });
+  expect(setup.status).toBe(200);
+
+  return {
+    tenantId: setup.body.data.tenantId,
+    ownerIdentityId: setup.body.data.ownerIdentityId
+  };
+}
+
+async function attemptLogin(
+  tenantId: string,
+  body: { loginIdentifier: string; password: string }
+): Promise<number> {
+  const response = await invoke(authLogin, {
+    method: "POST",
+    path: "/api/v1/auth/login",
+    headers: {
+      "content-type": "application/json",
+      "x-awcms-mini-tenant-id": tenantId,
+      "x-forwarded-for": SOURCE_IP,
+      "user-agent": USER_AGENT
+    },
+    body,
+    cookies: createCookieJar(),
+    locals: { correlationId: CORRELATION_ID }
+  });
+
+  return response.status;
+}
+
+/** Read back with the admin (RLS-bypassing) role — the assertion is about what
+ * was persisted, not about who may read it. */
+async function readAuditRows(
+  tenantId: string,
+  action: string
+): Promise<AuditRow[]> {
+  const sql = getAdminSql();
+
+  return (await sql`
+    SELECT action, resource_id, severity, message, attributes, correlation_id
+    FROM awcms_mini_audit_events
+    WHERE tenant_id = ${tenantId} AND action = ${action}
+    ORDER BY created_at
+  `) as AuditRow[];
+}
+
+/**
+ * Asserts the "exactly one row" expectation these tests exist to enforce, and
+ * narrows the result so each caller doesn't repeat a null check that would
+ * only ever fire when that assertion has already failed.
+ */
+async function readSingleAuditRow(
+  tenantId: string,
+  action: string
+): Promise<AuditRow> {
+  const rows = await readAuditRows(tenantId, action);
+  expect(rows).toHaveLength(1);
+
+  const row = rows[0];
+
+  if (!row) {
+    throw new Error(`Expected exactly one "${action}" audit row.`);
+  }
+
+  return row;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("login audit trail (Issue #821)", () => {
+  beforeAll(async () => {
+    await applyMigrations();
+    await provisionAppRole();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    // The bootstrap login inside setup + several attempts per test share one
+    // source IP; without this the volumetric limiter (default 20/60s) could
+    // turn a later attempt into a 429 that never reaches the audit code.
+    resetRateLimitStoreForTests();
+  });
+
+  test("a successful password login writes exactly one login_succeeded row", async () => {
+    const { tenantId, ownerIdentityId } = await bootstrapTenant("audit-ok");
+
+    expect(
+      await attemptLogin(tenantId, {
+        loginIdentifier: OWNER_LOGIN,
+        password: OWNER_PASSWORD
+      })
+    ).toBe(200);
+
+    const row = await readSingleAuditRow(tenantId, "login_succeeded");
+    expect(row.resource_id).toBe(ownerIdentityId);
+    expect(row.severity).toBe("info");
+    expect(row.correlation_id).toBe(CORRELATION_ID);
+    expect(row.attributes?.method).toBe("password");
+    expect(row.attributes?.userAgent).toBe(USER_AGENT);
+
+    // Source attribution is present but pseudonymous: correlatable across
+    // rows, never the raw address (see lib/security/client-fingerprint.ts).
+    expect(row.attributes?.ipHash).toMatch(/^hmac-sha256:[0-9a-f]{64}$/);
+    expect(row.attributes?.ipHash).not.toContain(SOURCE_IP);
+
+    // No failure row was written alongside the success.
+    expect(await readAuditRows(tenantId, "login_failed")).toHaveLength(0);
+  });
+
+  test("a wrong password writes exactly one login_failed row carrying the reason", async () => {
+    const { tenantId, ownerIdentityId } = await bootstrapTenant("audit-bad-pw");
+
+    expect(
+      await attemptLogin(tenantId, {
+        loginIdentifier: OWNER_LOGIN,
+        password: "definitely-not-the-password"
+      })
+    ).toBe(401);
+
+    const row = await readSingleAuditRow(tenantId, "login_failed");
+    expect(row.severity).toBe("warning");
+    expect(row.correlation_id).toBe(CORRELATION_ID);
+    expect(row.attributes?.reason).toBe("invalid_credentials");
+    expect(row.attributes?.method).toBe("password");
+    expect(row.resource_id).toBe(ownerIdentityId);
+
+    expect(await readAuditRows(tenantId, "login_succeeded")).toHaveLength(0);
+  });
+
+  test("a locked account writes login_failed with the locked reason", async () => {
+    const { tenantId } = await bootstrapTenant("audit-locked");
+    const maxAttempts = Number(process.env.AUTH_LOGIN_MAX_ATTEMPTS ?? 5);
+
+    // Trip the per-identity lockout, then attempt once more: only that final
+    // attempt can produce the `locked` reason.
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      expect(
+        await attemptLogin(tenantId, {
+          loginIdentifier: OWNER_LOGIN,
+          password: "wrong-password"
+        })
+      ).toBe(401);
+    }
+
+    expect(
+      await attemptLogin(tenantId, {
+        loginIdentifier: OWNER_LOGIN,
+        password: OWNER_PASSWORD
+      })
+    ).toBe(401);
+
+    const reasons = (await readAuditRows(tenantId, "login_failed")).map(
+      (row) => row.attributes?.reason
+    );
+
+    // One row per attempt — no attempt is silently untraced, and the lockout
+    // that follows them is distinguishable from the attempts that caused it.
+    expect(reasons).toHaveLength(maxAttempts + 1);
+    expect(reasons.slice(0, maxAttempts)).toEqual(
+      Array.from({ length: maxAttempts }, () => "invalid_credentials")
+    );
+    expect(reasons.at(-1)).toBe("locked");
+  });
+
+  test("an unknown account is audited without revealing that it is unknown", async () => {
+    const { tenantId } = await bootstrapTenant("audit-unknown");
+
+    expect(
+      await attemptLogin(tenantId, {
+        loginIdentifier: "ghost@example.com",
+        password: "whatever"
+      })
+    ).toBe(401);
+
+    const row = await readSingleAuditRow(tenantId, "login_failed");
+
+    // Same reason a *real* account with a wrong password gets (asserted
+    // above) — the reason alone can never be used to enumerate accounts.
+    expect(row.attributes?.reason).toBe("invalid_credentials");
+
+    // The attacker-supplied identifier (usually an email — PII that no
+    // redaction key would catch under this name) is never persisted.
+    expect(JSON.stringify(row)).not.toContain("ghost@example.com");
+  });
+
+  test("no login audit row ever contains the submitted password", async () => {
+    const { tenantId } = await bootstrapTenant("audit-no-secret");
+
+    await attemptLogin(tenantId, {
+      loginIdentifier: OWNER_LOGIN,
+      password: OWNER_PASSWORD
+    });
+    await attemptLogin(tenantId, {
+      loginIdentifier: OWNER_LOGIN,
+      password: "wrong-password"
+    });
+
+    const sql = getAdminSql();
+    const rows = (await sql`
+      SELECT attributes, message FROM awcms_mini_audit_events
+      WHERE tenant_id = ${tenantId}
+    `) as { attributes: unknown; message: string }[];
+
+    expect(rows.length).toBeGreaterThan(0);
+
+    const serialized = JSON.stringify(rows);
+    expect(serialized).not.toContain(OWNER_PASSWORD);
+    expect(serialized).not.toContain("wrong-password");
+    // Neither the plaintext nor the argon2 hash of it.
+    expect(serialized).not.toContain("$argon2");
+  });
+
+  test("login_failed survives a rollback of the login transaction", async () => {
+    const { tenantId } = await bootstrapTenant("audit-rollback");
+    const admin = getAdminSql();
+
+    // Force the login transaction to throw *after* it has begun writing, the
+    // one case the in-transaction audit write cannot survive on its own.
+    // A trigger on the session INSERT is the least invasive way to reproduce
+    // it against the real schema (the success path's own audit row is written
+    // after this INSERT, so it is rolled back too — exactly the scenario).
+    await admin`
+      CREATE OR REPLACE FUNCTION awcms_mini_test_fail_session_insert()
+      RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'injected failure';
+      END;
+      $$ LANGUAGE plpgsql
+    `;
+    await admin`
+      CREATE TRIGGER awcms_mini_test_fail_session_insert_trigger
+      BEFORE INSERT ON awcms_mini_sessions
+      FOR EACH ROW EXECUTE FUNCTION awcms_mini_test_fail_session_insert()
+    `;
+
+    try {
+      let threw = false;
+
+      try {
+        await attemptLogin(tenantId, {
+          loginIdentifier: OWNER_LOGIN,
+          password: OWNER_PASSWORD
+        });
+      } catch (error) {
+        // The original error is rethrown untouched, never swallowed by the
+        // audit recovery.
+        threw = true;
+        expect(error).toBeInstanceOf(Error);
+      }
+
+      expect(threw).toBe(true);
+
+      // The rolled-back transaction took its own audit row with it...
+      expect(await readAuditRows(tenantId, "login_succeeded")).toHaveLength(0);
+
+      // ...but the failure is still on the record, written out-of-band.
+      const row = await readSingleAuditRow(tenantId, "login_failed");
+      expect(row.attributes?.reason).toBe("internal_error");
+      expect(row.severity).toBe("warning");
+    } finally {
+      await admin`
+        DROP TRIGGER IF EXISTS awcms_mini_test_fail_session_insert_trigger
+        ON awcms_mini_sessions
+      `;
+      await admin`
+        DROP FUNCTION IF EXISTS awcms_mini_test_fail_session_insert()
+      `;
+    }
+  });
+});

--- a/tests/integration/login-audit.integration.test.ts
+++ b/tests/integration/login-audit.integration.test.ts
@@ -331,4 +331,28 @@ suite("login audit trail (Issue #821)", () => {
       `;
     }
   });
+
+  // PR #839 review finding. `awcms_mini_audit_events.tenant_id` is
+  // `NOT NULL REFERENCES awcms_mini_tenants (id)`, so writing a `login_failed`
+  // row for a tenant that does not exist violates the FK, aborts the
+  // transaction, and turns the intended 403 into a 500 — reachable by any
+  // unauthenticated caller with a well-formed but unknown tenant header, i.e.
+  // a trivial way to force 500s. Verified against the real defect: with the
+  // guard removed, this returns 500.
+  test("an unknown-but-well-formed tenant is denied 403, not 500 (audit FK)", async () => {
+    const unknownTenantId = "00000000-0000-4000-8000-0000000000ff";
+
+    const admin = getAdminSql();
+    const rows = await admin`
+      SELECT 1 FROM awcms_mini_tenants WHERE id = ${unknownTenantId}
+    `;
+    expect(rows).toHaveLength(0);
+
+    const status = await attemptLogin(unknownTenantId, {
+      loginIdentifier: "nobody@example.test",
+      password: "whatever-not-a-real-password"
+    });
+
+    expect(status).toBe(403);
+  });
 });

--- a/tests/integration/reference-data.integration.test.ts
+++ b/tests/integration/reference-data.integration.test.ts
@@ -1889,3 +1889,245 @@ suite("reference_data integration", () => {
     ).toBe(validFrom);
   });
 });
+
+/**
+ * PR #839 review findings. The OpenAPI request body documents `{}` as a valid
+ * no-op, but the handler reached the unconditional `update*` path for it, and
+ * `readJsonBody(...) ?? {}` silently manufactured that same `{}` out of an
+ * absent or non-object body.
+ *
+ * These assert the MECHANISM, not the status code: a 200 alone cannot tell a
+ * genuine no-op apart from a write that happened to preserve every value, so
+ * each test pins `updated_at` and the audit trail — the things a spurious
+ * write actually moves.
+ */
+describe("reference-data PATCH no-op and body-shape handling", () => {
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  /**
+   * `action` alone is "update" for BOTH code kinds — `resource_type` is the
+   * discriminator, so both are pinned here. Counting on a made-up action name
+   * would return 0 before and after the change and pass vacuously.
+   */
+  async function updateAuditCountFor(
+    owner: Bootstrap,
+    resourceType: "reference_code" | "reference_tenant_code"
+  ): Promise<number> {
+    const sql = getTestSql();
+    const rows = await withTenant(sql, owner.tenantId, async (tx) => {
+      return (await tx`
+        SELECT count(*)::int AS count
+        FROM awcms_mini_audit_events
+        WHERE tenant_id = ${owner.tenantId}
+          AND module_key = 'reference_data'
+          AND action = 'update'
+          AND resource_type = ${resourceType}
+      `) as { count: number }[];
+    });
+    return rows[0]!.count;
+  }
+
+  async function tenantCodeUpdatedAt(
+    owner: Bootstrap,
+    tenantCodeId: string
+  ): Promise<string> {
+    const sql = getTestSql();
+    const rows = await withTenant(sql, owner.tenantId, async (tx) => {
+      return (await tx`
+        SELECT updated_at
+        FROM awcms_mini_reference_tenant_codes
+        WHERE tenant_id = ${owner.tenantId} AND id = ${tenantCodeId}
+      `) as { updated_at: Date }[];
+    });
+    return rows[0]!.updated_at.toISOString();
+  }
+
+  async function createTenantCodeFixture(owner: Bootstrap): Promise<string> {
+    await createValueSetFixture(
+      owner,
+      "currency",
+      "tenant_extend_and_override"
+    );
+    const created = await invoke<{ data: { tenantCode: { id: string } } }>(
+      createTenantCode,
+      {
+        method: "POST",
+        path: "/api/v1/reference-data/tenant-codes",
+        headers: authHeaders(owner, idKey()),
+        body: {
+          valueSet: "currency",
+          baseCodeId: null,
+          code: "EXT_NOOP",
+          labels: [{ locale: "en", label: "Unchanged" }],
+          sortOrder: 7,
+          metadata: { keep: true },
+          validFrom: "2026-01-01T00:00:00.000Z",
+          validTo: null
+        }
+      }
+    );
+    expect(created.status).toBe(200);
+    return created.body.data.tenantCode.id;
+  }
+
+  test("REGRESSION (PR #839, tenant-codes PATCH): the documented no-op `PATCH {}` must NOT bump updated_at or append an audit event -- pre-fix it ran the full unconditional update for a request that changes nothing", async () => {
+    const owner = await bootstrap();
+    const tenantCodeId = await createTenantCodeFixture(owner);
+
+    const updatedAtBefore = await tenantCodeUpdatedAt(owner, tenantCodeId);
+    const auditsBefore = await updateAuditCountFor(
+      owner,
+      "reference_tenant_code"
+    );
+
+    // A second of separation, so an `updated_at` bump cannot hide inside the
+    // timestamp resolution and pass this test by accident.
+    await Bun.sleep(1100);
+
+    const noop = await invoke<{
+      data: {
+        tenantCode: {
+          sortOrder: number;
+          metadata: Record<string, unknown>;
+          labels: { label: string }[];
+        };
+      };
+    }>(updateTenantCode, {
+      method: "PATCH",
+      path: `/api/v1/reference-data/tenant-codes/${tenantCodeId}`,
+      params: { id: tenantCodeId },
+      headers: authHeaders(owner, idKey()),
+      body: {}
+    });
+
+    // Still the documented 200 with the current representation -- the fix must
+    // not turn a documented no-op into an error.
+    expect(noop.status).toBe(200);
+    expect(noop.body.data.tenantCode.sortOrder).toBe(7);
+    expect(noop.body.data.tenantCode.metadata).toEqual({ keep: true });
+    expect(noop.body.data.tenantCode.labels[0]!.label).toBe("Unchanged");
+
+    expect(await tenantCodeUpdatedAt(owner, tenantCodeId)).toBe(
+      updatedAtBefore
+    );
+    expect(await updateAuditCountFor(owner, "reference_tenant_code")).toBe(
+      auditsBefore
+    );
+  });
+
+  test("REGRESSION (PR #839, tenant-codes PATCH): an ABSENT body is rejected 400, not silently normalized into the no-op `{}`", async () => {
+    const owner = await bootstrap();
+    const tenantCodeId = await createTenantCodeFixture(owner);
+    const updatedAtBefore = await tenantCodeUpdatedAt(owner, tenantCodeId);
+
+    const response = await invoke<{ error: { code: string } }>(
+      updateTenantCode,
+      {
+        method: "PATCH",
+        path: `/api/v1/reference-data/tenant-codes/${tenantCodeId}`,
+        params: { id: tenantCodeId },
+        headers: authHeaders(owner, idKey())
+        // no `body` at all
+      }
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe("VALIDATION_ERROR");
+    expect(await tenantCodeUpdatedAt(owner, tenantCodeId)).toBe(
+      updatedAtBefore
+    );
+  });
+
+  test.each([
+    ["a JSON array", [] as unknown],
+    ["a literal null", null as unknown],
+    ["a JSON scalar", 5 as unknown]
+  ])(
+    "REGRESSION (PR #839, tenant-codes PATCH): %s body is rejected 400 -- a field-by-field patch parser reads no known keys off it and would otherwise report a clean empty patch",
+    async (_label, body) => {
+      const owner = await bootstrap();
+      const tenantCodeId = await createTenantCodeFixture(owner);
+      const updatedAtBefore = await tenantCodeUpdatedAt(owner, tenantCodeId);
+
+      const response = await invoke<{ error: { code: string } }>(
+        updateTenantCode,
+        {
+          method: "PATCH",
+          path: `/api/v1/reference-data/tenant-codes/${tenantCodeId}`,
+          params: { id: tenantCodeId },
+          headers: authHeaders(owner, idKey()),
+          body
+        }
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe("VALIDATION_ERROR");
+      expect(await tenantCodeUpdatedAt(owner, tenantCodeId)).toBe(
+        updatedAtBefore
+      );
+    }
+  );
+
+  test("REGRESSION (PR #839, value-sets/codes PATCH): the no-op `PATCH {}` must NOT append a code_updated audit event, and a real patch on the same code still must", async () => {
+    const owner = await bootstrap();
+    await createValueSetFixture(
+      owner,
+      "currency",
+      "tenant_extend_and_override"
+    );
+    const created = await invoke(createCode, {
+      method: "POST",
+      path: "/api/v1/reference-data/value-sets/currency/codes",
+      params: { key: "currency" },
+      headers: authHeaders(owner, idKey()),
+      body: {
+        code: "IDR",
+        labels: [{ locale: "en", label: "Rupiah" }],
+        sortOrder: 1,
+        metadata: {},
+        validFrom: "2026-01-01T00:00:00.000Z",
+        validTo: null
+      }
+    });
+    expect(created.status).toBe(200);
+
+    const auditsBefore = await updateAuditCountFor(owner, "reference_code");
+
+    const noop = await invoke<{ data: { code: { sortOrder: number } } }>(
+      updateCode,
+      {
+        method: "PATCH",
+        path: "/api/v1/reference-data/value-sets/currency/codes/IDR",
+        params: { key: "currency", code: "IDR" },
+        headers: authHeaders(owner, idKey()),
+        body: {}
+      }
+    );
+    expect(noop.status).toBe(200);
+    expect(noop.body.data.code.sortOrder).toBe(1);
+    expect(await updateAuditCountFor(owner, "reference_code")).toBe(
+      auditsBefore
+    );
+
+    // The bidirectional half: the short-circuit must not have disabled the
+    // real update path. Without this, deleting the update call entirely would
+    // still pass the assertion above.
+    const real = await invoke<{ data: { code: { sortOrder: number } } }>(
+      updateCode,
+      {
+        method: "PATCH",
+        path: "/api/v1/reference-data/value-sets/currency/codes/IDR",
+        params: { key: "currency", code: "IDR" },
+        headers: authHeaders(owner, idKey()),
+        body: { sortOrder: 99 }
+      }
+    );
+    expect(real.status).toBe(200);
+    expect(real.body.data.code.sortOrder).toBe(99);
+    expect(await updateAuditCountFor(owner, "reference_code")).toBe(
+      auditsBefore + 1
+    );
+  });
+});

--- a/tests/integration/reference-data.integration.test.ts
+++ b/tests/integration/reference-data.integration.test.ts
@@ -2130,4 +2130,111 @@ describe("reference-data PATCH no-op and body-shape handling", () => {
       auditsBefore + 1
     );
   });
+
+  /**
+   * The empty-patch short-circuit bypasses `update*`, so every refusal that
+   * `update*` applies has to be re-applied on the no-op path too — otherwise
+   * the endpoint's ANSWER depends on how many fields the caller happened to
+   * send, which is exactly the bug class the short-circuit introduced.
+   *
+   * These pin each refusal axis against the REAL update path rather than
+   * against a hardcoded expectation, so the two cannot drift apart silently.
+   * The two routes legitimately differ here (tenant codes filter
+   * `deprecated_at`, global codes do not but guard `managed_by_descriptor`),
+   * which is precisely why each is asserted against its own update path.
+   */
+  test("REGRESSION (PR #839 round 3, tenant-codes PATCH): `PATCH {}` on a DEPRECATED code must 404 exactly like a real patch does -- updateTenantReferenceCode's UPDATE carries `AND deprecated_at IS NULL`, so a no-op that skips it would report a deprecated row back as a live 200", async () => {
+    const owner = await bootstrap();
+    const tenantCodeId = await createTenantCodeFixture(owner);
+
+    const deprecated = await invoke(deprecateTenantCode, {
+      method: "DELETE",
+      path: `/api/v1/reference-data/tenant-codes/${tenantCodeId}`,
+      params: { id: tenantCodeId },
+      headers: authHeaders(owner, idKey()),
+      body: { reason: "retired for this test" }
+    });
+    expect(deprecated.status).toBe(200);
+
+    // A REAL patch on the deprecated row -- establishes the update path's own
+    // answer instead of assuming it.
+    const realPatch = await invoke<{ error: { code: string } }>(
+      updateTenantCode,
+      {
+        method: "PATCH",
+        path: `/api/v1/reference-data/tenant-codes/${tenantCodeId}`,
+        params: { id: tenantCodeId },
+        headers: authHeaders(owner, idKey()),
+        body: { sortOrder: 3 }
+      }
+    );
+    expect(realPatch.status).toBe(404);
+
+    const noopPatch = await invoke<{ error: { code: string } }>(
+      updateTenantCode,
+      {
+        method: "PATCH",
+        path: `/api/v1/reference-data/tenant-codes/${tenantCodeId}`,
+        params: { id: tenantCodeId },
+        headers: authHeaders(owner, idKey()),
+        body: {}
+      }
+    );
+
+    // The parity claim itself: same row, same permission, same endpoint --
+    // only the patch size differs, so the answer must not.
+    expect(noopPatch.status).toBe(realPatch.status);
+    expect(noopPatch.body.error.code).toBe(realPatch.body.error.code);
+  });
+
+  test("REGRESSION (PR #839 round 3, value-sets/codes PATCH): `PATCH {}` on a DEPRECATED global code must match its real-patch answer -- updateReferenceCode deliberately does NOT filter deprecated_at, so this asymmetry with tenant codes is pinned rather than assumed", async () => {
+    const owner = await bootstrap();
+    await createValueSetFixture(
+      owner,
+      "currency",
+      "tenant_extend_and_override"
+    );
+    const created = await invoke(createCode, {
+      method: "POST",
+      path: "/api/v1/reference-data/value-sets/currency/codes",
+      params: { key: "currency" },
+      headers: authHeaders(owner, idKey()),
+      body: {
+        code: "OLD",
+        labels: [{ locale: "en", label: "Old" }],
+        sortOrder: 1,
+        metadata: {},
+        validFrom: "2026-01-01T00:00:00.000Z",
+        validTo: null
+      }
+    });
+    expect(created.status).toBe(200);
+
+    const deprecated = await invoke(deprecateCode, {
+      method: "DELETE",
+      path: "/api/v1/reference-data/value-sets/currency/codes/OLD",
+      params: { key: "currency", code: "OLD" },
+      headers: authHeaders(owner, idKey()),
+      body: { reason: "retired for this test" }
+    });
+    expect(deprecated.status).toBe(200);
+
+    const realPatch = await invoke(updateCode, {
+      method: "PATCH",
+      path: "/api/v1/reference-data/value-sets/currency/codes/OLD",
+      params: { key: "currency", code: "OLD" },
+      headers: authHeaders(owner, idKey()),
+      body: { sortOrder: 4 }
+    });
+
+    const noopPatch = await invoke(updateCode, {
+      method: "PATCH",
+      path: "/api/v1/reference-data/value-sets/currency/codes/OLD",
+      params: { key: "currency", code: "OLD" },
+      headers: authHeaders(owner, idKey()),
+      body: {}
+    });
+
+    expect(noopPatch.status).toBe(realPatch.status);
+  });
 });

--- a/tests/integration/reference-data.integration.test.ts
+++ b/tests/integration/reference-data.integration.test.ts
@@ -1613,4 +1613,279 @@ suite("reference_data integration", () => {
     });
     expect(missingKeyResult.status).toBe(400);
   });
+
+  test("REGRESSION (Issue #822, tenant-codes PATCH): a partial PATCH carrying ONLY `labels` must leave sortOrder/metadata/validFrom/validTo untouched -- pre-fix the route behaved like PUT and silently reset the omitted fields to 0/{}/now()/null", async () => {
+    const owner = await bootstrap();
+    await createValueSetFixture(
+      owner,
+      "currency",
+      "tenant_extend_and_override"
+    );
+
+    const validFrom = "2026-01-01T00:00:00.000Z";
+    const validTo = "2026-12-31T00:00:00.000Z";
+    const created = await invoke<{ data: { tenantCode: { id: string } } }>(
+      createTenantCode,
+      {
+        method: "POST",
+        path: "/api/v1/reference-data/tenant-codes",
+        headers: authHeaders(owner, idKey()),
+        body: {
+          valueSet: "currency",
+          baseCodeId: null,
+          code: "EXT_KEEP",
+          labels: [{ locale: "en", label: "Before" }],
+          sortOrder: 30,
+          metadata: { tujuan: "load-bearing" },
+          validFrom,
+          validTo
+        }
+      }
+    );
+    expect(created.status).toBe(200);
+    const tenantCodeId = created.body.data.tenantCode.id;
+
+    // The normative PATCH a client would send to rename a label and nothing
+    // else. Every other mutable field is ABSENT from the body.
+    const patched = await invoke<{
+      data: {
+        tenantCode: {
+          labels: { label: string }[];
+          sortOrder: number;
+          metadata: Record<string, unknown>;
+          validFrom: string;
+          validTo: string | null;
+        };
+      };
+    }>(updateTenantCode, {
+      method: "PATCH",
+      path: `/api/v1/reference-data/tenant-codes/${tenantCodeId}`,
+      params: { id: tenantCodeId },
+      headers: authHeaders(owner, idKey()),
+      body: { labels: [{ locale: "en", label: "After" }] }
+    });
+    expect(patched.status).toBe(200);
+    expect(patched.body.data.tenantCode.labels[0]!.label).toBe("After");
+    expect(patched.body.data.tenantCode.sortOrder).toBe(30);
+    expect(patched.body.data.tenantCode.metadata).toEqual({
+      tujuan: "load-bearing"
+    });
+    expect(new Date(patched.body.data.tenantCode.validFrom).toISOString()).toBe(
+      validFrom
+    );
+    expect(patched.body.data.tenantCode.validTo).not.toBeNull();
+    expect(new Date(patched.body.data.tenantCode.validTo!).toISOString()).toBe(
+      validTo
+    );
+
+    // Assert the persisted row directly -- the response body is built from the
+    // UPDATE's RETURNING clause, so a stale read would not catch a bad write.
+    const sql = getTestSql();
+    const rows = await withTenant(sql, owner.tenantId, async (tx) => {
+      return (await tx`
+        SELECT sort_order, metadata, valid_from, valid_to
+        FROM awcms_mini_reference_tenant_codes
+        WHERE tenant_id = ${owner.tenantId} AND id = ${tenantCodeId}
+      `) as {
+        sort_order: number;
+        metadata: Record<string, unknown>;
+        valid_from: Date;
+        valid_to: Date | null;
+      }[];
+    });
+    expect(Number(rows[0]!.sort_order)).toBe(30);
+    expect(rows[0]!.metadata).toEqual({ tujuan: "load-bearing" });
+    expect(rows[0]!.valid_from.toISOString()).toBe(validFrom);
+    expect(rows[0]!.valid_to!.toISOString()).toBe(validTo);
+  });
+
+  test("REGRESSION (Issue #822, tenant-codes PATCH): an EXPLICIT `validTo: null` genuinely clears the end of validity -- explicit null means clear, distinct from an absent field meaning keep", async () => {
+    const owner = await bootstrap();
+    await createValueSetFixture(
+      owner,
+      "currency",
+      "tenant_extend_and_override"
+    );
+
+    const created = await invoke<{ data: { tenantCode: { id: string } } }>(
+      createTenantCode,
+      {
+        method: "POST",
+        path: "/api/v1/reference-data/tenant-codes",
+        headers: authHeaders(owner, idKey()),
+        body: {
+          valueSet: "currency",
+          baseCodeId: null,
+          code: "EXT_CLEAR",
+          labels: [{ locale: "en", label: "Clearable" }],
+          sortOrder: 7,
+          validFrom: "2026-01-01T00:00:00.000Z",
+          validTo: "2026-12-31T00:00:00.000Z"
+        }
+      }
+    );
+    expect(created.status).toBe(200);
+    const tenantCodeId = created.body.data.tenantCode.id;
+
+    const patched = await invoke<{
+      data: { tenantCode: { validTo: string | null; sortOrder: number } };
+    }>(updateTenantCode, {
+      method: "PATCH",
+      path: `/api/v1/reference-data/tenant-codes/${tenantCodeId}`,
+      params: { id: tenantCodeId },
+      headers: authHeaders(owner, idKey()),
+      body: { validTo: null }
+    });
+    expect(patched.status).toBe(200);
+    expect(patched.body.data.tenantCode.validTo).toBeNull();
+    // ...and the sibling field omitted from THIS body still survives.
+    expect(patched.body.data.tenantCode.sortOrder).toBe(7);
+
+    const sql = getTestSql();
+    const rows = await withTenant(sql, owner.tenantId, async (tx) => {
+      return (await tx`
+        SELECT valid_to FROM awcms_mini_reference_tenant_codes
+        WHERE tenant_id = ${owner.tenantId} AND id = ${tenantCodeId}
+      `) as { valid_to: Date | null }[];
+    });
+    expect(rows[0]!.valid_to).toBeNull();
+  });
+
+  test("REGRESSION (Issue #822, codes PATCH): a partial PATCH carrying ONLY `labels` must leave sortOrder/metadata/validFrom/validTo untouched, and an explicit `validTo: null` must genuinely clear it", async () => {
+    const owner = await bootstrap();
+    await createValueSetFixture(owner, "currency", "none");
+
+    const validFrom = "2026-02-01T00:00:00.000Z";
+    const validTo = "2026-11-30T00:00:00.000Z";
+    const created = await invoke(createCode, {
+      method: "POST",
+      path: "/api/v1/reference-data/value-sets/currency/codes",
+      params: { key: "currency" },
+      headers: authHeaders(owner, idKey()),
+      body: {
+        code: "IDR",
+        labels: [{ locale: "en", label: "Before" }],
+        sortOrder: 42,
+        metadata: { symbol: "Rp" },
+        validFrom,
+        validTo
+      }
+    });
+    expect(created.status).toBe(200);
+
+    const patched = await invoke<{
+      data: {
+        code: {
+          labels: { label: string }[];
+          sortOrder: number;
+          metadata: Record<string, unknown>;
+          validFrom: string;
+          validTo: string | null;
+        };
+      };
+    }>(updateCode, {
+      method: "PATCH",
+      path: "/api/v1/reference-data/value-sets/currency/codes/IDR",
+      params: { key: "currency", code: "IDR" },
+      headers: authHeaders(owner, idKey()),
+      body: { labels: [{ locale: "en", label: "After" }] }
+    });
+    expect(patched.status).toBe(200);
+    expect(patched.body.data.code.labels[0]!.label).toBe("After");
+    expect(patched.body.data.code.sortOrder).toBe(42);
+    expect(patched.body.data.code.metadata).toEqual({ symbol: "Rp" });
+    expect(new Date(patched.body.data.code.validFrom).toISOString()).toBe(
+      validFrom
+    );
+    expect(new Date(patched.body.data.code.validTo!).toISOString()).toBe(
+      validTo
+    );
+
+    // Explicit null clears -- proving null and "absent" are NOT conflated.
+    const cleared = await invoke<{
+      data: { code: { validTo: string | null; sortOrder: number } };
+    }>(updateCode, {
+      method: "PATCH",
+      path: "/api/v1/reference-data/value-sets/currency/codes/IDR",
+      params: { key: "currency", code: "IDR" },
+      headers: authHeaders(owner, idKey()),
+      body: { validTo: null }
+    });
+    expect(cleared.status).toBe(200);
+    expect(cleared.body.data.code.validTo).toBeNull();
+    expect(cleared.body.data.code.sortOrder).toBe(42);
+
+    const sql = getTestSql();
+    const rows = await withTenant(sql, owner.tenantId, async (tx) => {
+      return (await tx`
+        SELECT sort_order, metadata, valid_from, valid_to
+        FROM awcms_mini_reference_codes
+        WHERE value_set_id = (
+          SELECT id FROM awcms_mini_reference_value_sets WHERE key = 'currency'
+        ) AND code = 'IDR'
+      `) as {
+        sort_order: number;
+        metadata: Record<string, unknown>;
+        valid_from: Date;
+        valid_to: Date | null;
+      }[];
+    });
+    expect(Number(rows[0]!.sort_order)).toBe(42);
+    expect(rows[0]!.metadata).toEqual({ symbol: "Rp" });
+    expect(rows[0]!.valid_from.toISOString()).toBe(validFrom);
+    expect(rows[0]!.valid_to).toBeNull();
+  });
+
+  test("REGRESSION (Issue #822): a PATCH sending `validFrom: null` is REJECTED (400) rather than silently reset to now() -- valid_from is NOT NULL and load-bearing for downstream documents", async () => {
+    const owner = await bootstrap();
+    await createValueSetFixture(
+      owner,
+      "currency",
+      "tenant_extend_and_override"
+    );
+
+    const validFrom = "2026-01-01T00:00:00.000Z";
+    const created = await invoke<{ data: { tenantCode: { id: string } } }>(
+      createTenantCode,
+      {
+        method: "POST",
+        path: "/api/v1/reference-data/tenant-codes",
+        headers: authHeaders(owner, idKey()),
+        body: {
+          valueSet: "currency",
+          baseCodeId: null,
+          code: "EXT_NN",
+          labels: [{ locale: "en", label: "Not nullable" }],
+          validFrom
+        }
+      }
+    );
+    expect(created.status).toBe(200);
+    const tenantCodeId = created.body.data.tenantCode.id;
+
+    const rejected = await invoke(updateTenantCode, {
+      method: "PATCH",
+      path: `/api/v1/reference-data/tenant-codes/${tenantCodeId}`,
+      params: { id: tenantCodeId },
+      headers: authHeaders(owner, idKey()),
+      body: { validFrom: null }
+    });
+    expect(rejected.status).toBe(400);
+    expect((rejected.body as { error: { code: string } }).error.code).toBe(
+      "VALIDATION_ERROR"
+    );
+
+    // The stored validFrom is untouched by the rejected request.
+    const unchanged = await invoke<{
+      data: { tenantCode: { validFrom: string } };
+    }>(getTenantCode, {
+      method: "GET",
+      path: `/api/v1/reference-data/tenant-codes/${tenantCodeId}`,
+      params: { id: tenantCodeId },
+      headers: authHeaders(owner)
+    });
+    expect(
+      new Date(unchanged.body.data.tenantCode.validFrom).toISOString()
+    ).toBe(validFrom);
+  });
 });

--- a/tests/unit/ci-check-parity.test.ts
+++ b/tests/unit/ci-check-parity.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Gate paritas `bun run check` ⊆ `.github/workflows/ci.yml` — Issue #823 (epic #818).
+ *
+ * `ci.yml` mencerminkan langkah-langkah `check` **secara manual**. Cermin itu sudah
+ * melenceng **empat kali** (#685, #740, #745/#746, #750, lalu #823 menemukan lima
+ * langkah lagi yang tak pernah dipasang: `api:docs:check`, `repo:inventory:check`,
+ * `i18n:pot:check`, `config:docs:check`, `logging:lint:check`). Tiap kali polanya
+ * sama: langkah baru ditambahkan ke `check`, lolos lokal, dan CI diam-diam
+ * menjalankan subset — regresi bisa merge hijau.
+ *
+ * Komentar peringatan di `ci.yml` tidak menghentikannya empat kali. Test inilah
+ * gate-nya: menambah langkah ke `check` tanpa memasangnya di `ci.yml` = merah.
+ *
+ * Arah pemeriksaan sengaja satu arah (`check` ⊆ `ci.yml`): `ci.yml` boleh
+ * menjalankan lebih banyak (mis. `db:migrate`, performance suite, DR drill) —
+ * yang dilarang adalah `check` punya langkah yang CI lewatkan.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "../..");
+
+/**
+ * Langkah `check` yang sengaja TIDAK dicari sebagai `bun run <x>` literal di
+ * ci.yml karena CI menjalankannya lewat bentuk lain — bukan pengecualian dari
+ * cakupan, hanya dari pencocokan string.
+ */
+const RUN_DIFFERENTLY = new Map<string, string>([
+  // ci.yml memanggil `bun test` langsung (setelah `db:migrate`), bukan `bun run test`.
+  ["test", "bun test"],
+  // ci.yml build lewat job/langkah terpisah dengan env berbeda.
+  ["build", "bun run build"]
+]);
+
+function packageScripts(): Record<string, string> {
+  const pkg = JSON.parse(
+    readFileSync(resolve(ROOT, "package.json"), "utf8")
+  ) as {
+    scripts: Record<string, string>;
+  };
+  return pkg.scripts;
+}
+
+/** Ekstrak nama script dari komposit `check` (`bun run a && bun run b && ...`). */
+function checkSteps(): string[] {
+  const composite = packageScripts().check;
+  expect(composite, "package.json harus punya script `check`").toBeDefined();
+  return [...composite.matchAll(/bun run ([a-z0-9:_-]+)/g)].map((m) => m[1]!);
+}
+
+function ciWorkflow(): string {
+  return readFileSync(resolve(ROOT, ".github/workflows/ci.yml"), "utf8");
+}
+
+describe("paritas `bun run check` vs .github/workflows/ci.yml (Issue #823)", () => {
+  test("`check` komposit dapat diurai dan tidak kosong", () => {
+    const steps = checkSteps();
+    expect(steps.length).toBeGreaterThan(10);
+    expect(steps).toContain("lint");
+    expect(steps).toContain("typecheck");
+  });
+
+  test("setiap langkah `check` benar-benar ada sebagai script di package.json", () => {
+    const scripts = packageScripts();
+    const missing = checkSteps().filter((step) => !(step in scripts));
+    expect(
+      missing,
+      `Langkah \`check\` menunjuk script yang tidak ada: ${missing.join(", ")}`
+    ).toEqual([]);
+  });
+
+  test("setiap langkah `check` dijalankan juga oleh ci.yml", () => {
+    const ci = ciWorkflow();
+    const missing = checkSteps().filter((step) => {
+      const alternate = RUN_DIFFERENTLY.get(step);
+      if (alternate) return !ci.includes(alternate);
+      return !new RegExp(
+        `bun run ${step.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?![a-z0-9:_-])`
+      ).test(ci);
+    });
+
+    expect(
+      missing,
+      `ci.yml tidak menjalankan langkah \`check\` berikut: ${missing.join(", ")}.\n` +
+        `Ini kelas bug yang sudah berulang 4x (#685/#740/#745/#746/#750/#823): sebuah langkah ` +
+        `ditambahkan ke \`check\`, lolos lokal, lalu CI diam-diam menjalankan subset.\n` +
+        `Tambahkan langkah itu ke .github/workflows/ci.yml — atau, bila CI memang ` +
+        `menjalankannya dengan bentuk perintah lain, daftarkan di RUN_DIFFERENTLY pada test ini.`
+    ).toEqual([]);
+  });
+
+  test("RUN_DIFFERENTLY tidak menyimpan entri usang", () => {
+    const steps = new Set(checkSteps());
+    const stale = [...RUN_DIFFERENTLY.keys()].filter(
+      (step) => !steps.has(step)
+    );
+    expect(
+      stale,
+      `RUN_DIFFERENTLY memuat langkah yang bukan lagi bagian \`check\`: ${stale.join(", ")}. ` +
+        `Entri usang membuat pengecualian bertahan diam-diam setelah alasannya hilang.`
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/ci-check-parity.test.ts
+++ b/tests/unit/ci-check-parity.test.ts
@@ -45,7 +45,11 @@ function packageScripts(): Record<string, string> {
 /** Ekstrak nama script dari komposit `check` (`bun run a && bun run b && ...`). */
 function checkSteps(): string[] {
   const composite = packageScripts().check;
-  expect(composite, "package.json harus punya script `check`").toBeDefined();
+  if (!composite) {
+    throw new Error(
+      "package.json tidak punya script `check` — gate paritas ini tidak bermakna tanpanya."
+    );
+  }
   return [...composite.matchAll(/bun run ([a-z0-9:_-]+)/g)].map((m) => m[1]!);
 }
 

--- a/tests/unit/ci-check-parity.test.ts
+++ b/tests/unit/ci-check-parity.test.ts
@@ -18,6 +18,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { parse } from "yaml";
 
 const ROOT = resolve(import.meta.dir, "../..");
 
@@ -53,8 +54,45 @@ function checkSteps(): string[] {
   return [...composite.matchAll(/bun run ([a-z0-9:_-]+)/g)].map((m) => m[1]!);
 }
 
-function ciWorkflow(): string {
-  return readFileSync(resolve(ROOT, ".github/workflows/ci.yml"), "utf8");
+type WorkflowStep = { run?: unknown };
+type WorkflowJob = { steps?: WorkflowStep[] };
+type Workflow = { jobs?: Record<string, WorkflowJob> };
+
+/**
+ * ONLY the `run:` command bodies, never the raw file text.
+ *
+ * The first version of this gate scanned the whole file, so a mere mention of
+ * `bun test` — in a comment, a step `name:`, or this file's own warning prose —
+ * satisfied the check even with the real `run:` step deleted. The gate would
+ * have stayed green in exactly the drift scenario it exists to catch, which is
+ * the same "gate is green over a real defect" failure the gate was written to
+ * end. Parsing the YAML and looking only at executable commands is the whole
+ * point. (Review finding, PR #839.)
+ */
+function ciRunCommands(): string {
+  const workflow = parse(
+    readFileSync(resolve(ROOT, ".github/workflows/ci.yml"), "utf8")
+  ) as Workflow;
+
+  const jobs = Object.values(workflow.jobs ?? {});
+  if (jobs.length === 0) {
+    throw new Error(
+      ".github/workflows/ci.yml tidak punya job apa pun setelah diurai — gate paritas ini tidak bermakna tanpanya."
+    );
+  }
+
+  const commands = jobs
+    .flatMap((job) => job.steps ?? [])
+    .map((step) => step.run)
+    .filter((run): run is string => typeof run === "string");
+
+  if (commands.length === 0) {
+    throw new Error(
+      ".github/workflows/ci.yml tidak punya satu pun langkah `run:` setelah diurai — parser di test ini kemungkinan sudah tidak cocok dengan bentuk workflow-nya."
+    );
+  }
+
+  return commands.join("\n");
 }
 
 describe("paritas `bun run check` vs .github/workflows/ci.yml (Issue #823)", () => {
@@ -75,7 +113,7 @@ describe("paritas `bun run check` vs .github/workflows/ci.yml (Issue #823)", () 
   });
 
   test("setiap langkah `check` dijalankan juga oleh ci.yml", () => {
-    const ci = ciWorkflow();
+    const ci = ciRunCommands();
     const missing = checkSteps().filter((step) => {
       const alternate = RUN_DIFFERENTLY.get(step);
       if (alternate) return !ci.includes(alternate);
@@ -92,6 +130,40 @@ describe("paritas `bun run check` vs .github/workflows/ci.yml (Issue #823)", () 
         `Tambahkan langkah itu ke .github/workflows/ci.yml — atau, bila CI memang ` +
         `menjalankannya dengan bentuk perintah lain, daftarkan di RUN_DIFFERENTLY pada test ini.`
     ).toEqual([]);
+  });
+
+  /**
+   * Meta-test: memaku properti yang membuat gate ini nyata, bukan hiasan.
+   * Versi pertamanya memindai seluruh teks file, jadi komentar yang menyebut
+   * `bun test` sudah memuaskannya walau step `run:` aslinya dihapus — gate
+   * hijau persis di skenario yang jadi alasan ia ada. Tanpa test ini, regresi
+   * itu bisa kembali tanpa suara. (Temuan review, PR #839.)
+   */
+  test("sumber pemeriksaan HANYA `run:`, bukan komentar/nama langkah — gate ini tidak boleh bisa dibohongi prosa", () => {
+    const raw = readFileSync(resolve(ROOT, ".github/workflows/ci.yml"), "utf8");
+    const runOnly = ciRunCommands();
+
+    // ci.yml memang memuat komentar; kalau tidak, test ini tak membuktikan apa pun.
+    expect(raw).toMatch(/^\s*#/m);
+    expect(runOnly.length).toBeLessThan(raw.length);
+    expect(runOnly).not.toMatch(/^\s*#/m);
+
+    // Bukti langsung: sebuah token yang HANYA muncul di komentar tidak boleh
+    // terbaca oleh sumber pemeriksaan.
+    const commentOnlyToken = "bun run this-step-exists-only-in-a-comment";
+    const spoofed = raw.replace(/^(#.*)$/m, `$1\n# ${commentOnlyToken}`);
+    expect(spoofed).toContain(commentOnlyToken);
+
+    const spoofedRunOnly = (() => {
+      const workflow = parse(spoofed) as Workflow;
+      return Object.values(workflow.jobs ?? {})
+        .flatMap((job) => job.steps ?? [])
+        .map((step) => step.run)
+        .filter((run): run is string => typeof run === "string")
+        .join("\n");
+    })();
+
+    expect(spoofedRunOnly).not.toContain(commentOnlyToken);
   });
 
   test("RUN_DIFFERENTLY tidak menyimpan entri usang", () => {

--- a/tests/unit/data-exchange-descriptor-contract-parity.test.ts
+++ b/tests/unit/data-exchange-descriptor-contract-parity.test.ts
@@ -1,0 +1,136 @@
+/**
+ * `GET /api/v1/data-exchange/descriptors` serves the module registry's
+ * descriptors more or less verbatim, so the TypeScript descriptor shape and
+ * the published `DataExchangeDescriptor` schema are two hand-maintained copies
+ * of one contract — with nothing tying them together.
+ *
+ * They already drifted once: `sensitiveFields.naturalKeyField` (Issue #820)
+ * was added to the descriptor type and set by the default
+ * `data_exchange.reference_items` descriptor, while the schema kept
+ * `additionalProperties: false` listing only `fieldNames`/`rawValuePermission`
+ * — so the endpoint's real response violated its own published contract, and
+ * every gate stayed green. `api:spec:check` only proves the BUNDLE is fresh
+ * relative to its sources; it never compares a response, or the data a
+ * response is built from, against a schema. Nothing else in the repo does
+ * either (no ajv, no runtime schema validation anywhere).
+ *
+ * This validates the REAL registry descriptors against the REAL schema, so a
+ * new descriptor property cannot ship without the schema learning about it.
+ * Narrow by design: it covers the drift that actually happened rather than
+ * standing in for general response-vs-schema contract validation, which is
+ * tracked separately as Issue #844.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+
+import { listModules } from "../../src/modules";
+import { collectExchangeDescriptors } from "../../src/modules/data-exchange/domain/exchange-registry";
+
+const SPEC_PATH = "openapi/modules/data-exchange.openapi.yaml";
+
+type SchemaNode = {
+  type?: string;
+  properties?: Record<string, SchemaNode>;
+  additionalProperties?: boolean;
+  required?: string[];
+};
+
+function loadSchema(name: string): SchemaNode {
+  const spec = parse(readFileSync(SPEC_PATH, "utf8")) as {
+    components?: { schemas?: Record<string, SchemaNode> };
+  };
+  const schema = spec.components?.schemas?.[name];
+  if (!schema) {
+    throw new Error(
+      `${SPEC_PATH} has no components.schemas.${name} — the schema this test pins was renamed or removed.`
+    );
+  }
+  return schema;
+}
+
+/**
+ * Every key present on `value` must be declared in `schema.properties` when
+ * the schema is closed (`additionalProperties: false`). Returns the offending
+ * paths rather than throwing, so one failure can report every drifted key at
+ * once instead of only the first.
+ */
+function undeclaredKeys(
+  value: Record<string, unknown>,
+  schema: SchemaNode,
+  path: string
+): string[] {
+  if (schema.additionalProperties !== false) return [];
+
+  const declared = new Set(Object.keys(schema.properties ?? {}));
+  const problems: string[] = [];
+
+  for (const [key, child] of Object.entries(value)) {
+    if (!declared.has(key)) {
+      problems.push(`${path}.${key}`);
+      continue;
+    }
+
+    const childSchema = schema.properties?.[key];
+    if (
+      childSchema &&
+      child !== null &&
+      typeof child === "object" &&
+      !Array.isArray(child)
+    ) {
+      problems.push(
+        ...undeclaredKeys(
+          child as Record<string, unknown>,
+          childSchema,
+          `${path}.${key}`
+        )
+      );
+    }
+  }
+
+  return problems;
+}
+
+describe("data-exchange descriptor contract parity", () => {
+  const descriptors = collectExchangeDescriptors(listModules());
+
+  test("the registry actually has descriptors to check -- an empty list would make every assertion below vacuous", () => {
+    expect(descriptors.length).toBeGreaterThan(0);
+  });
+
+  test("no registered descriptor carries a property the published DataExchangeDescriptor schema does not declare", () => {
+    const schema = loadSchema("DataExchangeDescriptor");
+    const problems = descriptors.flatMap((descriptor) =>
+      undeclaredKeys(
+        descriptor as unknown as Record<string, unknown>,
+        schema,
+        descriptor.key
+      )
+    );
+
+    expect(problems).toEqual([]);
+  });
+
+  test("naturalKeyField specifically is declared -- the exact key that drifted (Issue #820)", () => {
+    const schema = loadSchema("DataExchangeDescriptor");
+    const sensitiveFields = schema.properties?.sensitiveFields;
+
+    expect(sensitiveFields).toBeDefined();
+    expect(Object.keys(sensitiveFields!.properties ?? {})).toContain(
+      "naturalKeyField"
+    );
+  });
+
+  test("the parity check is load-bearing: an undeclared property IS reported", () => {
+    const schema = loadSchema("DataExchangeDescriptor");
+    const problems = undeclaredKeys(
+      { key: "x", somethingUndeclared: 1 },
+      schema,
+      "synthetic"
+    );
+
+    // Without this, a closed-schema check that silently passed everything
+    // would look identical to a clean run.
+    expect(problems).toEqual(["synthetic.somethingUndeclared"]);
+  });
+});

--- a/tests/unit/data-exchange-descriptor-permission-ssr.test.ts
+++ b/tests/unit/data-exchange-descriptor-permission-ssr.test.ts
@@ -1,6 +1,6 @@
 /**
  * PR #839 security review, HIGH 1 — the SSR side of the descriptor
- * `requiredPermission` gate.
+ * `requiredPermission` / `rawValuePermission` gates.
  *
  * `src/pages/admin/data-exchange/imports/[id].astro` does not go through the
  * preview route; it queries and projects staged rows itself. It replicated
@@ -9,47 +9,134 @@
  * six API routes and by nothing in the UI. This pins the decision function
  * the page now shares with those routes.
  *
+ * The module-enabled axis (the review's SECOND parity finding) is pinned
+ * against a REAL tenant + a real `awcms_mini_tenant_modules` row in
+ * `tests/integration/data-exchange.integration.test.ts` — the fake `tx` here
+ * can only prove the function asks the question, not that its answer matches
+ * what the route computes.
+ *
  * `.astro` files are outside `tsc`'s reach (see the repo's own note on this),
- * so the page's use of it is additionally exercised end-to-end in
- * `tests/integration/data-exchange.integration.test.ts` — a green typecheck
- * proves nothing about that file.
+ * so the page's use of these helpers is additionally exercised end-to-end
+ * there and by a live-server pass — a green typecheck proves nothing about
+ * that file.
  */
 import { describe, expect, test } from "bun:test";
 
 import { isDescriptorPermissionGranted } from "../../src/modules/data-exchange/application/descriptor-authorization";
 
 const BROAD = new Set(["data_exchange.imports.read"]);
+const TENANT = "00000000-0000-0000-0000-0000000000aa";
+
+/**
+ * `resolveModuleEnabled` issues one tagged-template query and reads
+ * `rows[0]?.enabled ?? true`. A tagged template is just a call, so a plain
+ * function stands in for `Bun.SQL` here; `[]` reproduces the real "no row =
+ * enabled by default" convention.
+ */
+function fakeTx(rows: { enabled: boolean }[]): Bun.SQL {
+  return (() => Promise.resolve(rows)) as unknown as Bun.SQL;
+}
+
+const ENABLED = fakeTx([{ enabled: true }]);
+const DISABLED = fakeTx([{ enabled: false }]);
+const NO_ROW = fakeTx([]);
 
 describe("isDescriptorPermissionGranted", () => {
-  test("allows when the descriptor declares no extra requirement", () => {
-    expect(isDescriptorPermissionGranted(BROAD, undefined)).toBe(true);
+  test("allows when the descriptor declares no extra requirement", async () => {
+    expect(
+      await isDescriptorPermissionGranted(ENABLED, TENANT, BROAD, undefined)
+    ).toBe(true);
   });
 
-  test("denies the generic data_exchange reader a descriptor's own permission", () => {
-    expect(isDescriptorPermissionGranted(BROAD, "hr.payroll.read")).toBe(false);
+  test("denies the generic data_exchange reader a descriptor's own permission", async () => {
+    expect(
+      await isDescriptorPermissionGranted(
+        ENABLED,
+        TENANT,
+        BROAD,
+        "hr.payroll.read"
+      )
+    ).toBe(false);
   });
 
-  test("allows the holder of the descriptor's own permission", () => {
+  test("allows the holder of the descriptor's own permission", async () => {
     const permissions = new Set([
       "data_exchange.imports.read",
       "hr.payroll.read"
     ]);
 
-    expect(isDescriptorPermissionGranted(permissions, "hr.payroll.read")).toBe(
-      true
-    );
+    expect(
+      await isDescriptorPermissionGranted(
+        ENABLED,
+        TENANT,
+        permissions,
+        "hr.payroll.read"
+      )
+    ).toBe(true);
   });
 
-  test("a broad permission set never substitutes for the declared key", () => {
+  test("a broad permission set never substitutes for the declared key", async () => {
     const permissions = new Set([
       "data_exchange.imports.read",
       "data_exchange.imports.manage",
       "data_exchange.preview_errors.read"
     ]);
 
-    expect(isDescriptorPermissionGranted(permissions, "hr.payroll.read")).toBe(
-      false
-    );
+    expect(
+      await isDescriptorPermissionGranted(
+        ENABLED,
+        TENANT,
+        permissions,
+        "hr.payroll.read"
+      )
+    ).toBe(false);
+  });
+
+  /**
+   * The review's second parity finding. `fetchGrantedPermissionKeys` does not
+   * filter disabled modules, so the subject genuinely still HOLDS
+   * `hr.payroll.read` here — `permissions.has()` alone said yes while the
+   * route said `403 MODULE_DISABLED`.
+   */
+  test("denies a held permission whose module the tenant has disabled", async () => {
+    const permissions = new Set([
+      "data_exchange.imports.read",
+      "hr.payroll.read"
+    ]);
+
+    expect(permissions.has("hr.payroll.read")).toBe(true);
+    expect(
+      await isDescriptorPermissionGranted(
+        DISABLED,
+        TENANT,
+        permissions,
+        "hr.payroll.read"
+      )
+    ).toBe(false);
+  });
+
+  test("no tenant_modules row means enabled, matching resolveModuleEnabled's default", async () => {
+    const permissions = new Set(["hr.payroll.read"]);
+
+    expect(
+      await isDescriptorPermissionGranted(
+        NO_ROW,
+        TENANT,
+        permissions,
+        "hr.payroll.read"
+      )
+    ).toBe(true);
+  });
+
+  test("checks module state BEFORE RBAC, as authorizeInTransaction orders it", async () => {
+    expect(
+      await isDescriptorPermissionGranted(
+        DISABLED,
+        TENANT,
+        new Set(),
+        "hr.payroll.read"
+      )
+    ).toBe(false);
   });
 
   /**
@@ -67,19 +154,31 @@ describe("isDescriptorPermissionGranted", () => {
     ["hr..read", "empty middle segment"],
     [".payroll.read", "empty leading segment"],
     ["hr.payroll.", "empty trailing segment"]
-  ])("denies a malformed key (%s — %s)", (key) => {
-    expect(isDescriptorPermissionGranted(BROAD, key)).toBe(false);
-  });
-
-  test("a malformed key is denied even to a caller literally holding that string", () => {
+  ])("denies a malformed key (%s — %s)", async (key) => {
     expect(
-      isDescriptorPermissionGranted(new Set(["hr.payroll"]), "hr.payroll")
+      await isDescriptorPermissionGranted(ENABLED, TENANT, BROAD, key)
     ).toBe(false);
   });
 
-  test("denies everything to a caller with no permissions at all", () => {
-    expect(isDescriptorPermissionGranted(new Set(), "hr.payroll.read")).toBe(
-      false
-    );
+  test("a malformed key is denied even to a caller literally holding that string", async () => {
+    expect(
+      await isDescriptorPermissionGranted(
+        ENABLED,
+        TENANT,
+        new Set(["hr.payroll"]),
+        "hr.payroll"
+      )
+    ).toBe(false);
+  });
+
+  test("denies everything to a caller with no permissions at all", async () => {
+    expect(
+      await isDescriptorPermissionGranted(
+        ENABLED,
+        TENANT,
+        new Set(),
+        "hr.payroll.read"
+      )
+    ).toBe(false);
   });
 });

--- a/tests/unit/data-exchange-descriptor-permission-ssr.test.ts
+++ b/tests/unit/data-exchange-descriptor-permission-ssr.test.ts
@@ -1,0 +1,85 @@
+/**
+ * PR #839 security review, HIGH 1 — the SSR side of the descriptor
+ * `requiredPermission` gate.
+ *
+ * `src/pages/admin/data-exchange/imports/[id].astro` does not go through the
+ * preview route; it queries and projects staged rows itself. It replicated
+ * the raw-value decision but never made the `requiredPermission` one, so a
+ * descriptor owned by another module (`hr.payroll.read`) was enforced by all
+ * six API routes and by nothing in the UI. This pins the decision function
+ * the page now shares with those routes.
+ *
+ * `.astro` files are outside `tsc`'s reach (see the repo's own note on this),
+ * so the page's use of it is additionally exercised end-to-end in
+ * `tests/integration/data-exchange.integration.test.ts` — a green typecheck
+ * proves nothing about that file.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { isDescriptorPermissionGranted } from "../../src/modules/data-exchange/application/descriptor-authorization";
+
+const BROAD = new Set(["data_exchange.imports.read"]);
+
+describe("isDescriptorPermissionGranted", () => {
+  test("allows when the descriptor declares no extra requirement", () => {
+    expect(isDescriptorPermissionGranted(BROAD, undefined)).toBe(true);
+  });
+
+  test("denies the generic data_exchange reader a descriptor's own permission", () => {
+    expect(isDescriptorPermissionGranted(BROAD, "hr.payroll.read")).toBe(false);
+  });
+
+  test("allows the holder of the descriptor's own permission", () => {
+    const permissions = new Set([
+      "data_exchange.imports.read",
+      "hr.payroll.read"
+    ]);
+
+    expect(isDescriptorPermissionGranted(permissions, "hr.payroll.read")).toBe(
+      true
+    );
+  });
+
+  test("a broad permission set never substitutes for the declared key", () => {
+    const permissions = new Set([
+      "data_exchange.imports.read",
+      "data_exchange.imports.manage",
+      "data_exchange.preview_errors.read"
+    ]);
+
+    expect(isDescriptorPermissionGranted(permissions, "hr.payroll.read")).toBe(
+      false
+    );
+  });
+
+  /**
+   * Fails CLOSED, exactly as `authorizeDescriptorPermissionKey` does on the
+   * route path (it answers 500 there rather than skipping the check). A
+   * declaration the base cannot parse is never downgraded to "no
+   * requirement" — the empty-segment cases matter because `"a..b".split(".")`
+   * still has length 3.
+   */
+  test.each([
+    ["hr.payroll", "too few segments"],
+    ["hr.payroll.read.extra", "too many segments"],
+    ["", "empty"],
+    ["..", "all segments empty"],
+    ["hr..read", "empty middle segment"],
+    [".payroll.read", "empty leading segment"],
+    ["hr.payroll.", "empty trailing segment"]
+  ])("denies a malformed key (%s — %s)", (key) => {
+    expect(isDescriptorPermissionGranted(BROAD, key)).toBe(false);
+  });
+
+  test("a malformed key is denied even to a caller literally holding that string", () => {
+    expect(
+      isDescriptorPermissionGranted(new Set(["hr.payroll"]), "hr.payroll")
+    ).toBe(false);
+  });
+
+  test("denies everything to a caller with no permissions at all", () => {
+    expect(isDescriptorPermissionGranted(new Set(), "hr.payroll.read")).toBe(
+      false
+    );
+  });
+});

--- a/tests/unit/data-exchange-registry.test.ts
+++ b/tests/unit/data-exchange-registry.test.ts
@@ -26,6 +26,7 @@ function baseDescriptor(
     schemaVersion: "1.0",
     limits: { maxFileBytes: 1024, maxRowCount: 100, maxFieldsPerRow: 10 },
     adapterRegistryKey: "reference_items",
+    sensitiveFields: { fieldNames: [] },
     description: "test descriptor",
     ...overrides
   };
@@ -103,6 +104,36 @@ describe("validateExchangeRegistry — synthetic invalid descriptors", () => {
 
   test("rejects a missing adapterRegistryKey", () => {
     const descriptor = baseDescriptor({ adapterRegistryKey: "" });
+    const result = validateExchangeRegistry([fakeModule(descriptor)]);
+    expect(result.valid).toBe(false);
+  });
+
+  // Issue #820 Cacat 1: `sensitiveFields` used to be optional, and omitting
+  // it made the preview route return every staged value raw with no
+  // raw-value check at all — forgetting to declare it OPENED the data.
+  test("rejects a descriptor that omits sensitiveFields entirely", () => {
+    const descriptor = baseDescriptor();
+    delete (descriptor as { sensitiveFields?: unknown }).sensitiveFields;
+    const result = validateExchangeRegistry([fakeModule(descriptor)]);
+    expect(result.valid).toBe(false);
+    expect(
+      result.issues.some((i) =>
+        i.message.includes("sensitiveFields is required")
+      )
+    ).toBe(true);
+  });
+
+  test("accepts an explicit empty sensitiveFields.fieldNames (affirmatively non-sensitive)", () => {
+    const result = validateExchangeRegistry([
+      fakeModule(baseDescriptor({ sensitiveFields: { fieldNames: [] } }))
+    ]);
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects an empty sensitiveFields.naturalKeyField", () => {
+    const descriptor = baseDescriptor({
+      sensitiveFields: { fieldNames: [], naturalKeyField: "" }
+    });
     const result = validateExchangeRegistry([fakeModule(descriptor)]);
     expect(result.valid).toBe(false);
   });

--- a/tests/unit/data-exchange-staged-row-masking.test.ts
+++ b/tests/unit/data-exchange-staged-row-masking.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Staged-row preview masking (Issue #820, Cacat 1 and Cacat 4).
+ *
+ * These cover the projection helpers in isolation. The decision of WHICH
+ * projection a request gets — the part that was actually broken — is
+ * covered against the real route in
+ * `tests/integration/data-exchange.integration.test.ts`, since a correct
+ * helper that the route never reaches for is precisely the defect class
+ * this issue is about.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  maskAllFields,
+  maskSensitiveFields,
+  PREVIEW_OFFSET_MAX,
+  type StagedRowRow
+} from "../../src/modules/data-exchange/application/staged-row-directory";
+import { MAX_EXCHANGE_ROW_COUNT } from "../../src/modules/data-exchange/domain/exchange-registry";
+
+function row(overrides: Partial<StagedRowRow> = {}): StagedRowRow {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    importBatchId: "00000000-0000-0000-0000-000000000002",
+    rowNumber: 1,
+    fields: { email: "person@example.com", nik: "3201000000000001", note: "x" },
+    naturalKey: "person@example.com",
+    proposedAction: "create",
+    validationErrors: null,
+    validationWarnings: null,
+    commitStatus: "pending",
+    commitResourceId: null,
+    commitError: null,
+    committedAt: null,
+    ...overrides
+  };
+}
+
+describe("maskSensitiveFields", () => {
+  test("masks only the declared fields", () => {
+    const masked = maskSensitiveFields(row(), { fieldNames: ["email", "nik"] });
+    expect(masked.fields.email).toBe("[REDACTED]");
+    expect(masked.fields.nik).toBe("[REDACTED]");
+    expect(masked.fields.note).toBe("x");
+  });
+
+  test("masks naturalKey when naturalKeyField is itself sensitive (Cacat 4)", () => {
+    const masked = maskSensitiveFields(row(), {
+      fieldNames: ["email"],
+      naturalKeyField: "email"
+    });
+    // Masking `fields.email` while echoing the same value back as
+    // naturalKey would have masked nothing at all — a profile import's
+    // dedup key IS the identifier.
+    expect(masked.naturalKey).toBe("[REDACTED]");
+  });
+
+  test("leaves naturalKey alone when its source field is not sensitive", () => {
+    const masked = maskSensitiveFields(row({ naturalKey: "widget-a" }), {
+      fieldNames: ["email"],
+      naturalKeyField: "code"
+    });
+    expect(masked.naturalKey).toBe("widget-a");
+    expect(masked.fields.email).toBe("[REDACTED]");
+  });
+
+  test("leaves naturalKey alone when no naturalKeyField is declared", () => {
+    const masked = maskSensitiveFields(row(), { fieldNames: ["email"] });
+    expect(masked.naturalKey).toBe("person@example.com");
+  });
+
+  test("a null naturalKey stays null rather than becoming a redaction marker", () => {
+    const masked = maskSensitiveFields(row({ naturalKey: null }), {
+      fieldNames: ["email"],
+      naturalKeyField: "email"
+    });
+    expect(masked.naturalKey).toBeNull();
+  });
+
+  test("an empty fieldNames policy is a pass-through", () => {
+    const original = row();
+    expect(maskSensitiveFields(original, { fieldNames: [] })).toBe(original);
+  });
+
+  test("does not mutate the input row", () => {
+    const original = row();
+    maskSensitiveFields(original, {
+      fieldNames: ["email"],
+      naturalKeyField: "email"
+    });
+    expect(original.fields.email).toBe("person@example.com");
+    expect(original.naturalKey).toBe("person@example.com");
+  });
+});
+
+describe("maskAllFields (default-deny projection, Cacat 1)", () => {
+  test("redacts every field value and the naturalKey", () => {
+    const masked = maskAllFields(row());
+    expect(Object.values(masked.fields)).toEqual([
+      "[REDACTED]",
+      "[REDACTED]",
+      "[REDACTED]"
+    ]);
+    expect(masked.naturalKey).toBe("[REDACTED]");
+  });
+
+  test("keeps field NAMES and non-content metadata so the preview stays navigable", () => {
+    const masked = maskAllFields(row());
+    expect(Object.keys(masked.fields)).toEqual(["email", "nik", "note"]);
+    expect(masked.rowNumber).toBe(1);
+    expect(masked.proposedAction).toBe("create");
+    expect(masked.commitStatus).toBe("pending");
+  });
+
+  test("keeps validationErrors (field name + message) but drops free-text warnings", () => {
+    const masked = maskAllFields(
+      row({
+        validationErrors: [{ field: "nik", message: "must be 16 digits" }],
+        // A warning is free text an adapter may have interpolated a raw
+        // value into — it cannot be masked field-wise, so it is dropped.
+        validationWarnings: ["value 3201000000000001 looks suspicious"]
+      })
+    );
+    expect(masked.validationErrors).toEqual([
+      { field: "nik", message: "must be 16 digits" }
+    ]);
+    expect(masked.validationWarnings).toEqual([]);
+  });
+
+  test("a null naturalKey stays null", () => {
+    expect(maskAllFields(row({ naturalKey: null })).naturalKey).toBeNull();
+  });
+
+  test("does not mutate the input row", () => {
+    const original = row();
+    maskAllFields(original);
+    expect(original.fields.email).toBe("person@example.com");
+    expect(original.naturalKey).toBe("person@example.com");
+  });
+});
+
+describe("PREVIEW_OFFSET_MAX (Issue #831)", () => {
+  test("equals the registry's hard cap on rows per batch, so it hides no reachable row", () => {
+    expect(PREVIEW_OFFSET_MAX).toBe(MAX_EXCHANGE_ROW_COUNT);
+  });
+});

--- a/tests/unit/data-exchange-staged-row-masking.test.ts
+++ b/tests/unit/data-exchange-staged-row-masking.test.ts
@@ -91,6 +91,55 @@ describe("maskSensitiveFields", () => {
     expect(original.fields.email).toBe("person@example.com");
     expect(original.naturalKey).toBe("person@example.com");
   });
+
+  /**
+   * PR #839 security review: masking `fields.email` while handing the same
+   * address back through an adapter-authored warning masks nothing at all —
+   * the identical failure `maskAllFields` already guards against, in the
+   * neighbouring channel. Free text an adapter may have interpolated a raw
+   * value into must not survive on EITHER path.
+   */
+  test("drops free-text validationWarnings that may quote a masked value", () => {
+    const masked = maskSensitiveFields(
+      row({
+        validationWarnings: ["email person@example.com is already registered"]
+      }),
+      { fieldNames: ["email"], naturalKeyField: "email" }
+    );
+
+    expect(masked.validationWarnings).toEqual([]);
+    expect(JSON.stringify(masked)).not.toContain("person@example.com");
+  });
+
+  test("redacts commitError, the adapter's own free-text reason", () => {
+    const masked = maskSensitiveFields(
+      row({
+        commitStatus: "failed",
+        commitError: "duplicate key: person@example.com"
+      }),
+      { fieldNames: ["email"], naturalKeyField: "email" }
+    );
+
+    expect(masked.commitError).toBe("[REDACTED]");
+    expect(JSON.stringify(masked)).not.toContain("person@example.com");
+  });
+
+  test("keeps the FACT of a failure — commitStatus survives, only the reason goes", () => {
+    const masked = maskSensitiveFields(
+      row({ commitStatus: "failed", commitError: "boom person@example.com" }),
+      { fieldNames: ["email"] }
+    );
+
+    expect(masked.commitStatus).toBe("failed");
+    expect(masked.commitError).toBe("[REDACTED]");
+  });
+
+  test("a null commitError / null warnings stay null rather than becoming markers", () => {
+    const masked = maskSensitiveFields(row(), { fieldNames: ["email"] });
+
+    expect(masked.commitError).toBeNull();
+    expect(masked.validationWarnings).toBeNull();
+  });
 });
 
 describe("maskAllFields (default-deny projection, Cacat 1)", () => {
@@ -127,8 +176,32 @@ describe("maskAllFields (default-deny projection, Cacat 1)", () => {
     expect(masked.validationWarnings).toEqual([]);
   });
 
+  /**
+   * PR #839 security review: `commitError` is the adapter's own
+   * `outcome.reason` — free text on the same footing as a warning — and was
+   * passed through verbatim even on this default-deny path, where by
+   * definition the base does not know which of the descriptor's fields are
+   * safe.
+   */
+  test("redacts commitError, keeping only the fact of the failure", () => {
+    const masked = maskAllFields(
+      row({
+        commitStatus: "failed",
+        commitError: "conflict on person@example.com"
+      })
+    );
+
+    expect(masked.commitStatus).toBe("failed");
+    expect(masked.commitError).toBe("[REDACTED]");
+    expect(JSON.stringify(masked)).not.toContain("person@example.com");
+  });
+
   test("a null naturalKey stays null", () => {
     expect(maskAllFields(row({ naturalKey: null })).naturalKey).toBeNull();
+  });
+
+  test("a null commitError stays null rather than becoming a marker", () => {
+    expect(maskAllFields(row()).commitError).toBeNull();
   });
 
   test("does not mutate the input row", () => {

--- a/tests/unit/offset-pagination.test.ts
+++ b/tests/unit/offset-pagination.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_PAGE_NUMBER,
+  boundedPageNumber,
+  boundedPageSize,
+  parsePageParam
+} from "../../src/modules/_shared/offset-pagination";
+
+describe("boundedPageNumber (Issue #819)", () => {
+  test("passes through an ordinary in-range page", () => {
+    expect(boundedPageNumber(1)).toBe(1);
+    expect(boundedPageNumber(7)).toBe(7);
+  });
+
+  test("defaults to page 1 when absent", () => {
+    expect(boundedPageNumber(undefined)).toBe(1);
+  });
+
+  test("clamps a deep offset to MAX_PAGE_NUMBER (?page=1e8 → OFFSET 1e9 DoS)", () => {
+    expect(boundedPageNumber(1e8)).toBe(MAX_PAGE_NUMBER);
+    expect(MAX_PAGE_NUMBER).toBe(10_000);
+  });
+
+  test("returns 1 for NaN rather than propagating it into OFFSET (?page=abc → 500)", () => {
+    expect(boundedPageNumber(Number("abc"))).toBe(1);
+    expect(boundedPageNumber(Number.NaN)).toBe(1);
+  });
+
+  test("returns 1 for ±Infinity", () => {
+    expect(boundedPageNumber(Number.POSITIVE_INFINITY)).toBe(1);
+    expect(boundedPageNumber(Number.NEGATIVE_INFINITY)).toBe(1);
+  });
+
+  test("clamps a negative page up to 1", () => {
+    expect(boundedPageNumber(-1)).toBe(1);
+    expect(boundedPageNumber(0)).toBe(1);
+  });
+
+  test("truncates a fractional page (OFFSET 1.5 is a Postgres error)", () => {
+    expect(boundedPageNumber(1.5)).toBe(1);
+    expect(boundedPageNumber(3.9)).toBe(3);
+    expect(boundedPageNumber(0.5)).toBe(1);
+  });
+
+  test("honours a caller-supplied maxPage", () => {
+    expect(boundedPageNumber(500, 100)).toBe(100);
+  });
+
+  test("every clamped page yields a finite, non-negative, integral OFFSET", () => {
+    const pageSize = 10;
+    for (const raw of [
+      1e8,
+      Number.NaN,
+      -1,
+      1.5,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      undefined
+    ]) {
+      const offset = (boundedPageNumber(raw) - 1) * pageSize;
+      expect(Number.isSafeInteger(offset)).toBe(true);
+      expect(offset).toBeGreaterThanOrEqual(0);
+      expect(offset).toBeLessThanOrEqual((MAX_PAGE_NUMBER - 1) * pageSize);
+    }
+  });
+});
+
+describe("boundedPageSize (Issue #819)", () => {
+  test("passes through an in-range size", () => {
+    expect(boundedPageSize(25, 10, 50)).toBe(25);
+  });
+
+  test("falls back to the default when absent or NaN", () => {
+    expect(boundedPageSize(undefined, 10, 50)).toBe(10);
+    expect(boundedPageSize(Number.NaN, 10, 50)).toBe(10);
+    expect(boundedPageSize(Number.POSITIVE_INFINITY, 10, 50)).toBe(10);
+  });
+
+  test("clamps both ends and truncates fractions", () => {
+    expect(boundedPageSize(1e8, 10, 50)).toBe(50);
+    expect(boundedPageSize(0, 10, 50)).toBe(1);
+    expect(boundedPageSize(-5, 10, 50)).toBe(1);
+    expect(boundedPageSize(12.7, 10, 50)).toBe(12);
+  });
+});
+
+describe("parsePageParam (Issue #819)", () => {
+  test("defaults to 1 for a missing or blank ?page=", () => {
+    expect(parsePageParam(null)).toBe(1);
+    expect(parsePageParam(undefined)).toBe(1);
+    expect(parsePageParam("")).toBe(1);
+    expect(parsePageParam("   ")).toBe(1);
+  });
+
+  test("parses a normal ?page=", () => {
+    expect(parsePageParam("3")).toBe(3);
+  });
+
+  test("normalises the hostile inputs from the issue", () => {
+    expect(parsePageParam("1e8")).toBe(MAX_PAGE_NUMBER);
+    expect(parsePageParam("abc")).toBe(1);
+    expect(parsePageParam("-1")).toBe(1);
+    expect(parsePageParam("1.5")).toBe(1);
+    expect(parsePageParam("Infinity")).toBe(1);
+  });
+
+  test("never returns a value that would render as NaN in pagination nav links", () => {
+    for (const raw of ["abc", "1e8", "-1", "1.5", "Infinity", "", null]) {
+      const page = parsePageParam(raw);
+      expect(Number.isInteger(page)).toBe(true);
+      expect(String(page)).not.toContain("NaN");
+    }
+  });
+});

--- a/tests/unit/reference-data-code-patch.test.ts
+++ b/tests/unit/reference-data-code-patch.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for the reference-data PATCH body parser (Issue #822).
+ *
+ * The parser had NO unit tests: its semantics were only ever exercised through
+ * the integration suite, which meant the pure decision table below — absent vs
+ * explicit null vs value, per field — was never pinned directly.
+ *
+ * Both PATCH schemas are `additionalProperties: false`, but the parser read the
+ * keys it knew and ignored the rest, so a client typo (`validUntil` for
+ * `validTo`) parsed as an EMPTY patch. Together with the routes' empty-patch
+ * no-op branch that answered 200 while changing nothing: the request looked
+ * accepted while doing nothing at all. (Review finding, PR #839.)
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  mergeReferenceCodePatchInput,
+  parseReferenceCodePatchInput
+} from "../../src/modules/reference-data/domain/code-patch";
+import type { ReferenceCodeMutableFields } from "../../src/modules/reference-data/domain/code-patch";
+
+const STORED: ReferenceCodeMutableFields = {
+  labels: [{ locale: "en", label: "Stored", description: null }],
+  sortOrder: 7,
+  metadata: { keep: true },
+  validFrom: new Date("2026-01-01T00:00:00.000Z"),
+  validTo: new Date("2026-12-31T00:00:00.000Z")
+};
+
+describe("parseReferenceCodePatchInput — unknown fields", () => {
+  test("rejects an unknown field rather than parsing it as an empty patch", () => {
+    const result = parseReferenceCodePatchInput({ validUntil: "2026-06-01" });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.map((e) => e.field)).toEqual(["validUntil"]);
+  });
+
+  test("rejects an unknown field even when a KNOWN field is also present -- a valid field must not launder an invalid one", () => {
+    const result = parseReferenceCodePatchInput({
+      sortOrder: 3,
+      validUntil: "2026-06-01"
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.map((e) => e.field)).toContain("validUntil");
+  });
+
+  test("reports EVERY unknown field, not just the first", () => {
+    const result = parseReferenceCodePatchInput({
+      typoOne: 1,
+      typoTwo: 2
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.map((e) => e.field).sort()).toEqual([
+      "typoOne",
+      "typoTwo"
+    ]);
+  });
+
+  test("`{}` stays valid -- the documented no-op must not be collateral damage of the unknown-field check", () => {
+    const result = parseReferenceCodePatchInput({});
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(Object.keys(result.patch)).toEqual([]);
+  });
+
+  test.each([
+    ["labels", { labels: [{ locale: "en", label: "New" }] }],
+    ["sortOrder", { sortOrder: 3 }],
+    ["metadata", { metadata: { a: 1 } }],
+    ["validFrom", { validFrom: "2026-02-01T00:00:00.000Z" }],
+    ["validTo", { validTo: null }]
+  ])(
+    "every field the parser documents is accepted, so the known-field set cannot drift from the parser (%s)",
+    (_label, body) => {
+      const result = parseReferenceCodePatchInput(body);
+      expect(result.ok).toBe(true);
+    }
+  );
+});
+
+describe("parseReferenceCodePatchInput — absent vs null vs value", () => {
+  test("an absent field is absent from the patch, so the merge keeps the stored value", () => {
+    const result = parseReferenceCodePatchInput({ sortOrder: 3 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.patch.validTo).toBeUndefined();
+    const merged = mergeReferenceCodePatchInput(STORED, result.patch);
+    expect(merged.validTo).toBe(STORED.validTo);
+    expect(merged.sortOrder).toBe(3);
+    expect(merged.labels).toBe(STORED.labels);
+  });
+
+  test.each([
+    ["sortOrder", "sortOrder", 0],
+    ["metadata", "metadata", {}],
+    ["validTo", "validTo", null]
+  ])(
+    "an explicit null CLEARS %s rather than being conflated with absent",
+    (_label, field, cleared) => {
+      const result = parseReferenceCodePatchInput({ [field]: null });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const merged = mergeReferenceCodePatchInput(
+        STORED,
+        result.patch
+      ) as Record<string, unknown>;
+      expect(merged[field]).toEqual(cleared);
+    }
+  );
+
+  test.each([["labels"], ["validFrom"]])(
+    "an explicit null on %s is REJECTED -- the column is never nullable, so silently defaulting it would be data loss",
+    (field) => {
+      const result = parseReferenceCodePatchInput({ [field]: null });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.errors.map((e) => e.field)).toContain(field);
+    }
+  );
+});

--- a/tests/unit/request-body-limit.test.ts
+++ b/tests/unit/request-body-limit.test.ts
@@ -5,8 +5,10 @@ import {
   BODY_SIZE_TIER_BYTES,
   bodyTooLargeResponse,
   checkContentLengthCeiling,
+  invalidJsonObjectBodyResponse,
   readFormBody,
   readJsonBody,
+  readJsonObjectBody,
   readTextBody
 } from "../../src/lib/security/request-body-limit";
 
@@ -239,5 +241,99 @@ describe("tier configuration invariant", () => {
     for (const bytes of Object.values(BODY_SIZE_TIER_BYTES)) {
       expect(bytes).toBeLessThanOrEqual(BODY_SIZE_HARD_CEILING_BYTES);
     }
+  });
+});
+
+/**
+ * `readJsonObjectBody` exists because `readJsonBody` cannot distinguish the
+ * cases below — every one of them arrives as `value: null`, which handlers
+ * then squash into a valid empty request with `?? {}`. These tests assert the
+ * distinction itself, not merely that "invalid input is rejected".
+ */
+describe("readJsonObjectBody", () => {
+  test("an empty body is `absent`, NOT an empty object", async () => {
+    const result = await readJsonObjectBody(jsonRequest(""));
+    expect(result).toEqual({ tooLarge: false, ok: false, reason: "absent" });
+  });
+
+  test("a whitespace-only body is `absent` too", async () => {
+    const result = await readJsonObjectBody(jsonRequest("  \n\t "));
+    expect(result).toEqual({ tooLarge: false, ok: false, reason: "absent" });
+  });
+
+  test("malformed JSON is `malformed`, NOT an empty object", async () => {
+    const result = await readJsonObjectBody(jsonRequest("{ not json"));
+    expect(result).toEqual({ tooLarge: false, ok: false, reason: "malformed" });
+  });
+
+  test("a literal JSON null is `not_object` (typeof null === 'object')", async () => {
+    const result = await readJsonObjectBody(jsonRequest("null"));
+    expect(result).toEqual({
+      tooLarge: false,
+      ok: false,
+      reason: "not_object"
+    });
+  });
+
+  test("a JSON array is `not_object` — it must never reach a field-by-field patch parser, which would read no known keys off it and report a clean empty patch", async () => {
+    const result = await readJsonObjectBody(jsonRequest("[1,2,3]"));
+    expect(result).toEqual({
+      tooLarge: false,
+      ok: false,
+      reason: "not_object"
+    });
+  });
+
+  test.each(["5", '"text"', "true"])(
+    "the JSON scalar %s is `not_object`",
+    async (scalar) => {
+      const result = await readJsonObjectBody(jsonRequest(scalar));
+      expect(result).toEqual({
+        tooLarge: false,
+        ok: false,
+        reason: "not_object"
+      });
+    }
+  );
+
+  test("`{}` IS a real body — an empty object is a valid request, distinct from no body at all", async () => {
+    const result = await readJsonObjectBody(jsonRequest("{}"));
+    expect(result).toEqual({ tooLarge: false, ok: true, value: {} });
+  });
+
+  test("a populated object round-trips verbatim", async () => {
+    const result = await readJsonObjectBody(
+      jsonRequest('{"sortOrder":3,"metadata":{"a":1}}')
+    );
+    expect(result).toEqual({
+      tooLarge: false,
+      ok: true,
+      value: { sortOrder: 3, metadata: { a: 1 } }
+    });
+  });
+
+  test("an oversized body still short-circuits to tooLarge before any parsing", async () => {
+    const oversized = JSON.stringify({
+      pad: "x".repeat(BODY_SIZE_TIER_BYTES.default + 1)
+    });
+    const result = await readJsonObjectBody(jsonRequest(oversized));
+    expect(result.tooLarge).toBe(true);
+  });
+
+  test("every rejection reason maps to a 400 with its own message", async () => {
+    const reasons = ["absent", "malformed", "not_object"] as const;
+    const messages = new Set<string>();
+
+    for (const reason of reasons) {
+      const response = invalidJsonObjectBodyResponse(reason);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as {
+        error: { code: string; message: string };
+      };
+      expect(body.error.code).toBe("VALIDATION_ERROR");
+      messages.add(body.error.message);
+    }
+
+    expect(messages.size).toBe(reasons.length);
   });
 });

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   checkAppEnvValue,
+  checkAuthJwtSecretNotDefault,
   checkEmailConfig,
   checkGoogleOidcConfig,
   checkNewsMediaR2AllowedMimeTypesKnown,
@@ -52,6 +53,55 @@ describe("checkRequiredVars", () => {
     const failed = results.find((result) => result.name === "APP_ENV");
 
     expect(failed?.status).toBe("fail");
+  });
+});
+
+/**
+ * PR #839 security review, HIGH 2. `AUTH_JWT_SECRET` keys the audit-log
+ * `ipHash` HMAC (`src/lib/security/client-fingerprint.ts`), so the
+ * placeholder `.env.example` ships is a published HMAC key — every `ipHash`
+ * written under it is reversible. `checkRequiredVars` only proves non-empty,
+ * and the placeholder is non-empty, so it sailed straight through: this is
+ * the `checkSyncHmacSecretNotDefault` gate applied to the one other secret
+ * whose default `.env.example` carries.
+ */
+describe("checkAuthJwtSecretNotDefault", () => {
+  const PLACEHOLDER = "change-me-in-production";
+
+  test("fails on the exact placeholder .env.example ships", () => {
+    const result = checkAuthJwtSecretNotDefault({
+      ...VALID_ENV,
+      AUTH_JWT_SECRET: PLACEHOLDER
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("fail");
+  });
+
+  test("the placeholder it rejects is the one .env.example actually ships", async () => {
+    const envExample = await Bun.file(".env.example").text();
+
+    expect(envExample).toContain(`AUTH_JWT_SECRET=${PLACEHOLDER}`);
+  });
+
+  test("passes for a real secret", () => {
+    const result = checkAuthJwtSecretNotDefault(VALID_ENV);
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("defers the unset case to checkRequiredVars rather than double-failing", () => {
+    const result = checkAuthJwtSecretNotDefault({
+      ...VALID_ENV,
+      AUTH_JWT_SECRET: undefined
+    } as NodeJS.ProcessEnv);
+
+    expect(result.status).toBe("pass");
+  });
+
+  test("does not echo a real secret into its own detail text", () => {
+    const result = checkAuthJwtSecretNotDefault(VALID_ENV);
+
+    expect(result.detail).not.toContain(VALID_ENV.AUTH_JWT_SECRET as string);
   });
 });
 
@@ -873,6 +923,37 @@ describe("runEnvValidation", () => {
 
     const results = runEnvValidation(env);
     expect(results.every((result) => result.status === "pass")).toBe(true);
+  });
+
+  /**
+   * The boot gate itself, not just the check in isolation — PR #839: a
+   * deployment must not start with the audit ipHash HMAC keyed by a value
+   * published in this repo.
+   */
+  test("fails end-to-end when AUTH_JWT_SECRET is left at the placeholder", () => {
+    const env = {
+      ...VALID_ENV,
+      AUTH_JWT_SECRET: "change-me-in-production",
+      AWCMS_MINI_SYNC_ENABLED: "false",
+      R2_ENABLED: "false",
+      EMAIL_ENABLED: "false"
+    } as NodeJS.ProcessEnv;
+
+    const results = runEnvValidation(env);
+    expect(results.some((result) => result.status === "fail")).toBe(true);
+  });
+
+  test("fails end-to-end when AUTH_JWT_SECRET is unset", () => {
+    const env = {
+      ...VALID_ENV,
+      AUTH_JWT_SECRET: undefined,
+      AWCMS_MINI_SYNC_ENABLED: "false",
+      R2_ENABLED: "false",
+      EMAIL_ENABLED: "false"
+    } as NodeJS.ProcessEnv;
+
+    const results = runEnvValidation(env);
+    expect(results.some((result) => result.status === "fail")).toBe(true);
   });
 
   test("fails end-to-end when TENANT_DOMAIN_DNS_PROVIDER=cloudflare is missing its required vars", () => {


### PR DESCRIPTION
Gelombang 1 dari epic #818 — dikerjakan 6 agent paralel dengan isolasi worktree, lalu diintegrasikan dan diuji bersama.

Closes #819
Closes #820
Closes #821
Closes #822
Closes #823
Closes #824
Closes #830
Closes #831

## Ringkasan per issue

| Issue | Perbaikan | Bukti |
|---|---|---|
| **#824** | Fan-out health per-modul → prefetch batch | **94 → 6 query**/render; cold **3841ms → 361ms**; test yang timeout **7278ms → 755ms** (budget 5000ms, margin 6.6×) |
| **#830** | 7 index (murni migration `077`, nol perubahan kode) | Blog admin list: Seq Scan cost **3835 → 2.9**, **19.9ms → 0.068ms**. Job scheduled: cost **1827 → 8.3** |
| **#820 + #831** | 4 cacat keamanan `data-exchange` preview + clamp offset | Default-deny, `rawValuePermission` ditegakkan, fail-open jadi **tak terepresentasikan** (parameter non-nullable), `naturalKey` di-mask |
| **#819** | Clamp `?page=` dua sisi + guard NaN | `?page=1e8` → OFFSET 1e9 **hilang**; `?page=abc` → 500 **hilang** |
| **#821** | Audit login sukses & gagal | Gate base-ready doc 01 yang gagal di kode — kini terpenuhi |
| **#822** | PATCH parsial sejati (absent=pertahankan, null=kosongkan) | 4 field berhenti direset diam-diam |
| **#823** | 5 gate `check` yang absen + **gate paritas** | Kelas drift ke-4 ditutup permanen |

## Yang agent temukan di luar issue — ini bagian pentingnya

**#820 — halaman admin `.astro` punya salinan independen keempat cacat.** `imports/[id].astro` tak melewati route API sama sekali: query staged-row, proyeksi, dan `CAN_SEE_RAW` sendiri. Memperbaiki route saja meninggalkan kebocoran identik di UI. Lebih buruk: **`tsc` tidak memeriksa `.astro` dan `build` juga lolos** — perubahan signature akan crash saat runtime dengan semua gate hijau. Membuat parameter non-nullable lalu membiarkan type checker bekerja **menemukan 2 fail-open lagi**: `commit.ts` dan `exports/[id]/download.ts` (menyajikan isi file mentah — call site paling berbahaya). Satu test lama ternyata **menegaskan** perilaku fail-open itu; ditulis ulang.

**#824 — diagnosis akar penyebab di issue (dan di audit saya) hanya menjelaskan sebagian kecil.** Penyebab dominan bukan fan-out query, melainkan **cache stampede di `readYamlCached`**: cache di-`set` *setelah* `await`, sehingga 22 modul mem-parse OpenAPI **~1 MB** yang sama **22× paralel**. Ironisnya fungsi itu justru saya kutip sebagai preseden yang benar untuk ditiru. Bukti pembedanya: dengan 94 query, render **kedua** hanya 10ms → seluruh biaya DB ≈10ms, bukan 5.6 detik. Batching tetap dipertahankan karena ia yang menghapus pertumbuhan linear terhadap jumlah modul.

**#830 — mengoreksi premis issue saya.** Klaim "`(tenant_id, status, published_at DESC)` tidak menolong job scheduled" **salah** — EXPLAIN menunjukkan index itu **sudah** dipakai sebagai Bitmap Index Scan. Cacat sebenarnya lebih sempit: index itu tak bisa menerapkan batas `scheduled_at <= now()`, sehingga beban tumbuh mengikuti **backlog terjadwal**, bukan post yang jatuh tempo. Agent juga **membuang pengukuran pertamanya** setelah sadar seed-nya tidak realistis dan dead tuple mengacaukan hasil.

**#822 — OpenAPI melegitimasi bug-nya.** Skema update memuat `sortOrder: {default: 0}` — mendokumentasikan reset yang merusak data itu sebagai perilaku yang disengaja. Memperbaiki kode saja meninggalkan kontrak yang berbohong.

## Gate #823 membuktikan dirinya di PR ini sendiri

Dua dari lima gate yang baru dipasang **langsung menangkap drift nyata** pada PR ini: `api:docs:check` (`api-reference.md` basi setelah 2 agent mengubah OpenAPI) dan `i18n:pot:check` (POT basi setelah edit `.astro`). Keduanya sebelumnya **release-only** — drift ini akan merge hijau dan baru muncul saat tag rilis.

Gate paritasnya sendiri diverifikasi menangkap drift: menyisipkan langkah palsu ke `check` → merah dengan pesan yang menyebut langkah itu; hijau lagi setelah dipulihkan.

## Verifikasi

- **`bun run check` penuh HIJAU** terhadap Postgres bersih: 21 gate, **4672 test / 0 fail**, build sukses.
- Full suite menemukan 1 kegagalan yang test bertarget tiap agent lewatkan: `tests/foundation.test.ts` memuat daftar migration hardcoded, dan `077` dari #830 memecahkannya. Diperbaiki di sini — **inilah gunanya menjalankan suite penuh setelah integrasi**.
- Tiap agent memakai **DB scratch sendiri** → nol kontensi (koneksi DB bersama tetap di 9 sepanjang gelombang).
- Konflik merge hanya di `repo-inventory.md` (generated, 3 agent meregenerasinya masing-masing) — diselesaikan dengan **regenerasi dari pohon hasil merge**, bukan memilih salah satu sisi.

## Catatan reviewer

- **#821** minta perhatian khusus (agent sendiri meminta security-auditor): keputusan `resourceId` pada login gagal (trade-off enumeration), dan skema `ipHash`. Konteks: IP mentah di audit **bertabrakan dengan redactor #687** — akan tersimpan `[REDACTED]` permanen. Rename key untuk mengakalinya = regresi keamanan, jadi dipakai HMAC-SHA256 berkunci. Unit test mengunci dua arah agar perubahan daftar redaksi tak diam-diam mengosongkan sumber tiap baris auth.
- **#820** minta diverifikasi: (a) adakah permukaan **lain** yang memproyeksikan staged row, (b) apakah `409` pada `download` menghalangi pengambilan artefak sah saat modul sengaja dipensiunkan (pilihan sadar: fail-closed).

## Belum termasuk

Branch protection `main` **sudah aktif** (separuh owner-action #823) — dikonfigurasi terpisah lewat API, bukan lewat PR ini; doc `branch-protection.md` diperbarui di sini.

Spin-off: #837 (kelas PATCH #822 di `organization-structure`), #838 (query-plan budget agar index #830 tak regresi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
