### PR TITLE
fix(release): trigger release.yml on the changeset tag awcms-mini@* (#825)

### DIFF
--- a/.changeset/eleven-release-tags-align.md
+++ b/.changeset/eleven-release-tags-align.md
@@ -1,0 +1,32 @@
+---
+"awcms-mini": patch
+---
+
+fix(release): align `release.yml` trigger with the tag Changesets actually emits (`awcms-mini@*`)
+
+The automated release path was structurally dead: `.changeset/config.json`'s
+`privatePackages: { version: true, tag: true }` makes `bun run changeset:tag`
+create `awcms-mini@X.Y.Z`, but `.github/workflows/release.yml` triggered on
+`push: tags: v*.*.*` — a pattern that tag can never match. Per the owner's
+Option 1 decision (follow Changesets), the trigger is now `awcms-mini@*` and
+`privatePackages.tag: true` is retained; the manual `vX.Y.Z` tag is no longer
+a supported entry point.
+
+Consistency changes so the whole chain uses the same tag shape:
+
+- `scripts/release-verify.ts` `normalizeTagVersion` now strips the
+  `awcms-mini@` prefix (in addition to `refs/tags/` and a legacy `v`), so
+  the `release:verify` gate correctly compares `awcms-mini@X.Y.Z` against
+  `package.json`.
+- The `gh release create` title uses the bare version instead of
+  `github.ref_name`, so it reads "awcms-mini X.Y.Z" rather than
+  "awcms-mini awcms-mini@X.Y.Z". The GitHub Release git tag is unchanged
+  (`awcms-mini@X.Y.Z`).
+- `docs/awcms-mini/release-process.md` now distinguishes the git tag
+  (`awcms-mini@X.Y.Z`) from the container image tag (bare `X.Y.Z`), and the
+  cosign verification example keys on `refs/tags/awcms-mini@.*`.
+
+Owner-only follow-ups remain open on Issue #825 (NOT done here): review
+`required_reviewers` on the `release` GitHub Environment (the rehearsal run
+hung >26h waiting on it), and approve a rehearsal end-to-end through
+sign + attest + publish. No release tag was pushed by this change.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,13 @@
 #
 # Two entry points, deliberately with no boolean toggles between them:
 #
-#   1. `push: tags: v*.*.*`      — a REAL release. Requires the tag's commit
+#   1. `push: tags: awcms-mini@*` — a REAL release. This is the exact tag
+#      shape Changesets emits for this private package: `.changeset/
+#      config.json`'s `privatePackages: { version: true, tag: true }` makes
+#      `bun run changeset:tag` create `awcms-mini@X.Y.Z` (see the existing
+#      `awcms-mini@0.0.x` tags), so the trigger and the tag generator are
+#      the SAME source of truth — no manual `vX.Y.Z` tag, no version↔tag
+#      drift (Issue #825, epic #818). Requires the tag's commit
 #      to already be an ancestor of `origin/main` (see "Guard" step below —
 #      this repo has no branch-protection rule today, see
 #      docs/awcms-mini/branch-protection.md, so this is the closest
@@ -30,7 +36,11 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*.*"
+      # Package-scoped tag Changesets emits for this private package
+      # (`awcms-mini@X.Y.Z`) — NOT `v*.*.*`. See the header comment and
+      # Issue #825: the previous `v*.*.*` trigger could never match a
+      # changeset-generated tag, so the automated release path was dead.
+      - "awcms-mini@*"
   workflow_dispatch: {}
 
 concurrency:
@@ -394,8 +404,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Positional arg is the git tag name Changesets created
+          # (`awcms-mini@X.Y.Z`); the human-facing title uses the bare
+          # version so it doesn't read "awcms-mini awcms-mini@X.Y.Z".
           gh release create "${{ github.ref_name }}" \
-            --title "awcms-mini ${{ github.ref_name }}" \
+            --title "awcms-mini ${{ needs.validate.outputs.version }}" \
             --notes-file RELEASE_NOTES.md \
             "CHECKSUMS.txt" \
             "sbom-source.cdx.json" \

--- a/docs/awcms-mini/release-process.md
+++ b/docs/awcms-mini/release-process.md
@@ -18,8 +18,8 @@ flowchart TD
   CS -- No, non-exempt files changed --> Block[changesets.yml fails PR]
   CS -- Yes / docs-only --> Merge[Merge to main]
   Merge --> Version[bun run changeset:version<br/>bump + CHANGELOG]
-  Version --> Commit[chore release: vX.Y.Z]
-  Commit --> Tag[git tag vX.Y.Z + push]
+  Version --> Commit[chore release: X.Y.Z]
+  Commit --> Tag[bun run changeset:tag<br/>awcms-mini@X.Y.Z + git push --tags]
   Tag --> Validate[release.yml: validate job<br/>ancestor-of-main guard,<br/>release:verify, full check]
   Dispatch[workflow_dispatch<br/>rehearsal, any branch] --> Validate
   Validate --> BuildJob[build job: image + SBOM x2<br/>+ checksums, no signing creds]
@@ -66,10 +66,26 @@ run against a single checkout with no network/git-history dependency.
 
 Two entry points, both converging on the same job graph:
 
-| Trigger                        | Effect                                                                                                                                   |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `push` a tag matching `v*.*.*` | **Real release.** Publishes an image, GitHub Release, and moves `:latest`.                                                               |
-| `workflow_dispatch` (any ref)  | **Rehearsal.** Runs the identical pipeline against a `dryrun-<sha>` image tag. No GitHub Release is created, `:latest` is never touched. |
+| Trigger                              | Effect                                                                                                                                   |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `push` a tag matching `awcms-mini@*` | **Real release.** Publishes an image, GitHub Release, and moves `:latest`.                                                               |
+| `workflow_dispatch` (any ref)        | **Rehearsal.** Runs the identical pipeline against a `dryrun-<sha>` image tag. No GitHub Release is created, `:latest` is never touched. |
+
+> **Git tag vs image tag — these are deliberately different strings.**
+> The **git tag** is the one Changesets emits for this private package,
+> `awcms-mini@X.Y.Z` (`.changeset/config.json`
+> `privatePackages: { version: true, tag: true }` → `bun run
+changeset:tag`; the existing `awcms-mini@0.0.x` tags prove the format).
+> That is exactly what `release.yml`'s `push: tags: awcms-mini@*` fires on,
+> so the tag generator and the trigger are one source of truth — there is
+> **no** manual `vX.Y.Z` tag and no version↔tag drift (Issue #825). The
+> **container image tag**, by contrast, is the _bare_ version read from
+> `package.json` — `ghcr.io/ahliweb/awcms-mini:X.Y.Z` (no `v`, no
+> `awcms-mini@` prefix) — plus `:sha-<commit>` and, for a real release,
+> `:latest`. `release.yml`'s `validate` job derives both from
+> `package.json`, not from the tag string, so `release:verify` only has to
+> confirm the pushed `awcms-mini@X.Y.Z` tag matches that same
+> `package.json` version.
 
 ### `validate` job (read-only)
 
@@ -231,7 +247,7 @@ throwaway `ghcr.io/ahliweb/awcms-mini:dryrun-<short-sha>` tag. It never
 creates a GitHub Release and never moves `:latest`, so it cannot be
 mistaken for (or accidentally become) a production release. Rehearse this
 at least once, with a reviewer actually approving the environment gate,
-before the first real `vX.Y.Z` tag is pushed.
+before the first real `awcms-mini@X.Y.Z` tag is pushed.
 
 Rehearsal images accumulate in the `ghcr.io/ahliweb/awcms-mini` package
 under `dryrun-*` tags; a maintainer can delete old ones periodically via
@@ -246,18 +262,24 @@ Every check below uses only public data (the registry, GitHub's public
 attestation API, Sigstore's public transparency log) — none require access
 to this repository's secrets or CI environment.
 
+The image tag below is the **bare** version `X.Y.Z` (see the git-tag-vs-
+image-tag note above), e.g. `ghcr.io/ahliweb/awcms-mini:0.24.0` — not the
+`awcms-mini@X.Y.Z` git tag.
+
 ```bash
 # 1. Verify the image's SLSA build provenance attestation
-gh attestation verify oci://ghcr.io/ahliweb/awcms-mini:vX.Y.Z \
+gh attestation verify oci://ghcr.io/ahliweb/awcms-mini:X.Y.Z \
   --owner ahliweb
 
 # 2. Verify the image's SBOM attestation
-gh attestation verify oci://ghcr.io/ahliweb/awcms-mini:vX.Y.Z \
+gh attestation verify oci://ghcr.io/ahliweb/awcms-mini:X.Y.Z \
   --owner ahliweb --predicate-type https://cyclonedx.org/bom
 
-# 3. Verify the keyless cosign signature directly (no gh CLI required)
-cosign verify ghcr.io/ahliweb/awcms-mini:vX.Y.Z \
-  --certificate-identity-regexp "^https://github.com/ahliweb/awcms-mini/.github/workflows/release.yml@refs/tags/v.*" \
+# 3. Verify the keyless cosign signature directly (no gh CLI required).
+#    The signing identity is keyed on the GIT tag ref the run fired on,
+#    i.e. refs/tags/awcms-mini@X.Y.Z — hence the `awcms-mini@` in the regexp.
+cosign verify ghcr.io/ahliweb/awcms-mini:X.Y.Z \
+  --certificate-identity-regexp "^https://github.com/ahliweb/awcms-mini/.github/workflows/release.yml@refs/tags/awcms-mini@.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # 4. Verify provenance for the downloadable source artifacts
@@ -283,12 +305,14 @@ bad release:
 1. **Do not delete the git tag, the GitHub Release, or the `ghcr.io`
    image/tag.** Consumers may have already pulled it; removing it breaks
    their ability to even diagnose what they have.
-2. **Mark the GitHub Release as a pre-release** (`gh release edit vX.Y.Z
---prerelease`) and add a note at the top of its body pointing to the
-   fixed version, so `gh release view --repo ahliweb/awcms-mini` and the
-   releases page both surface the warning immediately.
-3. **Cut a new patch release** (`vX.Y.Z+1`) through the normal path
-   (changeset → `changeset:version` → tag → `release.yml`) with the fix.
+2. **Mark the GitHub Release as a pre-release** (`gh release edit
+awcms-mini@X.Y.Z --prerelease`) and add a note at the top of its body
+   pointing to the fixed version, so `gh release view --repo
+ahliweb/awcms-mini` and the releases page both surface the warning
+   immediately.
+3. **Cut a new patch release** (`awcms-mini@X.Y.Z+1`) through the normal
+   path (changeset → `changeset:version` → `changeset:tag` → `release.yml`)
+   with the fix.
    Do not force-push a corrected tag over the same version number — image
    digests and attestations already issued for the old tag would then
    silently point at different bytes than the tag name implies, which

--- a/scripts/release-verify.ts
+++ b/scripts/release-verify.ts
@@ -32,10 +32,24 @@ export type ReleaseVerifyProblem = {
   message: string;
 };
 
-/** Accepts "v1.2.3", "refs/tags/v1.2.3", or a bare "1.2.3". */
+/**
+ * Extracts the bare "X.Y.Z" version from a release tag ref.
+ *
+ * The canonical tag this repo actually ships is the package-scoped tag
+ * Changesets emits for this private package — `awcms-mini@X.Y.Z` (Issue
+ * #825: `.changeset/config.json` `privatePackages.tag: true` +
+ * `.github/workflows/release.yml`'s `push: tags: awcms-mini@*` trigger).
+ * `refs/tags/` (raw `GITHUB_REF`) and a bare/`v`-prefixed form are also
+ * tolerated so a manually-typed `bun run release:verify awcms-mini@X.Y.Z`
+ * / `v X.Y.Z` / `X.Y.Z` all normalize identically.
+ *
+ * Accepts "awcms-mini@1.2.3", "refs/tags/awcms-mini@1.2.3", "v1.2.3",
+ * "refs/tags/v1.2.3", or a bare "1.2.3".
+ */
 export function normalizeTagVersion(tagRef: string): string {
   const withoutRefsPrefix = tagRef.replace(/^refs\/tags\//, "");
-  return withoutRefsPrefix.replace(/^v/, "");
+  const withoutPackagePrefix = withoutRefsPrefix.replace(/^awcms-mini@/, "");
+  return withoutPackagePrefix.replace(/^v/, "");
 }
 
 export function checkVersionMatchesTag(

--- a/tests/unit/release-verify.test.ts
+++ b/tests/unit/release-verify.test.ts
@@ -14,6 +14,14 @@ describe("normalizeTagVersion", () => {
     expect(normalizeTagVersion("v1.2.3")).toBe("1.2.3");
     expect(normalizeTagVersion("1.2.3")).toBe("1.2.3");
   });
+
+  test("strips the changeset package-scoped 'awcms-mini@' prefix (Issue #825)", () => {
+    // The canonical tag `bun run changeset:tag` emits for this private
+    // package, and exactly what `release.yml`'s `awcms-mini@*` trigger
+    // fires on — GITHUB_REF arrives as refs/tags/awcms-mini@X.Y.Z.
+    expect(normalizeTagVersion("awcms-mini@0.24.0")).toBe("0.24.0");
+    expect(normalizeTagVersion("refs/tags/awcms-mini@0.24.0")).toBe("0.24.0");
+  });
 });
 
 describe("checkVersionMatchesTag", () => {
@@ -78,6 +86,17 @@ describe("runReleaseVerify", () => {
     const problems = runReleaseVerify({
       packageVersion: "0.24.0",
       tagRef: "v0.24.0",
+      changelogContent: "## [0.24.0] - 2026-07-12\n",
+      changesetFileNames: ["config.json", "README.md"]
+    });
+
+    expect(problems).toEqual([]);
+  });
+
+  test("accepts the real changeset-emitted tag 'awcms-mini@X.Y.Z' (Issue #825)", () => {
+    const problems = runReleaseVerify({
+      packageVersion: "0.24.0",
+      tagRef: "refs/tags/awcms-mini@0.24.0",
       changelogContent: "## [0.24.0] - 2026-07-12\n",
       changesetFileNames: ["config.json", "README.md"]
     });


### PR DESCRIPTION
Perbaiki jalur rilis otomatis yang secara struktural mati: `.changeset/config.json` `privatePackages: { tag: true }` membuat `changeset:tag` menghasilkan `awcms-mini@X.Y.Z`, tetapi `release.yml` ter-trigger pada `push: tags: v*.*.*` — pola yang tag itu tak pernah cocoki. Nol rilis pernah terjadi. Per keputusan Option 1 owner (ikuti Changesets), trigger kini `awcms-mini@*`.

## Perubahan
- `.github/workflows/release.yml`: trigger `awcms-mini@*`; judul `gh release create` pakai versi bare ("awcms-mini X.Y.Z"), git tag Release tetap `awcms-mini@X.Y.Z`.
- `scripts/release-verify.ts`: `normalizeTagVersion` kini strip prefix `awcms-mini@` (selain `refs/tags/` dan legacy `v`) agar gate `release:verify` benar membandingkan `awcms-mini@X.Y.Z` vs `package.json`.
- `docs/awcms-mini/release-process.md`: bedakan git tag (`awcms-mini@X.Y.Z`) dari container image tag (bare `X.Y.Z`); contoh verifikasi cosign key `refs/tags/awcms-mini@.*`.
- Test unit `release-verify` untuk prefix baru + changeset.

## Owner-only follow-ups (TIDAK diselesaikan di sini — #825 tetap terbuka)
- Review `required_reviewers` pada GitHub Environment `release` (rehearsal run menggantung >26 jam menunggunya).
- Approve rehearsal end-to-end lewat sign + attest + publish.
- **Tidak ada tag rilis yang di-push oleh perubahan ini.**

Part of #825 (bagian kode; owner-only follow-ups di atas tetap terbuka)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
