### PR TITLE
fix(organization-structure, reference-data): OpenAPI PATCH schemas all-optional (#837)

### DIFF
--- a/.changeset/openapi-patch-schemas-837.md
+++ b/.changeset/openapi-patch-schemas-837.md
@@ -1,0 +1,18 @@
+---
+"awcms-mini": patch
+---
+
+Selaraskan kontrak OpenAPI PATCH `organization_structure` dan `reference-data`
+value-sets dengan semantik partial-PATCH yang benar (Issue #837, epic #818).
+Runtime sudah diperbaiki di PR #852 (absent = pertahankan, `null` = kosongkan),
+tetapi skema OpenAPI masih "berbohong": PATCH legal-entities/locations memakai
+ulang skema Create (`required: [name]`), PATCH unit-types/units/value-sets masih
+`required: [name]` — semuanya melegitimasi reset yang justru dihapus di runtime.
+
+Perubahan: PATCH kini memakai skema Update khusus yang all-optional
+(`OrganizationStructureUpdateLegalEntityRequest`,
+`OrganizationStructureUpdateUnitTypeRequest`,
+`OrganizationStructureUpdateLocationRequest`), `OrganizationStructureUpdateUnitRequest`
+dan `ReferenceDataUpdateValueSetRequest` tak lagi `required: [name]`. Skema Create
+tetap menuntut `name` (memang wajib saat pembuatan). `name`/`effectiveFrom` tetap
+non-nullable pada PATCH karena runtime menolak `null` (NOT NULL) dengan 400.

--- a/docs/awcms-mini/api-reference.md
+++ b/docs/awcms-mini/api-reference.md
@@ -7297,7 +7297,7 @@ High-risk mutation -- requires Idempotency-Key, audited critical, rejects self-p
 | `X-Correlation-ID` | header | no       | string        | Optional server-side trace correlation ID.  |
 | `X-Request-ID`     | header | no       | string        | Optional client-generated request trace ID. |
 
-**Request body** (required): [`OrganizationStructureCreateLegalEntityRequest`](#schema-organizationstructurecreatelegalentityrequest)
+**Request body** (required): [`OrganizationStructureUpdateLegalEntityRequest`](#schema-organizationstructureupdatelegalentityrequest)
 
 **Responses**
 
@@ -7530,7 +7530,7 @@ High-risk mutation -- requires Idempotency-Key.
 | `X-Correlation-ID` | header | no       | string        | Optional server-side trace correlation ID.  |
 | `X-Request-ID`     | header | no       | string        | Optional client-generated request trace ID. |
 
-**Request body** (required): [`OrganizationStructureCreateLocationRequest`](#schema-organizationstructurecreatelocationrequest)
+**Request body** (required): [`OrganizationStructureUpdateLocationRequest`](#schema-organizationstructureupdatelocationrequest)
 
 **Responses**
 
@@ -7685,7 +7685,7 @@ High-risk mutation -- requires Idempotency-Key.
 | `X-Correlation-ID` | header | no       | string        | Optional server-side trace correlation ID.  |
 | `X-Request-ID`     | header | no       | string        | Optional client-generated request trace ID. |
 
-**Request body** (required): object
+**Request body** (required): [`OrganizationStructureUpdateUnitTypeRequest`](#schema-organizationstructureupdateunittyperequest)
 
 **Responses**
 
@@ -14838,11 +14838,69 @@ Locale code (2-letter, e.g. "en", "id") to string. Must include an "en" entry.
 }
 ```
 
+### Schema: OrganizationStructureUpdateLegalEntityRequest
+
+Issue #837 -- true partial-PATCH body. Every property is optional: an ABSENT property keeps its stored value. A nullable property sent as explicit null CLEARS it (registrationIdentifier[Label] -> null, effectiveTo -> open-ended). name and effectiveFrom are NOT NULL, so an explicit null for either is rejected 400 -- omit them to keep the stored value rather than nulling them.
+
+| Field                         | Type               | Required | Nullable | Description |
+| ----------------------------- | ------------------ | -------- | -------- | ----------- |
+| `name`                        | string             | no       | no       |             |
+| `registrationIdentifier`      | string             | no       | yes      |             |
+| `registrationIdentifierLabel` | string             | no       | yes      |             |
+| `effectiveFrom`               | string (date-time) | no       | no       |             |
+| `effectiveTo`                 | string (date-time) | no       | yes      |             |
+
+**Example**
+
+```json
+{
+  "name": "string",
+  "registrationIdentifier": "string",
+  "registrationIdentifierLabel": "string",
+  "effectiveFrom": "2026-01-01T00:00:00.000Z",
+  "effectiveTo": "2026-01-01T00:00:00.000Z"
+}
+```
+
+### Schema: OrganizationStructureUpdateLocationRequest
+
+Issue #837 -- true partial-PATCH body. Every property is optional: an ABSENT property keeps its stored value. A nullable property sent as explicit null CLEARS it (address/city/region/postalCode/countryCode/ latitude/longitude -> null). name is NOT NULL, so an explicit null is rejected 400 -- omit it to keep the stored value rather than nulling it.
+
+| Field          | Type   | Required | Nullable | Description |
+| -------------- | ------ | -------- | -------- | ----------- |
+| `name`         | string | no       | no       |             |
+| `addressLine1` | string | no       | yes      |             |
+| `addressLine2` | string | no       | yes      |             |
+| `city`         | string | no       | yes      |             |
+| `region`       | string | no       | yes      |             |
+| `postalCode`   | string | no       | yes      |             |
+| `countryCode`  | string | no       | yes      |             |
+| `latitude`     | number | no       | yes      |             |
+| `longitude`    | number | no       | yes      |             |
+
+**Example**
+
+```json
+{
+  "name": "string",
+  "addressLine1": "string",
+  "addressLine2": "string",
+  "city": "string",
+  "region": "string",
+  "postalCode": "string",
+  "countryCode": "string",
+  "latitude": -90,
+  "longitude": -180
+}
+```
+
 ### Schema: OrganizationStructureUpdateUnitRequest
+
+Issue #837 -- true partial-PATCH body. Every property is optional: an ABSENT property keeps its stored value. A nullable property sent as explicit null CLEARS it (legalEntityId/unitTypeId -> null, effectiveTo -> open-ended). name and effectiveFrom are NOT NULL, so an explicit null for either is rejected 400 -- omit them to keep the stored value rather than nulling them.
 
 | Field           | Type               | Required | Nullable | Description |
 | --------------- | ------------------ | -------- | -------- | ----------- |
-| `name`          | string             | yes      | no       |             |
+| `name`          | string             | no       | no       |             |
 | `legalEntityId` | string (uuid)      | no       | yes      |             |
 | `unitTypeId`    | string (uuid)      | no       | yes      |             |
 | `effectiveFrom` | string (date-time) | no       | no       |             |
@@ -14857,6 +14915,24 @@ Locale code (2-letter, e.g. "en", "id") to string. Must include an "en" entry.
   "unitTypeId": "00000000-0000-0000-0000-000000000000",
   "effectiveFrom": "2026-01-01T00:00:00.000Z",
   "effectiveTo": "2026-01-01T00:00:00.000Z"
+}
+```
+
+### Schema: OrganizationStructureUpdateUnitTypeRequest
+
+Issue #837 -- true partial-PATCH body. Every property is optional: an ABSENT property keeps its stored value. description sent as explicit null CLEARS it. name is NOT NULL, so an explicit null is rejected 400 -- omit it to keep the stored value rather than nulling it.
+
+| Field         | Type   | Required | Nullable | Description |
+| ------------- | ------ | -------- | -------- | ----------- |
+| `name`        | string | no       | no       |             |
+| `description` | string | no       | yes      |             |
+
+**Example**
+
+```json
+{
+  "name": "string",
+  "description": "string"
 }
 ```
 
@@ -15331,9 +15407,11 @@ Partial PATCH body. Every property is optional: a property that is ABSENT from t
 
 ### Schema: ReferenceDataUpdateValueSetRequest
 
+Issue #837 -- true partial-PATCH body. Every property is optional: an ABSENT property keeps its stored value. description sent as explicit null CLEARS it. name is NOT NULL, so an explicit null is rejected 400 -- omit it to keep the stored value rather than nulling it. The pre-#837 route defaulted an omitted description to null, so a PATCH that changed only name silently cleared the stored description.
+
 | Field         | Type   | Required | Nullable | Description |
 | ------------- | ------ | -------- | -------- | ----------- |
-| `name`        | string | yes      | no       |             |
+| `name`        | string | no       | no       |             |
 | `description` | string | no       | yes      |             |
 
 **Example**

--- a/openapi/awcms-mini-public-api.openapi.yaml
+++ b/openapi/awcms-mini-public-api.openapi.yaml
@@ -12217,7 +12217,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationStructureCreateLegalEntityRequest"
+              $ref: "#/components/schemas/OrganizationStructureUpdateLegalEntityRequest"
       responses:
         "200":
           description: Legal entity updated.
@@ -12703,7 +12703,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationStructureCreateLocationRequest"
+              $ref: "#/components/schemas/OrganizationStructureUpdateLocationRequest"
       responses:
         "200":
           description: Operational location updated.
@@ -13020,19 +13020,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - name
-              additionalProperties: false
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                  maxLength: 200
-                description:
-                  type: string
-                  nullable: true
-                  maxLength: 2000
+              $ref: "#/components/schemas/OrganizationStructureUpdateUnitTypeRequest"
       responses:
         "200":
           description: Organization-unit type updated.
@@ -27710,11 +27698,77 @@ components:
           type: string
           format: date-time
           nullable: true
+    OrganizationStructureUpdateLegalEntityRequest:
+      type: object
+      additionalProperties: false
+      description: "Issue #837 -- true partial-PATCH body. Every property is optional: an ABSENT property keeps its stored value. A nullable property sent as explicit null CLEARS it (registrationIdentifier[Label] -> null, effectiveTo -> open-ended). name and effectiveFrom are NOT NULL, so an explicit null for either is rejected 400 -- omit them to keep the stored value rather than nulling them."
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 300
+        registrationIdentifier:
+          type: string
+          nullable: true
+          maxLength: 200
+        registrationIdentifierLabel:
+          type: string
+          nullable: true
+          maxLength: 120
+        effectiveFrom:
+          type: string
+          format: date-time
+        effectiveTo:
+          type: string
+          format: date-time
+          nullable: true
+    OrganizationStructureUpdateLocationRequest:
+      type: object
+      additionalProperties: false
+      description: "Issue #837 -- true partial-PATCH body. Every property is optional: an ABSENT property keeps its stored value. A nullable property sent as explicit null CLEARS it (address/city/region/postalCode/countryCode/ latitude/longitude -> null). name is NOT NULL, so an explicit null is rejected 400 -- omit it to keep the stored value rather than nulling it."
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        addressLine1:
+          type: string
+          nullable: true
+          maxLength: 300
+        addressLine2:
+          type: string
+          nullable: true
+          maxLength: 300
+        city:
+          type: string
+          nullable: true
+          maxLength: 300
+        region:
+          type: string
+          nullable: true
+          maxLength: 300
+        postalCode:
+          type: string
+          nullable: true
+          maxLength: 300
+        countryCode:
+          type: string
+          nullable: true
+          pattern: ^[A-Z]{2}$
+        latitude:
+          type: number
+          nullable: true
+          minimum: -90
+          maximum: 90
+        longitude:
+          type: number
+          nullable: true
+          minimum: -180
+          maximum: 180
     OrganizationStructureUpdateUnitRequest:
       type: object
-      required:
-        - name
       additionalProperties: false
+      description: "Issue #837 -- true partial-PATCH body. Every property is optional: an ABSENT property keeps its stored value. A nullable property sent as explicit null CLEARS it (legalEntityId/unitTypeId -> null, effectiveTo -> open-ended). name and effectiveFrom are NOT NULL, so an explicit null for either is rejected 400 -- omit them to keep the stored value rather than nulling them."
       properties:
         name:
           type: string
@@ -27735,6 +27789,19 @@ components:
           type: string
           format: date-time
           nullable: true
+    OrganizationStructureUpdateUnitTypeRequest:
+      type: object
+      additionalProperties: false
+      description: "Issue #837 -- true partial-PATCH body. Every property is optional: an ABSENT property keeps its stored value. description sent as explicit null CLEARS it. name is NOT NULL, so an explicit null is rejected 400 -- omit it to keep the stored value rather than nulling it."
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        description:
+          type: string
+          nullable: true
+          maxLength: 2000
     PartyCreateRequest:
       type: object
       required:
@@ -28276,9 +28343,8 @@ components:
           description: Omit to keep the stored value; null clears the end of validity.
     ReferenceDataUpdateValueSetRequest:
       type: object
-      required:
-        - name
       additionalProperties: false
+      description: "Issue #837 -- true partial-PATCH body. Every property is optional: an ABSENT property keeps its stored value. description sent as explicit null CLEARS it. name is NOT NULL, so an explicit null is rejected 400 -- omit it to keep the stored value rather than nulling it. The pre-#837 route defaulted an omitted description to null, so a PATCH that changed only name silently cleared the stored description."
       properties:
         name:
           type: string

--- a/openapi/modules/organization-structure.openapi.yaml
+++ b/openapi/modules/organization-structure.openapi.yaml
@@ -158,7 +158,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationStructureCreateLegalEntityRequest"
+              $ref: "#/components/schemas/OrganizationStructureUpdateLegalEntityRequest"
       responses:
         "200":
           description: Legal entity updated.
@@ -458,18 +458,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required: [name]
-              additionalProperties: false
-              properties:
-                name:
-                  type: string
-                  minLength: 1
-                  maxLength: 200
-                description:
-                  type: string
-                  nullable: true
-                  maxLength: 2000
+              $ref: "#/components/schemas/OrganizationStructureUpdateUnitTypeRequest"
       responses:
         "200":
           description: Organization-unit type updated.
@@ -1298,7 +1287,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/OrganizationStructureCreateLocationRequest"
+              $ref: "#/components/schemas/OrganizationStructureUpdateLocationRequest"
       responses:
         "200":
           description: Operational location updated.
@@ -1911,14 +1900,67 @@ components:
         effectiveTo: { type: string, format: date-time, nullable: true }
     OrganizationStructureUpdateUnitRequest:
       type: object
-      required: [name]
       additionalProperties: false
+      description: >-
+        Issue #837 -- true partial-PATCH body. Every property is optional: an
+        ABSENT property keeps its stored value. A nullable property sent as
+        explicit null CLEARS it (legalEntityId/unitTypeId -> null, effectiveTo ->
+        open-ended). name and effectiveFrom are NOT NULL, so an explicit null for
+        either is rejected 400 -- omit them to keep the stored value rather than
+        nulling them.
       properties:
         name: { type: string, minLength: 1, maxLength: 200 }
         legalEntityId: { type: string, format: uuid, nullable: true }
         unitTypeId: { type: string, format: uuid, nullable: true }
         effectiveFrom: { type: string, format: date-time }
         effectiveTo: { type: string, format: date-time, nullable: true }
+    OrganizationStructureUpdateLegalEntityRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Issue #837 -- true partial-PATCH body. Every property is optional: an
+        ABSENT property keeps its stored value. A nullable property sent as
+        explicit null CLEARS it (registrationIdentifier[Label] -> null,
+        effectiveTo -> open-ended). name and effectiveFrom are NOT NULL, so an
+        explicit null for either is rejected 400 -- omit them to keep the stored
+        value rather than nulling them.
+      properties:
+        name: { type: string, minLength: 1, maxLength: 300 }
+        registrationIdentifier: { type: string, nullable: true, maxLength: 200 }
+        registrationIdentifierLabel:
+          { type: string, nullable: true, maxLength: 120 }
+        effectiveFrom: { type: string, format: date-time }
+        effectiveTo: { type: string, format: date-time, nullable: true }
+    OrganizationStructureUpdateUnitTypeRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Issue #837 -- true partial-PATCH body. Every property is optional: an
+        ABSENT property keeps its stored value. description sent as explicit null
+        CLEARS it. name is NOT NULL, so an explicit null is rejected 400 -- omit
+        it to keep the stored value rather than nulling it.
+      properties:
+        name: { type: string, minLength: 1, maxLength: 200 }
+        description: { type: string, nullable: true, maxLength: 2000 }
+    OrganizationStructureUpdateLocationRequest:
+      type: object
+      additionalProperties: false
+      description: >-
+        Issue #837 -- true partial-PATCH body. Every property is optional: an
+        ABSENT property keeps its stored value. A nullable property sent as
+        explicit null CLEARS it (address/city/region/postalCode/countryCode/
+        latitude/longitude -> null). name is NOT NULL, so an explicit null is
+        rejected 400 -- omit it to keep the stored value rather than nulling it.
+      properties:
+        name: { type: string, minLength: 1, maxLength: 200 }
+        addressLine1: { type: string, nullable: true, maxLength: 300 }
+        addressLine2: { type: string, nullable: true, maxLength: 300 }
+        city: { type: string, nullable: true, maxLength: 300 }
+        region: { type: string, nullable: true, maxLength: 300 }
+        postalCode: { type: string, nullable: true, maxLength: 300 }
+        countryCode: { type: string, nullable: true, pattern: "^[A-Z]{2}$" }
+        latitude: { type: number, nullable: true, minimum: -90, maximum: 90 }
+        longitude: { type: number, nullable: true, minimum: -180, maximum: 180 }
     OrganizationStructureTreeNode:
       type: object
       description: Issue #749 -- one node of the nested hierarchy tree.

--- a/openapi/modules/reference-data.openapi.yaml
+++ b/openapi/modules/reference-data.openapi.yaml
@@ -1702,9 +1702,14 @@ components:
           nullable: true
     ReferenceDataUpdateValueSetRequest:
       type: object
-      required:
-        - name
       additionalProperties: false
+      description: >-
+        Issue #837 -- true partial-PATCH body. Every property is optional: an
+        ABSENT property keeps its stored value. description sent as explicit null
+        CLEARS it. name is NOT NULL, so an explicit null is rejected 400 -- omit
+        it to keep the stored value rather than nulling it. The pre-#837 route
+        defaulted an omitted description to null, so a PATCH that changed only
+        name silently cleared the stored description.
       properties:
         name:
           type: string


### PR DESCRIPTION
Selaraskan kontrak OpenAPI PATCH `organization_structure` & `reference-data` value-sets dengan semantik partial-PATCH yang benar. Runtime sudah diperbaiki di PR #852 (absent = pertahankan, `null` = kosongkan), tetapi skema OpenAPI masih "berbohong": PATCH memakai ulang skema Create (`required: [name]`), melegitimasi reset yang justru dihapus di runtime.

## Perubahan
- PATCH kini memakai skema Update khusus yang all-optional: `OrganizationStructureUpdateLegalEntityRequest`, `OrganizationStructureUpdateUnitTypeRequest`, `OrganizationStructureUpdateLocationRequest`, `OrganizationStructureUpdateUnitRequest`, `ReferenceDataUpdateValueSetRequest`.
- Skema Create tetap menuntut `name` (wajib saat pembuatan).
- `name`/`effectiveFrom` tetap non-nullable pada PATCH karena runtime menolak `null` (NOT NULL) dengan 400.

## Scope
`openapi/awcms-mini-public-api.openapi.yaml`, `openapi/modules/organization-structure.openapi.yaml`, `openapi/modules/reference-data.openapi.yaml` + changeset. Tanpa perubahan runtime (sudah di #852).

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)
