### PR TITLE
perf(epic-818): make query-plan ANALYZE real + gate the silent no-op (#849)

### DIFF
--- a/.changeset/analyze-noop-queryplan-849.md
+++ b/.changeset/analyze-noop-queryplan-849.md
@@ -1,0 +1,32 @@
+---
+"awcms-mini": patch
+---
+
+Buat `ANALYZE` di suite query-plan benar-benar berjalan dan gagal keras kalau
+tidak (Issue #849, epic #818). PostgreSQL **diam-diam melewati** `ANALYZE` atas
+tabel yang tidak dimiliki peran pemanggil — hanya WARNING, bukan error, exit
+status sukses. Karena query-plan check menjalankan `ANALYZE` lewat peran
+least-privilege `awcms_mini_app` (yang tidak memiliki tabel), statistik planner
+tidak pernah disegarkan; budget lolos/gagal karena kebetulan timing autovacuum,
+bukan pengukuran nyata (`admin_list` sempat merah palsu karena `Sort`;
+`blog-posts-fulltext-search` sempat merah palsu ~874 di jalur script ber-bloat).
+
+Perbaikan: modul baru `src/lib/performance/analyze-fixtures.ts`
+(`analyzeQueryPlanFixtures`) menyegarkan statistik lewat koneksi **privileged**
+(pemilik tabel) lalu **membuktikan** itu berjalan dengan memeriksa
+`pg_stat_user_tables.analyze_count` benar-benar naik untuk setiap tabel — kalau
+tidak, ia melempar (test: `beforeAll` gagal; script: exit 1 dengan pesan yang
+bisa ditindaklanjuti). Integration harness memakai `getAdminSql()`; script
+`performance:query-plan:check` memakai `PERF_ANALYZE_DATABASE_URL` (URL
+owner/superuser), fallback ke `DATABASE_URL`. CI menyetel
+`PERF_ANALYZE_DATABASE_URL` ke peran migration-owner. EXPLAIN tetap berjalan
+RLS-enforced sebagai peran least-privilege — ANALYZE dipisah sebagai operasi
+maintenance milik owner.
+
+Tidak ada perubahan threshold budget: dengan statistik akurat semua budget lolos
+dengan margin sehat (fts 472–667/800, reporting 562–1132/1300, admin-list
+57–71/200). Klaim lama "fts latently red 939.5 vs 800" **tidak tereproduksi** —
+biaya statistik-akurat tak pernah melewati ~667. Proof `DROP INDEX` kini
+menegakkan biaya sekaligus bentuk plan (dropped ~316–472 vs budget 200), dan
+gate pure-unit baru memastikan setiap tabel penggerak budget ada di daftar
+ANALYZE.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,10 +265,19 @@ jobs:
       # bad plan lives in a dedicated integration test (never run as part
       # of this CI step, which only ever evaluates the real, currently-
       # registered budgets).
+      # Issue #849 (epic #818): `PERF_ANALYZE_DATABASE_URL` is the PRIVILEGED
+      # (migration-owner) role — the query-plan check refreshes planner
+      # statistics through it (`ANALYZE` needs table ownership; the app role's
+      # ANALYZE is silently skipped) while its EXPLAINs still run RLS-enforced
+      # as the least-privilege `awcms_mini_app` role in `DATABASE_URL`. The
+      # owner URL is the same non-secret dev default this job assembles for
+      # migrations (see "Assemble DATABASE_URL" above); without it the check
+      # now FAILS loudly rather than measuring budgets on stale statistics.
       - name: Performance query-plan budget check
         env:
           APP_ENV: test
           DATABASE_URL: "postgres://awcms_mini_app:ci-performance-app-role-password@localhost:5432/awcms-mini"
+          PERF_ANALYZE_DATABASE_URL: "postgres://awcms-mini:awcms_mini_password@localhost:5432/awcms-mini"
         run: bun run performance:query-plan:check -- --confirm-non-production=test
 
       - name: Build Astro foundation

--- a/docs/awcms-mini/performance-suite.md
+++ b/docs/awcms-mini/performance-suite.md
@@ -52,6 +52,8 @@ src/lib/performance/
   query-plan-budgets.ts      pure: versioned regression-budget registry +
                               EXPLAIN (FORMAT JSON) evaluator
   query-plan-runner.ts       I/O: runs EXPLAIN under RLS, rolled back always
+  analyze-fixtures.ts        I/O: owner ANALYZE + verify analyze_count
+                              advanced (Issue #849 — no silent no-op)
   workload.ts                I/O: one real, withTenant-gated operation per
                               work class (interactive/critical_transaction/
                               reporting/background_sync/maintenance)
@@ -270,61 +272,70 @@ test goes further and performs the real `DROP INDEX` (restoring it in a
 `finally`), which is the check Issue #838's own Definition of Done asks
 for.
 
-### Known limitation: the budgets' cost bound rides on stale statistics
+### Deterministic planner statistics (Issue #849)
 
-The `EXPLAIN` cost a budget compares against is only meaningful if
-PostgreSQL's planner statistics are accurate, and in this suite they
-generally are **not**:
+A budget's `EXPLAIN` cost — and, for the `admin_list` budgets, even its
+plan SHAPE — is only meaningful if PostgreSQL's planner statistics are
+accurate. Before Issue #849 (epic #818) they were **not deterministically
+so**, and the budgets passed or failed by accident of autovacuum timing:
 
-- Both scripts and the integration harness run as the least-privilege
-  `awcms_mini_app` role, which does not own these tables. PostgreSQL
-  **skips** an `ANALYZE` of a table the role does not own with a WARNING,
-  not an error — so `beforeAll`'s `ANALYZE` in
-  `performance-query-plan-check.integration.test.ts` is a silent no-op
-  (verified against `pg_stat_user_tables.last_analyze`, which never
-  changes).
-- Issue #782 already root-caused the same class of problem for
-  `audit-events-tenant-activity-reporting` (~11 pre-ANALYZE vs ~1088 once
-  autovacuum catches up).
+- Both scripts and the integration harness run their queries as the
+  least-privilege `awcms_mini_app` role (correctly — so FORCE'd RLS is
+  exercised), which does not own these tables. PostgreSQL **silently
+  skips** an `ANALYZE` of a table the issuing role does not own — a
+  WARNING, never an error, exit status success — so `beforeAll`'s
+  `ANALYZE` in `performance-query-plan-check.integration.test.ts` was a
+  no-op (verified against `pg_stat_user_tables`, whose `analyze_count`
+  never advanced), and the script never issued an `ANALYZE` at all.
+- The check then rode on whatever stale/absent statistics happened to be
+  in place. Measured both directions of the resulting flake at the `safe`
+  scale: the `admin_list` budgets go RED with a spurious `Sort` under
+  absent column statistics, and `blog-posts-fulltext-search` goes RED at
+  ~874 (vs its 800 budget) on the bloated post-`DELETE` script path until
+  autovacuum's background `ANALYZE` happens to catch up.
 
-Consequences worth knowing before trusting or recalibrating any number
-here:
+**The fix** (`src/lib/performance/analyze-fixtures.ts`,
+`analyzeQueryPlanFixtures`): refresh statistics through a PRIVILEGED
+(table-owner) connection before evaluating, and PROVE it worked by
+asserting `pg_stat_user_tables.analyze_count` strictly advanced for every
+driving table — throwing (test: `beforeAll` fails; script: exit 1 with an
+actionable message) if any `ANALYZE` was silently skipped. The integration
+harness passes `getAdminSql()`; the script reads `PERF_ANALYZE_DATABASE_URL`
+(an owner/superuser URL), falling back to `DATABASE_URL`. There is no
+silent no-op path left.
 
-- Plan-SHAPE assertions survive a bad statistics regime; cost assertions
-  do not. Measured: with the index dropped, the same regression costs
-  939.88 against an accurately-ANALYZEd database but ~8 in the integration
-  suite — while the `Sort` node is present in **both**. This is the
-  concrete reason `admin_list` budgets lead with shape.
-- **`CREATE INDEX` half-fixes the statistics, and that is worse than not
-  fixing them.** Building an index updates `pg_class.reltuples`/`relpages`
-  as a side effect (measured on `awcms_mini_blog_pages`: `-1/0` →
-  `2000/334`), so the planner suddenly knows the real row count while
-  still having **zero** column statistics. For the blog admin lists that
-  half-informed state is the only one in which the budget's own index
-  loses:
+Once statistics are accurate the existing budgets are correct as-is — no
+threshold change was needed. Measured at the `safe` scale with a verified
+owner `ANALYZE` (both the clean single-seed and the accumulated CI
+script-path regimes):
 
-  | `pg_class` state                          | plan                                    | cost  |
-  | ----------------------------------------- | --------------------------------------- | ----- |
-  | `reltuples=-1` (pristine, never analyzed) | `Index Scan(..._tenant_updated_idx)`    | 8.3   |
-  | `reltuples` real, ZERO column statistics  | `Sort` + `Scan(..._tenant_deleted_idx)` | 8.19  |
-  | fully `ANALYZE`d (any real deployment)    | `Index Scan(..._tenant_updated_idx)`    | 57.17 |
+| budget                              | accurate cost | `maxTotalCost` |
+| ----------------------------------- | ------------: | -------------: |
+| `blog-posts-fulltext-search`        |     472 – 667 |            800 |
+| `audit-events-tenant-activity-…`    |    562 – 1132 |           1300 |
+| `blog-posts-admin-list` / `-pages-` |       57 – 71 |            200 |
 
-  The two plans are tied to within ~1%, so the planner takes the
-  marginally cheaper one — a coin flip, not a judgement. The middle row
-  does not occur in any real database (autovacuum's ANALYZE produces the
-  third), and it is the reason the `DROP INDEX` proof asserts its
-  restoration against `pg_indexes.indexdef` rather than by re-running
-  `EXPLAIN`: restoring an index is a schema fact, so it is asserted as
-  one.
+(The earlier note that `blog-posts-fulltext-search` was "latently red at
+939.5 vs 800" once statistics became accurate did **not** reproduce —
+accurate-statistics cost never exceeds ~667 for that query at this scale.
+The ~874 figure only exists in the _stale_, no-`ANALYZE` regime this fix
+eliminates.)
 
-- `blog-posts-fulltext-search` currently passes CI only because of this.
-  Against a `VACUUM FULL ANALYZE`d database at the same `safe` scale it
-  measures **939.5 against its approved `maxTotalCost` of 800** — i.e. it
-  is latently red and would fail the moment the statistics become
-  accurate. Fixing the no-op `ANALYZE` therefore requires recalibrating
-  that budget in the same reviewed change (an approved threshold change,
-  per the governance rule above) and is deliberately NOT bundled into
-  Issue #838.
+With accurate statistics the `DROP INDEX` adversarial proof now asserts
+BOTH dimensions: the index-present plan measures ~57 (`Index Scan`, green)
+and the dropped-index plan measures ~316–472 (`Bitmap Heap Scan` + `Sort`)
+against the 200 budget — so both the forbidden `Sort` node AND the cost
+overrun are checked, where before only the shape carried signal. The
+`admin_list` budgets still LEAD with plan shape (an index that stops
+serving the `ORDER BY` is the invariant they encode), but the cost bound
+is no longer worthless.
+
+Note on the restore assertion: `CREATE INDEX` refreshes
+`pg_class.reltuples`/`relpages` but NOT `pg_statistic` column histograms,
+so re-`EXPLAIN`ing immediately after the `finally`-block restore would run
+on half-refreshed statistics. The proof therefore asserts the restored
+index against `pg_indexes.indexdef` (a schema fact) rather than by
+re-running `EXPLAIN`.
 
 ## Machine-readable + human report artifacts
 

--- a/scripts/performance-query-plan-check.ts
+++ b/scripts/performance-query-plan-check.ts
@@ -24,6 +24,7 @@
  *     [--seed=<string>] [--json-output=<path>]
  */
 import { getDatabaseClient } from "../src/lib/database/client";
+import { analyzeQueryPlanFixtures } from "../src/lib/performance/analyze-fixtures";
 import { buildFixturePlan } from "../src/lib/performance/fixture-generator";
 import {
   resetPerformanceFixtureRows,
@@ -106,6 +107,40 @@ async function main() {
   console.log(
     `performance-query-plan-check: seeded ${plan.tenants.length} tenants in ${seedSummary.durationMs.toFixed(0)}ms.\n`
   );
+
+  // Issue #849 (epic #818): refresh planner statistics DETERMINISTICALLY
+  // before evaluating budgets, so a budget's PASS/FAIL reflects a real
+  // measurement instead of whatever stale/absent statistics autovacuum
+  // happened (or failed) to refresh in time. `ANALYZE` requires table
+  // OWNERSHIP: issued on `sql` (the least-privilege `awcms_mini_app` role
+  // this script otherwise runs as, so its EXPLAINs stay RLS-enforced) it is
+  // SILENTLY skipped with only a WARNING. So run it on a separate PRIVILEGED
+  // (owner/superuser) connection and PROVE it advanced
+  // `pg_stat_user_tables.analyze_count` — `analyzeQueryPlanFixtures` throws
+  // otherwise, and this script then fails loudly rather than reporting
+  // budgets measured on stale statistics. In CI that privileged URL is
+  // `PERF_ANALYZE_DATABASE_URL` (the migration-owner role); it falls back to
+  // `DATABASE_URL` for the common case where the operator already points the
+  // script at an owning role.
+  const analyzeUrl = process.env.PERF_ANALYZE_DATABASE_URL ?? databaseUrl;
+  const analyzeSql = new Bun.SQL(analyzeUrl);
+  try {
+    const analyzeResults = await analyzeQueryPlanFixtures(analyzeSql);
+    console.log(
+      `performance-query-plan-check: refreshed planner statistics for ` +
+        `${analyzeResults.length} driving tables via ` +
+        `${process.env.PERF_ANALYZE_DATABASE_URL ? "PERF_ANALYZE_DATABASE_URL" : "DATABASE_URL"} ` +
+        `(analyze_count advanced on every table).\n`
+    );
+  } catch (error) {
+    console.error(
+      `\nperformance-query-plan-check: BLOCKED — ${(error as Error).message}\n`
+    );
+    process.exitCode = 1;
+    return;
+  } finally {
+    await analyzeSql.end();
+  }
 
   // A deterministic, non-noisy-neighbor tenant — representative of ordinary
   // per-tenant query volume rather than the deliberately skewed tenant.

--- a/src/lib/performance/analyze-fixtures.ts
+++ b/src/lib/performance/analyze-fixtures.ts
@@ -1,0 +1,124 @@
+/**
+ * Deterministic, VERIFIED `ANALYZE` for the query-plan budget suite (Issue
+ * #849, epic #818).
+ *
+ * The query-plan budgets (`query-plan-budgets.ts`) gate PostgreSQL's chosen
+ * plan SHAPE and estimated COST at a fixed synthetic fixture scale. Both of
+ * those depend entirely on the planner's statistics (`pg_class.reltuples`,
+ * `pg_statistic` column histograms). Right after a bulk fixture seed those
+ * statistics are stale or absent until an `ANALYZE` refreshes them — and
+ * whether autovacuum's background `ANALYZE` happens to have run yet is a pure
+ * timing race, so a budget can pass or FAIL by accident rather than by real
+ * measurement (Issue #782 already root-caused one direction of this; Issue
+ * #849 is the other).
+ *
+ * The trap Issue #849 exists to close: `ANALYZE` run by a role that does NOT
+ * OWN the table is SILENTLY SKIPPED by PostgreSQL — a WARNING, never an
+ * error, exit status success. The least-privilege `awcms_mini_app` role the
+ * suite's queries run as (correctly — so FORCE'd RLS is exercised) is exactly
+ * such a role, so an `ANALYZE awcms_mini_blog_posts` issued on that
+ * connection does NOTHING while looking like it worked. The budgets then pass
+ * only because whatever stale/absent statistics happened to be in place
+ * produced an acceptable plan — not because the code is correct.
+ *
+ * This module runs `ANALYZE` on the driving tables through a caller-supplied
+ * PRIVILEGED (table-owner/superuser) connection and PROVES it actually
+ * refreshed the statistics by checking `pg_stat_user_tables.analyze_count`
+ * advanced for every table — the honest signal, immune to exit-code lies and
+ * to timestamp resolution. If any table's `analyze_count` did not advance it
+ * throws, so a silently-skipped `ANALYZE` can never again pass unnoticed.
+ */
+
+/**
+ * Every table that drives a registered `QUERY_PLAN_BUDGETS` query
+ * (`query-plan-runner.ts`'s `QUERY_PLAN_QUERIES`). Keeping this list next to
+ * the verifier — and asserting in
+ * `tests/unit/performance-query-plan-registry-consistency.test.ts` that it
+ * covers every registered query's driving table — means adding a budget over
+ * a not-yet-ANALYZEd table (a fresh stale-statistics flake) fails a pure-unit
+ * gate rather than surfacing as a mysterious CI flake.
+ */
+export const QUERY_PLAN_ANALYZE_TABLES = [
+  "awcms_mini_audit_events",
+  "awcms_mini_abac_decision_logs",
+  "awcms_mini_blog_posts",
+  "awcms_mini_blog_pages",
+  "awcms_mini_object_sync_queue"
+] as const;
+
+export type QueryPlanAnalyzeResult = {
+  table: string;
+  analyzeCountBefore: number;
+  analyzeCountAfter: number;
+};
+
+async function readAnalyzeCounts(
+  sql: Bun.SQL,
+  tables: readonly string[]
+): Promise<Map<string, number>> {
+  const rows = (await sql`
+    SELECT relname, analyze_count::int AS analyze_count
+    FROM pg_stat_user_tables
+    WHERE relname = ANY(${sql.array(tables as string[], "text")})
+  `) as { relname: string; analyze_count: number }[];
+
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    counts.set(row.relname, row.analyze_count);
+  }
+  return counts;
+}
+
+/**
+ * Runs `ANALYZE` on each of `tables` via `privilegedSql` (which MUST own the
+ * tables) and verifies each one's `pg_stat_user_tables.analyze_count` strictly
+ * advanced. Returns the before/after counts for every table.
+ *
+ * Throws if any table's statistics did not refresh — the caller should treat
+ * that as a hard failure (it means the connection lacks table ownership and
+ * every `ANALYZE` was a silent no-op, Issue #849). `privilegedSql` is
+ * deliberately NOT the least-privilege app-role connection the query-plan
+ * checks themselves run on; ANALYZE is an owner-only maintenance operation,
+ * kept separate from the RLS-enforced EXPLAIN path.
+ */
+export async function analyzeQueryPlanFixtures(
+  privilegedSql: Bun.SQL,
+  tables: readonly string[] = QUERY_PLAN_ANALYZE_TABLES
+): Promise<QueryPlanAnalyzeResult[]> {
+  const before = await readAnalyzeCounts(privilegedSql, tables);
+
+  for (const table of tables) {
+    // `table` is a compile-time constant from QUERY_PLAN_ANALYZE_TABLES (or a
+    // caller-supplied literal in tests) — never user input; `ANALYZE` takes
+    // no bind parameters, so `unsafe` interpolation is required and safe here.
+    await privilegedSql.unsafe(`ANALYZE ${table}`);
+  }
+
+  const after = await readAnalyzeCounts(privilegedSql, tables);
+
+  const results: QueryPlanAnalyzeResult[] = tables.map((table) => ({
+    table,
+    analyzeCountBefore: before.get(table) ?? 0,
+    analyzeCountAfter: after.get(table) ?? 0
+  }));
+
+  const skipped = results.filter(
+    (result) => result.analyzeCountAfter <= result.analyzeCountBefore
+  );
+
+  if (skipped.length > 0) {
+    throw new Error(
+      "analyzeQueryPlanFixtures: ANALYZE did NOT refresh planner statistics " +
+        `for ${skipped.map((s) => s.table).join(", ")} ` +
+        "(pg_stat_user_tables.analyze_count did not advance). PostgreSQL " +
+        "SILENTLY SKIPS (a WARNING, never an error) an ANALYZE issued by a " +
+        "role that does not OWN the table — the least-privilege awcms_mini_app " +
+        "role is exactly such a role (Issue #849). Run ANALYZE from a " +
+        "privileged, table-owning connection: pass getAdminSql() in tests, or " +
+        "set PERF_ANALYZE_DATABASE_URL to an owner/superuser role for " +
+        "scripts/performance-query-plan-check.ts."
+    );
+  }
+
+  return results;
+}

--- a/src/lib/performance/query-plan-budgets.ts
+++ b/src/lib/performance/query-plan-budgets.ts
@@ -183,7 +183,13 @@ export const QUERY_PLAN_BUDGETS: QueryPlanBudget[] = [
     // independent reproductions, 1132.46) while still failing hard on an
     // actual regression (e.g. a dropped index) — those spike into the
     // tens of thousands via a forbidden Seq Scan, not a few hundred
-    // points of cost.
+    // points of cost. Issue #849 (epic #818) makes this measurement
+    // deterministic rather than autovacuum-timing-dependent: the check
+    // now forces an owner `ANALYZE` before evaluating (verified via
+    // pg_stat_user_tables.analyze_count — src/lib/performance/
+    // analyze-fixtures.ts), so this budget's evaluated cost is the real
+    // accurately-analyzed ~1132, every run, not the lucky-snapshot ~11
+    // this comment's history warns about.
     maxTotalCost: 1300,
     maxExecutionTimeMs: 80,
     approval: {

--- a/tests/integration/performance-query-plan-check.integration.test.ts
+++ b/tests/integration/performance-query-plan-check.integration.test.ts
@@ -27,6 +27,11 @@ import {
   evaluateQueryPlan,
   QUERY_PLAN_BUDGETS
 } from "../../src/lib/performance/query-plan-budgets";
+import {
+  analyzeQueryPlanFixtures,
+  QUERY_PLAN_ANALYZE_TABLES,
+  type QueryPlanAnalyzeResult
+} from "../../src/lib/performance/analyze-fixtures";
 import { buildFixturePlan } from "../../src/lib/performance/fixture-generator";
 import { seedPerformanceFixtures } from "../../src/lib/performance/fixture-seeder";
 import {
@@ -40,21 +45,11 @@ import { SAFE_SCALE_PROFILE } from "../../src/lib/performance/scale-profiles";
 
 const suite = integrationEnabled ? describe : describe.skip;
 
-const ANALYZED_TABLES = [
-  "awcms_mini_audit_events",
-  "awcms_mini_abac_decision_logs",
-  "awcms_mini_blog_posts",
-  // Issue #838 — now seeded (scale-profiles.ts `blogPages`) and the
-  // `blog-pages-admin-list` budget's driving table, so it needs the same
-  // fresh statistics as every other budget's table.
-  "awcms_mini_blog_pages",
-  "awcms_mini_object_sync_queue"
-];
-
 suite(
   "performance query-plan budgets (Issue #744) — real Postgres, adversarial proof",
   () => {
     let tenantId: string;
+    let analyzeResults: QueryPlanAnalyzeResult[];
 
     beforeAll(async () => {
       await applyMigrations();
@@ -65,13 +60,34 @@ suite(
       await seedPerformanceFixtures(getTestSql(), plan);
       tenantId = plan.tenants[0]!.tenantId;
 
-      // Fresh planner statistics — autovacuum ANALYZE may not have run yet
-      // right after a bulk seed, and stale/absent stats can bias the
-      // planner toward a Seq Scan even for a genuinely selective, indexed
-      // query, which would make the "good" budgets flaky rather than a
-      // real signal.
-      for (const table of ANALYZED_TABLES) {
-        await getTestSql().unsafe(`ANALYZE ${table}`);
+      // Fresh, ACCURATE planner statistics. Issue #849: an `ANALYZE` issued
+      // on `getTestSql()` (the least-privilege `awcms_mini_app` role) is
+      // SILENTLY SKIPPED — the role does not own these tables, so PostgreSQL
+      // emits a WARNING and returns success WITHOUT refreshing anything. The
+      // budgets below would then pass or fail by accident of autovacuum
+      // timing rather than a real measurement. Running `ANALYZE` via the
+      // PRIVILEGED (owner) `getAdminSql()` connection — and PROVING it
+      // advanced `pg_stat_user_tables.analyze_count` for every table
+      // (`analyzeQueryPlanFixtures` throws otherwise) — is what makes this
+      // suite deterministic. Reverting to `getTestSql()` here makes this
+      // `beforeAll` throw, which is the red half of the Issue #849 fix.
+      analyzeResults = await analyzeQueryPlanFixtures(
+        getAdminSql(),
+        QUERY_PLAN_ANALYZE_TABLES
+      );
+    });
+
+    test("Issue #849: the beforeAll ANALYZE genuinely refreshed planner statistics (not a silent no-op)", () => {
+      expect(analyzeResults.length).toBe(QUERY_PLAN_ANALYZE_TABLES.length);
+
+      // analyze_count strictly advanced for EVERY driving table — the honest,
+      // resolution-independent proof that ANALYZE actually ran, rather than
+      // trusting the exit code of a command PostgreSQL skips silently.
+      for (const result of analyzeResults) {
+        expect([
+          result.table,
+          result.analyzeCountAfter > result.analyzeCountBefore
+        ]).toEqual([result.table, true]);
       }
     });
 
@@ -218,74 +234,40 @@ suite(
         ).toBe(true);
         expect(regressed.findings.some((f) => f.includes("Sort"))).toBe(true);
 
-        // NOTE — deliberately NOT asserting `rootTotalCost >
-        // budget.maxTotalCost` here, even though the same DROP measures
-        // 939.88 vs a 200 budget against a properly-ANALYZEd database.
-        // In THIS suite the regressed plan's estimated cost is ~8: the
-        // `ANALYZE` in `beforeAll` above is a silent no-op, because
-        // `getTestSql()` is the least-privilege `awcms_mini_app` role and
-        // PostgreSQL skips (with a WARNING, not an error) an ANALYZE of a
-        // table the role does not own — verified directly against
-        // pg_stat_user_tables: `last_analyze` never changes. So the
-        // planner is working from absent/stale statistics and its cost
-        // ESTIMATE is not meaningful here, while the plan SHAPE still is.
-        //
-        // That asymmetry is the whole reason this budget leads with a
-        // plan-shape rule instead of a cost threshold: the shape signal
-        // survives a statistics regime that makes the cost signal
-        // worthless. `tests/unit/performance-query-plan-budgets.test.ts`
-        // covers the cost bound against the real measured 939.88 plan.
-        //
-        // Fixing that no-op ANALYZE is deliberately out of scope for Issue
-        // #838 and needs its own approved threshold change: with accurate
-        // statistics the PRE-EXISTING `blog-posts-fulltext-search` budget
-        // measures 939.5 against its approved maxTotalCost of 800 (same
-        // stale-stats calibration Issue #782 already root-caused for
-        // `audit-events-tenant-activity-reporting`), so it would go red the
-        // moment the ANALYZE starts working.
+        // The cost dimension is ALSO asserted now (Issue #849). Before this
+        // issue, the `beforeAll` ANALYZE was a silent no-op — issued on the
+        // least-privilege `getTestSql()` role, which does not own these
+        // tables, so PostgreSQL skipped it with a WARNING and the planner
+        // ran on absent/stale statistics whose cost ESTIMATE was meaningless
+        // (the dropped-index plan estimated ~8, indistinguishable from the
+        // index-present plan). This suite now ANALYZEs via the owning
+        // `getAdminSql()` connection and proves it ran, so the estimate is
+        // real: the index-present plan measures ~57 (Index Scan, asserted
+        // green by `before` above) and the dropped-index plan measures
+        // ~316-472 (Bitmap Heap Scan + Sort) against this budget's
+        // `maxTotalCost` of 200. Both the plan SHAPE and the COST now carry
+        // signal, and both are asserted.
+        expect([
+          budgetId,
+          "regressed cost",
+          regressed.rootTotalCost > budget.maxTotalCost
+        ]).toEqual([budgetId, "regressed cost", true]);
+        expect(regressed.findings.some((f) => f.includes("Total Cost"))).toBe(
+          true
+        );
 
         // ...and the index is physically back afterwards, proving the
         // `finally` above really did put the schema back for every later
         // test in this database.
         //
-        // This is asserted STRUCTURALLY (the index's own definition in
-        // pg_indexes) rather than by re-running EXPLAIN and expecting the
-        // green plan to return. Re-EXPLAINing looks like the stronger
-        // check but is actually unsound HERE, and it was measured, not
-        // guessed — the restored plan legitimately comes back as
-        // `Limit -> Sort -> Result -> Index Scan(..._tenant_deleted_idx)`
-        // at cost 8.19 vs the index-ordered plan's 8.3. The two candidate
-        // plans are TIED to within ~1%, and the planner picks the
-        // marginally cheaper one:
-        //
-        //   pg_class state                          | plan                       | cost
-        //   ----------------------------------------|----------------------------|------
-        //   reltuples=-1 (pristine, never analyzed) | Index Scan(tenant_updated) |  8.3
-        //   reltuples=2000, ZERO column statistics  | Sort + Scan(tenant_deleted)|  8.19
-        //   fully ANALYZEd (any real database)      | Index Scan(tenant_updated) | 57.17
-        //
-        // The middle row is the state THIS test creates and nothing else
-        // does: `CREATE INDEX` updates `pg_class.reltuples`/`relpages` as
-        // a side effect (-1/0 -> 2000/334), so the planner suddenly knows
-        // the real row count while still having NO column statistics at
-        // all (`pg_statistic` = 0 rows, `last_autoanalyze` = null — see
-        // Issue #849: this suite's ANALYZE is a silent no-op because the
-        // app role does not own these tables). That half-informed state
-        // does not exist in any real deployment, where autovacuum's
-        // ANALYZE produces the third row — index-ordered, no sort, which
-        // is exactly what this budget encodes and what Issue #830's own
-        // EXPLAIN evidence showed.
-        //
-        // Restoring the index is a SCHEMA fact, so assert the schema. The
-        // plan-shape guarantee is already covered by `before` above, and
-        // deliberately NOT re-asserted here against a statistics regime
-        // this suite does not have. (Fixing it by ANALYZEing in the
-        // `finally` is rejected on purpose: CI runs `bun test` and
-        // `performance:query-plan:check` against the SAME database, so
-        // ANALYZEing `awcms_mini_blog_posts` from inside a test would make
-        // the pre-existing `blog-posts-fulltext-search` budget — latently
-        // red at 939.5 vs its approved 800 — fail in the later script run.
-        // Also tracked in Issue #849.)
+        // Asserted STRUCTURALLY (the index's own normalized definition in
+        // pg_indexes) rather than by re-running EXPLAIN: restoring the index
+        // is a SCHEMA fact, so assert the schema. The plan-shape/cost
+        // guarantee for the restored index is already covered by `before`
+        // above. (Note: `CREATE INDEX` refreshes `pg_class.reltuples`/
+        // `relpages` but NOT `pg_statistic` column histograms, so re-EXPLAIN
+        // after the restore would run on half-refreshed stats — the schema
+        // round-trip below is the clean, timing-independent assertion.)
         const restoredDef = await indexDefinition(indexName);
 
         // Not merely "an index with that name exists" — PostgreSQL's own

--- a/tests/unit/performance-query-plan-registry-consistency.test.ts
+++ b/tests/unit/performance-query-plan-registry-consistency.test.ts
@@ -8,11 +8,14 @@
 import { describe, expect, test } from "bun:test";
 
 import { QUERY_PLAN_BUDGETS } from "../../src/lib/performance/query-plan-budgets";
+import { QUERY_PLAN_ANALYZE_TABLES } from "../../src/lib/performance/analyze-fixtures";
 import {
   QUERY_PLAN_QUERIES,
   REGRESSION_FIXTURE_BUDGET,
   REGRESSION_FIXTURE_QUERY
 } from "../../src/lib/performance/query-plan-runner";
+
+const PLACEHOLDER_TENANT = "00000000-0000-0000-0000-000000000000";
 
 describe("query-plan budgets <-> queries id parity", () => {
   test("every budget id has a matching query definition", () => {
@@ -45,5 +48,32 @@ describe("query-plan budgets <-> queries id parity", () => {
     expect(budgetIds.has(REGRESSION_FIXTURE_QUERY.id)).toBe(false);
     expect(queryIds.has(REGRESSION_FIXTURE_QUERY.id)).toBe(false);
     expect(REGRESSION_FIXTURE_BUDGET.id).toBe(REGRESSION_FIXTURE_QUERY.id);
+  });
+});
+
+describe("query-plan ANALYZE table coverage (Issue #849)", () => {
+  // A budget whose driving table is NOT in QUERY_PLAN_ANALYZE_TABLES would be
+  // evaluated against stale/absent planner statistics — exactly the
+  // non-deterministic flake Issue #849 exists to close. This pure-unit gate
+  // turns "someone added a budget over a not-yet-ANALYZEd table" into a red
+  // test here, instead of a mysterious CI flake later.
+  test("every registered query references at least one ANALYZEd driving table", () => {
+    for (const query of QUERY_PLAN_QUERIES) {
+      const { text } = query.build(PLACEHOLDER_TENANT);
+      const covered = QUERY_PLAN_ANALYZE_TABLES.some((table) =>
+        text.includes(table)
+      );
+      expect([query.id, covered]).toEqual([query.id, true]);
+    }
+  });
+
+  test("no ANALYZEd table is orphaned — each is the driving table of some registered query", () => {
+    const allQueryText = QUERY_PLAN_QUERIES.map(
+      (query) => query.build(PLACEHOLDER_TENANT).text
+    ).join("\n");
+
+    for (const table of QUERY_PLAN_ANALYZE_TABLES) {
+      expect([table, allQueryText.includes(table)]).toEqual([table, true]);
+    }
   });
 });


### PR DESCRIPTION
Closes #849

## Root cause (verified, not assumed)

PostgreSQL **silently skips** an `ANALYZE` of a table the issuing role does not OWN — a WARNING, never an error, exit status success. The query-plan budget suite issued `ANALYZE` on the least-privilege `awcms_mini_app` role (which owns none of the driving tables), so planner statistics were never refreshed. Budgets then passed or failed by accident of autovacuum timing, not real measurement.

Verified directly against a real PostgreSQL (`pg_stat_user_tables.analyze_count`):

- **No-op confirmed**: app-role `ANALYZE` leaves `analyze_count`/`last_analyze` unchanged for all 5 driving tables; owner `ANALYZE` advances them.
- **Non-determinism, both directions** (measured at `safe` scale): under stale/absent statistics the `admin_list` budgets go RED on a spurious `Sort`, and `blog-posts-fulltext-search` hits **873.81 (>800)** on the bloated post-`DELETE` script path. Under a real owner `ANALYZE` every budget passes with healthy margin.

### Premise correction

The pre-existing comments claimed fixing `ANALYZE` would push `blog-posts-fulltext-search` to **939.5 (>800)** and require a threshold change. That **did not reproduce**: accurate-statistics cost never exceeds ~667 for that query at this scale (472 clean single-seed, 667 bloated CI regime). **No budget threshold change was needed.** The ~874 figure only exists in the stale, no-`ANALYZE` regime this fix eliminates.

## Fix

- **`src/lib/performance/analyze-fixtures.ts`** (new) — `analyzeQueryPlanFixtures()` runs `ANALYZE` via a caller-supplied PRIVILEGED (owner) connection and PROVES it worked by asserting `pg_stat_user_tables.analyze_count` strictly advanced for every driving table; throws otherwise. No silent no-op path remains.
- **Integration test** — `beforeAll` now ANALYZEs via `getAdminSql()` (owner) and a new test asserts `analyze_count` advanced. The `DROP INDEX` proof now also asserts the cost overrun (dropped ~316–472 vs the 200 budget), sound now that statistics are accurate.
- **`scripts/performance-query-plan-check.ts`** — refreshes statistics via `PERF_ANALYZE_DATABASE_URL` (owner; falls back to `DATABASE_URL`) and exits 1 with an actionable message if `ANALYZE` was a no-op. EXPLAIN still runs RLS-enforced as the app role.
- **CI** — the query-plan step now passes `PERF_ANALYZE_DATABASE_URL` (the non-secret migration-owner dev default).
- **Pure-unit gate** — every registered budget's driving table must be in `QUERY_PLAN_ANALYZE_TABLES`, so a future budget over a not-yet-ANALYZEd table fails a unit test rather than flaking in CI.
- Docs (`performance-suite.md`) and the stale budget comment updated.

## Red → green proof

**Integration test** (real Postgres):
- RED — revert `beforeAll` to `getTestSql()` (app-role no-op): `beforeAll` throws `ANALYZE did NOT refresh planner statistics ...`, suite `0 pass, 1 fail`.
- GREEN — `getAdminSql()` (owner): `7 pass, 0 fail`.

**Script**:
- RED — app-role `DATABASE_URL` only, no `PERF_ANALYZE_DATABASE_URL`: `BLOCKED — ANALYZE did NOT refresh planner statistics ...`, **exit 1**.
- GREEN — `PERF_ANALYZE_DATABASE_URL`=owner: `refreshed planner statistics for 5 driving tables (analyze_count advanced)`, all budgets PASS, **exit 0**.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run build`, all registry checks — green.
- `bun test` with `DATABASE_URL` set (CI-equivalent, real Postgres): **4949 pass, 8 skip, 0 fail**.
- `bun run changesets:policy:check` — OK (1 changeset for 6 non-docs files).
- Affected integration suite `7 pass, 0 fail`; unit consistency `25 pass`.

(Note: `bun run check` without `DATABASE_URL` surfaces 10 failures in an ungated `describe` block in `tests/integration/reference-data.integration.test.ts` — a pre-existing gating gap on `main`, unrelated to this change; they pass with `DATABASE_URL` set, which is how CI runs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)